### PR TITLE
fix(web): consistent Venezuela geo-grouping (full country name) + groupByCountry unit tests

### DIFF
--- a/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
@@ -117,7 +117,12 @@ export class ResourceFacetsDto {
   @ApiProperty({ example: { water: 5, food: 3 } })
   byCategory!: Record<string, number>;
 
-  @ApiProperty({ example: { VE: 3, CO: 2 } })
+  @ApiProperty({
+    example: { Venezuela: 3, Colombia: 2 },
+    description:
+      'Counts keyed by the stored `country` string. Values mirror the ingestion ' +
+      'source `pais` field (full Spanish names, NOT ISO 3166-1 alpha-2 codes).',
+  })
   byCountry!: Record<string, number>;
 
   @ApiProperty({ example: 8 })

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start -p 3001",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "node --test \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@reliefhub/api-client": "workspace:*",

--- a/apps/web/src/components/molecules/resource-filter-bar.tsx
+++ b/apps/web/src/components/molecules/resource-filter-bar.tsx
@@ -21,7 +21,12 @@ import { categoryLabel } from '@/lib/categories';
 interface ResourceFilterBarProps {
   /** Facet counts keyed by category slug, e.g. { water: 5, food: 3 } */
   byCategory: Record<string, number>;
-  /** Facet counts keyed by ISO 3166-1 alpha-2 country code, e.g. { VE: 3, CO: 2 } */
+  /**
+   * Facet counts keyed by the stored country string. The ingestion source
+   * stores full Spanish country names (e.g. { Venezuela: 3, Colombia: 2 }),
+   * which are shown verbatim in the country <select> and sent back as the
+   * `country` filter value — so grouping must match those same strings.
+   */
   byCountry: Record<string, number>;
   activeCategory: string;
   activeCountry: string;
@@ -102,9 +107,9 @@ export function ResourceFilterBar({
               className="rounded-lg border-2 border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 focus:border-gray-900 focus:outline-none"
             >
               <option value="">{t.all_countries}</option>
-              {countryOptions.map(([code, count]) => (
-                <option key={code} value={code}>
-                  {code} ({count})
+              {countryOptions.map(([country, count]) => (
+                <option key={country} value={country}>
+                  {country} ({count})
                 </option>
               ))}
             </select>

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -16,7 +16,7 @@
 
 import { useState, useTransition, useEffect, useMemo, useRef } from 'react';
 import { createResponseGridClient } from '@reliefhub/api-client';
-import type { components } from '@reliefhub/api-client';
+import { groupByCountry, type ResourceViewDto } from '@/lib/group-by-country';
 import { PublicResourceCard } from '@/components/organisms/public-resource-card';
 import { ResourceFilterBar } from '@/components/molecules/resource-filter-bar';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -31,43 +31,7 @@ if (!API_URL) {
   );
 }
 
-type ResourceViewDto = components['schemas']['ResourceViewDto'];
-
 const LIMIT = 50;
-
-/**
- * Returns true when a country value represents Venezuela.
- * The ingested data stores the source's `pais` field as a full Spanish name
- * (e.g. "Venezuela"), not an ISO code — so we match case-insensitively on
- * the full name and also accept the ISO 3166-1 alpha-2 fallback "VE".
- */
-function isVenezuela(country: string): boolean {
-  const c = country.trim().toLowerCase();
-  return c === 'venezuela' || c === 've';
-}
-
-/** Groups items into: Venezuela, Diaspora (non-Venezuela with country), Others (no country). */
-function groupByCountry(items: ResourceViewDto[]): {
-  venezuela: ResourceViewDto[];
-  diaspora: ResourceViewDto[];
-  other: ResourceViewDto[];
-} {
-  const venezuela: ResourceViewDto[] = [];
-  const diaspora: ResourceViewDto[] = [];
-  const other: ResourceViewDto[] = [];
-
-  for (const item of items) {
-    if (item.country != null && item.country !== '' && isVenezuela(item.country)) {
-      venezuela.push(item);
-    } else if (item.country != null && item.country !== '') {
-      diaspora.push(item);
-    } else {
-      other.push(item);
-    }
-  }
-
-  return { venezuela, diaspora, other };
-}
 
 interface ResourceListProps {
   emergencyId: string;
@@ -75,7 +39,7 @@ interface ResourceListProps {
   total: number;
   /** Facet counts keyed by category slug */
   facetsByCategory: Record<string, number>;
-  /** Facet counts keyed by country code */
+  /** Facet counts keyed by the stored country string (full Spanish name, e.g. "Venezuela") */
   facetsByCountry: Record<string, number>;
   t: Messages['resource_card'];
   tVerification: Messages['verification_badge'];

--- a/apps/web/src/lib/group-by-country.test.ts
+++ b/apps/web/src/lib/group-by-country.test.ts
@@ -1,0 +1,114 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  groupByCountry,
+  isVenezuela,
+  type ResourceViewDto,
+} from './group-by-country.ts';
+
+/**
+ * groupByCountry only inspects `country`, but we build a complete
+ * ResourceViewDto so the fixtures stay type-honest against the real DTO.
+ */
+function makeResource(id: string, country: string | null): ResourceViewDto {
+  return {
+    id,
+    type: 'collection_point',
+    stage: 'origin',
+    name: `Resource ${id}`,
+    description: null,
+    location: { address: '—', latitude: 0, longitude: 0 },
+    verificationLevel: 'unverified',
+    publicStatus: 'active',
+    ownerOrganizationId: null,
+    accepts: [],
+    contact: null,
+    schedule: null,
+    manager: null,
+    sourceName: null,
+    externalUpdatedAt: null,
+    country,
+    city: null,
+  };
+}
+
+test('groups a full-name "Venezuela" (the real ingested value) into venezuela', () => {
+  const ve = makeResource('1', 'Venezuela');
+  const { venezuela, diaspora, other } = groupByCountry([ve]);
+
+  assert.deepEqual(venezuela, [ve]);
+  assert.equal(diaspora.length, 0);
+  assert.equal(other.length, 0);
+});
+
+test('matches Venezuela case-insensitively, trimmed, and via the "VE" fallback', () => {
+  const items = [
+    makeResource('1', 'venezuela'),
+    makeResource('2', '  VENEZUELA  '),
+    makeResource('3', 'VE'),
+    makeResource('4', 've'),
+  ];
+
+  const { venezuela, diaspora, other } = groupByCountry(items);
+
+  assert.equal(venezuela.length, 4);
+  assert.equal(diaspora.length, 0);
+  assert.equal(other.length, 0);
+});
+
+test('buckets other full Spanish country names into diaspora', () => {
+  const es = makeResource('1', 'España');
+  const co = makeResource('2', 'Colombia');
+
+  const { venezuela, diaspora, other } = groupByCountry([es, co]);
+
+  assert.equal(venezuela.length, 0);
+  assert.deepEqual(diaspora, [es, co]);
+  assert.equal(other.length, 0);
+});
+
+test('buckets null and empty-string country into other', () => {
+  const items = [makeResource('1', null), makeResource('2', '')];
+
+  const { venezuela, diaspora, other } = groupByCountry(items);
+
+  assert.equal(venezuela.length, 0);
+  assert.equal(diaspora.length, 0);
+  assert.equal(other.length, 2);
+});
+
+test('partitions a mixed list while preserving per-group order', () => {
+  const items = [
+    makeResource('1', 'Venezuela'),
+    makeResource('2', 'España'),
+    makeResource('3', null),
+    makeResource('4', 've'),
+  ];
+
+  const { venezuela, diaspora, other } = groupByCountry(items);
+
+  assert.deepEqual(
+    venezuela.map((r) => r.id),
+    ['1', '4'],
+  );
+  assert.deepEqual(
+    diaspora.map((r) => r.id),
+    ['2'],
+  );
+  assert.deepEqual(
+    other.map((r) => r.id),
+    ['3'],
+  );
+});
+
+test('isVenezuela accepts the full name and ISO code, rejects everything else', () => {
+  assert.equal(isVenezuela('Venezuela'), true);
+  assert.equal(isVenezuela('venezuela'), true);
+  assert.equal(isVenezuela('  Venezuela  '), true);
+  assert.equal(isVenezuela('VE'), true);
+  assert.equal(isVenezuela('ve'), true);
+  assert.equal(isVenezuela('España'), false);
+  assert.equal(isVenezuela('Colombia'), false);
+  assert.equal(isVenezuela('Venezolano'), false);
+  assert.equal(isVenezuela(''), false);
+});

--- a/apps/web/src/lib/group-by-country.ts
+++ b/apps/web/src/lib/group-by-country.ts
@@ -1,0 +1,52 @@
+/**
+ * Geographic grouping for the public resource list.
+ *
+ * `ResourceViewDto.country` is populated by the acopiove ingest mapper from the
+ * source `pais` field, which holds a FULL SPANISH COUNTRY NAME (e.g.
+ * "Venezuela", "España") — NOT an ISO 3166-1 alpha-2 code. The facet
+ * `byCountry` keys and the country <select> in the filter bar therefore also
+ * use those full names (the dropdown shows whatever string is stored). To stay
+ * consistent with that stored value we match Venezuela case-insensitively on
+ * the full name, and also accept the bare ISO code "VE" as a defensive fallback
+ * for any record that happens to be stored that way.
+ */
+
+import type { components } from '@reliefhub/api-client';
+
+export type ResourceViewDto = components['schemas']['ResourceViewDto'];
+
+export interface GroupedResources {
+  venezuela: ResourceViewDto[];
+  diaspora: ResourceViewDto[];
+  other: ResourceViewDto[];
+}
+
+/**
+ * Returns true when a country value represents Venezuela.
+ * Matches the full Spanish name "Venezuela" (case-insensitive, whitespace
+ * trimmed) as stored by the ingestion source, plus the ISO 3166-1 alpha-2
+ * fallback "VE".
+ */
+export function isVenezuela(country: string): boolean {
+  const c = country.trim().toLowerCase();
+  return c === 'venezuela' || c === 've';
+}
+
+/** Groups items into: Venezuela, Diaspora (non-Venezuela with country), Other (no country). */
+export function groupByCountry(items: ResourceViewDto[]): GroupedResources {
+  const venezuela: ResourceViewDto[] = [];
+  const diaspora: ResourceViewDto[] = [];
+  const other: ResourceViewDto[] = [];
+
+  for (const item of items) {
+    if (item.country != null && item.country !== '' && isVenezuela(item.country)) {
+      venezuela.push(item);
+    } else if (item.country != null && item.country !== '') {
+      diaspora.push(item);
+    } else {
+      other.push(item);
+    }
+  }
+
+  return { venezuela, diaspora, other };
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

`resources.country` is populated by the acopiove ingest mapper (`apps/api/src/contexts/resources/application/acopiove-mapper.ts`) from the source `pais` field, which holds **full Spanish country names** ("Venezuela", "España") — **not** ISO 3166-1 alpha-2 codes. The public emergency resource list groups points geographically (Venezuela → Diaspora → Other), but the historical match against `'VE'` could never hit the ingested data, sending every Venezuelan point into "Diaspora". Several doc comments also still described the value as an ISO alpha-2 code.

## Approach

Option (a): normalize the **match** to the stored value, and make the surrounding docs honest — no data migration, kept consistent end-to-end against the facet `byCountry` keys.

I verified the whole chain uses the same stored full-name string:

- **Ingest** → `resources.country` stores `pais` verbatim (`"Venezuela"`).
- **Facets** → `byCountry[row.country]` keys by the raw column → `{ Venezuela: N, … }`.
- **Filter dropdown** → the country `<select>` shows those keys as both option value and label, sending `country=Venezuela`.
- **API filter** → `eq(resourcesTable.country, q.country)` matches the stored string.
- **Grouping** → `groupByCountry` now matches `"Venezuela"` (case/whitespace-insensitive) plus a defensive `"VE"` fallback.

## Changes

- **Extract** `isVenezuela` / `groupByCountry` from the `ResourceList` client component into a pure, testable module `apps/web/src/lib/group-by-country.ts`, and consume it from `resource-list.tsx`.
- **Add** `apps/web/src/lib/group-by-country.test.ts` (`node:test`, zero deps) — covers `country='Venezuela'` (the real ingested value), the `"VE"` fallback, case/whitespace handling, diaspora (`España`/`Colombia`), `null`/`""` → Other, and per-group ordering.
- **Wire** a `test` script (`node --test`, native TS type-stripping on Node 22) and exclude `**/*.test.ts` from the Next production typecheck (Node needs the explicit `.ts` import extension that `tsc`'s bundler resolution rejects).
- **Fix stale docs** so they describe the stored full-name string instead of "ISO 3166-1 alpha-2": the `byCountry` prop comments in `resource-list.tsx` and `resource-filter-bar.tsx` (incl. a `code` → `country` rename), and the `ResourceFacetsDto.byCountry` OpenAPI example/description in `response.dto.ts`.

## Verification

- `pnpm --filter @reliefhub/api-client build && pnpm --filter web build` — both pass.
- `pnpm --filter web test` (`node --test`) — 6/6 green.
- `pnpm --filter web lint` — clean.
- API production code type-checks clean under `tsconfig.build.json` (the `response.dto.ts` edit included). The pre-existing `*.spec.ts` type errors under the dev tsconfig are unrelated to this change.

> Note: this branch also carries the broader ResponseGrid feature work it was branched from; the change described above is this session's contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5Qv8ihyhGhaq69Y7dfG8w)_