### PR TITLE
feat(web): redesign emergency landing + public home (Banda oficial)

### DIFF
--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -130,8 +130,8 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
   const sectionTitle = 'font-display text-base font-bold text-navy';
 
   return (
-    <main className="flex min-h-screen justify-center bg-surface">
-      <div className="w-full max-w-md bg-surface">
+    <main className="min-h-screen bg-surface">
+      <div className="mx-auto w-full max-w-md bg-surface lg:max-w-6xl">
         <OfficialHeaderBand
           name={emergency.name}
           status={emergency.status}
@@ -139,31 +139,39 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
           te={te}
         />
 
-        <div className="flex flex-col gap-5 px-4 pb-12 pt-5">
+        <div className="flex flex-col gap-5 px-4 pb-12 pt-5 lg:gap-6 lg:px-8">
           <StatusBanner status={emergency.status} t={t.status_banner} />
 
-          {/* Comunicado oficial */}
-          <AnnouncementCard
-            announcement={typeof emergency.announcement === 'string' ? emergency.announcement : null}
-            updatedAt={emergency.updatedAt}
-            t={t.announcement}
-          />
-
-          {/* Lo más eficaz ahora — donación */}
-          {isActive && (
-            <EffectiveActionCard
-              href={`/e/${slug}/donar`}
-              overline={te.effective_overline}
-              title={te.effective_title}
-              cta={te.effective_cta}
+          {/* Comunicado oficial + "Lo más eficaz ahora" (lado a lado en escritorio) */}
+          {isActive ? (
+            <div className="grid gap-5 lg:grid-cols-3">
+              <div className="lg:col-span-2">
+                <AnnouncementCard
+                  announcement={typeof emergency.announcement === 'string' ? emergency.announcement : null}
+                  updatedAt={emergency.updatedAt}
+                  t={t.announcement}
+                />
+              </div>
+              <EffectiveActionCard
+                href={`/e/${slug}/donar`}
+                overline={te.effective_overline}
+                title={te.effective_title}
+                cta={te.effective_cta}
+              />
+            </div>
+          ) : (
+            <AnnouncementCard
+              announcement={typeof emergency.announcement === 'string' ? emergency.announcement : null}
+              updatedAt={emergency.updatedAt}
+              t={t.announcement}
             />
           )}
 
-          {/* Métricas */}
+          {/* Métricas (fila de KPIs) */}
           {metrics !== undefined && (
             <section aria-labelledby="metrics-heading">
               <h2 id="metrics-heading" className="sr-only">{te.metrics_heading}</h2>
-              <div className="grid grid-cols-2 gap-2.5">
+              <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
                 <MetricCard value={metrics.needs.open} label={te.metric_tile_open} tone="navy" />
                 <MetricCard value={metrics.resources.active} label={te.metric_tile_points} tone="navy" />
                 <MetricCard value={metrics.needs.closed} label={te.metric_tile_covered} tone="success" />
@@ -172,6 +180,8 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
             </section>
           )}
 
+          {/* Paneles — columna única en móvil, dashboard multi-columna en escritorio */}
+          <div className="columns-1 gap-5 lg:columns-2 [&>*]:mb-5 [&>*]:break-inside-avoid">
           {/* ¿Cómo quieres ayudar? */}
           <section aria-labelledby="actions-heading" className="flex flex-col gap-3">
             <h2 id="actions-heading" className={sectionTitle}>{te.actions_heading}</h2>
@@ -283,8 +293,9 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
               </ul>
             )}
           </section>
+          </div>
 
-          {/* Mapa de la emergencia */}
+          {/* Mapa de la emergencia (ancho completo) */}
           <section aria-labelledby="map-heading" className="flex flex-col gap-3">
             <h2 id="map-heading" className={sectionTitle}>{te.map_heading}</h2>
             <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -1,22 +1,23 @@
 import type { Metadata, ResolvingMetadata } from 'next';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getToken } from '@/lib/auth';
+import { OfficialHeaderBand } from '@/components/organisms/official-header-band';
 import { PublicResourceCard } from '@/components/organisms/public-resource-card';
 import { EmergencyMapWrapper } from '@/components/emergency-map-wrapper';
 import { NeedsFilter } from '@/components/needs-filter';
-import { Badge } from '@/components/atoms/badge';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { MetricCard } from '@/components/molecules/metric-card';
 import { StatusBanner } from '@/components/molecules/status-banner';
 import { AnnouncementCard } from '@/components/molecules/announcement-card';
-import { LanguageSwitcher } from '@/components/molecules/language-switcher';
+import { EffectiveActionCard } from '@/components/molecules/effective-action-card';
+import { HelpActionRow } from '@/components/molecules/help-action-row';
+import { FamilySearchCard } from '@/components/molecules/family-search-card';
+import { NeedCard } from '@/components/molecules/need-card';
+import { LandingFooter } from '@/components/molecules/landing-footer';
 import type { MapPoint } from '@/components/emergency-map';
 import { getT } from '@/i18n/server';
-import { FreshnessIndicator } from '@/components/atoms/freshness-indicator';
-import { PrivacyLocationNotice } from '@/components/atoms/privacy-location-notice';
 
 export const dynamic = 'force-dynamic';
 
@@ -63,6 +64,7 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
 
   const emergencyId = emergency.id;
   const token = await getToken();
+  const isActive = emergency.status === 'active';
 
   const rawCategory = typeof resolvedSearchParams.category === 'string' ? resolvedSearchParams.category : undefined;
   const rawPriority = typeof resolvedSearchParams.priority === 'string' ? resolvedSearchParams.priority : undefined;
