### PR TITLE
feat(web): página de docs de la API pública para desarrolladores (/docs)

### DIFF
--- a/apps/web/src/app/docs/code-block.tsx
+++ b/apps/web/src/app/docs/code-block.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+/**
+ * CodeBlock — presentational code/JSON/curl sample for the developer docs page
+ * (/docs). Dark navy surface so samples stand out from the warm page, with an
+ * optional language label and a copy-to-clipboard button.
+ *
+ * Client component (clipboard + local "copied" state). Per the project i18n
+ * pattern, the translated button labels are passed in as plain-string props
+ * from the Server Component that renders it — no dictionary is read here.
+ */
+import { useState } from 'react';
+
+interface CodeBlockProps {
+  code: string;
+  /** Short language tag shown in the header bar, e.g. "cURL", "JSON". */
+  lang?: string;
+  copyLabel: string;
+  copiedLabel: string;
+}
+
+export function CodeBlock({ code, lang, copyLabel, copiedLabel }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (e.g. non-secure context) — fail silently.
+    }
+  }
+
+  return (
+    <div className="overflow-hidden rounded-card border border-navy/15 bg-navy text-white">
+      <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
+        <span className="font-display text-[11px] font-bold uppercase tracking-[0.12em] text-white/55">
+          {lang ?? 'HTTP'}
+        </span>
+        <button
+          type="button"
+          onClick={copy}
+          className="rounded-md px-2 py-1 text-[12px] font-semibold text-white/75 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-white/50"
+        >
+          {copied ? copiedLabel : copyLabel}
+        </button>
+      </div>
+      <pre className="overflow-x-auto px-4 py-3.5 text-[12.5px] leading-[1.6]">
+        <code className="font-mono">{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -1,0 +1,660 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { SiteHeaderBand } from '@/components/organisms/site-header-band';
+import { CoordinationIllustration } from '@/components/atoms/illustrations';
+import { getT } from '@/i18n/server';
+import { CodeBlock } from './code-block';
+
+/**
+ * /docs — public developer documentation for the ResponseGrid API.
+ *
+ * Audience: third-party projects that want to CONSUME our verified data
+ * (logistics points + validated needs) and build on top of it — the "source of
+ * truth" use case. Read endpoints are the centrepiece; contributing data (the
+ * authenticated writes) is a secondary section.
+ *
+ * Server Component. Prose/labels come from the i18n dictionary (t.docs); code
+ * samples are language-neutral constants built against the deployment's API
+ * base URL.
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.responsegrid.app';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await getT();
+  const d = t.docs;
+  return {
+    title: d.meta_title,
+    description: d.meta_description,
+    alternates: { canonical: '/docs' },
+    openGraph: {
+      title: d.meta_title,
+      description: d.meta_description,
+      url: '/docs',
+      siteName: 'ResponseGrid',
+      type: 'website',
+      images: [{ url: '/icons/icon-512.png', width: 512, height: 512, alt: 'ResponseGrid' }],
+    },
+  };
+}
+
+// ── Small presentational helpers (server components) ─────────────────────────
+
+function Section({ id, title, children }: { id: string; title: string; children: ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-6">
+      <h2 className="font-display text-xl font-bold text-navy lg:text-2xl">{title}</h2>
+      <div className="mt-3 flex flex-col gap-4">{children}</div>
+    </section>
+  );
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p className="text-[15px] leading-[1.65] text-ink-soft">{children}</p>;
+}
+
+function Endpoint({ method, path, auth }: { method: 'GET' | 'POST'; path: string; auth?: boolean }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2.5 rounded-card border border-line bg-surface-alt px-3.5 py-2.5">
+      <span
+        className={`rounded-md px-2 py-0.5 font-mono text-[12px] font-bold text-white ${
+          method === 'GET' ? 'bg-success' : 'bg-accent'
+        }`}
+      >
+        {method}
+      </span>
+      <code className="break-all font-mono text-[13px] text-ink">{path}</code>
+      {auth ? (
+        <span className="ml-auto rounded-md bg-navy/10 px-2 py-0.5 font-mono text-[11px] font-semibold text-navy">
+          Authorization: Bearer
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function Table({ headers, rows }: { headers: string[]; rows: ReactNode[][] }) {
+  return (
+    <div className="overflow-x-auto rounded-card border border-line">
+      <table className="w-full border-collapse text-left text-[13.5px]">
+        <thead>
+          <tr className="bg-surface-alt">
+            {headers.map((h) => (
+              <th
+                key={h}
+                className="px-3.5 py-2.5 font-display text-[11px] font-bold uppercase tracking-wide text-muted"
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((cells, i) => (
+            <tr key={i} className="border-t border-line align-top">
+              {cells.map((c, j) => (
+                <td key={j} className="px-3.5 py-2.5 text-ink-soft">
+                  {c}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Mono({ children }: { children: ReactNode }) {
+  return <code className="font-mono text-[12.5px] text-ink">{children}</code>;
+}
+
+function Chips({ items }: { items: string[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {items.map((it) => (
+        <code
+          key={it}
+          className="rounded-md border border-line bg-surface-alt px-2 py-1 font-mono text-[12.5px] text-ink"
+        >
+          {it}
+        </code>
+      ))}
+    </div>
+  );
+}
+
+function Callout({ children, tone = 'note' }: { children: ReactNode; tone?: 'note' | 'warn' }) {
+  const tones = {
+    note: 'border-line bg-surface-alt',
+    warn: 'border-warning/30 bg-warning-soft',
+  } as const;
+  return (
+    <div className={`rounded-card border px-4 py-3 text-[14px] leading-[1.6] text-ink-soft ${tones[tone]}`}>
+      {children}
+    </div>
+  );
+}
+
+function Card({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="rounded-card border border-line bg-surface-alt p-5">
+      <h3 className="font-display text-base font-bold text-navy">{title}</h3>
+      <p className="mt-1.5 text-[14px] leading-[1.55] text-ink-soft">{children}</p>
+    </div>
+  );
+}
+
+function SubHeading({ children }: { children: ReactNode }) {
+  return <h3 className="mt-2 font-display text-base font-bold text-navy">{children}</h3>;
+}
+
+export default async function DocsPage() {
+  const { t } = await getT();
+  const d = t.docs;
+
+  const toc: [string, string][] = [
+    ['intro', d.nav_intro],
+    ['concepts', d.nav_concepts],
+    ['auth', d.nav_auth],
+    ['quickstart', d.nav_quickstart],
+    ['emergencies', d.nav_emergencies],
+    ['resources', d.nav_resources],
+    ['needs', d.nav_needs],
+    ['enums', d.nav_enums],
+    ['write', d.nav_write],
+    ['practices', d.nav_practices],
+    ['links', d.nav_links],
+  ];
+
+  // ── Language-neutral code samples (built against this deployment) ───────────
+  const curlQuickstart = `curl ${API_BASE}/emergencies
+
+curl "${API_BASE}/emergencies/{emergencyId}/public/resources?limit=100"`;
+
+  const jsQuickstart = `const base = "${API_BASE}";
+
+// 1) pick an emergency
+const list = await fetch(base + "/emergencies").then((r) => r.json());
+const id = list[0].id;
+
+// 2) fetch its public points and plot them
+const url = base + "/emergencies/" + id + "/public/resources?limit=100";
+const { items } = await fetch(url).then((r) => r.json());
+
+for (const p of items) {
+  addMarker({
+    title: p.name,
+    lat: p.location.latitude,
+    lng: p.location.longitude,
+    status: p.publicStatus, // active | saturated | paused | closed
+  });
+}`;
+
+  const emergenciesJson = `[
+  {
+    "id": "11111111-1111-4111-8111-111111111111",
+    "name": "Emergencia sísmica — Venezuela",
+    "slug": "venezuela",
+    "country": "VE",
+    "status": "active",
+    "announcement": "El puente de acceso norte está cortado.",
+    "dontBringList": ["ropa usada", "medicamentos caducados"],
+    "updatedAt": "2026-06-25T10:00:00.000Z"
+  }
+]`;
+
+  const curlBySlug = `curl ${API_BASE}/emergencies/by-slug/venezuela`;
+
+  const curlResources = `curl "${API_BASE}/emergencies/{emergencyId}/public/resources?category=water&limit=100&page=1"`;
+
+  const resourcesJson = `{
+  "items": [
+    {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "type": "collection_point",
+      "stage": "destination",
+      "name": "Cruz Roja — Centro de acopio",
+      "description": "Acopio de agua y alimentos no perecederos",
+      "location": {
+        "address": "Calle Mayor 1, Valencia",
+        "latitude": 39.4699,
+        "longitude": -0.3763
+      },
+      "verificationLevel": "official",
+      "publicStatus": "active",
+      "accepts": ["water", "food"],
+      "contact": "+34 600 000 000",
+      "schedule": "Lun-Vie 08-18",
+      "manager": "Juan Pérez",
+      "sourceName": "acopiove.org",
+      "externalUpdatedAt": "2026-06-27T00:00:00.000Z",
+      "country": "España",
+      "city": "Valencia",
+      "ownerOrganizationId": null
+    }
+  ],
+  "total": 128,
+  "page": 1,
+  "limit": 100
+}`;
+
+  const facetsJson = `{
+  "byCategory": { "water": 12, "food": 9, "medical": 4 },
+  "byCountry": { "VE": 18, "CO": 7 },
+  "total": 25
+}`;
+
+  const curlNeeds = `curl "${API_BASE}/emergencies/{emergencyId}/public/needs?priority=high"`;
+
+  const needsJson = `[
+  {
+    "id": "9c2f...",
+    "title": "Agua para 50 familias",
+    "description": null,
+    "priority": "high",
+    "status": "validated",
+    "location": {
+      "address": "Caracas",
+      "latitude": 10.49,
+      "longitude": -66.90
+    },
+    "locationSensitivity": "approximate",
+    "items": [
+      { "name": "Agua", "quantity": 100, "unit": "litros", "category": "water" }
+    ],
+    "createdAt": "2026-06-27T09:00:00.000Z",
+    "expiresAt": "2026-06-29T09:00:00.000Z",
+    "lastVerifiedAt": "2026-06-27T10:00:00.000Z"
+  }
+]`;
+
+  const curlRegister = `curl -X POST ${API_BASE}/auth/register \\
+  -H "Content-Type: application/json" \\
+  -d '{"email":"dev@ong.org","password":"supersecret","name":"Mi ONG"}'
+
+# → { "accessToken": "eyJhbGciOi..." }`;
+
+  const curlCreateNeed = `curl -X POST ${API_BASE}/emergencies/{emergencyId}/needs \\
+  -H "Authorization: Bearer $TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "title": "Agua para 50 familias",
+    "priority": "high",
+    "location": { "address": "Caracas", "latitude": 10.49, "longitude": -66.90 },
+    "items": [{ "name": "Agua", "quantity": 100, "unit": "litros", "category": "water" }]
+  }'`;
+
+  const curlCreateOffer = `curl -X POST ${API_BASE}/emergencies/{emergencyId}/offers \\
+  -H "Authorization: Bearer $TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "category": "food",
+    "description": "Arroz 25kg",
+    "quantity": 50,
+    "unit": "sacos",
+    "location": { "address": "Valencia", "latitude": 39.47, "longitude": -0.38 }
+  }'`;
+
+  const curlCreateResource = `curl -X POST ${API_BASE}/emergencies/{emergencyId}/resources \\
+  -H "Authorization: Bearer $TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "type": "collection_point",
+    "stage": "destination",
+    "name": "Punto de acopio barrio Norte",
+    "location": { "address": "Av. Norte 12", "latitude": 10.50, "longitude": -66.91 },
+    "accepts": ["water", "food"]
+  }'`;
+
+  const resourceFields: [string, string, string][] = [
+    ['name', 'string', d.f_name],
+    ['type', 'enum', d.f_type],
+    ['stage', 'enum', d.f_stage],
+    ['location', '{ address, latitude, longitude }', d.f_location],
+    ['publicStatus', 'enum', d.f_status],
+    ['verificationLevel', 'enum', d.f_verification],
+    ['accepts', 'string[]', d.f_accepts],
+    ['contact', 'string | null', d.f_contact],
+    ['schedule', 'string | null', d.f_schedule],
+    ['manager', 'string | null', d.f_manager],
+    ['sourceName', 'string | null', d.f_source],
+    ['externalUpdatedAt', 'string | null', d.f_freshness],
+    ['country', 'string | null', d.f_country],
+    ['city', 'string | null', d.f_city],
+    ['id', 'string (uuid)', d.f_id],
+    ['ownerOrganizationId', 'string | null', d.f_owner],
+  ];
+
+  return (
+    <main className="flex-1 bg-surface">
+      <div className="mx-auto w-full max-w-md bg-surface lg:max-w-6xl">
+        <SiteHeaderBand />
+
+        <div className="px-5 pb-16 pt-8 lg:px-8 lg:pt-10">
+          {/* Hero */}
+          <header className="grid items-center gap-8 lg:grid-cols-2 lg:gap-12">
+            <div>
+              <p className="font-display text-xs font-bold uppercase tracking-[0.14em] text-accent">
+                {d.overline}
+              </p>
+              <h1 className="mt-2 font-display text-[28px] font-extrabold leading-[1.1] tracking-tight text-navy lg:text-[40px] lg:leading-[1.05]">
+                {d.h1}
+              </h1>
+              <p className="mt-4 text-[15px] leading-[1.6] text-ink-soft lg:text-base">{d.lead}</p>
+            </div>
+            <div aria-hidden="true">
+              <CoordinationIllustration className="w-full" />
+            </div>
+          </header>
+
+          {/* Body: sticky TOC + content */}
+          <div className="mt-12 lg:mt-16 lg:grid lg:grid-cols-[13rem_minmax(0,1fr)] lg:gap-12">
+            {/* TOC — sidebar on lg, <details> on mobile */}
+            <aside className="mb-8 lg:mb-0">
+              <details className="rounded-card border border-line bg-surface-alt p-4 lg:hidden">
+                <summary className="cursor-pointer font-display text-sm font-bold text-navy">
+                  {d.toc_heading}
+                </summary>
+                <nav className="mt-3 flex flex-col gap-2">
+                  {toc.map(([id, label]) => (
+                    <a key={id} href={`#${id}`} className="text-[14px] text-ink-soft hover:text-accent">
+                      {label}
+                    </a>
+                  ))}
+                </nav>
+              </details>
+              <nav
+                aria-label={d.toc_heading}
+                className="sticky top-6 hidden self-start lg:flex lg:flex-col lg:gap-1.5"
+              >
+                <p className="mb-1 font-display text-[11px] font-bold uppercase tracking-wide text-muted">
+                  {d.toc_heading}
+                </p>
+                {toc.map(([id, label]) => (
+                  <a
+                    key={id}
+                    href={`#${id}`}
+                    className="rounded-md px-2 py-1 text-[13.5px] text-ink-soft transition-colors hover:bg-surface-alt hover:text-accent"
+                  >
+                    {label}
+                  </a>
+                ))}
+              </nav>
+            </aside>
+
+            <div className="flex min-w-0 flex-col gap-12">
+              {/* Overview */}
+              <Section id="intro" title={d.intro_heading}>
+                <Lead>{d.intro_p1}</Lead>
+                <Lead>{d.intro_p2}</Lead>
+
+                <div>
+                  <h3 className="mb-2 font-display text-base font-bold text-navy">{d.base_url_heading}</h3>
+                  <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={API_BASE} lang="Base URL" />
+                  <p className="mt-2 text-[13px] leading-[1.55] text-muted">{d.base_url_note}</p>
+                </div>
+
+                <dl className="grid gap-3 sm:grid-cols-2">
+                  {[
+                    [d.overview_format_label, d.overview_format_value],
+                    [d.overview_read_label, d.overview_read_value],
+                    [d.overview_write_label, d.overview_write_value],
+                    [d.overview_scope_label, d.overview_scope_value],
+                  ].map(([label, value]) => (
+                    <div key={label} className="rounded-card border border-line bg-surface-alt px-4 py-3">
+                      <dt className="font-display text-[11px] font-bold uppercase tracking-wide text-muted">
+                        {label}
+                      </dt>
+                      <dd className="mt-1 text-[14px] leading-[1.55] text-ink-soft">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </Section>
+
+              {/* Concepts */}
+              <Section id="concepts" title={d.concepts_heading}>
+                <Lead>{d.concepts_intro}</Lead>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Card title={d.concept_emergency_t}>{d.concept_emergency_b}</Card>
+                  <Card title={d.concept_resource_t}>{d.concept_resource_b}</Card>
+                  <Card title={d.concept_need_t}>{d.concept_need_b}</Card>
+                  <Card title={d.concept_trust_t}>{d.concept_trust_b}</Card>
+                </div>
+              </Section>
+
+              {/* Authentication */}
+              <Section id="auth" title={d.auth_heading}>
+                <Lead>{d.auth_intro}</Lead>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Card title={d.auth_read_t}>{d.auth_read_b}</Card>
+                  <Card title={d.auth_write_t}>{d.auth_write_b}</Card>
+                </div>
+              </Section>
+
+              {/* Quickstart */}
+              <Section id="quickstart" title={d.qs_heading}>
+                <Lead>{d.qs_intro}</Lead>
+                <ol className="ml-4 list-decimal space-y-1.5 text-[14.5px] leading-[1.6] text-ink-soft marker:font-bold marker:text-accent">
+                  <li>{d.qs_step1}</li>
+                  <li>{d.qs_step2}</li>
+                  <li>{d.qs_step3}</li>
+                </ol>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={curlQuickstart} lang="cURL" />
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={jsQuickstart} lang="JavaScript" />
+                <Callout>{d.qs_note}</Callout>
+              </Section>
+
+              {/* List emergencies */}
+              <Section id="emergencies" title={d.e_heading}>
+                <Endpoint method="GET" path="/emergencies" />
+                <Lead>{d.e_intro}</Lead>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={emergenciesJson} lang="JSON" />
+                <Lead>{d.e_fields}</Lead>
+                <Endpoint method="GET" path="/emergencies/by-slug/{slug}" />
+                <Lead>{d.e_byslug}</Lead>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={curlBySlug} lang="cURL" />
+              </Section>
+
+              {/* Logistics points (read) — the star */}
+              <Section id="resources" title={d.r_heading}>
+                <Endpoint method="GET" path="/emergencies/{emergencyId}/public/resources" />
+                <Lead>{d.r_intro}</Lead>
+
+                <SubHeading>{d.r_params_heading}</SubHeading>
+                <Table
+                  headers={[d.th_param, d.th_desc]}
+                  rows={[
+                    [<Mono key="p">page</Mono>, d.r_param_page],
+                    [<Mono key="l">limit</Mono>, d.r_param_limit],
+                    [<Mono key="c">category</Mono>, d.r_param_category],
+                    [<Mono key="co">country</Mono>, d.r_param_country],
+                  ]}
+                />
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={curlResources} lang="cURL" />
+
+                <SubHeading>{d.r_response_heading}</SubHeading>
+                <Lead>{d.r_response_intro}</Lead>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={resourcesJson} lang="JSON" />
+
+                <SubHeading>{d.r_fields_heading}</SubHeading>
+                <Lead>{d.r_fields_intro}</Lead>
+                <Table
+                  headers={[d.th_field, d.th_type, d.th_desc]}
+                  rows={resourceFields.map(([f, ty, desc]) => [
+                    <Mono key={f}>{f}</Mono>,
+                    <Mono key={`${f}-t`}>{ty}</Mono>,
+                    desc,
+                  ])}
+                />
+
+                <SubHeading>{d.r_facets_heading}</SubHeading>
+                <Endpoint method="GET" path="/emergencies/{emergencyId}/public/resources/facets" />
+                <Lead>{d.r_facets_intro}</Lead>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={facetsJson} lang="JSON" />
+              </Section>
+
+              {/* Needs (read) */}
+              <Section id="needs" title={d.n_heading}>
+                <Endpoint method="GET" path="/emergencies/{emergencyId}/public/needs" />
+                <Lead>{d.n_intro}</Lead>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={curlNeeds} lang="cURL" />
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={needsJson} lang="JSON" />
+                <Lead>{d.n_fields}</Lead>
+                <Callout tone="warn">{d.n_privacy}</Callout>
+              </Section>
+
+              {/* States & categories */}
+              <Section id="enums" title={d.enums_heading}>
+                <Lead>{d.enums_intro}</Lead>
+
+                <SubHeading>{d.enum_status_heading}</SubHeading>
+                <Lead>{d.enum_status_intro}</Lead>
+                <Table
+                  headers={[d.th_value, d.th_desc]}
+                  rows={[
+                    [<Mono key="a">active</Mono>, d.status_active],
+                    [<Mono key="s">saturated</Mono>, d.status_saturated],
+                    [<Mono key="p">paused</Mono>, d.status_paused],
+                    [<Mono key="c">closed</Mono>, d.status_closed],
+                  ]}
+                />
+
+                <SubHeading>{d.enum_verification_heading}</SubHeading>
+                <Lead>{d.enum_verification_intro}</Lead>
+                <Table
+                  headers={[d.th_value, d.th_desc]}
+                  rows={[
+                    [<Mono key="u">unverified</Mono>, d.verification_unverified],
+                    [<Mono key="v">verified</Mono>, d.verification_verified],
+                    [<Mono key="o">official</Mono>, d.verification_official],
+                  ]}
+                />
+
+                <SubHeading>{d.enum_type_heading}</SubHeading>
+                <Lead>{d.enum_type_intro}</Lead>
+                <Chips
+                  items={[
+                    'collection_point',
+                    'delivery_point',
+                    'collection_and_delivery',
+                    'warehouse',
+                    'transport',
+                    'supplier',
+                    'venue',
+                  ]}
+                />
+
+                <SubHeading>{d.enum_stage_heading}</SubHeading>
+                <Lead>{d.enum_stage_intro}</Lead>
+                <Chips items={['origin', 'intermediate', 'destination']} />
+
+                <SubHeading>{d.enum_category_heading}</SubHeading>
+                <Lead>{d.enum_category_intro}</Lead>
+                <Chips
+                  items={[
+                    'hygiene',
+                    'water',
+                    'food',
+                    'medical',
+                    'shelter',
+                    'tools',
+                    'other',
+                    'medicines',
+                    'medical_equipment',
+                    'medical_supplies',
+                    'medical_personnel',
+                  ]}
+                />
+
+                <SubHeading>{d.enum_priority_heading}</SubHeading>
+                <Lead>{d.enum_priority_intro}</Lead>
+                <Chips items={['low', 'medium', 'high', 'urgent']} />
+              </Section>
+
+              {/* Contribute data (writes) */}
+              <Section id="write" title={d.w_heading}>
+                <Lead>{d.w_intro}</Lead>
+                <Callout tone="warn">{d.w_moderation_note}</Callout>
+
+                <Lead>{d.w_auth_step}</Lead>
+                <Endpoint method="POST" path="/auth/register" />
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={curlRegister} lang="cURL" />
+
+                <SubHeading>{d.w_need_t}</SubHeading>
+                <Endpoint method="POST" path="/emergencies/{emergencyId}/needs" auth />
+                <Lead>{d.w_need_b}</Lead>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={curlCreateNeed} lang="cURL" />
+
+                <SubHeading>{d.w_offer_t}</SubHeading>
+                <Endpoint method="POST" path="/emergencies/{emergencyId}/offers" auth />
+                <Lead>{d.w_offer_b}</Lead>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={curlCreateOffer} lang="cURL" />
+
+                <SubHeading>{d.w_resource_t}</SubHeading>
+                <Endpoint method="POST" path="/emergencies/{emergencyId}/resources" auth />
+                <Lead>{d.w_resource_b}</Lead>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={curlCreateResource} lang="cURL" />
+              </Section>
+
+              {/* Best practices */}
+              <Section id="practices" title={d.bp_heading}>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Card title={d.bp_cache_t}>{d.bp_cache_b}</Card>
+                  <Card title={d.bp_attribution_t}>{d.bp_attribution_b}</Card>
+                  <Card title={d.bp_canonical_t}>{d.bp_canonical_b}</Card>
+                  <Card title={d.bp_privacy_t}>{d.bp_privacy_b}</Card>
+                  <Card title={d.bp_cors_t}>{d.bp_cors_b}</Card>
+                </div>
+              </Section>
+
+              {/* Reference & links */}
+              <Section id="links" title={d.links_heading}>
+                <div className="flex flex-col gap-3">
+                  <a
+                    href={`${API_BASE}/docs`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded-card border border-line bg-surface-alt p-5 transition-colors hover:border-accent"
+                  >
+                    <h3 className="font-display text-base font-bold text-navy">{d.links_swagger_t}</h3>
+                    <p className="mt-1.5 text-[14px] leading-[1.55] text-ink-soft">{d.links_swagger_b}</p>
+                    <code className="mt-2 inline-block font-mono text-[12.5px] text-accent">{`${API_BASE}/docs`}</code>
+                  </a>
+                  <a
+                    href={`${API_BASE}/docs-json`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded-card border border-line bg-surface-alt p-5 transition-colors hover:border-accent"
+                  >
+                    <h3 className="font-display text-base font-bold text-navy">{d.links_openapi_t}</h3>
+                    <p className="mt-1.5 text-[14px] leading-[1.55] text-ink-soft">{d.links_openapi_b}</p>
+                    <code className="mt-2 inline-block font-mono text-[12.5px] text-accent">{`${API_BASE}/docs-json`}</code>
+                  </a>
+                  <div className="rounded-card border border-line bg-surface-alt p-5">
+                    <h3 className="font-display text-base font-bold text-navy">{d.links_client_t}</h3>
+                    <p className="mt-1.5 text-[14px] leading-[1.55] text-ink-soft">{d.links_client_b}</p>
+                    <code className="mt-2 inline-block font-mono text-[12.5px] text-ink">@reliefhub/api-client</code>
+                  </div>
+                </div>
+              </Section>
+
+              {/* CTA */}
+              <section className="rounded-card border border-line bg-surface-alt px-6 py-8 text-center">
+                <h2 className="font-display text-xl font-bold text-navy">{d.cta_heading}</h2>
+                <p className="mx-auto mt-2 max-w-md text-[14.5px] leading-[1.55] text-muted">{d.cta_body}</p>
+                <Link
+                  href="/#emergencias"
+                  className="mt-5 inline-block rounded-xl bg-navy px-6 py-3.5 text-[15px] font-bold text-white transition-colors hover:bg-navy-700 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+                >
+                  {d.cta_button}
+                </Link>
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -165,6 +165,7 @@ export default async function DocsPage() {
     ['enums', d.nav_enums],
     ['write', d.nav_write],
     ['practices', d.nav_practices],
+    ['license', d.nav_license],
     ['links', d.nav_links],
   ];
 
@@ -308,6 +309,12 @@ for (const p of items) {
     "accepts": ["water", "food"]
   }'`;
 
+  const attributionText =
+    'ResponseGrid by Global Emergency — CC BY-SA 4.0 — https://responsegrid.app';
+
+  const attributionHtml =
+    '<a href="https://responsegrid.app">ResponseGrid</a> by <a href="https://globalemergency.online">Global Emergency</a>, licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>';
+
   const resourceFields: [string, string, string][] = [
     ['name', 'string', d.f_name],
     ['type', 'enum', d.f_type],
@@ -402,6 +409,7 @@ for (const p of items) {
                     [d.overview_read_label, d.overview_read_value],
                     [d.overview_write_label, d.overview_write_value],
                     [d.overview_scope_label, d.overview_scope_value],
+                    [d.overview_license_label, d.overview_license_value],
                   ].map(([label, value]) => (
                     <div key={label} className="rounded-card border border-line bg-surface-alt px-4 py-3">
                       <dt className="font-display text-[11px] font-bold uppercase tracking-wide text-muted">
@@ -607,6 +615,26 @@ for (const p of items) {
                   <Card title={d.bp_privacy_t}>{d.bp_privacy_b}</Card>
                   <Card title={d.bp_cors_t}>{d.bp_cors_b}</Card>
                 </div>
+              </Section>
+
+              {/* License & attribution */}
+              <Section id="license" title={d.license_heading}>
+                <Lead>{d.license_intro}</Lead>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Card title={d.license_attribution_t}>{d.license_attribution_b}</Card>
+                  <Card title={d.license_sharealike_t}>{d.license_sharealike_b}</Card>
+                </div>
+                <Lead>{d.license_snippet_intro}</Lead>
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={attributionText} lang="TXT" />
+                <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={attributionHtml} lang="HTML" />
+                <a
+                  href="https://creativecommons.org/licenses/by-sa/4.0/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[14px] font-semibold text-accent hover:underline"
+                >
+                  {d.license_full_link} →
+                </a>
               </Section>
 
               {/* Reference & links */}

--- a/apps/web/src/components/organisms/global-footer.tsx
+++ b/apps/web/src/components/organisms/global-footer.tsx
@@ -34,6 +34,7 @@ export function GlobalFooter({ tf }: GlobalFooterProps) {
     { href: '/como-funciona', label: tf.resources_how },
     { href: '/transparencia', label: tf.resources_transparency },
     { href: '/verificar', label: tf.resources_verify },
+    { href: '/docs', label: tf.resources_developers },
   ];
 
   return (

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -686,6 +686,7 @@ export const en = {
     nav_enums: 'States & categories',
     nav_write: 'Contribute data (with a token)',
     nav_practices: 'Best practices',
+    nav_license: 'License & attribution',
     nav_links: 'Reference & links',
 
     // Overview
@@ -705,6 +706,8 @@ export const en = {
     overview_write_value: 'Require a JWT (Bearer) token. See “Contribute data”.',
     overview_scope_label: 'Scope',
     overview_scope_value: 'Everything hangs off an emergency, identified by its UUID or slug.',
+    overview_license_label: 'Data licence',
+    overview_license_value: 'CC BY-SA 4.0 — attribution required + share-alike.',
 
     // Concepts
     concepts_heading: 'Concepts',
@@ -823,9 +826,9 @@ export const en = {
     bp_cache_t: 'Cache and poll sensibly',
     bp_cache_b:
       'Do not hammer the API: paginate, cache responses and refresh every few minutes. Use updatedAt, lastVerifiedAt and externalUpdatedAt to know how fresh a datum is.',
-    bp_attribution_t: 'Cite the source',
+    bp_attribution_t: 'Cite the source (required)',
     bp_attribution_b:
-      'If you reuse this data, attribute ResponseGrid / Global Emergency and link back to the emergency. It helps people reach the canonical information and reduces misinformation.',
+      'Not just courtesy: the data licence (CC BY-SA 4.0) requires you to attribute ResponseGrid / Global Emergency and link back. Ready-to-paste text is in “License & attribution”.',
     bp_canonical_t: 'Respect the trust levels',
     bp_canonical_b:
       'Show your users the verificationLevel and publicStatus. An “official and operational” point is not the same as a “verified and saturated” one: that signal is exactly the value we add.',
@@ -835,6 +838,19 @@ export const en = {
     bp_cors_t: 'Call from your server',
     bp_cors_b:
       'The public GETs are anonymous, but the API restricts browser CORS to allowed origins. Consume server to server, or proxy through your backend.',
+
+    // License & attribution
+    license_heading: 'License & attribution',
+    license_intro:
+      'The data returned by the API is published under Creative Commons Attribution-ShareAlike 4.0 (CC BY-SA 4.0). You may use, redistribute and adapt it —including commercially— as long as you meet two conditions. (This is the licence of the data; the project code has its own licence.)',
+    license_attribution_t: 'Attribution required',
+    license_attribution_b:
+      'Credit ResponseGrid / Global Emergency, state the licence and link back to the source. The credit must be visible wherever you show the data.',
+    license_sharealike_t: 'Share-alike',
+    license_sharealike_b:
+      'If you remix, transform or build a database from this data and distribute it, you must release it under this same licence, CC BY-SA 4.0.',
+    license_snippet_intro: 'Ready-to-paste attribution:',
+    license_full_link: 'Full legal text of the licence',
 
     // Reference & links
     links_heading: 'Reference & links',

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -35,6 +35,7 @@ export const en = {
       resources_how: 'How it works',
       resources_transparency: 'Transparency',
       resources_verify: 'Verify a campaign',
+      resources_developers: 'Developer API',
       legal_heading: 'Legal',
       privacy: 'Privacy',
       terms: 'Terms & conditions',
@@ -662,5 +663,220 @@ export const en = {
     cta_heading: 'Check verified campaigns',
     cta_body: 'Enter an active emergency and filter by verified points and campaigns.',
     cta_button: 'View active emergencies',
+  },
+
+  // ── Page: Developer API (/docs) ───────────────────────────────────────────
+  docs: {
+    meta_title: 'Developer API — ResponseGrid',
+    meta_description:
+      "ResponseGrid public API docs: read every emergency's verified logistics points and validated needs without login, to build maps and services on top of the source of truth.",
+    overline: 'Developer API',
+    h1: 'Build on the source of truth',
+    lead:
+      'The ResponseGrid public API gives you login-free access to the verified logistics points and validated needs of every emergency. It exists so any project —a map, a search tool, a dashboard— can consume official, real-time data instead of duplicating it.',
+
+    toc_heading: 'On this page',
+    nav_intro: 'Overview',
+    nav_concepts: 'Concepts',
+    nav_auth: 'Authentication',
+    nav_quickstart: 'Quickstart: a map of points',
+    nav_emergencies: 'List emergencies',
+    nav_resources: 'Logistics points (read)',
+    nav_needs: 'Needs (read)',
+    nav_enums: 'States & categories',
+    nav_write: 'Contribute data (with a token)',
+    nav_practices: 'Best practices',
+    nav_links: 'Reference & links',
+
+    // Overview
+    intro_heading: 'Overview',
+    intro_p1:
+      'ResponseGrid coordinates aid during a disaster: it publishes verified logistics points, gathers and validates needs, and keeps it all on a real-time map. This API exposes that same information so you can integrate it into your own product.',
+    intro_p2:
+      "The goal is to avoid a hundred conflicting maps: you consume the verified data and we are the source of truth. Only what local coordination has validated is published, so what you read is already vetted.",
+    base_url_heading: 'Base URL',
+    base_url_note:
+      'The base URL depends on the deployment; use the production one we give you. The examples on this page use this instance.',
+    overview_format_label: 'Format',
+    overview_format_value: 'JSON over HTTPS. All responses are UTF-8.',
+    overview_read_label: 'Reads',
+    overview_read_value: 'Public, no authentication. Every GET in this section is anonymous.',
+    overview_write_label: 'Writes',
+    overview_write_value: 'Require a JWT (Bearer) token. See “Contribute data”.',
+    overview_scope_label: 'Scope',
+    overview_scope_value: 'Everything hangs off an emergency, identified by its UUID or slug.',
+
+    // Concepts
+    concepts_heading: 'Concepts',
+    concepts_intro: 'Four ideas are enough to consume the API with confidence:',
+    concept_emergency_t: 'Emergency',
+    concept_emergency_b:
+      'The container for everything. It has a name, a human-readable slug (e.g. “venezuela”), a country and a status (active / paused / closed). Every point and need belongs to an emergency.',
+    concept_resource_t: 'Logistics point',
+    concept_resource_b:
+      'A physical site: a collection or delivery point, warehouse, transport, supplier or venue. It carries a name, a location (address + coordinates), what it accepts, contact, schedule and an operational status light.',
+    concept_need_t: 'Need',
+    concept_need_b:
+      'What is requested on the ground (water, food, medical supplies, personnel…), with a priority and items. Only needs validated by coordination are exposed publicly.',
+    concept_trust_t: 'Trust levels',
+    concept_trust_b:
+      'Every point carries a level: queued (not trustworthy yet), verified (validated by local coordination) or official (accredited organisation). The public API only returns verified or official points — that is what makes it a source of truth.',
+
+    // Authentication
+    auth_heading: 'Authentication',
+    auth_intro: 'There are two planes. Tell them apart before integrating.',
+    auth_read_t: 'Reads — no token',
+    auth_read_b:
+      'The read endpoints (emergencies, public points, public needs) need no credentials. If all you want is to display data, you do not need to authenticate.',
+    auth_write_t: 'Writes — Bearer token',
+    auth_write_b:
+      'To create needs, offers or points you need an account. Register or log in and you get an accessToken (JWT) that you send in the Authorization: Bearer <token> header.',
+
+    // Quickstart
+    qs_heading: 'Quickstart: a map of points',
+    qs_intro:
+      'The most common case: plot on a map where aid can be collected or delivered. Three calls and you are done.',
+    qs_step1: 'Pick an emergency: list the active ones and keep its id (or resolve the slug).',
+    qs_step2: 'Fetch its public points, paginating (up to 100 per page).',
+    qs_step3: 'Draw a marker per point and colour it by its status.',
+    qs_note:
+      'Consume the API from your backend (server to server). Browser requests from another domain are subject to the API’s CORS allowlist; if your app is client-only, proxy through your own server.',
+
+    // List emergencies
+    e_heading: 'List emergencies',
+    e_intro:
+      'Returns the active emergencies. Use it to get the emergencyId the rest of the calls need.',
+    e_byslug:
+      'If you already know the slug (you see it in the public URL, e.g. /e/venezuela) you can resolve the emergency directly:',
+    e_fields:
+      'Each emergency includes id, name, slug, country, status, announcement (official notice or null), dontBringList (what NOT to bring) and updatedAt.',
+
+    // Logistics points (read) — star
+    r_heading: 'Logistics points (read)',
+    r_intro:
+      'The main endpoint. Returns, paginated, the published points of an emergency: only the verified or official and visible ones. This is what you would plot on a map.',
+    r_params_heading: 'Query parameters',
+    r_param_page: 'Page, starting at 1.',
+    r_param_limit: 'Items per page. Default 50, maximum 100.',
+    r_param_category: 'Filter by a category the point accepts (slug, e.g. water, food).',
+    r_param_country: 'Filter by country as stored by the source (e.g. VE or “Venezuela”).',
+    r_response_heading: 'Response',
+    r_response_intro: 'A paged object: items (the points), total, page and limit.',
+    r_fields_heading: 'Public fields of a point',
+    r_fields_intro:
+      'The public information is minimal but enough to locate and decide: name, where it is, what it accepts and how it is operating.',
+    r_facets_heading: 'Facets (to build filters)',
+    r_facets_intro:
+      'If you need to build filters in your UI, this endpoint gives you the counts by category and by country of the visible points, without having to download them all.',
+
+    // Needs (read)
+    n_heading: 'Needs (read)',
+    n_intro:
+      'Returns the validated needs of an emergency. Useful to show what is required and where. Accepts filters by category (category) and priority (priority).',
+    n_privacy:
+      'Privacy: some needs expose approximate coordinates (locationSensitivity: "approximate") so as not to reveal a requester’s home. Do not try to de-obfuscate them; treat them as indicative.',
+    n_fields:
+      'Each need includes id, title, description, location, locationSensitivity, priority, items (with name, quantity, unit and category), status, createdAt, expiresAt and lastVerifiedAt.',
+
+    // States & categories
+    enums_heading: 'States & categories',
+    enums_intro:
+      'Values you will see in responses. Show them to your users instead of inventing your own: that way your app speaks the same language as the rest of the ecosystem.',
+    enum_status_heading: 'Operational status (status light)',
+    enum_status_intro: 'The publicStatus field of each point:',
+    status_active: 'Operational and accepting aid.',
+    status_saturated: 'Overwhelmed: better not to bring more supplies right now.',
+    status_paused: 'Temporarily paused.',
+    status_closed: 'Closed.',
+    enum_verification_heading: 'Trust level',
+    enum_verification_intro: 'The verificationLevel field (the public API only returns the last two):',
+    verification_unverified: 'Queued, not validated (not shown in the public API).',
+    verification_verified: 'Validated by local coordination.',
+    verification_official: 'Published by an accredited organisation.',
+    enum_type_heading: 'Point type',
+    enum_type_intro: 'The type field:',
+    enum_stage_heading: 'Role in the chain',
+    enum_stage_intro: 'The stage field: origin, intermediate or destination.',
+    enum_category_heading: 'Categories',
+    enum_category_intro: 'Used in accepts (points), in items[].category (needs) and as the category filter.',
+    enum_priority_heading: 'Priority',
+    enum_priority_intro: 'The priority field of needs: low, medium, high, urgent.',
+
+    // Contribute data
+    w_heading: 'Contribute data (with a token)',
+    w_intro:
+      'Beyond reading, you can feed the platform from your integration: register needs, supply offers (deliveries) or logistics points. These operations require a token (see Authentication).',
+    w_moderation_note:
+      'Important: what you submit is not published instantly. Needs start as “pending” and points as “unverified”; local coordination validates them before they appear in the public endpoints. That is what keeps the source clean.',
+    w_auth_step: 'First, get a token:',
+    w_need_t: 'Create a need',
+    w_need_b: 'Minimum: title, priority, location and items (at least one). Returns the created id.',
+    w_offer_t: 'Offer supplies (a delivery)',
+    w_offer_b:
+      'A donation, general or directed at a specific need (targetNeedId). Minimum: category, description, quantity and location. If the emergency is not accepting intake (paused/closed) it returns 409.',
+    w_resource_t: 'Register a logistics point',
+    w_resource_b:
+      'Minimum: type, stage, name and location. Optional: accepts, contact, schedule, country, city. It starts unverified until coordination publishes it.',
+
+    // Best practices
+    bp_heading: 'Best practices',
+    bp_cache_t: 'Cache and poll sensibly',
+    bp_cache_b:
+      'Do not hammer the API: paginate, cache responses and refresh every few minutes. Use updatedAt, lastVerifiedAt and externalUpdatedAt to know how fresh a datum is.',
+    bp_attribution_t: 'Cite the source',
+    bp_attribution_b:
+      'If you reuse this data, attribute ResponseGrid / Global Emergency and link back to the emergency. It helps people reach the canonical information and reduces misinformation.',
+    bp_canonical_t: 'Respect the trust levels',
+    bp_canonical_b:
+      'Show your users the verificationLevel and publicStatus. An “official and operational” point is not the same as a “verified and saturated” one: that signal is exactly the value we add.',
+    bp_privacy_t: 'Protect privacy',
+    bp_privacy_b:
+      'Treat approximate locations as such and do not cross-reference data to re-identify people. Aid comes before a pretty dataset.',
+    bp_cors_t: 'Call from your server',
+    bp_cors_b:
+      'The public GETs are anonymous, but the API restricts browser CORS to allowed origins. Consume server to server, or proxy through your backend.',
+
+    // Reference & links
+    links_heading: 'Reference & links',
+    links_swagger_t: 'Interactive reference (Swagger)',
+    links_swagger_b: 'Explore and try every endpoint live.',
+    links_openapi_t: 'OpenAPI specification',
+    links_openapi_b: 'The OpenAPI JSON, to generate clients or import into your tools.',
+    links_client_t: 'Typed TypeScript client',
+    links_client_b:
+      'The @reliefhub/api-client package (openapi-fetch): types and autocomplete to consume the API from TypeScript.',
+
+    // Tables
+    th_field: 'Field',
+    th_type: 'Type',
+    th_desc: 'Description',
+    th_param: 'Parameter',
+    th_value: 'Value',
+
+    // Point field descriptions
+    f_id: 'Unique identifier of the point.',
+    f_name: 'Name of the centre or point.',
+    f_type: 'Point type (see “Point type”).',
+    f_stage: 'Role in the chain: origin, intermediate or destination.',
+    f_description: 'Free-text description. May be null.',
+    f_location: 'Address and coordinates (latitude, longitude).',
+    f_status: 'Operational status: the status light (active, saturated, paused, closed).',
+    f_verification: 'Trust level: verified or official.',
+    f_accepts: 'Categories the point accepts (e.g. ["water","food"]).',
+    f_contact: 'Phone or contact for the point. May be null.',
+    f_schedule: 'Opening hours. May be null.',
+    f_manager: 'Person in charge. May be null.',
+    f_source: 'Origin of the data when it comes from an external source. May be null.',
+    f_freshness: 'Date (ISO 8601) of the last update at the source. May be null.',
+    f_country: 'Country as stored by the source (often the full name). May be null.',
+    f_city: 'City. May be null.',
+    f_owner: 'Organisation that owns the point. May be null.',
+
+    cta_heading: 'Building something with this?',
+    cta_body: 'Start from the active emergencies and pull their public points. Cite us as the source and link back.',
+    cta_button: 'View active emergencies',
+
+    copy: 'Copy',
+    copied: 'Copied',
   },
 } as Messages;

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -34,6 +34,7 @@ export const es = {
       resources_how: 'Cómo funciona',
       resources_transparency: 'Transparencia',
       resources_verify: 'Verificar una campaña',
+      resources_developers: 'API para desarrolladores',
       legal_heading: 'Legal',
       privacy: 'Privacidad',
       terms: 'Términos y condiciones',
@@ -817,6 +818,224 @@ export const es = {
     cta_heading: 'Consulta las campañas verificadas',
     cta_body: 'Entra en una emergencia activa y filtra por puntos y campañas verificados.',
     cta_button: 'Ver emergencias activas',
+  },
+
+  // ── Página: API para desarrolladores (/docs) ──────────────────────────────
+  docs: {
+    meta_title: 'API para desarrolladores — ResponseGrid',
+    meta_description:
+      'Documentación de la API pública de ResponseGrid: consulta sin login los puntos logísticos verificados y las necesidades validadas de cada emergencia para construir mapas y servicios sobre la fuente de la verdad.',
+    overline: 'API para desarrolladores',
+    h1: 'Construye sobre la fuente de la verdad',
+    lead:
+      'La API pública de ResponseGrid te da acceso, sin login, a los puntos logísticos verificados y a las necesidades validadas de cada emergencia. Está pensada para que cualquier proyecto —un mapa, un buscador, un panel— consuma datos oficiales y en tiempo real en vez de duplicarlos.',
+
+    toc_heading: 'En esta página',
+    nav_intro: 'Visión general',
+    nav_concepts: 'Conceptos',
+    nav_auth: 'Autenticación',
+    nav_quickstart: 'Inicio rápido: un mapa de puntos',
+    nav_emergencies: 'Listar emergencias',
+    nav_resources: 'Puntos logísticos (lectura)',
+    nav_needs: 'Necesidades (lectura)',
+    nav_enums: 'Estados y categorías',
+    nav_write: 'Aportar datos (con token)',
+    nav_practices: 'Buenas prácticas',
+    nav_links: 'Referencia y enlaces',
+
+    // Visión general
+    intro_heading: 'Visión general',
+    intro_p1:
+      'ResponseGrid coordina la ayuda durante una catástrofe: publica los puntos logísticos verificados, recoge y valida las necesidades, y lo mantiene todo en un mapa en tiempo real. Esta API expone esa misma información para que la integres en tu propio producto.',
+    intro_p2:
+      'El objetivo es que no haya cien mapas distintos contradiciéndose: tú consumes los datos verificados y nosotros somos la fuente de la verdad. Solo se publica lo que la coordinación local ha validado, así que lo que lees ya está depurado.',
+    base_url_heading: 'URL base',
+    base_url_note:
+      'La URL base depende del despliegue; usa la que te indiquemos para producción. Los ejemplos de esta página usan esta instancia.',
+    overview_format_label: 'Formato',
+    overview_format_value: 'JSON sobre HTTPS. Todas las respuestas son UTF-8.',
+    overview_read_label: 'Lectura',
+    overview_read_value: 'Pública, sin autenticación. Todos los GET de esta sección son anónimos.',
+    overview_write_label: 'Escritura',
+    overview_write_value: 'Requiere un token JWT (Bearer). Ver «Aportar datos».',
+    overview_scope_label: 'Ámbito',
+    overview_scope_value: 'Todo cuelga de una emergencia, identificada por su UUID o su slug.',
+
+    // Conceptos
+    concepts_heading: 'Conceptos',
+    concepts_intro:
+      'Cuatro ideas bastan para consumir la API con criterio:',
+    concept_emergency_t: 'Emergencia',
+    concept_emergency_b:
+      'El contenedor de todo. Tiene un nombre, un slug legible (p. ej. «venezuela»), país y estado (activa / en pausa / cerrada). Cada punto y cada necesidad pertenece a una emergencia.',
+    concept_resource_t: 'Punto logístico',
+    concept_resource_b:
+      'Un sitio físico: punto de recogida o de entrega, almacén, transporte, proveedor o local. Trae nombre, ubicación (dirección + coordenadas), qué acepta, contacto, horario y un semáforo de estado operativo.',
+    concept_need_t: 'Necesidad',
+    concept_need_b:
+      'Lo que se pide en el terreno (agua, alimentos, material sanitario, personal…), con prioridad e ítems. Públicamente solo se exponen las necesidades validadas por coordinación.',
+    concept_trust_t: 'Niveles de confianza',
+    concept_trust_b:
+      'Cada punto lleva un nivel: en cola (aún no fiable), verificado (validado por la coordinación local) u oficial (organización acreditada). La API pública solo devuelve puntos verificados u oficiales: por eso es fuente de la verdad.',
+
+    // Autenticación
+    auth_heading: 'Autenticación',
+    auth_intro:
+      'Hay dos planos. Distínguelos antes de integrar.',
+    auth_read_t: 'Lectura — sin token',
+    auth_read_b:
+      'Los endpoints de consulta (emergencias, puntos públicos, necesidades públicas) no requieren credenciales. Si solo quieres mostrar datos, no necesitas autenticarte.',
+    auth_write_t: 'Escritura — token Bearer',
+    auth_write_b:
+      'Para crear necesidades, ofertas o puntos necesitas una cuenta. Regístrate o haz login y recibirás un accessToken (JWT) que envías en la cabecera Authorization: Bearer <token>.',
+
+    // Inicio rápido
+    qs_heading: 'Inicio rápido: un mapa de puntos',
+    qs_intro:
+      'El caso más común: pintar en un mapa dónde se puede recoger o entregar ayuda. Tres llamadas y listo.',
+    qs_step1: 'Elige una emergencia: lista las activas y quédate con su id (o resuelve el slug).',
+    qs_step2: 'Pide sus puntos públicos paginando (hasta 100 por página).',
+    qs_step3: 'Pinta un marcador por cada punto y coloréalo según su estado.',
+    qs_note:
+      'Consume la API desde tu backend (servidor a servidor). Las peticiones desde el navegador de otro dominio están sujetas a la lista CORS de la API; si tu app es solo-cliente, haz de proxy desde tu servidor.',
+
+    // Listar emergencias
+    e_heading: 'Listar emergencias',
+    e_intro:
+      'Devuelve las emergencias activas. Úsalo para obtener el emergencyId que necesitan el resto de llamadas.',
+    e_byslug:
+      'Si ya conoces el slug (lo ves en la URL pública, p. ej. /e/venezuela), puedes resolver la emergencia directamente:',
+    e_fields:
+      'Cada emergencia incluye id, name, slug, country, status, announcement (comunicado oficial o null), dontBringList (qué NO llevar) y updatedAt.',
+
+    // Puntos logísticos (lectura) — estrella
+    r_heading: 'Puntos logísticos (lectura)',
+    r_intro:
+      'El endpoint principal. Devuelve, paginados, los puntos publicados de una emergencia: solo los verificados u oficiales y visibles. Es lo que pintarías en un mapa.',
+    r_params_heading: 'Parámetros de consulta',
+    r_param_page: 'Página, empezando en 1.',
+    r_param_limit: 'Elementos por página. Por defecto 50, máximo 100.',
+    r_param_category: 'Filtra por categoría que el punto acepta (slug, p. ej. water, food).',
+    r_param_country: 'Filtra por país tal y como lo guarda el origen (p. ej. VE o «Venezuela»).',
+    r_response_heading: 'Respuesta',
+    r_response_intro:
+      'Un objeto paginado: items (los puntos), total, page y limit.',
+    r_fields_heading: 'Campos públicos de un punto',
+    r_fields_intro:
+      'La información pública es mínima pero suficiente para ubicar y decidir: nombre, dónde está, qué acepta y en qué estado opera.',
+    r_facets_heading: 'Facetas (para construir filtros)',
+    r_facets_intro:
+      'Si necesitas montar filtros en tu interfaz, este endpoint te da los recuentos por categoría y por país de los puntos visibles, sin tener que descargarlos todos.',
+
+    // Necesidades (lectura)
+    n_heading: 'Necesidades (lectura)',
+    n_intro:
+      'Devuelve las necesidades validadas de una emergencia. Útil para mostrar qué hace falta y dónde. Acepta filtros por categoría (category) y prioridad (priority).',
+    n_privacy:
+      'Privacidad: algunas necesidades exponen coordenadas aproximadas (locationSensitivity: "approximate") para no revelar el domicilio de quien pide. No intentes desofuscarlas; trátalas como orientativas.',
+    n_fields:
+      'Cada necesidad incluye id, title, description, location, locationSensitivity, priority, items (con name, quantity, unit y category), status, createdAt, expiresAt y lastVerifiedAt.',
+
+    // Estados y categorías
+    enums_heading: 'Estados y categorías',
+    enums_intro:
+      'Valores que verás en las respuestas. Muéstralos a tus usuarios en lugar de inventar los tuyos: así tu app habla el mismo idioma que el resto del ecosistema.',
+    enum_status_heading: 'Estado operativo (semáforo)',
+    enum_status_intro: 'El campo publicStatus de cada punto:',
+    status_active: 'Operativo y aceptando ayuda.',
+    status_saturated: 'Desbordado: mejor no llevar más material ahora.',
+    status_paused: 'En pausa temporal.',
+    status_closed: 'Cerrado.',
+    enum_verification_heading: 'Nivel de confianza',
+    enum_verification_intro: 'El campo verificationLevel (la API pública solo devuelve los dos últimos):',
+    verification_unverified: 'En cola, sin validar (no aparece en la API pública).',
+    verification_verified: 'Validado por la coordinación local.',
+    verification_official: 'Publicado por una organización acreditada.',
+    enum_type_heading: 'Tipo de punto',
+    enum_type_intro: 'El campo type:',
+    enum_stage_heading: 'Rol en la cadena',
+    enum_stage_intro: 'El campo stage: origin (origen), intermediate (intermedio) o destination (destino).',
+    enum_category_heading: 'Categorías',
+    enum_category_intro: 'Usadas en accepts (puntos), en items[].category (necesidades) y como filtro category.',
+    enum_priority_heading: 'Prioridad',
+    enum_priority_intro: 'El campo priority de las necesidades: low, medium, high, urgent.',
+
+    // Aportar datos
+    w_heading: 'Aportar datos (con token)',
+    w_intro:
+      'Además de leer, puedes alimentar la plataforma desde tu integración: dar de alta necesidades, ofertas de material (entregas) o puntos logísticos. Estas operaciones requieren un token (ver Autenticación).',
+    w_moderation_note:
+      'Importante: lo que envías no se publica al instante. Las necesidades nacen como «pendientes» y los puntos como «sin verificar»; la coordinación local los valida antes de que aparezcan en los endpoints públicos. Es lo que mantiene la calidad de la fuente.',
+    w_auth_step: 'Primero, consigue un token:',
+    w_need_t: 'Crear una necesidad',
+    w_need_b: 'Mínimo: title, priority, location e items (al menos uno). Devuelve el id creado.',
+    w_offer_t: 'Ofrecer material (entrega)',
+    w_offer_b:
+      'Una donación, general o dirigida a una necesidad concreta (targetNeedId). Mínimo: category, description, quantity y location. Si la emergencia no acepta altas (en pausa/cerrada) responde 409.',
+    w_resource_t: 'Registrar un punto logístico',
+    w_resource_b:
+      'Mínimo: type, stage, name y location. Opcional: accepts, contact, schedule, country, city. Nace sin verificar hasta que coordinación lo publica.',
+
+    // Buenas prácticas
+    bp_heading: 'Buenas prácticas',
+    bp_cache_t: 'Cachea y consulta con cabeza',
+    bp_cache_b:
+      'No martillees la API: pagina, cachea las respuestas y refresca cada pocos minutos. Usa updatedAt, lastVerifiedAt y externalUpdatedAt para saber qué tan fresco es un dato.',
+    bp_attribution_t: 'Cita la fuente',
+    bp_attribution_b:
+      'Si reutilizas estos datos, atribuye a ResponseGrid / Global Emergency y enlaza de vuelta a la emergencia. Ayuda a que la gente llegue a la información canónica y reduce la desinformación.',
+    bp_canonical_t: 'Respeta los niveles de confianza',
+    bp_canonical_b:
+      'Muestra a tus usuarios el verificationLevel y el publicStatus. Un punto «oficial y operativo» no es lo mismo que uno «verificado y saturado»: esa señal es justo el valor que aportamos.',
+    bp_privacy_t: 'Cuida la privacidad',
+    bp_privacy_b:
+      'Trata las ubicaciones aproximadas como tales y no cruces datos para reidentificar a personas. La ayuda va antes que el dato bonito.',
+    bp_cors_t: 'Llama desde tu servidor',
+    bp_cors_b:
+      'Los GET públicos son anónimos, pero la API restringe el CORS de navegador a orígenes permitidos. Consume servidor a servidor o haz de proxy desde tu backend.',
+
+    // Referencia y enlaces
+    links_heading: 'Referencia y enlaces',
+    links_swagger_t: 'Referencia interactiva (Swagger)',
+    links_swagger_b: 'Explora y prueba todos los endpoints en vivo.',
+    links_openapi_t: 'Especificación OpenAPI',
+    links_openapi_b: 'El JSON de OpenAPI, para generar clientes o importar en tus herramientas.',
+    links_client_t: 'Cliente TypeScript tipado',
+    links_client_b:
+      'Paquete @reliefhub/api-client (openapi-fetch): tipos y autocompletado para consumir la API desde TypeScript.',
+
+    // Tablas
+    th_field: 'Campo',
+    th_type: 'Tipo',
+    th_desc: 'Descripción',
+    th_param: 'Parámetro',
+    th_value: 'Valor',
+
+    // Descripciones de campos del punto
+    f_id: 'Identificador único del punto.',
+    f_name: 'Nombre del centro o punto.',
+    f_type: 'Tipo de punto (ver «Tipo de punto»).',
+    f_stage: 'Rol en la cadena: origen, intermedio o destino.',
+    f_description: 'Descripción libre. Puede ser null.',
+    f_location: 'Dirección y coordenadas (latitude, longitude).',
+    f_status: 'Estado operativo: el semáforo (active, saturated, paused, closed).',
+    f_verification: 'Nivel de confianza: verified u official.',
+    f_accepts: 'Categorías que el punto acepta (p. ej. ["water","food"]).',
+    f_contact: 'Teléfono o contacto del punto. Puede ser null.',
+    f_schedule: 'Horario de atención. Puede ser null.',
+    f_manager: 'Persona responsable. Puede ser null.',
+    f_source: 'Origen del dato cuando procede de una fuente externa. Puede ser null.',
+    f_freshness: 'Fecha (ISO 8601) de la última actualización en el origen. Puede ser null.',
+    f_country: 'País tal y como lo guarda el origen (a menudo el nombre completo). Puede ser null.',
+    f_city: 'Ciudad. Puede ser null.',
+    f_owner: 'Organización propietaria del punto. Puede ser null.',
+
+    cta_heading: '¿Construyes algo con esto?',
+    cta_body: 'Empieza por las emergencias activas y trae sus puntos públicos. Cítanos como fuente y enlaza de vuelta.',
+    cta_button: 'Ver emergencias activas',
+
+    copy: 'Copiar',
+    copied: 'Copiado',
   },
 };
 

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -841,6 +841,7 @@ export const es = {
     nav_enums: 'Estados y categorías',
     nav_write: 'Aportar datos (con token)',
     nav_practices: 'Buenas prácticas',
+    nav_license: 'Licencia y atribución',
     nav_links: 'Referencia y enlaces',
 
     // Visión general
@@ -860,6 +861,8 @@ export const es = {
     overview_write_value: 'Requiere un token JWT (Bearer). Ver «Aportar datos».',
     overview_scope_label: 'Ámbito',
     overview_scope_value: 'Todo cuelga de una emergencia, identificada por su UUID o su slug.',
+    overview_license_label: 'Licencia de datos',
+    overview_license_value: 'CC BY-SA 4.0 — atribución obligatoria + compartir igual.',
 
     // Conceptos
     concepts_heading: 'Conceptos',
@@ -981,9 +984,9 @@ export const es = {
     bp_cache_t: 'Cachea y consulta con cabeza',
     bp_cache_b:
       'No martillees la API: pagina, cachea las respuestas y refresca cada pocos minutos. Usa updatedAt, lastVerifiedAt y externalUpdatedAt para saber qué tan fresco es un dato.',
-    bp_attribution_t: 'Cita la fuente',
+    bp_attribution_t: 'Cita la fuente (obligatorio)',
     bp_attribution_b:
-      'Si reutilizas estos datos, atribuye a ResponseGrid / Global Emergency y enlaza de vuelta a la emergencia. Ayuda a que la gente llegue a la información canónica y reduce la desinformación.',
+      'No es solo cortesía: la licencia de los datos (CC BY-SA 4.0) te obliga a atribuir a ResponseGrid / Global Emergency y a enlazar de vuelta. Tienes el texto listo para pegar en «Licencia y atribución».',
     bp_canonical_t: 'Respeta los niveles de confianza',
     bp_canonical_b:
       'Muestra a tus usuarios el verificationLevel y el publicStatus. Un punto «oficial y operativo» no es lo mismo que uno «verificado y saturado»: esa señal es justo el valor que aportamos.',
@@ -993,6 +996,19 @@ export const es = {
     bp_cors_t: 'Llama desde tu servidor',
     bp_cors_b:
       'Los GET públicos son anónimos, pero la API restringe el CORS de navegador a orígenes permitidos. Consume servidor a servidor o haz de proxy desde tu backend.',
+
+    // Licencia y atribución
+    license_heading: 'Licencia y atribución',
+    license_intro:
+      'Los datos que devuelve la API se publican bajo Creative Commons Reconocimiento-CompartirIgual 4.0 (CC BY-SA 4.0). Puedes usarlos, redistribuirlos y adaptarlos —incluso con fines comerciales— siempre que cumplas dos condiciones. (Es la licencia de los datos; el código del proyecto tiene su propia licencia.)',
+    license_attribution_t: 'Atribución obligatoria',
+    license_attribution_b:
+      'Da crédito a ResponseGrid / Global Emergency, indica la licencia y enlaza de vuelta a la fuente. El crédito debe estar visible allá donde muestres los datos.',
+    license_sharealike_t: 'Compartir igual',
+    license_sharealike_b:
+      'Si mezclas, transformas o construyes una base de datos a partir de estos datos y la distribuyes, debes publicarla bajo esta misma licencia, CC BY-SA 4.0.',
+    license_snippet_intro: 'Texto de atribución listo para pegar:',
+    license_full_link: 'Texto legal completo de la licencia',
 
     // Referencia y enlaces
     links_heading: 'Referencia y enlaces',


### PR DESCRIPTION
## Qué

Nueva página pública **`/docs`** en el dominio principal (la web Next.js): documentación de la API para que otros proyectos **consuman nuestros datos y construyan sobre la fuente de la verdad**.

Está **centrada en los endpoints de lectura (GET)** —los que queremos que usen los proyectos que nos replican— con el caso de uso de *montar un mapa de puntos de recogida/entrega*. "Aportar datos" (los POST autenticados) queda como sección secundaria.

## Contenido de la página

**Consumo / lectura (el centro):**
- `GET /emergencies` y `GET /emergencies/by-slug/{slug}` — para obtener el `emergencyId`.
- `GET /emergencies/{emergencyId}/public/resources` — puntos logísticos publicados, con filtros (`category`, `country`), paginación (`page`, `limit` máx. 100) y tabla de **campos públicos** (nombre, dirección + coordenadas, `publicStatus`, `verificationLevel`, qué acepta, contacto, horario, frescura del origen…).
- `GET /emergencies/{emergencyId}/public/resources/facets` — recuentos por categoría/país para construir filtros.
- `GET /emergencies/{emergencyId}/public/needs` — necesidades validadas (filtros `category`, `priority`), con nota de privacidad sobre coordenadas aproximadas.
- **Inicio rápido**: las 3 llamadas para pintar un mapa (cURL + JavaScript).

**Referencia y secundario:**
- Conceptos (emergencia, punto, necesidad, niveles de confianza) y el modelo de autenticación (lectura sin token / escritura con JWT Bearer).
- Estados y categorías: `publicStatus` (semáforo operativo/saturado/en pausa/cerrado), `verificationLevel`, `type`, `stage`, categorías y prioridad.
- **Aportar datos** (con token): `POST /auth/register` + crear necesidad / oferta (entrega) / punto. Con aviso de moderación (no se publica hasta que coordinación valida).
- Buenas prácticas: caché y polling, atribución a la fuente, respetar niveles de confianza, privacidad y **CORS** (consumir servidor a servidor).
- Enlaces a Swagger (`/docs`), OpenAPI (`/docs-json`) y al cliente tipado `@reliefhub/api-client`.

## Detalles de implementación

- Ruta `apps/web/src/app/docs/page.tsx` (server component) + `code-block.tsx` (client, botón de copiar). Índice lateral pegajoso en escritorio y desplegable en móvil; estilo coherente con las páginas estáticas existentes (banda de cabecera + footer global + tokens del design system).
- **Bilingüe ES/EN** vía el sistema i18n: claves `docs.*` añadidas a `es.ts` y `en.ts`. Los ejemplos de código/JSON son neutros al idioma.
- La URL base mostrada se lee de `NEXT_PUBLIC_API_URL` (con nota de que depende del despliegue).
- Nuevo enlace **"API para desarrolladores"** en la columna de recursos del footer global.

## Verificación

- ✅ `eslint` (web) sin errores.
- ✅ `tsc --noEmit` (web) sin errores.
- ✅ `next build` completo; la ruta `/docs` aparece como dinámica (`ƒ`).

## Notas

- Endpoints, DTOs, enums y formas de respuesta documentados verificados contra el código de `apps/api`.
- Para que la página muestre la URL base real de producción, conviene tener `NEXT_PUBLIC_API_URL` definida en el proyecto de Vercel (el cliente del web ya la usa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcakQaZS7H2Qw33PnMrgAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcakQaZS7H2Qw33PnMrgAB)_