@@ -98,11 +100,7 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
   // Build map points from resources and needs that have valid coordinates
   const mapPoints: MapPoint[] = [
     ...activeResources
-      .filter(
-        (r) =>
-          r.location.latitude !== 0 &&
-          r.location.longitude !== 0,
-      )
+      .filter((r) => r.location.latitude !== 0 && r.location.longitude !== 0)
       .map(
         (r): MapPoint => ({
           id: r.id,
@@ -114,11 +112,7 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
         }),
       ),
     ...validatedNeeds
-      .filter(
-        (n) =>
-          n.location.latitude !== 0 &&
-          n.location.longitude !== 0,
-      )
+      .filter((n) => n.location.latitude !== 0 && n.location.longitude !== 0)
       .map(
         (n): MapPoint => ({
           id: n.id,
@@ -132,332 +126,194 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
   ];
 
   const te = t.emergency;
+  const dontList = emergency.dontBringList.length > 0 ? emergency.dontBringList : te.dont_bring_items;
+  const sectionTitle = 'font-display text-base font-bold text-navy';
 
   return (
-    <main className="min-h-screen flex flex-col items-center justify-start bg-white px-4 py-10">
-      <div className="w-full max-w-xl flex flex-col gap-10">
-
-        {/* ── 1. CABECERA OFICIAL ───────────────────────────────────────── */}
-        <header className="flex flex-col gap-3">
-          <div className="flex items-start justify-between gap-4">
-            <Link
-              href="/"
-              className="text-sm text-gray-400 underline underline-offset-2 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 rounded w-fit"
-            >
-              {te.back_all}
-            </Link>
-            <LanguageSwitcher />
-          </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-              {emergency.name}
-            </h1>
-            {emergency.status === 'active' && (
-              <Badge variant="active" aria-label={te.status_active_aria}>
-                {te.status_active}
-              </Badge>
-            )}
-          </div>
-          <p className="text-sm font-medium text-gray-500 tracking-wide uppercase">
-            {te.official_source}
-          </p>
-        </header>
-
-        {/* ── 1b. BANNER DE ESTADO ─────────────────────────────────────── */}
-        <StatusBanner status={emergency.status} t={t.status_banner} />
-
-        {/* ── 1c. COMUNICADO OFICIAL ───────────────────────────────────── */}
-        <AnnouncementCard
-          announcement={
-            typeof emergency.announcement === 'string'
-              ? emergency.announcement
-              : null
-          }
+    <main className="flex min-h-screen justify-center bg-surface">
+      <div className="w-full max-w-md bg-surface">
+        <OfficialHeaderBand
+          name={emergency.name}
+          status={emergency.status}
           updatedAt={emergency.updatedAt}
-          t={t.announcement}
+          te={te}
         />
 
-        {/* ── 2. RESUMEN (métricas) ────────────────────────────────────── */}
-        {metrics !== undefined && (
-          <section aria-labelledby="metrics-heading" className="flex flex-col gap-3">
-            <h2
-              id="metrics-heading"
-              className="text-xl font-bold text-gray-900"
-            >
-              {te.metrics_heading}
-            </h2>
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-              <MetricCard value={metrics.needs.open} label={te.metric_needs_open} />
-              <MetricCard value={metrics.needs.closed} label={te.metric_needs_closed} />
-              <MetricCard value={metrics.resources.active} label={te.metric_resources_active} />
-              <MetricCard value={metrics.resources.pending} label={te.metric_resources_pending} />
-            </div>
-          </section>
-        )}
+        <div className="flex flex-col gap-5 px-4 pb-12 pt-5">
+          <StatusBanner status={emergency.status} t={t.status_banner} />
 
-        {/* ── 3. QUÉ NO LLEVAR ─────────────────────────────────────────── */}
-        <section aria-labelledby="dont-bring-heading" className="flex flex-col gap-4">
-          <h2
-            id="dont-bring-heading"
-            className="text-xl font-bold text-gray-900"
-          >
-            {te.dont_bring_heading}
-          </h2>
-          <p className="text-sm text-gray-600">
-            {te.dont_bring_intro}
-          </p>
-          <ul className="flex flex-col gap-2" role="list">
-            {(emergency.dontBringList.length > 0 ? emergency.dontBringList : te.dont_bring_items).map((item) => (
-              <li
-                key={item}
-                className="flex items-start gap-3 text-sm text-gray-800"
-              >
-                <span
-                  aria-hidden="true"
-                  className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-900 flex items-center justify-center font-bold text-gray-900 text-xs"
-                >
-                  ✕
-                </span>
-                {item}
-              </li>
-            ))}
-          </ul>
-        </section>
+          {/* Comunicado oficial */}
+          <AnnouncementCard
+            announcement={typeof emergency.announcement === 'string' ? emergency.announcement : null}
+            updatedAt={emergency.updatedAt}
+            t={t.announcement}
+          />
 
-        {/* ── 4. BOTONES DE ACCIÓN ─────────────────────────────────────── */}
-        <section aria-labelledby="actions-heading" className="flex flex-col gap-4">
-          <h2
-            id="actions-heading"
-            className="text-xl font-bold text-gray-900"
-          >
-            {te.actions_heading}
-          </h2>
-          {emergency.status === 'active' ? (
-            <div className="flex flex-col gap-3">
-              <Link
-                href={`/e/${slug}/registrar`}
-                className="flex items-center justify-center w-full py-4 px-6 text-lg font-semibold text-white bg-gray-900 rounded-lg border-2 border-gray-900 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors"
-              >
-                {te.action_offer_resource}
-              </Link>
-              <Link
-                href={`/e/${slug}/peticion`}
-                className="flex items-center justify-center w-full py-4 px-6 text-lg font-semibold text-gray-900 bg-white rounded-lg border-2 border-gray-900 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors"
-              >
-                {te.action_submit_petition}
-              </Link>
-              <Link
-                href={`/e/${slug}/donar`}
-                className="flex items-center justify-center w-full py-4 px-6 text-lg font-semibold text-gray-900 bg-white rounded-lg border-2 border-gray-900 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors"
-              >
-                {te.action_donate}
-              </Link>
-              <Link
-                href={`/e/${slug}/voluntario`}
-                className="flex items-center justify-center w-full py-4 px-6 text-lg font-semibold text-gray-900 bg-white rounded-lg border-2 border-gray-900 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors"
-              >
-                {te.action_volunteer}
-              </Link>
-              <Link
-                href={`/e/${slug}/reportar`}
-                className="flex items-center justify-center w-full py-4 px-6 text-base font-semibold text-red-800 bg-red-50 rounded-lg border-2 border-red-600 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2 transition-colors"
-              >
-                {te.action_report_damage}
-              </Link>
-            </div>
-          ) : null}
-
-          {/* "Buscar familiar" — visible whether active or paused */}
-          <div
-            className={`${emergency.status === 'active' ? 'border-t border-gray-200 pt-4' : ''}`}
-          >
-            <Link
-              href={`/e/${slug}/buscar-familiar`}
-              className="flex items-center justify-center w-full py-4 px-6 text-lg font-semibold text-gray-900 bg-amber-50 rounded-lg border-2 border-amber-600 hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-600 focus:ring-offset-2 transition-colors"
-            >
-              {te.action_find_family}
-            </Link>
-            <p className="mt-2 text-xs text-center text-gray-500">
-              Los datos son privados y solo accesibles para personal autorizado.
-            </p>
-          </div>
-
-          {emergency.status !== 'active' && (
-            <p className="rounded-lg border-2 border-gray-200 bg-gray-50 px-5 py-4 text-sm text-gray-500">
-              {te.actions_paused}
-            </p>
-          )}
-        </section>
-
-        {/* ── 5. PUNTOS ACTIVOS ────────────────────────────────────────── */}
-        <section aria-labelledby="points-heading" className="flex flex-col gap-4">
-          <h2
-            id="points-heading"
-            className="text-xl font-bold text-gray-900"
-          >
-            {te.points_heading}
-          </h2>
-
-          {activeResources.length === 0 ? (
-            <EmptyState
-              title={te.points_empty_title}
-              description={te.points_empty_description}
+          {/* Lo más eficaz ahora — donación */}
+          {isActive && (
+            <EffectiveActionCard
+              href={`/e/${slug}/donar`}
+              overline={te.effective_overline}
+              title={te.effective_title}
+              cta={te.effective_cta}
             />
-          ) : (
-            <ul
-              className="flex flex-col gap-3"
-              aria-label={te.points_aria_label}
-              role="list"
-            >
-              {activeResources.map((resource) => (
-                <li key={resource.id}>
-                  <PublicResourceCard
-                    resource={resource}
-                    t={t.resource_card}
-                    tVerification={t.verification_badge}
-                    tStatusLight={t.status_light}
-                  />
-                </li>
-              ))}
-            </ul>
           )}
-        </section>
 
-        {/* ── 6. NECESIDADES VALIDADAS ─────────────────────────────────── */}
-        <section aria-labelledby="needs-heading" className="flex flex-col gap-4">
-          <h2
-            id="needs-heading"
-            className="text-xl font-bold text-gray-900"
-          >
-            {te.needs_heading}
-          </h2>
-
-          <NeedsFilter t={t.needs_filter} te={t.emergency} />
-
-          {validatedNeeds.length === 0 ? (
-            <EmptyState title={te.needs_empty_title} />
-          ) : (
-            <ul className="flex flex-col gap-3" role="list" aria-label={te.needs_aria_label}>
-              {validatedNeeds.map((need) => (
-                <li
-                  key={need.id}
-                  className="flex flex-col gap-3 rounded-lg border-2 border-gray-900 bg-white p-4"
-                >
-                  <div className="flex flex-col gap-1">
-                    <h3 className="text-base font-bold text-gray-900 leading-tight">
-                      {need.title}
-                    </h3>
-                    <FreshnessIndicator
-                      expiresAt={need.expiresAt}
-                      lastVerifiedAt={need.lastVerifiedAt}
-                    />
-                    <div className="flex flex-wrap gap-2 text-sm text-gray-600">
-                      {need.items[0] !== undefined && (
-                        <span className="font-medium">
-                          {te[`category_${need.items[0].category}` as keyof typeof te] ?? need.items[0].category}
-                        </span>
-                      )}
-                      <span aria-hidden="true" className="text-gray-300">·</span>
-                      <span>{te.needs_priority_label} {te[`priority_${need.priority}` as keyof typeof te] ?? need.priority}</span>
-                      {need.items.length > 0 && (
-                        <>
-                          <span aria-hidden="true" className="text-gray-300">·</span>
-                          <span>
-                            {String(need.items[0]?.quantity ?? '')}
-                            {need.items[0]?.unit != null ? ` ${String(need.items[0].unit)}` : ''}
-                          </span>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                  {need.locationSensitivity === 'approximate' && (
-                    <PrivacyLocationNotice text={te.privacy_approximate_location} />
-                  )}
-                  {emergency.status === 'active' && (
-                    <Link
-                      href={`/e/${slug}/donar?needId=${need.id}`}
-                      className="inline-flex items-center justify-center rounded-lg border-2 border-gray-900 px-4 py-2 text-sm font-semibold text-gray-900 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors w-fit"
-                    >
-                      {te.needs_offer_button}
-                    </Link>
-                  )}
-                </li>
-              ))}
-            </ul>
+          {/* Métricas */}
+          {metrics !== undefined && (
+            <section aria-labelledby="metrics-heading">
+              <h2 id="metrics-heading" className="sr-only">{te.metrics_heading}</h2>
+              <div className="grid grid-cols-2 gap-2.5">
+                <MetricCard value={metrics.needs.open} label={te.metric_tile_open} tone="navy" />
+                <MetricCard value={metrics.resources.active} label={te.metric_tile_points} tone="navy" />
+                <MetricCard value={metrics.needs.closed} label={te.metric_tile_covered} tone="success" />
+                <MetricCard value={metrics.resources.pending} label={te.metric_tile_queue} tone="accent" />
+              </div>
+            </section>
           )}
-        </section>
 
-        {/* ── 7. MAPA DE LA EMERGENCIA ─────────────────────────────────── */}
-        <section aria-labelledby="map-heading" className="flex flex-col gap-4">
-          <h2
-            id="map-heading"
-            className="text-xl font-bold text-gray-900"
-          >
-            {te.map_heading}
-          </h2>
-          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-3 h-3 rounded-full bg-green-500" aria-hidden="true" />
-              {te.map_legend_active}
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-3 h-3 rounded-full bg-yellow-400" aria-hidden="true" />
-              {te.map_legend_saturated}
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-3 h-3 rounded-full bg-orange-500" aria-hidden="true" />
-              {te.map_legend_paused}
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-3 h-3 rounded-full bg-red-500" aria-hidden="true" />
-              {te.map_legend_need}
-            </span>
-          </div>
-          <p className="text-xs text-gray-400 flex items-center gap-1">
-            <span aria-hidden="true">🔒</span>
-            {te.map_user_location_notice}
-          </p>
-          <EmergencyMapWrapper points={mapPoints} emergencyId={emergencyId} />
-        </section>
+          {/* ¿Cómo quieres ayudar? */}
+          <section aria-labelledby="actions-heading" className="flex flex-col gap-3">
+            <h2 id="actions-heading" className={sectionTitle}>{te.actions_heading}</h2>
+            {isActive && (
+              <div className="flex flex-col gap-2.5">
+                <HelpActionRow
+                  href={`/e/${slug}/registrar`}
+                  icon="📦"
+                  title={te.action_offer_resource}
+                  subtitle={te.help_offer_subtitle}
+                  variant="primary"
+                />
+                <HelpActionRow
+                  href={`/e/${slug}/voluntario`}
+                  icon="🙋"
+                  title={te.action_volunteer}
+                  subtitle={te.help_volunteer_subtitle}
+                />
+                <HelpActionRow
+                  href={`/e/${slug}/peticion`}
+                  icon="🧾"
+                  title={te.action_submit_petition}
+                  subtitle={te.help_petition_subtitle}
+                />
+                <HelpActionRow
+                  href={`/e/${slug}/reportar`}
+                  icon="⚠️"
+                  title={te.help_report_title}
+                  variant="danger"
+                />
+              </div>
+            )}
 
-        {/* ── 8. PIE ───────────────────────────────────────────────────── */}
-        <footer className="border-t border-gray-200 pt-6 flex items-center justify-between gap-4 flex-wrap">
-          {token !== null && (
-            <div className="flex items-center gap-4 flex-wrap">
-              <Link
-                href={`/e/${slug}/mis-puntos`}
-                className="text-sm text-gray-400 underline underline-offset-2 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 rounded"
-              >
-                {te.footer_my_points}
-              </Link>
-              <Link
-                href={`/e/${slug}/mi-voluntariado`}
-                className="text-sm text-gray-400 underline underline-offset-2 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 rounded"
-              >
-                {te.footer_my_volunteer}
-              </Link>
-              <Link
-                href={`/e/${slug}/mi-busqueda`}
-                className="text-sm text-gray-400 underline underline-offset-2 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 rounded"
-              >
-                {te.footer_my_search}
-              </Link>
-              <Link
-                href={`/e/${slug}/reportar`}
-                className="text-sm text-gray-400 underline underline-offset-2 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 rounded"
-              >
-                {te.footer_report}
-              </Link>
+            <FamilySearchCard
+              href={`/e/${slug}/buscar-familiar`}
+              title={te.family_title}
+              subtitle={te.family_subtitle}
+            />
+
+            {!isActive && (
+              <p className="rounded-card border border-line bg-surface-alt px-4 py-4 text-sm text-muted">
+                {te.actions_paused}
+              </p>
+            )}
+          </section>
+
+          {/* Qué NO hacer ahora */}
+          <section aria-labelledby="dont-do-heading" className="flex flex-col gap-3">
+            <div>
+              <h2 id="dont-do-heading" className={sectionTitle}>{te.dont_do_heading}</h2>
+              <p className="mt-0.5 text-[12.5px] text-muted">{te.dont_do_intro}</p>
             </div>
-          )}
-          <Link
-            href={`/e/${slug}/coordinacion`}
-            className="text-sm text-gray-400 underline underline-offset-2 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 rounded ml-auto"
-          >
-            {te.footer_coordination}
-          </Link>
-        </footer>
+            <ul className="flex flex-col gap-2.5" role="list">
+              {dontList.map((item) => (
+                <li key={item} className="flex items-center gap-2.5 text-sm text-ink">
+                  <span
+                    aria-hidden="true"
+                    className="flex h-[22px] w-[22px] flex-shrink-0 items-center justify-center rounded-full bg-danger-soft text-xs font-extrabold text-danger"
+                  >
+                    ✕
+                  </span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </section>
 
+          {/* Puntos activos */}
+          <section aria-labelledby="points-heading" className="flex flex-col gap-3">
+            <div className="flex items-baseline justify-between gap-2">
+              <h2 id="points-heading" className={sectionTitle}>{te.points_heading}</h2>
+              {activeResources.length > 0 && (
+                <span className="text-xs text-muted-soft">
+                  {te.points_count.replace('{count}', String(activeResources.length))}
+                </span>
+              )}
+            </div>
+            {activeResources.length === 0 ? (
+              <EmptyState title={te.points_empty_title} description={te.points_empty_description} />
+            ) : (
+              <ul className="flex flex-col gap-2.5" aria-label={te.points_aria_label} role="list">
+                {activeResources.map((resource) => (
+                  <li key={resource.id}>
+                    <PublicResourceCard
+                      resource={resource}
+                      t={t.resource_card}
+                      tVerification={t.verification_badge}
+                      tStatusLight={t.status_light}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* Necesidades validadas */}
+          <section aria-labelledby="needs-heading" className="flex flex-col gap-3">
+            <h2 id="needs-heading" className={sectionTitle}>{te.needs_heading}</h2>
+            <NeedsFilter t={t.needs_filter} te={t.emergency} />
+            {validatedNeeds.length === 0 ? (
+              <EmptyState title={te.needs_empty_title} />
+            ) : (
+              <ul className="flex flex-col gap-2.5" role="list" aria-label={te.needs_aria_label}>
+                {validatedNeeds.map((need) => (
+                  <li key={need.id}>
+                    <NeedCard need={need} te={te} slug={slug} active={isActive} />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* Mapa de la emergencia */}
+          <section aria-labelledby="map-heading" className="flex flex-col gap-3">
+            <h2 id="map-heading" className={sectionTitle}>{te.map_heading}</h2>
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-3 w-3 rounded-full bg-green-500" aria-hidden="true" />
+                {te.map_legend_active}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-3 w-3 rounded-full bg-yellow-400" aria-hidden="true" />
+                {te.map_legend_saturated}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-3 w-3 rounded-full bg-orange-500" aria-hidden="true" />
+                {te.map_legend_paused}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-3 w-3 rounded-full bg-red-500" aria-hidden="true" />
+                {te.map_legend_need}
+              </span>
+            </div>
+            <p className="flex items-center gap-1 text-xs text-muted-soft">
+              <span aria-hidden="true">🔒</span>
+              {te.map_user_location_notice}
+            </p>
+            <EmergencyMapWrapper points={mapPoints} emergencyId={emergencyId} />
+          </section>
+
+          <LandingFooter slug={slug} te={te} authed={token !== null} />
+        </div>
       </div>
     </main>
   );

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,5 +1,51 @@
 @import "tailwindcss";
 
+/*
+ * ResponseGrid design system — "Banda oficial" direction.
+ * Tokens are consumed as Tailwind v4 utilities (e.g. bg-navy, text-accent,
+ * border-line, rounded-card, font-display). Fonts are wired to the next/font
+ * CSS variables declared on <html> in layout.tsx.
+ */
+@theme {
+  /* Typography */
+  --font-sans: var(--font-public-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-display: var(--font-archivo), ui-sans-serif, system-ui, sans-serif;
+
+  /* Brand */
+  --color-navy: #112b4a;
+  --color-navy-700: #13315c;
+  --color-accent: #e8740e;
+  --color-accent-600: #c85f08;
+
+  /* Warm neutral surfaces & ink */
+  --color-surface: #fbfaf8;
+  --color-surface-alt: #f4f1ec;
+  --color-ink: #1a2230;
+  --color-ink-soft: #2c3645;
+  --color-muted: #6a7382;
+  --color-muted-soft: #8a93a2;
+  --color-line: #e7e2da;
+  --color-line-soft: #eae5dd;
+
+  /* Semantic status */
+  --color-success: #1e8049;
+  --color-success-soft: #e9f7ee;
+  --color-success-dot: #3fbf6a;
+  --color-warning: #9a6210;
+  --color-warning-soft: #fcf3e0;
+  --color-warning-dot: #f2b400;
+  --color-danger: #c23a1e;
+  --color-danger-soft: #fbe3dc;
+  --color-danger-tint: #fceee6;
+  --color-official-soft: #e7eef7;
+  --color-family-soft: #fbf2dd;
+  --color-family-line: #e4c97a;
+  --color-family-ink: #7a5a12;
+
+  /* Radius */
+  --radius-card: 16px;
+}
+
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,8 +1,24 @@
 import type { Metadata } from 'next';
+import { Archivo, Public_Sans } from 'next/font/google';
 import './globals.css';
 import { SwRegister } from '@/components/providers/sw-register';
 import { getT } from '@/i18n/server';
 import { LocaleProvider } from '@/i18n/locale-context';
+
+// Display face (headings, metrics, wordmark) and body face — self-hosted by next/font.
+const archivo = Archivo({
+  subsets: ['latin'],
+  weight: ['500', '600', '700', '800'],
+  variable: '--font-archivo',
+  display: 'swap',
+});
+
+const publicSans = Public_Sans({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-public-sans',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: 'ResponseGrid',
@@ -17,8 +33,8 @@ export default async function RootLayout({
   const { locale } = await getT();
 
   return (
-    <html lang={locale} className="h-full">
-      <body className="min-h-full flex flex-col bg-white text-gray-900 antialiased">
+    <html lang={locale} className={`h-full ${archivo.variable} ${publicSans.variable}`}>
+      <body className="min-h-full flex flex-col bg-white text-ink antialiased font-sans">
         <LocaleProvider locale={locale}>
           {children}
         </LocaleProvider>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,9 +2,12 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { api } from '@/lib/api';
 import { getToken, authHeaders } from '@/lib/auth';
-import { Badge } from '@/components/atoms/badge';
+import { SiteHeaderBand } from '@/components/organisms/site-header-band';
+import { EmergencyDirectoryCard } from '@/components/organisms/emergency-directory-card';
+import { SiteFooter } from '@/components/organisms/site-footer';
+import { HowItWorksStep } from '@/components/molecules/how-it-works-step';
+import { TrustLevelsCard } from '@/components/molecules/trust-levels-card';
 import { EmptyState } from '@/components/molecules/empty-state';
-import { LanguageSwitcher } from '@/components/molecules/language-switcher';
 import { getT } from '@/i18n/server';
 
 // Emergency list must reflect live backend state on every request.
@@ -39,117 +42,117 @@ export default async function HomePage() {
     }
   }
 
-  const activeEmergencies = emergencies ?? [];
+  const all = emergencies ?? [];
+  const activeEmergencies = all.filter((e) => e.status === 'active');
+  const closedEmergencies = all.filter((e) => e.status !== 'active');
+
+  const th = t.home;
+  const sectionHeading = 'font-display text-lg font-bold text-navy';
 
   return (
-    <main className="min-h-screen flex flex-col items-center justify-start bg-white px-4 py-10">
-      <div className="w-full max-w-xl flex flex-col gap-10">
+    <main className="flex min-h-screen justify-center bg-surface">
+      <div className="w-full max-w-md bg-surface">
+        <SiteHeaderBand />
 
-        {/* ── CABECERA ─────────────────────────────────────────────────── */}
-        <header className="flex flex-col gap-2">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex flex-col gap-2">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                {t.home.title}
-              </h1>
-              <p className="text-base text-gray-600">
-                {t.home.subtitle}
-              </p>
-            </div>
-            <LanguageSwitcher />
-          </div>
-        </header>
-
-        {/* ── EMERGENCIAS ACTIVAS ───────────────────────────────────────── */}
-        <section aria-labelledby="emergencies-heading" className="flex flex-col gap-4">
-          <h2
-            id="emergencies-heading"
-            className="text-xl font-bold text-gray-900"
-          >
-            {t.home.active_emergencies}
-          </h2>
-
-          {activeEmergencies.length === 0 ? (
-            <EmptyState
-              title={t.home.no_emergencies_title}
-              description={t.home.no_emergencies_description}
-            />
-          ) : (
-            <ul className="flex flex-col gap-3" role="list" aria-label={t.home.aria_emergency_list}>
-              {activeEmergencies.map((emergency) => (
-                <li key={emergency.id}>
-                  <Link
-                    href={`/e/${emergency.slug}`}
-                    className="flex flex-col gap-2 rounded-lg border-2 border-gray-900 bg-white p-5 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 transition-colors"
-                  >
-                    <div className="flex flex-wrap items-center gap-3">
-                      <span className="text-lg font-bold text-gray-900 leading-tight">
-                        {emergency.name}
-                      </span>
-                      <Badge variant="active" aria-label="Estado: activa">
-                        {t.home.emergency_status_active}
-                      </Badge>
-                    </div>
-                    <p className="text-sm text-gray-500 font-medium uppercase tracking-wide">
-                      {emergency.country}
-                    </p>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-
-        {/* ── PIE / ENLACES ─────────────────────────────────────────── */}
-        <footer className="border-t-2 border-gray-100 pt-6">
-          <nav aria-label="Navegación secundaria" className="flex flex-wrap gap-4">
-            <Link
-              href="/organizaciones"
-              className="text-sm font-medium text-gray-600 hover:text-gray-900 underline underline-offset-2 transition-colors"
-            >
-              {t.home.my_orgs}
-            </Link>
-            {token != null && (
-              <Link
-                href="/notificaciones"
-                className="text-sm font-medium text-gray-600 hover:text-gray-900 underline underline-offset-2 transition-colors"
+        <div className="flex flex-col gap-8 px-5 pb-12 pt-6">
+          {/* ── Hero (SEO H1) ───────────────────────────────────────────── */}
+          <section>
+            <h1 className="font-display text-[27px] font-extrabold leading-[1.1] tracking-tight text-navy">
+              {th.hero_h1}
+            </h1>
+            <p className="mt-3.5 text-[15px] leading-[1.55] text-ink-soft">{th.hero_subtitle}</p>
+            <div className="mt-[18px] flex gap-2.5">
+              <a
+                href="#emergencias"
+                className="flex-1 rounded-xl bg-navy px-4 py-3.5 text-center text-[15px] font-bold text-white transition-colors hover:bg-navy-700 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
               >
-                {notificationUnreadCount > 0
-                  ? t.home.notifications_with_count.replace('{count}', String(notificationUnreadCount))
-                  : t.home.notifications}
-              </Link>
-            )}
-            <Link
-              href="/login"
-              className="text-sm font-medium text-gray-600 hover:text-gray-900 underline underline-offset-2 transition-colors"
-            >
-              {t.home.coordination_access}
-            </Link>
-            {isAdmin && (
-              <>
-                <Link
-                  href="/admin/acreditaciones"
-                  className="text-sm font-medium text-gray-400 hover:text-gray-700 underline underline-offset-2 transition-colors"
-                >
-                  {t.home.admin}
-                </Link>
-                <Link
-                  href="/admin/templates"
-                  className="text-sm font-medium text-gray-400 hover:text-gray-700 underline underline-offset-2 transition-colors"
-                >
-                  {t.home.templates}
-                </Link>
-                <Link
-                  href="/admin/auditoria"
-                  className="text-sm font-medium text-gray-400 hover:text-gray-700 underline underline-offset-2 transition-colors"
-                >
-                  {t.home.audit}
-                </Link>
-              </>
-            )}
-          </nav>
-        </footer>
+                {th.hero_cta_emergencies}
+              </a>
+              <a
+                href="#emergencias"
+                className="rounded-xl border-[1.5px] border-[#d8d2c8] bg-white px-5 py-3.5 text-center text-[15px] font-bold text-navy transition-colors hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+              >
+                {th.hero_cta_donate}
+              </a>
+            </div>
+          </section>
 
+          {/* ── Emergencias activas ─────────────────────────────────────── */}
+          <section id="emergencias" aria-labelledby="emergencias-heading" className="scroll-mt-4">
+            <div className="mb-3.5 flex items-baseline justify-between gap-2">
+              <h2 id="emergencias-heading" className={sectionHeading}>{th.active_emergencies}</h2>
+              {activeEmergencies.length > 0 && (
+                <span className="text-xs text-muted-soft">
+                  {th.active_count.replace('{count}', String(activeEmergencies.length))}
+                </span>
+              )}
+            </div>
+
+            {activeEmergencies.length === 0 ? (
+              <EmptyState title={th.no_emergencies_title} description={th.no_emergencies_description} />
+            ) : (
+              <ul className="flex flex-col gap-3" role="list" aria-label={th.aria_emergency_list}>
+                {activeEmergencies.map((emergency) => (
+                  <li key={emergency.id}>
+                    <EmergencyDirectoryCard
+                      emergency={emergency}
+                      activeLabel={th.emergency_status_active}
+                      enterLabel={th.enter_operation}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {closedEmergencies.length > 0 && (
+              <div className="mt-3 flex flex-col gap-2.5">
+                {closedEmergencies.map((emergency) => (
+                  <Link
+                    key={emergency.id}
+                    href={`/e/${emergency.slug}`}
+                    className="flex items-center gap-2.5 rounded-card border border-line bg-surface-alt px-4 py-3.5 transition-colors hover:border-navy/20 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+                  >
+                    <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-muted-soft" aria-hidden="true" />
+                    <span className="flex-1">
+                      <span className="block text-sm font-bold text-muted">{emergency.name}</span>
+                      <span className="block text-[11.5px] text-muted-soft">{th.closed_label}</span>
+                    </span>
+                    <span className="text-muted-soft" aria-hidden="true">→</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* ── Cómo funciona ───────────────────────────────────────────── */}
+          <section aria-labelledby="how-heading">
+            <h2 id="how-heading" className={`${sectionHeading} mb-3.5`}>{th.how_it_works_heading}</h2>
+            <div className="flex flex-col gap-4">
+              <HowItWorksStep index={1} title={th.step1_title} body={th.step1_body} />
+              <HowItWorksStep index={2} title={th.step2_title} body={th.step2_body} />
+              <HowItWorksStep index={3} title={th.step3_title} body={th.step3_body} tone="accent" />
+            </div>
+          </section>
+
+          {/* ── La confianza es el producto ─────────────────────────────── */}
+          <TrustLevelsCard
+            heading={th.trust_heading}
+            intro={th.trust_intro}
+            rows={[
+              { level: 'unverified', text: th.trust_unverified },
+              { level: 'verified', text: th.trust_verified },
+              { level: 'official', text: th.trust_official },
+            ]}
+            tVerification={t.verification_badge}
+          />
+
+          <SiteFooter
+            t={th}
+            authed={token !== null}
+            isAdmin={isAdmin}
+            notificationUnreadCount={notificationUnreadCount}
+          />
+        </div>
       </div>
     </main>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -50,18 +50,18 @@ export default async function HomePage() {
   const sectionHeading = 'font-display text-lg font-bold text-navy';
 
   return (
-    <main className="flex min-h-screen justify-center bg-surface">
-      <div className="w-full max-w-md bg-surface">
+    <main className="min-h-screen bg-surface">
+      <div className="mx-auto w-full max-w-md bg-surface lg:max-w-5xl">
         <SiteHeaderBand />
 
-        <div className="flex flex-col gap-8 px-5 pb-12 pt-6">
+        <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
           {/* ── Hero (SEO H1) ───────────────────────────────────────────── */}
           <section>
-            <h1 className="font-display text-[27px] font-extrabold leading-[1.1] tracking-tight text-navy">
+            <h1 className="font-display text-[27px] font-extrabold leading-[1.1] tracking-tight text-navy lg:text-[40px] lg:leading-[1.05]">
               {th.hero_h1}
             </h1>
-            <p className="mt-3.5 text-[15px] leading-[1.55] text-ink-soft">{th.hero_subtitle}</p>
-            <div className="mt-[18px] flex gap-2.5">
+            <p className="mt-3.5 max-w-2xl text-[15px] leading-[1.55] text-ink-soft lg:text-base">{th.hero_subtitle}</p>
+            <div className="mt-[18px] flex gap-2.5 sm:max-w-md">
               <a
                 href="#emergencias"
                 className="flex-1 rounded-xl bg-navy px-4 py-3.5 text-center text-[15px] font-bold text-white transition-colors hover:bg-navy-700 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
@@ -91,7 +91,7 @@ export default async function HomePage() {
             {activeEmergencies.length === 0 ? (
               <EmptyState title={th.no_emergencies_title} description={th.no_emergencies_description} />
             ) : (
-              <ul className="flex flex-col gap-3" role="list" aria-label={th.aria_emergency_list}>
+              <ul className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3" role="list" aria-label={th.aria_emergency_list}>
                 {activeEmergencies.map((emergency) => (
                   <li key={emergency.id}>
                     <EmergencyDirectoryCard
@@ -105,7 +105,7 @@ export default async function HomePage() {
             )}
 
             {closedEmergencies.length > 0 && (
-              <div className="mt-3 flex flex-col gap-2.5">
+              <div className="mt-3 grid gap-2.5 sm:grid-cols-2 xl:grid-cols-3">
                 {closedEmergencies.map((emergency) => (
                   <Link
                     key={emergency.id}
@@ -127,7 +127,7 @@ export default async function HomePage() {
           {/* ── Cómo funciona ───────────────────────────────────────────── */}
           <section aria-labelledby="how-heading">
             <h2 id="how-heading" className={`${sectionHeading} mb-3.5`}>{th.how_it_works_heading}</h2>
-            <div className="flex flex-col gap-4">
+            <div className="grid gap-4 sm:grid-cols-3 sm:gap-6">
               <HowItWorksStep index={1} title={th.step1_title} body={th.step1_body} />
               <HowItWorksStep index={2} title={th.step2_title} body={th.step2_body} />
               <HowItWorksStep index={3} title={th.step3_title} body={th.step3_body} tone="accent" />

--- a/apps/web/src/components/atoms/badge.tsx
+++ b/apps/web/src/components/atoms/badge.tsx
@@ -10,7 +10,11 @@ type BadgeVariant =
   | 'offer-open'
   | 'offer-matched'
   | 'offer-fulfilled'
-  | 'offer-cancelled';
+  | 'offer-cancelled'
+  | 'priority-urgent'
+  | 'priority-high'
+  | 'priority-medium'
+  | 'priority-low';
 
 interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   variant: BadgeVariant;
@@ -37,6 +41,15 @@ const VARIANT_CLASSES: Record<BadgeVariant, string> = {
     'inline-flex items-center rounded-full border border-green-400 bg-green-50 px-2.5 py-0.5 text-xs font-semibold text-green-800',
   'offer-cancelled':
     'inline-flex items-center rounded-full border border-gray-300 bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-500',
+  // Need-priority pills (Banda oficial brand)
+  'priority-urgent':
+    'inline-flex items-center rounded-full bg-danger-soft px-2 py-0.5 text-[10.5px] font-extrabold uppercase tracking-[0.05em] text-danger',
+  'priority-high':
+    'inline-flex items-center rounded-full bg-warning-soft px-2 py-0.5 text-[10.5px] font-extrabold uppercase tracking-[0.05em] text-warning',
+  'priority-medium':
+    'inline-flex items-center rounded-full bg-official-soft px-2 py-0.5 text-[10.5px] font-extrabold uppercase tracking-[0.05em] text-navy',
+  'priority-low':
+    'inline-flex items-center rounded-full bg-line-soft px-2 py-0.5 text-[10.5px] font-extrabold uppercase tracking-[0.05em] text-muted',
 };
 
 export function Badge({ variant, className = '', children, ...props }: BadgeProps) {

--- a/apps/web/src/components/atoms/brand-mark.tsx
+++ b/apps/web/src/components/atoms/brand-mark.tsx
@@ -1,0 +1,31 @@
+/**
+ * BrandMark — the ResponseGrid logo glyph: an accent rounded square holding an
+ * upward navy triangle. Decorative; the readable name lives in BrandLogo.
+ */
+interface BrandMarkProps {
+  /** Square side length in px. */
+  size?: number;
+  className?: string;
+}
+
+export function BrandMark({ size = 26, className = '' }: BrandMarkProps) {
+  const half = Math.round(size * 0.23);
+  const height = Math.round(size * 0.38);
+  return (
+    <span
+      aria-hidden="true"
+      className={`inline-flex flex-shrink-0 items-center justify-center bg-accent ${className}`.trim()}
+      style={{ width: size, height: size, borderRadius: Math.max(4, Math.round(size * 0.23)) }}
+    >
+      <span
+        style={{
+          width: 0,
+          height: 0,
+          borderLeft: `${half}px solid transparent`,
+          borderRight: `${half}px solid transparent`,
+          borderBottom: `${height}px solid var(--color-navy)`,
+        }}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/components/atoms/priority-badge.tsx
+++ b/apps/web/src/components/atoms/priority-badge.tsx
@@ -1,0 +1,36 @@
+/**
+ * PriorityBadge — coloured pill for a validated need's priority.
+ * Mirrors the VerificationBadge / StatusLight pattern: maps a domain value to a
+ * Badge variant and renders a caller-localised label.
+ */
+import { Badge } from '@/components/atoms/badge';
+
+export type Priority = 'low' | 'medium' | 'high' | 'urgent';
+
+interface PriorityBadgeProps {
+  priority: Priority;
+  /** Localised label, e.g. te.priority_urgent. */
+  label: string;
+  /** aria prefix, e.g. te.needs_priority_label. */
+  ariaPrefix?: string;
+  className?: string;
+}
+
+const VARIANT_MAP: Record<Priority, 'priority-urgent' | 'priority-high' | 'priority-medium' | 'priority-low'> = {
+  urgent: 'priority-urgent',
+  high: 'priority-high',
+  medium: 'priority-medium',
+  low: 'priority-low',
+};
+
+export function PriorityBadge({ priority, label, ariaPrefix, className }: PriorityBadgeProps) {
+  return (
+    <Badge
+      variant={VARIANT_MAP[priority]}
+      aria-label={ariaPrefix !== undefined ? `${ariaPrefix} ${label}` : label}
+      className={className}
+    >
+      {label}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/molecules/announcement-card.tsx
+++ b/apps/web/src/components/molecules/announcement-card.tsx
@@ -1,6 +1,6 @@
 /**
- * AnnouncementCard — displays the official coordinator announcement alongside
- * the last-updated timestamp.  Renders nothing when announcement is null.
+ * AnnouncementCard — official coordinator communiqué (Banda oficial look).
+ * Renders just the last-updated line when there is no announcement.
  * `t` is optional — falls back to Spanish when omitted.
  */
 
@@ -21,7 +21,7 @@ export function AnnouncementCard({
 }: AnnouncementCardProps) {
   if (announcement === null) {
     return (
-      <p className="text-xs text-gray-400">
+      <p className="text-xs text-muted-soft">
         {t.last_updated}{' '}
         <RelativeTime isoString={updatedAt} />
       </p>
@@ -31,15 +31,18 @@ export function AnnouncementCard({
   return (
     <aside
       aria-label={t.aria_label}
-      className="flex flex-col gap-2 rounded-lg border-2 border-gray-900 bg-gray-50 px-5 py-4"
+      className="flex flex-col gap-2 rounded-card border border-line bg-white px-4 py-4"
     >
-      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-        {t.official_label}
-      </p>
-      <p className="text-sm text-gray-900 leading-relaxed whitespace-pre-wrap">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-navy">
+          {t.official_label}
+        </span>
+        <span className="text-[11px] text-muted-soft">{t.source}</span>
+      </div>
+      <p className="text-[14.5px] leading-relaxed text-ink-soft whitespace-pre-wrap">
         {announcement}
       </p>
-      <p className="text-xs text-gray-400">
+      <p className="text-xs text-muted-soft">
         {t.last_updated}{' '}
         <RelativeTime isoString={updatedAt} />
       </p>

--- a/apps/web/src/components/molecules/brand-logo.tsx
+++ b/apps/web/src/components/molecules/brand-logo.tsx
@@ -1,0 +1,28 @@
+/**
+ * BrandLogo — BrandMark + "ResponseGrid" wordmark. Colour is inherited from the
+ * parent (text-current), so it sits on navy bands (white) or light surfaces (navy).
+ */
+import { BrandMark } from '@/components/atoms/brand-mark';
+
+interface BrandLogoProps {
+  /** Glyph side length in px. */
+  size?: number;
+  /** Extra classes for the wordmark text (size/colour overrides). */
+  wordmarkClassName?: string;
+  className?: string;
+}
+
+export function BrandLogo({
+  size = 26,
+  wordmarkClassName = 'text-base',
+  className = '',
+}: BrandLogoProps) {
+  return (
+    <span className={`inline-flex items-center gap-2.5 ${className}`.trim()}>
+      <BrandMark size={size} />
+      <span className={`font-display font-extrabold tracking-tight ${wordmarkClassName}`.trim()}>
+        ResponseGrid
+      </span>
+    </span>
+  );
+}

--- a/apps/web/src/components/molecules/effective-action-card.tsx
+++ b/apps/web/src/components/molecules/effective-action-card.tsx
@@ -1,0 +1,29 @@
+/**
+ * EffectiveActionCard — the accent "Lo más eficaz ahora" card steering people to
+ * verified money donations (the highest-leverage action in an emergency).
+ */
+import Link from 'next/link';
+
+interface EffectiveActionCardProps {
+  href: string;
+  overline: string;
+  title: string;
+  cta: string;
+}
+
+export function EffectiveActionCard({ href, overline, title, cta }: EffectiveActionCardProps) {
+  return (
+    <Link
+      href={href}
+      className="block rounded-card bg-accent px-[18px] pb-5 pt-[18px] text-white transition-colors hover:bg-accent-600 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
+    >
+      <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.12em] opacity-90">
+        {overline}
+      </p>
+      <p className="mb-3.5 font-display text-[19px] font-bold leading-[1.18]">{title}</p>
+      <span className="block rounded-[11px] bg-white px-3 py-3 text-center text-[15px] font-bold text-navy">
+        {cta} →
+      </span>
+    </Link>
+  );
+}

--- a/apps/web/src/components/molecules/family-search-card.tsx
+++ b/apps/web/src/components/molecules/family-search-card.tsx
@@ -1,0 +1,27 @@
+/**
+ * FamilySearchCard — discreet entry point to family reunification. Visible
+ * whether the emergency is active or paused; data is private by design.
+ */
+import Link from 'next/link';
+
+interface FamilySearchCardProps {
+  href: string;
+  title: string;
+  subtitle: string;
+}
+
+export function FamilySearchCard({ href, title, subtitle }: FamilySearchCardProps) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-3 rounded-card border-[1.5px] border-family-line bg-family-soft px-4 py-3.5 transition-[filter] hover:brightness-[0.99] focus:outline-none focus:ring-2 focus:ring-family-line focus:ring-offset-2"
+    >
+      <span className="text-xl leading-none" aria-hidden="true">👪</span>
+      <span className="flex min-w-0 flex-col">
+        <span className="text-[15px] font-bold text-family-ink">{title}</span>
+        <span className="text-[11.5px] text-[#9c7b33]">{subtitle}</span>
+      </span>
+      <span className="ml-auto pl-2 font-bold text-[#c9a94e]" aria-hidden="true">→</span>
+    </Link>
+  );
+}

--- a/apps/web/src/components/molecules/help-action-row.tsx
+++ b/apps/web/src/components/molecules/help-action-row.tsx
@@ -1,0 +1,47 @@
+/**
+ * HelpActionRow — a single "¿Cómo quieres ayudar?" action: icon, title, optional
+ * subtitle and a trailing arrow. Linked. Variants set the visual weight.
+ */
+import Link from 'next/link';
+
+type Variant = 'primary' | 'default' | 'danger';
+
+interface HelpActionRowProps {
+  href: string;
+  icon: string;
+  title: string;
+  subtitle?: string;
+  variant?: Variant;
+}
+
+const CONTAINER: Record<Variant, string> = {
+  primary: 'bg-navy text-white border border-navy hover:bg-navy-700 focus:ring-navy',
+  default: 'bg-white text-ink border-[1.5px] border-[#d8d2c8] hover:bg-surface focus:ring-navy',
+  danger: 'bg-danger-tint text-[#9a3b12] border-[1.5px] border-[#e9b79a] hover:brightness-[0.98] focus:ring-danger',
+};
+
+const ARROW: Record<Variant, string> = {
+  primary: 'opacity-60',
+  default: 'text-[#b5bcc6]',
+  danger: '',
+};
+
+export function HelpActionRow({ href, icon, title, subtitle, variant = 'default' }: HelpActionRowProps) {
+  return (
+    <Link
+      href={href}
+      className={`flex items-center gap-3 rounded-[13px] px-4 py-4 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${CONTAINER[variant]}`}
+    >
+      <span className="text-xl leading-none" aria-hidden="true">{icon}</span>
+      <span className="flex min-w-0 flex-col">
+        <span className="text-[15.5px] font-bold leading-tight">{title}</span>
+        {subtitle !== undefined && (
+          <span className={`text-xs ${variant === 'primary' ? 'opacity-70' : 'text-muted'}`}>
+            {subtitle}
+          </span>
+        )}
+      </span>
+      <span className={`ml-auto pl-2 ${ARROW[variant]}`} aria-hidden="true">→</span>
+    </Link>
+  );
+}

--- a/apps/web/src/components/molecules/how-it-works-step.tsx
+++ b/apps/web/src/components/molecules/how-it-works-step.tsx
@@ -1,0 +1,27 @@
+/**
+ * HowItWorksStep — a numbered step in the Home "Cómo funciona" section.
+ */
+interface HowItWorksStepProps {
+  index: number;
+  title: string;
+  body: string;
+  /** Step accent — the final step uses the accent colour. */
+  tone?: 'navy' | 'accent';
+}
+
+export function HowItWorksStep({ index, title, body, tone = 'navy' }: HowItWorksStepProps) {
+  return (
+    <div className="flex gap-3.5">
+      <span
+        className={`flex h-[30px] w-[30px] flex-shrink-0 items-center justify-center rounded-full font-display text-[15px] font-extrabold text-white ${tone === 'accent' ? 'bg-accent' : 'bg-navy'}`}
+        aria-hidden="true"
+      >
+        {index}
+      </span>
+      <div>
+        <div className="text-[15px] font-bold text-ink">{title}</div>
+        <div className="mt-0.5 text-[13px] leading-[1.45] text-muted">{body}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/molecules/landing-footer.tsx
+++ b/apps/web/src/components/molecules/landing-footer.tsx
@@ -1,0 +1,36 @@
+/**
+ * LandingFooter — trust line + coordination access for the emergency landing.
+ * Surfaces the authenticated self-service links only when a session is present.
+ */
+import Link from 'next/link';
+import type { Messages } from '@/i18n/messages/es';
+
+interface LandingFooterProps {
+  slug: string;
+  te: Messages['emergency'];
+  authed: boolean;
+}
+
+const linkClass =
+  'text-[12.5px] text-muted-soft underline underline-offset-2 transition-colors hover:text-navy focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 rounded w-fit';
+
+export function LandingFooter({ slug, te, authed }: LandingFooterProps) {
+  return (
+    <footer className="mt-2 flex flex-col gap-3 border-t border-line pt-5">
+      <span className="text-[13px] font-semibold text-navy">{te.footer_verify}</span>
+
+      {authed && (
+        <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+          <Link href={`/e/${slug}/mis-puntos`} className={linkClass}>{te.footer_my_points}</Link>
+          <Link href={`/e/${slug}/mi-voluntariado`} className={linkClass}>{te.footer_my_volunteer}</Link>
+          <Link href={`/e/${slug}/mi-busqueda`} className={linkClass}>{te.footer_my_search}</Link>
+          <Link href={`/e/${slug}/reportar`} className={linkClass}>{te.footer_report}</Link>
+        </div>
+      )}
+
+      <Link href={`/e/${slug}/coordinacion`} className={linkClass}>
+        {te.footer_coordination} →
+      </Link>
+    </footer>
+  );
+}

--- a/apps/web/src/components/molecules/language-switcher.tsx
+++ b/apps/web/src/components/molecules/language-switcher.tsx
@@ -7,7 +7,7 @@
  * Uses a pair of <button> elements (not a <select>) for clarity and accessibility.
  * Classified as a molecule: it composes multiple button atoms with cookie/locale logic.
  *
- * Visibility: shown on home and emergency landing pages.
+ * `tone="dark"` renders for placement on the navy header band.
  */
 
 import { useLocale } from '@/i18n/locale-context';
@@ -20,7 +20,11 @@ function switchLocale(next: Locale) {
   window.location.reload();
 }
 
-export function LanguageSwitcher() {
+interface LanguageSwitcherProps {
+  tone?: 'light' | 'dark';
+}
+
+export function LanguageSwitcher({ tone = 'light' }: LanguageSwitcherProps) {
   const locale = useLocale();
 
   const locales: Locale[] = ['es', 'en'];
@@ -33,6 +37,14 @@ export function LanguageSwitcher() {
     >
       {locales.map((loc) => {
         const isActive = locale === loc;
+        const activeClass =
+          tone === 'dark'
+            ? 'border-white bg-white text-navy cursor-default'
+            : 'border-gray-900 bg-gray-900 text-white cursor-default';
+        const idleClass =
+          tone === 'dark'
+            ? 'border-white/30 bg-transparent text-white/80 hover:border-white hover:text-white'
+            : 'border-gray-300 bg-white text-gray-600 hover:border-gray-600 hover:text-gray-900';
         return (
           <button
             key={loc}
@@ -41,10 +53,9 @@ export function LanguageSwitcher() {
             onClick={() => { if (!isActive) switchLocale(loc); }}
             aria-pressed={isActive}
             className={[
-              'text-xs font-semibold px-2 py-1 rounded border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-1',
-              isActive
-                ? 'border-gray-900 bg-gray-900 text-white cursor-default'
-                : 'border-gray-300 bg-white text-gray-600 hover:border-gray-600 hover:text-gray-900',
+              'text-xs font-semibold px-2 py-1 rounded border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1',
+              tone === 'dark' ? 'focus:ring-white' : 'focus:ring-gray-900',
+              isActive ? activeClass : idleClass,
             ].join(' ')}
           >
             {loc.toUpperCase()}

--- a/apps/web/src/components/molecules/metric-card.tsx
+++ b/apps/web/src/components/molecules/metric-card.tsx
@@ -1,21 +1,31 @@
+type Tone = 'navy' | 'success' | 'accent';
+
 interface MetricCardProps {
   value: number | string;
   label: string;
+  /** Colour of the figure. Defaults to navy. */
+  tone?: Tone;
 }
 
+const TONE_CLASS: Record<Tone, string> = {
+  navy: 'text-navy',
+  success: 'text-success',
+  accent: 'text-accent',
+};
+
 /**
- * MetricCard — a single metric tile (big number + descriptive label).
- * Used in the 2×2 / 4-column metrics grid on the emergency public page.
+ * MetricCard — a single metric tile (big figure + label) for the emergency
+ * summary grid. Branded "Banda oficial" look: warm card, Archivo figure.
  */
-export function MetricCard({ value, label }: MetricCardProps) {
+export function MetricCard({ value, label, tone = 'navy' }: MetricCardProps) {
   return (
-    <div className="flex flex-col items-center rounded-lg border-2 border-gray-200 bg-gray-50 px-4 py-5">
-      <span className="text-3xl font-extrabold text-gray-900 tabular-nums">
+    <div className="rounded-card border border-line bg-white px-3.5 py-3">
+      <span
+        className={`block font-display text-[26px] font-extrabold leading-none tabular-nums ${TONE_CLASS[tone]}`}
+      >
         {value}
       </span>
-      <span className="mt-1 text-xs font-medium text-gray-500 text-center leading-tight">
-        {label}
-      </span>
+      <span className="mt-1.5 block text-xs leading-tight text-muted">{label}</span>
     </div>
   );
 }

--- a/apps/web/src/components/molecules/need-card.tsx
+++ b/apps/web/src/components/molecules/need-card.tsx
@@ -1,0 +1,58 @@
+/**
+ * NeedCard — a validated need (Banda oficial look): priority pill + freshness on
+ * top, title, the headline item, optional privacy notice and an offer CTA.
+ */
+import Link from 'next/link';
+import type { components } from '@reliefhub/api-client';
+import { PriorityBadge, type Priority } from '@/components/atoms/priority-badge';
+import { FreshnessIndicator } from '@/components/atoms/freshness-indicator';
+import { PrivacyLocationNotice } from '@/components/atoms/privacy-location-notice';
+import type { Messages } from '@/i18n/messages/es';
+
+type NeedViewDto = components['schemas']['NeedViewDto'];
+
+interface NeedCardProps {
+  need: NeedViewDto;
+  te: Messages['emergency'];
+  slug: string;
+  active: boolean;
+}
+
+export function NeedCard({ need, te, slug, active }: NeedCardProps) {
+  const priority = need.priority as Priority;
+  const item = need.items[0];
+  const categoryLabel =
+    item !== undefined
+      ? (te[`category_${item.category}` as keyof typeof te] as string | undefined) ?? item.category
+      : undefined;
+  const quantity =
+    item !== undefined
+      ? `${String(item.quantity)}${item.unit != null ? ` ${String(item.unit)}` : ''}`
+      : undefined;
+  const detail = [quantity, categoryLabel].filter(Boolean).join(' · ');
+  const approximate = need.locationSensitivity === 'approximate';
+
+  return (
+    <article className="flex flex-col gap-2.5 rounded-card border border-line bg-white p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <PriorityBadge
+          priority={priority}
+          label={te[`priority_${priority}` as keyof typeof te] as string}
+          ariaPrefix={te.needs_priority_label}
+        />
+        <FreshnessIndicator expiresAt={need.expiresAt} lastVerifiedAt={need.lastVerifiedAt} />
+      </div>
+      <h3 className="text-[15px] font-bold leading-tight text-ink">{need.title}</h3>
+      {detail !== '' && <p className="text-[12.5px] text-muted">{detail}</p>}
+      {approximate && <PrivacyLocationNotice text={te.privacy_approximate_location} />}
+      {active && (
+        <Link
+          href={`/e/${slug}/donar?needId=${need.id}`}
+          className="inline-flex w-fit items-center justify-center rounded-lg border border-navy bg-white px-4 py-2 text-sm font-semibold text-navy transition-colors hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+        >
+          {te.needs_offer_button}
+        </Link>
+      )}
+    </article>
+  );
+}

--- a/apps/web/src/components/molecules/status-banner.tsx
+++ b/apps/web/src/components/molecules/status-banner.tsx
@@ -22,10 +22,10 @@ export function StatusBanner({ status, t = es.status_banner }: StatusBannerProps
       role="alert"
       aria-live="polite"
       className={[
-        'flex flex-col gap-1 rounded-lg border-2 px-5 py-4',
+        'flex flex-col gap-1 rounded-card border px-4 py-4',
         isPaused
-          ? 'border-amber-500 bg-amber-50 text-amber-900'
-          : 'border-gray-400 bg-gray-100 text-gray-700',
+          ? 'border-warning-dot bg-warning-soft text-warning'
+          : 'border-line bg-surface-alt text-muted',
       ].join(' ')}
     >
       <p className="text-base font-bold leading-snug">

--- a/apps/web/src/components/molecules/trust-levels-card.tsx
+++ b/apps/web/src/components/molecules/trust-levels-card.tsx
@@ -22,9 +22,9 @@ export function TrustLevelsCard({ heading, intro, rows, tVerification }: TrustLe
     <div className="rounded-card border border-line bg-white p-[18px]">
       <h3 className="font-display text-base font-bold text-navy">{heading}</h3>
       <p className="mt-1 text-[13px] leading-[1.45] text-muted">{intro}</p>
-      <ul className="mt-3.5 flex flex-col gap-2.5">
+      <ul className="mt-3.5 grid gap-2.5 sm:grid-cols-3 sm:gap-4">
         {rows.map((row) => (
-          <li key={row.level} className="flex items-center gap-2.5">
+          <li key={row.level} className="flex items-center gap-2.5 sm:flex-col sm:items-start sm:gap-1.5">
             <VerificationBadge level={row.level} t={tVerification} />
             <span className="text-[12.5px] text-muted">{row.text}</span>
           </li>

--- a/apps/web/src/components/molecules/trust-levels-card.tsx
+++ b/apps/web/src/components/molecules/trust-levels-card.tsx
@@ -1,0 +1,35 @@
+/**
+ * TrustLevelsCard — "La confianza es el producto": explains each verification
+ * level next to the very badge users will see across the platform.
+ */
+import { VerificationBadge, type VerificationLevel } from '@/components/atoms/verification-badge';
+import type { Messages } from '@/i18n/messages/es';
+
+interface TrustLevelRow {
+  level: VerificationLevel;
+  text: string;
+}
+
+interface TrustLevelsCardProps {
+  heading: string;
+  intro: string;
+  rows: TrustLevelRow[];
+  tVerification: Messages['verification_badge'];
+}
+
+export function TrustLevelsCard({ heading, intro, rows, tVerification }: TrustLevelsCardProps) {
+  return (
+    <div className="rounded-card border border-line bg-white p-[18px]">
+      <h3 className="font-display text-base font-bold text-navy">{heading}</h3>
+      <p className="mt-1 text-[13px] leading-[1.45] text-muted">{intro}</p>
+      <ul className="mt-3.5 flex flex-col gap-2.5">
+        {rows.map((row) => (
+          <li key={row.level} className="flex items-center gap-2.5">
+            <VerificationBadge level={row.level} t={tVerification} />
+            <span className="text-[12.5px] text-muted">{row.text}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/organisms/emergency-directory-card.tsx
+++ b/apps/web/src/components/organisms/emergency-directory-card.tsx
@@ -1,0 +1,48 @@
+/**
+ * EmergencyDirectoryCard — one active emergency in the public Home directory.
+ * Status pill + freshness, name (H3), region, optional announcement excerpt and
+ * an "enter the operation" affordance. The whole card links to /e/[slug].
+ */
+import Link from 'next/link';
+import type { components } from '@reliefhub/api-client';
+import { RelativeTime } from '@/components/atoms/relative-time';
+
+type EmergencyViewDto = components['schemas']['EmergencyViewDto'];
+
+interface EmergencyDirectoryCardProps {
+  emergency: EmergencyViewDto;
+  activeLabel: string;
+  enterLabel: string;
+}
+
+export function EmergencyDirectoryCard({ emergency, activeLabel, enterLabel }: EmergencyDirectoryCardProps) {
+  return (
+    <Link
+      href={`/e/${emergency.slug}`}
+      className="block rounded-card border border-line bg-white p-4 transition-colors hover:border-navy/30 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+    >
+      <article>
+        <div className="mb-2 flex items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-success-soft px-2.5 py-1 text-[11px] font-bold text-success">
+            <span className="h-1.5 w-1.5 rounded-full bg-success-dot" aria-hidden="true" />
+            {activeLabel}
+          </span>
+          <span className="flex items-center gap-1 text-[11.5px] text-muted-soft">
+            <span aria-hidden="true">🕑</span>
+            <RelativeTime isoString={emergency.updatedAt} />
+          </span>
+        </div>
+        <h3 className="text-base font-bold leading-tight text-navy">{emergency.name}</h3>
+        <p className="mt-0.5 text-[12.5px] text-muted-soft">{emergency.country}</p>
+        {emergency.announcement != null && emergency.announcement !== '' && (
+          <p className="mt-2 line-clamp-3 text-[13.5px] leading-[1.45] text-ink-soft">
+            {emergency.announcement}
+          </p>
+        )}
+        <span className="mt-3 inline-flex items-center gap-1.5 text-sm font-bold text-accent">
+          {enterLabel} →
+        </span>
+      </article>
+    </Link>
+  );
+}

--- a/apps/web/src/components/organisms/official-header-band.tsx
+++ b/apps/web/src/components/organisms/official-header-band.tsx
@@ -33,7 +33,7 @@ export function OfficialHeaderBand({ name, status, updatedAt, te }: OfficialHead
         : te.header_status_closed;
 
   return (
-    <header className="rounded-b-[28px] bg-navy px-5 pb-7 pt-6 text-white">
+    <header className="rounded-b-[28px] bg-navy px-5 pb-7 pt-6 text-white lg:px-8">
       <div className="mb-5 flex items-center justify-between gap-3">
         <Link
           href="/"
@@ -45,22 +45,26 @@ export function OfficialHeaderBand({ name, status, updatedAt, te }: OfficialHead
         <LanguageSwitcher tone="dark" />
       </div>
 
-      <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-accent">
-        {te.header_overline}
-      </p>
-      <h1 className="font-display text-[30px] font-extrabold leading-[1.02] tracking-tight">
-        {name}
-      </h1>
+      <div className="lg:flex lg:items-end lg:justify-between lg:gap-6">
+        <div>
+          <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-accent">
+            {te.header_overline}
+          </p>
+          <h1 className="font-display text-[30px] font-extrabold leading-[1.02] tracking-tight lg:text-4xl">
+            {name}
+          </h1>
+        </div>
 
-      <div className="mt-4 flex flex-wrap items-center gap-2.5">
-        <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-wide">
-          <span className={`h-2 w-2 rounded-full ${DOT_CLASS[status]}`} aria-hidden="true" />
-          {statusLabel}
-        </span>
-        <span className="flex items-center gap-1.5 text-xs text-[#b7c6da]">
-          <span aria-hidden="true">🕑</span>
-          <RelativeTime isoString={updatedAt} />
-        </span>
+        <div className="mt-4 flex flex-wrap items-center gap-2.5 lg:mt-0 lg:flex-shrink-0">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-wide">
+            <span className={`h-2 w-2 rounded-full ${DOT_CLASS[status]}`} aria-hidden="true" />
+            {statusLabel}
+          </span>
+          <span className="flex items-center gap-1.5 text-xs text-[#b7c6da]">
+            <span aria-hidden="true">🕑</span>
+            <RelativeTime isoString={updatedAt} />
+          </span>
+        </div>
       </div>
     </header>
   );

--- a/apps/web/src/components/organisms/official-header-band.tsx
+++ b/apps/web/src/components/organisms/official-header-band.tsx
@@ -1,0 +1,67 @@
+/**
+ * OfficialHeaderBand — the navy "Banda oficial" header for an emergency landing.
+ * Brand row + language switch, accent overline, emergency name (H1), and an
+ * operational-status pill with the last-updated time.
+ */
+import Link from 'next/link';
+import { BrandLogo } from '@/components/molecules/brand-logo';
+import { LanguageSwitcher } from '@/components/molecules/language-switcher';
+import { RelativeTime } from '@/components/atoms/relative-time';
+import type { Messages } from '@/i18n/messages/es';
+
+type Status = 'active' | 'paused' | 'closed';
+
+interface OfficialHeaderBandProps {
+  name: string;
+  status: Status;
+  updatedAt: string;
+  te: Messages['emergency'];
+}
+
+const DOT_CLASS: Record<Status, string> = {
+  active: 'bg-success-dot',
+  paused: 'bg-warning-dot',
+  closed: 'bg-white/50',
+};
+
+export function OfficialHeaderBand({ name, status, updatedAt, te }: OfficialHeaderBandProps) {
+  const statusLabel =
+    status === 'active'
+      ? te.header_status_active
+      : status === 'paused'
+        ? te.header_status_paused
+        : te.header_status_closed;
+
+  return (
+    <header className="rounded-b-[28px] bg-navy px-5 pb-7 pt-6 text-white">
+      <div className="mb-5 flex items-center justify-between gap-3">
+        <Link
+          href="/"
+          aria-label="ResponseGrid"
+          className="rounded focus:outline-none focus:ring-2 focus:ring-white/60"
+        >
+          <BrandLogo size={24} wordmarkClassName="text-base" />
+        </Link>
+        <LanguageSwitcher tone="dark" />
+      </div>
+
+      <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-accent">
+        {te.header_overline}
+      </p>
+      <h1 className="font-display text-[30px] font-extrabold leading-[1.02] tracking-tight">
+        {name}
+      </h1>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2.5">
+        <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-wide">
+          <span className={`h-2 w-2 rounded-full ${DOT_CLASS[status]}`} aria-hidden="true" />
+          {statusLabel}
+        </span>
+        <span className="flex items-center gap-1.5 text-xs text-[#b7c6da]">
+          <span aria-hidden="true">🕑</span>
+          <RelativeTime isoString={updatedAt} />
+        </span>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/organisms/public-resource-card.tsx
+++ b/apps/web/src/components/organisms/public-resource-card.tsx
@@ -12,6 +12,10 @@ interface PublicResourceCardProps {
   tStatusLight: Messages['status_light'];
 }
 
+/**
+ * PublicResourceCard — a verified logistics point (Banda oficial look):
+ * trust + operational pills on top, name, then type · stage.
+ */
 export function PublicResourceCard({ resource, t, tVerification, tStatusLight }: PublicResourceCardProps) {
   const typeLabels: Record<ResourceViewDto['type'], string> = {
     collection_point: t.type_collection_point,
@@ -31,21 +35,19 @@ export function PublicResourceCard({ resource, t, tVerification, tStatusLight }:
 
   return (
     <article
-      aria-label={`Punto activo: ${resource.name}`}
-      className="flex flex-col gap-2 rounded-lg border-2 border-gray-900 bg-white p-4"
+      aria-label={`${resource.name}`}
+      className="flex flex-col gap-1.5 rounded-card border border-line bg-white p-4"
     >
-      <h3 className="text-lg font-bold text-gray-900 leading-tight">
-        {resource.name}
-      </h3>
-      <div className="flex flex-wrap items-center gap-2 text-sm text-gray-700">
-        <span className="font-medium">{typeLabels[resource.type]}</span>
-        <span aria-hidden="true" className="text-gray-300">·</span>
-        <span>{stageLabels[resource.stage]}</span>
-        <span aria-hidden="true" className="text-gray-300">·</span>
+      <div className="flex flex-wrap items-center gap-2">
         <VerificationBadge level={resource.verificationLevel} t={tVerification} />
-        <span aria-hidden="true" className="text-gray-300">·</span>
         <StatusLight status={resource.publicStatus} t={tStatusLight} />
       </div>
+      <h3 className="text-[15px] font-bold leading-tight text-ink">
+        {resource.name}
+      </h3>
+      <p className="text-[12.5px] text-muted">
+        {typeLabels[resource.type]} · {stageLabels[resource.stage]}
+      </p>
     </article>
   );
 }

--- a/apps/web/src/components/organisms/site-footer.tsx
+++ b/apps/web/src/components/organisms/site-footer.tsx
@@ -1,0 +1,54 @@
+/**
+ * SiteFooter — Home page footer. Carries the indexable GlobalEmergency blurb +
+ * SEO link row, and preserves the functional coordination/account navigation.
+ */
+import Link from 'next/link';
+import type { Messages } from '@/i18n/messages/es';
+
+interface SiteFooterProps {
+  t: Messages['home'];
+  authed: boolean;
+  isAdmin: boolean;
+  notificationUnreadCount: number;
+}
+
+const navLinkClass =
+  'text-sm font-medium text-muted underline underline-offset-2 transition-colors hover:text-navy focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 rounded';
+
+export function SiteFooter({ t, authed, isAdmin, notificationUnreadCount }: SiteFooterProps) {
+  return (
+    <footer className="mt-2 border-t border-line pt-5">
+      <p className="font-display text-sm font-extrabold text-navy">{t.footer_org}</p>
+      <p className="mt-1.5 mb-3 text-[12.5px] leading-[1.5] text-muted-soft">{t.footer_tagline}</p>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-[12.5px] font-semibold text-navy">
+        <span>{t.footer_about}</span>
+        <span>{t.footer_transparency}</span>
+        <span>{t.footer_privacy}</span>
+        <span>{t.footer_verify_campaign}</span>
+      </div>
+
+      <nav
+        aria-label={t.aria_secondary_nav}
+        className="mt-4 flex flex-wrap gap-x-4 gap-y-1.5 border-t border-line pt-4"
+      >
+        <Link href="/organizaciones" className={navLinkClass}>{t.my_orgs}</Link>
+        {authed && (
+          <Link href="/notificaciones" className={navLinkClass}>
+            {notificationUnreadCount > 0
+              ? t.notifications_with_count.replace('{count}', String(notificationUnreadCount))
+              : t.notifications}
+          </Link>
+        )}
+        <Link href="/login" className={navLinkClass}>{t.coordination_access}</Link>
+        {isAdmin && (
+          <>
+            <Link href="/admin/acreditaciones" className={navLinkClass}>{t.admin}</Link>
+            <Link href="/admin/templates" className={navLinkClass}>{t.templates}</Link>
+            <Link href="/admin/auditoria" className={navLinkClass}>{t.audit}</Link>
+          </>
+        )}
+      </nav>
+    </footer>
+  );
+}

--- a/apps/web/src/components/organisms/site-header-band.tsx
+++ b/apps/web/src/components/organisms/site-header-band.tsx
@@ -1,0 +1,23 @@
+/**
+ * SiteHeaderBand — navy brand band for the public Home directory.
+ */
+import Link from 'next/link';
+import { BrandLogo } from '@/components/molecules/brand-logo';
+import { LanguageSwitcher } from '@/components/molecules/language-switcher';
+
+export function SiteHeaderBand() {
+  return (
+    <header className="rounded-b-[28px] bg-navy px-5 pb-5 pt-6">
+      <div className="flex items-center justify-between gap-3 text-white">
+        <Link
+          href="/"
+          aria-label="ResponseGrid"
+          className="rounded focus:outline-none focus:ring-2 focus:ring-white/60"
+        >
+          <BrandLogo size={24} wordmarkClassName="text-base" />
+        </Link>
+        <LanguageSwitcher tone="dark" />
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/organisms/site-header-band.tsx
+++ b/apps/web/src/components/organisms/site-header-band.tsx
@@ -7,7 +7,7 @@ import { LanguageSwitcher } from '@/components/molecules/language-switcher';
 
 export function SiteHeaderBand() {
   return (
-    <header className="rounded-b-[28px] bg-navy px-5 pb-5 pt-6">
+    <header className="rounded-b-[28px] bg-navy px-5 pb-5 pt-6 lg:px-8">
       <div className="flex items-center justify-between gap-3 text-white">
         <Link
           href="/"

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -35,6 +35,43 @@ export const en = {
     templates: 'Templates',
     audit: 'Audit',
     aria_emergency_list: 'List of active emergencies',
+    aria_secondary_nav: 'Secondary navigation',
+    enter_operation: 'Enter the operation',
+    active_count: '{count} ongoing',
+    closed_label: 'Closed · report available',
+
+    // Hero
+    hero_h1: 'Coordinate emergency aid without overloading logistics',
+    hero_subtitle:
+      'ResponseGrid connects citizens, organisations and coordinators during a disaster: it publishes verified points, validates real needs and matches supply offers with those who request them. Official information, in real time.',
+    hero_cta_emergencies: 'View active emergencies',
+    hero_cta_donate: 'Donate',
+
+    // How it works
+    how_it_works_heading: 'How it works',
+    step1_title: 'You register what you offer',
+    step1_body: 'We capture your offer instantly. Nothing is published until it is validated.',
+    step2_title: 'Coordination verifies',
+    step2_body: 'Local coordinators validate every point, campaign and need.',
+    step3_title: 'It becomes useful aid',
+    step3_body: 'Your signals turn into decisions, without pointless trips.',
+
+    // Trust is the product
+    trust_heading: 'Trust is the product',
+    trust_intro: 'Every resource and campaign shows its verification level.',
+    trust_unverified: 'In queue · do not bring supplies',
+    trust_verified: 'Validated by local coordination',
+    trust_official: 'Accredited organisation',
+
+    // SEO footer
+    footer_org: 'GlobalEmergency',
+    footer_tagline:
+      'Emergency aid coordination platform. Multi-emergency, multilingual (ES/EN), privacy by design and data hosted in the EU.',
+    footer_about: 'About us',
+    footer_transparency: 'Transparency',
+    footer_privacy: 'Privacy (GDPR)',
+    footer_verify_campaign: 'Verify campaign',
+
     meta_title: 'ResponseGrid — Active emergencies',
     meta_description:
       'Emergency aid coordination platform. Check active emergencies and how you can help.',
@@ -45,6 +82,41 @@ export const en = {
     official_source: 'Official source · ResponseGrid',
     status_active: 'Active emergency',
     status_active_aria: 'Status: active emergency',
+
+    // Banda oficial — header
+    header_overline: 'Emergency operation',
+    header_status_active: 'Active operation',
+    header_status_paused: 'Paused',
+    header_status_closed: 'Closed',
+
+    // Metric tiles
+    metric_tile_open: 'Open needs',
+    metric_tile_points: 'Active points',
+    metric_tile_covered: 'Covered',
+    metric_tile_queue: 'In queue',
+
+    // Most effective now
+    effective_overline: 'Most effective right now',
+    effective_title: 'Donate money to verified organisations',
+    effective_cta: 'View verified campaigns',
+
+    // "How do you want to help?" subtitles
+    help_offer_subtitle: 'Warehouse · transport · space',
+    help_volunteer_subtitle: 'Availability and skills',
+    help_petition_subtitle: 'Request validated supplies',
+    help_report_title: 'Report damage or trapped people',
+
+    // Family search
+    family_title: 'Search for a relative',
+    family_subtitle: 'Private data · authorised personnel only',
+
+    // What NOT to do
+    dont_do_heading: 'What NOT to do right now',
+    dont_do_intro: 'Avoid overloading logistics and on-site risks.',
+
+    // Points / footer
+    points_count: '{count} verified',
+    footer_verify: '🛡 Is this campaign trustworthy? Verify it',
 
     metrics_heading: 'Summary',
     metric_needs_open: 'Open requests',
@@ -136,6 +208,7 @@ export const en = {
     official_label: 'Official announcement',
     last_updated: 'Last updated:',
     aria_label: 'Official announcement',
+    source: 'GlobalEmergency',
   },
 
   login: {

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -35,6 +35,43 @@ export const es = {
     templates: 'Plantillas',
     audit: 'Auditoría',
     aria_emergency_list: 'Lista de emergencias activas',
+    aria_secondary_nav: 'Navegación secundaria',
+    enter_operation: 'Entrar al operativo',
+    active_count: '{count} en curso',
+    closed_label: 'Cerrada · informe disponible',
+
+    // Hero
+    hero_h1: 'Coordina la ayuda en emergencias, sin saturar la logística',
+    hero_subtitle:
+      'ResponseGrid conecta a ciudadanía, organizaciones y coordinación durante una catástrofe: publica puntos verificados, valida necesidades reales y casa ofertas de material con quien las pide. Información oficial, en tiempo real.',
+    hero_cta_emergencies: 'Ver emergencias activas',
+    hero_cta_donate: 'Donar',
+
+    // Cómo funciona
+    how_it_works_heading: 'Cómo funciona',
+    step1_title: 'Registras lo que ofreces',
+    step1_body: 'Captamos tu ofrecimiento al instante. Nada se publica hasta validarse.',
+    step2_title: 'Coordinación verifica',
+    step2_body: 'Coordinadores locales validan cada punto, campaña y necesidad.',
+    step3_title: 'Se convierte en ayuda útil',
+    step3_body: 'Tus señales se vuelven decisiones, sin desplazamientos inútiles.',
+
+    // La confianza es el producto
+    trust_heading: 'La confianza es el producto',
+    trust_intro: 'Cada recurso y campaña muestra su nivel de verificación.',
+    trust_unverified: 'En cola · no llevar material',
+    trust_verified: 'Validado por coordinación local',
+    trust_official: 'Organización acreditada',
+
+    // Pie SEO
+    footer_org: 'GlobalEmergency',
+    footer_tagline:
+      'Plataforma de coordinación de ayuda en emergencias. Multi-emergencia, multilingüe (ES/EN), con privacidad por diseño y datos alojados en la UE.',
+    footer_about: 'Sobre nosotros',
+    footer_transparency: 'Transparencia',
+    footer_privacy: 'Privacidad (RGPD)',
+    footer_verify_campaign: 'Verificar campaña',
+
     meta_title: 'ResponseGrid — Emergencias activas',
     meta_description:
       'Plataforma de coordinación de ayuda en emergencias. Consulta las emergencias activas y cómo puedes colaborar.',
@@ -46,6 +83,41 @@ export const es = {
     official_source: 'Fuente oficial · ResponseGrid',
     status_active: 'Emergencia activa',
     status_active_aria: 'Estado: emergencia activa',
+
+    // Banda oficial — cabecera
+    header_overline: 'Operativo de emergencia',
+    header_status_active: 'Operativo activo',
+    header_status_paused: 'En pausa',
+    header_status_closed: 'Cerrada',
+
+    // Tarjetas de métricas
+    metric_tile_open: 'Necesidades abiertas',
+    metric_tile_points: 'Puntos activos',
+    metric_tile_covered: 'Cubiertas',
+    metric_tile_queue: 'En cola',
+
+    // Lo más eficaz ahora
+    effective_overline: 'Lo más eficaz ahora',
+    effective_title: 'Dona dinero a entidades verificadas',
+    effective_cta: 'Ver campañas verificadas',
+
+    // Subtítulos de "¿Cómo quieres ayudar?"
+    help_offer_subtitle: 'Almacén · transporte · espacio',
+    help_volunteer_subtitle: 'Disponibilidad y habilidades',
+    help_petition_subtitle: 'Solicitar material validado',
+    help_report_title: 'Reportar daños o personas atrapadas',
+
+    // Buscar familiar
+    family_title: 'Buscar a un familiar',
+    family_subtitle: 'Datos privados · solo personal autorizado',
+
+    // Qué NO hacer ahora
+    dont_do_heading: 'Qué NO hacer ahora',
+    dont_do_intro: 'Evita saturar la logística y los riesgos en zona.',
+
+    // Puntos / pie
+    points_count: '{count} verificados',
+    footer_verify: '🛡 ¿Es de fiar esta campaña? Verifícala',
 
     // Metrics
     metrics_heading: 'Resumen',
@@ -149,6 +221,7 @@ export const es = {
     official_label: 'Comunicado oficial',
     last_updated: 'Última actualización:',
     aria_label: 'Comunicado oficial',
+    source: 'GlobalEmergency',
   },
 
   // ── Login page ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Qué

Implementa el handoff de **Claude Design** `Landing Emergencia.dc.html` en la web real (`apps/web`), siguiendo el **Atomic Design** del proyecto. Se eligió la **dirección 01 · "Banda oficial"** para la landing de emergencia y se rediseñó también la **home pública / directorio** del mismo handoff.

- **`/e/[slug]`** (landing de emergencia): banda oficial navy con marca + selector ES/EN, título de la emergencia y estado operativo; comunicado oficial; tarjeta de acción "Lo más eficaz ahora" (donar); rejilla de métricas 2×2; "¿Cómo quieres ayudar?" (ofrecer recurso / voluntario / petición / reportar); buscar familiar; "Qué NO hacer ahora"; puntos activos; necesidades validadas; mapa y pie de confianza.
- **`/`** (home / directorio): hero SEO (H1 + subtítulo + CTAs), emergencias activas (+ cerradas), "Cómo funciona", "La confianza es el producto" y pie SEO de GlobalEmergency.

Toda la UI se conecta a los datos reales de la API (emergencia, recursos, necesidades, métricas) y conserva la accesibilidad y la i18n **ES/EN**.

## Cómo (Atomic Design)

- **Fundamentos de marca:** fuentes **Archivo + Public Sans** vía `next/font`; tokens de color (navy, accent, superficies cálidas, estados) y radio mediante **Tailwind v4 `@theme`** en `globals.css`.
- **Átomos:** `brand-mark`, `priority-badge` (+ variantes de prioridad en `badge`).
- **Moléculas:** `brand-logo`, `effective-action-card`, `help-action-row`, `family-search-card`, `need-card`, `landing-footer`, `how-it-works-step`, `trust-levels-card`; rebranding de `metric-card`, `announcement-card`, `status-banner` y tono oscuro en `language-switcher`.
- **Organismos:** `official-header-band`, `public-resource-card`, `site-header-band`, `emergency-directory-card`, `site-footer`.
- **Páginas/plantillas:** reescritura de `app/e/[slug]/page.tsx` y `app/page.tsx`.

Los colores/marca son **themeables** (accent / navy / radius), reflejando los props del diseño original.

## Verificación

- ✅ `pnpm --filter web lint` — limpio.
- ✅ `pnpm --filter web build` — TypeScript + build de producción OK (rutas `/` y `/e/[slug]` server-rendered).
- ℹ️ Requiere `@reliefhub/api-client` compilado (`pnpm --filter @reliefhub/api-client build`) antes del build de web.
- ⚠️ No se ha hecho verificación visual en navegador (requiere levantar API + Postgres/Redis + seed). Solo se ha verificado lint/tipos/build.

## Notas

- El blast radius en componentes compartidos es mínimo: `metric-card`/`announcement-card`/`status-banner`/`public-resource-card` solo se usan en la landing; en `badge` solo se **añadieron** variantes (additivo).
- La ficha "Plan SEO / handoff técnico" del diseño es una nota de especificación, no una pantalla, por lo que no se implementa como página.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HP2D4PM8ksBtjHMkYXikXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HP2D4PM8ksBtjHMkYXikXj)_