### PR TITLE
feat(resources): geo-proximity nearby endpoint (#28)

### DIFF
--- a/apps/api/src/contexts/resources/application/get-nearby-resources.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-nearby-resources.spec.ts
@@ -1,0 +1,159 @@
+import { InMemoryResourceRepository } from '../infrastructure/in-memory-resource.repository';
+import { GetNearbyResources } from './get-nearby-resources';
+import { Resource } from '../domain/resource';
+import { ResourceId } from '../domain/resource-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  ResourceType,
+  ResourceStage,
+  VerificationLevel,
+  PublicStatus,
+} from '../domain/resource-enums';
+import { Location } from '../../../shared/domain/location';
+
+const EM = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const OWNER_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+// Caracas origin point
+const ORIGIN_LAT = 10.4806;
+const ORIGIN_LNG = -66.9036;
+
+const makeVisible = (
+  name: string,
+  lat: number,
+  lng: number,
+  status: PublicStatus = PublicStatus.Active,
+) =>
+  Resource.fromSnapshot({
+    ...Resource.register({
+      id: ResourceId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      type: ResourceType.CollectionPoint,
+      stage: ResourceStage.Origin,
+      name,
+      location: Location.create({
+        address: `${name} address`,
+        latitude: lat,
+        longitude: lng,
+      }),
+      ownerUserId: OWNER_ID,
+    }).toSnapshot(),
+    verificationLevel: VerificationLevel.Verified,
+    publicStatus: status,
+    createdAt: new Date(),
+  });
+
+describe('GetNearbyResources', () => {
+  it('returns items with distanceMeters for visible resources within radius', async () => {
+    const repo = new InMemoryResourceRepository();
+    const useCase = new GetNearbyResources(repo);
+
+    // At origin (~0m)
+    await repo.save(makeVisible('Near', ORIGIN_LAT, ORIGIN_LNG));
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 5000,
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(typeof result.items[0].distanceMeters).toBe('number');
+    expect(result.items[0].distanceMeters).toBeGreaterThanOrEqual(0);
+    expect(result.items[0].name).toBe('Near');
+  });
+
+  it('returns empty array when no resources are within radius', async () => {
+    const repo = new InMemoryResourceRepository();
+    const useCase = new GetNearbyResources(repo);
+
+    // ~35km away from origin
+    await repo.save(makeVisible('Far', 10.8, -66.9));
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 5000,
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(0);
+  });
+
+  it('returns items ordered by distance ascending', async () => {
+    const repo = new InMemoryResourceRepository();
+    const useCase = new GetNearbyResources(repo);
+
+    // ~1.3km away
+    await repo.save(makeVisible('Medium', 10.49, -66.903));
+    // ~0m away
+    await repo.save(makeVisible('Near', ORIGIN_LAT, ORIGIN_LNG));
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 10000,
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].name).toBe('Near');
+    expect(result.items[1].name).toBe('Medium');
+    expect(result.items[0].distanceMeters).toBeLessThanOrEqual(
+      result.items[1].distanceMeters,
+    );
+  });
+
+  it('excludes hidden resources', async () => {
+    const repo = new InMemoryResourceRepository();
+    const useCase = new GetNearbyResources(repo);
+
+    await repo.save(makeVisible('Visible', ORIGIN_LAT, ORIGIN_LNG));
+    await repo.save(
+      makeVisible('Hidden', ORIGIN_LAT, ORIGIN_LNG, PublicStatus.Hidden),
+    );
+    await repo.save(
+      makeVisible('Closed', ORIGIN_LAT, ORIGIN_LNG, PublicStatus.Closed),
+    );
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 5000,
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].name).toBe('Visible');
+  });
+
+  it('includes Saturated and Paused visible resources', async () => {
+    const repo = new InMemoryResourceRepository();
+    const useCase = new GetNearbyResources(repo);
+
+    await repo.save(
+      makeVisible('Active', ORIGIN_LAT, ORIGIN_LNG, PublicStatus.Active),
+    );
+    await repo.save(
+      makeVisible('Saturated', ORIGIN_LAT, ORIGIN_LNG, PublicStatus.Saturated),
+    );
+    await repo.save(
+      makeVisible('Paused', ORIGIN_LAT, ORIGIN_LNG, PublicStatus.Paused),
+    );
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 5000,
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(3);
+  });
+});

--- a/apps/api/src/contexts/resources/application/get-nearby-resources.ts
+++ b/apps/api/src/contexts/resources/application/get-nearby-resources.ts
@@ -1,0 +1,30 @@
+import { ResourceRepository } from '../domain/ports/resource.repository';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ResourceView, toResourceView } from './resource-view';
+
+export interface NearbyResourceView extends ResourceView {
+  distanceMeters: number;
+}
+
+export class GetNearbyResources {
+  constructor(private readonly repo: ResourceRepository) {}
+
+  async execute(q: {
+    emergencyId: string;
+    lat: number;
+    lng: number;
+    radiusMeters: number;
+    limit: number;
+  }): Promise<{ items: NearbyResourceView[] }> {
+    const results = await this.repo.findNearbyVisible(
+      EmergencyId.fromString(q.emergencyId),
+      { lat: q.lat, lng: q.lng, radiusMeters: q.radiusMeters, limit: q.limit },
+    );
+    return {
+      items: results.map((r) => ({
+        ...toResourceView(r.resource),
+        distanceMeters: r.distanceMeters,
+      })),
+    };
+  }
+}

--- a/apps/api/src/contexts/resources/domain/ports/resource.repository.ts
+++ b/apps/api/src/contexts/resources/domain/ports/resource.repository.ts
@@ -37,4 +37,9 @@ export interface ResourceRepository {
     byCountry: Record<string, number>;
     total: number;
   }>;
+  /** Visible resources near a point, ordered by distance ascending. */
+  findNearbyVisible(
+    emergencyId: EmergencyId,
+    q: { lat: number; lng: number; radiusMeters: number; limit: number },
+  ): Promise<Array<{ resource: Resource; distanceMeters: number }>>;
 }

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { createDb, Db } from '../../../../shared/db';
 import { resourcesTable } from './schema';
 import { DrizzleResourceRepository } from './drizzle-resource.repository';
@@ -633,6 +633,151 @@ describe('DrizzleResourceRepository (integration)', () => {
       expect(byCategory['water']).not.toBe(3); // R3 excluded
       expect(byCountry['VE']).toBe(1); // R1
       expect(byCountry['CO']).toBe(1); // R2
+    });
+  });
+
+  // ─── Issue #28: findNearbyVisible ──────────────────────────────────────────
+
+  describe('findNearbyVisible', () => {
+    // Query point: Caracas, Venezuela
+    const GEO_EM = '28280000-0000-4000-8000-000000000028';
+    const GEO_LAT = 10.4806;
+    const GEO_LNG = -66.9036;
+
+    const makeGeoResource = (
+      name: string,
+      lat: number,
+      lng: number,
+      status: PublicStatus,
+    ) => {
+      const base = Resource.register({
+        id: ResourceId.create(),
+        emergencyId: EmergencyId.fromString(GEO_EM),
+        type: ResourceType.CollectionPoint,
+        stage: ResourceStage.Origin,
+        name,
+        location: Location.create({
+          address: `${name} addr`,
+          latitude: lat,
+          longitude: lng,
+        }),
+        ownerUserId: OWNER_ID,
+      });
+      return Resource.fromSnapshot({
+        ...base.toSnapshot(),
+        verificationLevel: VerificationLevel.Verified,
+        publicStatus: status,
+        createdAt: new Date(),
+      });
+    };
+
+    beforeEach(async () => {
+      // Clean only the geo emergency to avoid interfering with other tests
+      await db
+        .delete(resourcesTable)
+        .where(eq(resourcesTable.emergencyId, GEO_EM));
+    });
+
+    it('returns resources within radius ordered by distance, excludes far and hidden', async () => {
+      // R1: at origin ~0m — ACTIVE
+      const r1 = makeGeoResource(
+        'R1 origin',
+        GEO_LAT,
+        GEO_LNG,
+        PublicStatus.Active,
+      );
+      // R2: ~1.3km away — ACTIVE
+      const r2 = makeGeoResource(
+        'R2 nearby',
+        10.49,
+        -66.903,
+        PublicStatus.Active,
+      );
+      // R3: ~8km away — SATURATED (still visible, within 10km radius)
+      const r3 = makeGeoResource(
+        'R3 saturated',
+        10.553,
+        -66.9036,
+        PublicStatus.Saturated,
+      );
+      // R_far: ~35km away — ACTIVE (beyond 10km radius)
+      const rFar = makeGeoResource('R_far', 10.8, -66.9, PublicStatus.Active);
+      // R_hidden: same coords as R1 — HIDDEN (excluded by status)
+      const rHidden = makeGeoResource(
+        'R_hidden',
+        GEO_LAT,
+        GEO_LNG,
+        PublicStatus.Hidden,
+      );
+
+      await repo.save(r1);
+      await repo.save(r2);
+      await repo.save(r3);
+      await repo.save(rFar);
+      await repo.save(rHidden);
+
+      const results = await repo.findNearbyVisible(
+        EmergencyId.fromString(GEO_EM),
+        { lat: GEO_LAT, lng: GEO_LNG, radiusMeters: 10000, limit: 10 },
+      );
+
+      const names = results.map((r) => r.resource.name);
+      expect(names).toContain('R1 origin');
+      expect(names).toContain('R2 nearby');
+      expect(names).toContain('R3 saturated');
+      expect(names).not.toContain('R_far');
+      expect(names).not.toContain('R_hidden');
+      expect(results).toHaveLength(3);
+
+      // Ordered by distance ascending
+      expect(results[0].resource.name).toBe('R1 origin');
+      expect(results[1].distanceMeters).toBeGreaterThan(
+        results[0].distanceMeters,
+      );
+      expect(results[2].distanceMeters).toBeGreaterThan(
+        results[1].distanceMeters,
+      );
+
+      // Distance checks
+      expect(results[0].distanceMeters).toBeLessThan(10);
+      expect(results[1].distanceMeters).toBeGreaterThan(0);
+      expect(results[2].distanceMeters).toBeGreaterThan(
+        results[1].distanceMeters,
+      );
+      for (const r of results) {
+        expect(r.distanceMeters).toBeLessThanOrEqual(10000);
+      }
+    });
+
+    it('with radiusMeters=2000 returns only resources within 2km', async () => {
+      const r1 = makeGeoResource(
+        'R1 origin',
+        GEO_LAT,
+        GEO_LNG,
+        PublicStatus.Active,
+      );
+      const r2 = makeGeoResource(
+        'R2 nearby',
+        10.49,
+        -66.903,
+        PublicStatus.Active,
+      );
+      const r3 = makeGeoResource('R3 far', 10.6, -66.9, PublicStatus.Saturated);
+
+      await repo.save(r1);
+      await repo.save(r2);
+      await repo.save(r3);
+
+      const results = await repo.findNearbyVisible(
+        EmergencyId.fromString(GEO_EM),
+        { lat: GEO_LAT, lng: GEO_LNG, radiusMeters: 2000, limit: 10 },
+      );
+
+      const names = results.map((r) => r.resource.name);
+      expect(names).toContain('R1 origin');
+      expect(names).toContain('R2 nearby');
+      expect(names).not.toContain('R3 far');
+      expect(results).toHaveLength(2);
     });
   });
 

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
@@ -14,6 +14,70 @@ import {
 
 type Row = typeof resourcesTable.$inferSelect;
 
+/** Raw snake_case row returned by db.execute() (no Drizzle camelCase mapping). */
+type RawRow = {
+  id: string;
+  emergency_id: string;
+  type: string;
+  stage: string;
+  name: string;
+  description: string | null;
+  address: string;
+  latitude: number;
+  longitude: number;
+  owner_user_id: string;
+  owner_organization_id: string | null;
+  verification_level: string;
+  public_status: string;
+  created_at: Date;
+  contact: string | null;
+  schedule: string | null;
+  manager: string | null;
+  accepts: string[] | null;
+  source_name: string | null;
+  external_id: string | null;
+  external_updated_at: Date | null;
+  country: string | null;
+  city: string | null;
+  raw: unknown;
+};
+
+function rawRowToSnapshot(row: RawRow): ResourceSnapshot {
+  const provenance: Provenance | null = row.source_name
+    ? {
+        sourceName: row.source_name,
+        externalId: row.external_id as string,
+        externalUpdatedAt: row.external_updated_at ?? null,
+        raw: row.raw ?? null,
+      }
+    : null;
+  return {
+    id: row.id,
+    emergencyId: row.emergency_id,
+    type: row.type as ResourceType,
+    stage: row.stage as ResourceStage,
+    name: row.name,
+    description: row.description ?? null,
+    location: {
+      address: row.address,
+      latitude: row.latitude,
+      longitude: row.longitude,
+    },
+    ownerUserId: row.owner_user_id,
+    ownerOrganizationId: row.owner_organization_id ?? null,
+    verificationLevel: row.verification_level as VerificationLevel,
+    publicStatus: row.public_status as PublicStatus,
+    createdAt: row.created_at,
+    contact: row.contact ?? null,
+    schedule: row.schedule ?? null,
+    manager: row.manager ?? null,
+    accepts: row.accepts ?? [],
+    country: row.country ?? null,
+    city: row.city ?? null,
+    provenance,
+  };
+}
+
 function rowToProvenance(row: Row): Provenance | null {
   if (!row.sourceName) return null;
   // DB constraint ensures external_id is non-null whenever source_name is set.
@@ -288,6 +352,39 @@ export class DrizzleResourceRepository implements ResourceRepository {
       byCountry,
       total: Number(totalRows[0]?.cnt ?? 0),
     };
+  }
+
+  async findNearbyVisible(
+    emergencyId: EmergencyId,
+    q: { lat: number; lng: number; radiusMeters: number; limit: number },
+  ): Promise<Array<{ resource: Resource; distanceMeters: number }>> {
+    const VISIBLE = [
+      PublicStatus.Active,
+      PublicStatus.Saturated,
+      PublicStatus.Paused,
+    ];
+    const visibleArr = sql.join(
+      VISIBLE.map((v) => sql`${v}`),
+      sql`, `,
+    );
+
+    type NearbyRow = RawRow & { dist: number };
+
+    const result = await this.db.execute<NearbyRow>(sql`
+      SELECT *, earth_distance(ll_to_earth(${q.lat}, ${q.lng}), ll_to_earth(latitude, longitude)) AS dist
+      FROM resources
+      WHERE emergency_id = ${emergencyId.value}
+        AND public_status = ANY(ARRAY[${visibleArr}])
+        AND earth_box(ll_to_earth(${q.lat}, ${q.lng}), ${q.radiusMeters}) @> ll_to_earth(latitude, longitude)
+        AND earth_distance(ll_to_earth(${q.lat}, ${q.lng}), ll_to_earth(latitude, longitude)) <= ${q.radiusMeters}
+      ORDER BY dist ASC
+      LIMIT ${q.limit}
+    `);
+
+    return result.rows.map((row) => ({
+      resource: Resource.fromSnapshot(rawRowToSnapshot(row)),
+      distanceMeters: Math.round(Number(row.dist)),
+    }));
   }
 
   async countByEmergencyGroupedByPublicStatus(

--- a/apps/api/src/contexts/resources/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/dto.ts
@@ -142,6 +142,46 @@ export class UpdateResourcePublicStatusDto {
   status!: 'active' | 'saturated' | 'paused' | 'closed';
 }
 
+export class NearbyResourcesQueryDto {
+  @ApiProperty({ example: 10.4806, description: 'Latitude between -90 and 90' })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat!: number;
+
+  @ApiProperty({
+    example: -66.9036,
+    description: 'Longitude between -180 and 180',
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lng!: number;
+
+  @ApiProperty({
+    example: 5000,
+    description: 'Search radius in meters (max 100000)',
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100000)
+  radius!: number;
+
+  @ApiPropertyOptional({
+    example: 50,
+    description: 'Max results (default 50, max 100)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
 export class PublicResourcesQueryDto {
   @ApiPropertyOptional({
     description: 'Page number (1-based)',

--- a/apps/api/src/contexts/resources/infrastructure/http/public.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/public.controller.ts
@@ -7,8 +7,13 @@ import {
 } from '@nestjs/swagger';
 import { GetPublicResources } from '../../application/get-public-resources';
 import { GetResourceFacets } from '../../application/get-resource-facets';
-import { PagedResourcesDto, ResourceFacetsDto } from './response.dto';
-import { PublicResourcesQueryDto } from './dto';
+import { GetNearbyResources } from '../../application/get-nearby-resources';
+import {
+  PagedResourcesDto,
+  ResourceFacetsDto,
+  NearbyResourcesResponseDto,
+} from './response.dto';
+import { PublicResourcesQueryDto, NearbyResourcesQueryDto } from './dto';
 
 @ApiTags('public')
 @Controller()
@@ -16,6 +21,7 @@ export class PublicController {
   constructor(
     private readonly getPublicResources: GetPublicResources,
     private readonly getResourceFacets: GetResourceFacets,
+    private readonly getNearbyResources: GetNearbyResources,
   ) {}
 
   @Get('emergencies/:emergencyId/public/resources')
@@ -42,6 +48,32 @@ export class PublicController {
       limit: query.limit ?? 50,
       ...(query.category !== undefined && { category: query.category }),
       ...(query.country !== undefined && { country: query.country }),
+    });
+  }
+
+  @Get('emergencies/:emergencyId/public/resources/nearby')
+  @ApiOperation({
+    summary: 'Find visible resources near a GPS point, ordered by distance',
+  })
+  @ApiParam({
+    name: 'emergencyId',
+    description: 'Emergency UUID',
+    format: 'uuid',
+  })
+  @ApiOkResponse({
+    description: 'Resources within radius ordered by distance',
+    type: NearbyResourcesResponseDto,
+  })
+  async nearby(
+    @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
+    @Query() query: NearbyResourcesQueryDto,
+  ): Promise<NearbyResourcesResponseDto> {
+    return this.getNearbyResources.execute({
+      emergencyId,
+      lat: query.lat,
+      lng: query.lng,
+      radiusMeters: query.radius,
+      limit: query.limit ?? 50,
     });
   }
 

--- a/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
@@ -99,6 +99,19 @@ export class ResourceViewDto {
   city!: string | null;
 }
 
+export class NearbyResourceViewDto extends ResourceViewDto {
+  @ApiProperty({
+    example: 1234,
+    description: 'Distance from query point in meters (rounded)',
+  })
+  distanceMeters!: number;
+}
+
+export class NearbyResourcesResponseDto {
+  @ApiProperty({ type: [NearbyResourceViewDto] })
+  items!: NearbyResourceViewDto[];
+}
+
 export class PagedResourcesDto {
   @ApiProperty({ type: [ResourceViewDto] })
   items!: ResourceViewDto[];

--- a/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
@@ -4,6 +4,23 @@ import { ResourceId } from '../domain/resource-id';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
 import { VerificationLevel, PublicStatus } from '../domain/resource-enums';
 
+function haversineMeters(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number {
+  const R = 6371000;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
 export class InMemoryResourceRepository implements ResourceRepository {
   private store = new Map<string, ReturnType<Resource['toSnapshot']>>();
 
@@ -124,6 +141,41 @@ export class InMemoryResourceRepository implements ResourceRepository {
       .slice(offset, offset + q.limit)
       .map((s) => Resource.fromSnapshot(s));
     return Promise.resolve({ items, total });
+  }
+
+  findNearbyVisible(
+    emergencyId: EmergencyId,
+    q: { lat: number; lng: number; radiusMeters: number; limit: number },
+  ): Promise<Array<{ resource: Resource; distanceMeters: number }>> {
+    const visible = new Set<PublicStatus>([
+      PublicStatus.Active,
+      PublicStatus.Saturated,
+      PublicStatus.Paused,
+    ]);
+    const withDist = [...this.store.values()]
+      .filter(
+        (s) =>
+          s.emergencyId === emergencyId.value && visible.has(s.publicStatus),
+      )
+      .map((s) => {
+        const dist = haversineMeters(
+          q.lat,
+          q.lng,
+          s.location.latitude,
+          s.location.longitude,
+        );
+        return { snap: s, dist };
+      })
+      .filter(({ dist }) => dist <= q.radiusMeters)
+      .sort((a, b) => a.dist - b.dist)
+      .slice(0, q.limit);
+
+    return Promise.resolve(
+      withDist.map(({ snap, dist }) => ({
+        resource: Resource.fromSnapshot(snap),
+        distanceMeters: Math.round(dist),
+      })),
+    );
   }
 
   facets(emergencyId: EmergencyId): Promise<{

--- a/apps/api/src/contexts/resources/infrastructure/resources.module.ts
+++ b/apps/api/src/contexts/resources/infrastructure/resources.module.ts
@@ -10,6 +10,7 @@ import { RegisterResource } from '../application/register-resource';
 import { GetCoordinationQueue } from '../application/get-coordination-queue';
 import { GetPublicResources } from '../application/get-public-resources';
 import { GetResourceFacets } from '../application/get-resource-facets';
+import { GetNearbyResources } from '../application/get-nearby-resources';
 import { GetMyResources } from '../application/get-my-resources';
 import { VerifyResource } from '../application/verify-resource';
 import { PublishResource } from '../application/publish-resource';
@@ -151,6 +152,12 @@ const updateStatusProvider = {
   ) => new UpdateResourcePublicStatus(repo, membershipReader),
 };
 
+const getNearbyResourcesProvider = {
+  provide: GetNearbyResources,
+  inject: [RESOURCE_REPOSITORY],
+  useFactory: (repo: ResourceRepository) => new GetNearbyResources(repo),
+};
+
 const getMyResourcesProvider = {
   provide: GetMyResources,
   inject: [RESOURCE_REPOSITORY],
@@ -173,6 +180,7 @@ const getMyResourcesProvider = {
     publishProvider,
     publicResourcesProvider,
     getResourceFacetsProvider,
+    getNearbyResourcesProvider,
     updateStatusProvider,
     getMyResourcesProvider,
   ],

--- a/apps/api/test/nearby-resources.e2e-spec.ts
+++ b/apps/api/test/nearby-resources.e2e-spec.ts
@@ -1,0 +1,212 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import type { Server } from 'node:http';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+import { AppModule } from '../src/app.module';
+import { DomainExceptionFilter } from '../src/contexts/resources/infrastructure/http/domain-exception.filter';
+import { createDb } from '../src/shared/db';
+import { resourcesTable } from '../src/contexts/resources/infrastructure/drizzle/schema';
+import { emergenciesTable } from '../src/contexts/emergencies/infrastructure/drizzle/schema';
+import { DrizzleResourceRepository } from '../src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository';
+import { Resource } from '../src/contexts/resources/domain/resource';
+import { ResourceId } from '../src/contexts/resources/domain/resource-id';
+import { EmergencyId } from '../src/shared/domain/emergency-id';
+import {
+  ResourceType,
+  ResourceStage,
+  VerificationLevel,
+  PublicStatus,
+} from '../src/contexts/resources/domain/resource-enums';
+import { Location } from '../src/shared/domain/location';
+
+// ── Response shape types ──────────────────────────────────────────────────────
+
+interface NearbyResourceViewBody {
+  id: string;
+  name: string;
+  type: string;
+  stage: string;
+  verificationLevel: string;
+  publicStatus: string;
+  location: { address: string; latitude: number; longitude: number };
+  accepts: string[];
+  contact: string | null;
+  schedule: string | null;
+  manager: string | null;
+  country: string | null;
+  city: string | null;
+  sourceName: string | null;
+  externalUpdatedAt: string | null;
+  ownerOrganizationId: string | null;
+  distanceMeters: number;
+}
+
+interface NearbyResourcesBody {
+  items: NearbyResourceViewBody[];
+}
+
+// IDs that don't conflict with other e2e specs
+const EM = 'bbbbbbbb-1111-4111-8111-000000000028';
+const OWNER_ID = 'f2000000-0000-4000-8000-000000000028';
+
+const DB_URL =
+  process.env.DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub';
+
+// Caracas origin point
+const ORIGIN_LAT = 10.4806;
+const ORIGIN_LNG = -66.9036;
+
+const makeVisible = (name: string, lat: number, lng: number) =>
+  Resource.fromSnapshot({
+    ...Resource.register({
+      id: ResourceId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      type: ResourceType.CollectionPoint,
+      stage: ResourceStage.Origin,
+      name,
+      location: Location.create({
+        address: `${name} address`,
+        latitude: lat,
+        longitude: lng,
+      }),
+      ownerUserId: OWNER_ID,
+    }).toSnapshot(),
+    verificationLevel: VerificationLevel.Verified,
+    publicStatus: PublicStatus.Active,
+    createdAt: new Date(),
+  });
+
+describe('Nearby resources (e2e)', () => {
+  let app: INestApplication;
+  let server: Server;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new DomainExceptionFilter());
+    await app.init();
+    server = app.getHttpServer() as Server;
+
+    // Ensure the emergency exists
+    const { db, pool } = createDb(DB_URL);
+    try {
+      await db
+        .insert(emergenciesTable)
+        .values({
+          id: EM,
+          name: 'Nearby Resources Emergency',
+          slug: 'nearby-resources-emergency',
+          country: 'VE',
+          status: 'active',
+          createdAt: new Date(),
+        })
+        .onConflictDoNothing();
+    } finally {
+      await pool.end();
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // Helper: clean the emergency's resources then seed
+  async function withCleanRepo(
+    fn: (repo: DrizzleResourceRepository) => Promise<void>,
+  ) {
+    const { db, pool } = createDb(DB_URL);
+    try {
+      await db.delete(resourcesTable).where(eq(resourcesTable.emergencyId, EM));
+      const repo = new DrizzleResourceRepository(db);
+      await fn(repo);
+    } finally {
+      await pool.end();
+    }
+  }
+
+  it('GET .../nearby returns 200 with items array, all with distanceMeters, ordered ascending', async () => {
+    await withCleanRepo(async (repo) => {
+      // At origin (~0m)
+      await repo.save(makeVisible('R1 origin', ORIGIN_LAT, ORIGIN_LNG));
+      // ~1.3km away
+      await repo.save(makeVisible('R2 nearby', 10.49, -66.903));
+      // ~13km away
+      await repo.save(makeVisible('R3 far', 10.6, -66.9));
+    });
+
+    const res = await request(server)
+      .get(
+        `/emergencies/${EM}/public/resources/nearby?lat=${ORIGIN_LAT}&lng=${ORIGIN_LNG}&radius=20000`,
+      )
+      .expect(200);
+
+    const body = res.body as NearbyResourcesBody;
+    expect(body).toHaveProperty('items');
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.items.length).toBeGreaterThan(0);
+
+    // All items must have distanceMeters as a number
+    for (const item of body.items) {
+      expect(typeof item.distanceMeters).toBe('number');
+      expect(item.distanceMeters).toBeGreaterThanOrEqual(0);
+    }
+
+    // Items must be ordered ascending by distance
+    for (let i = 1; i < body.items.length; i++) {
+      expect(body.items[i].distanceMeters).toBeGreaterThanOrEqual(
+        body.items[i - 1].distanceMeters,
+      );
+    }
+  });
+
+  it('invalid lat (> 90) returns 400', async () => {
+    await request(server)
+      .get(
+        `/emergencies/${EM}/public/resources/nearby?lat=91&lng=${ORIGIN_LNG}&radius=5000`,
+      )
+      .expect(400);
+  });
+
+  it('invalid lng (< -180) returns 400', async () => {
+    await request(server)
+      .get(
+        `/emergencies/${EM}/public/resources/nearby?lat=${ORIGIN_LAT}&lng=-181&radius=5000`,
+      )
+      .expect(400);
+  });
+
+  it('radius > 100000 returns 400', async () => {
+    await request(server)
+      .get(
+        `/emergencies/${EM}/public/resources/nearby?lat=${ORIGIN_LAT}&lng=${ORIGIN_LNG}&radius=100001`,
+      )
+      .expect(400);
+  });
+
+  it('missing required param (no lat) returns 400', async () => {
+    await request(server)
+      .get(
+        `/emergencies/${EM}/public/resources/nearby?lng=${ORIGIN_LNG}&radius=5000`,
+      )
+      .expect(400);
+  });
+
+  it('limit=200 returns 400', async () => {
+    await request(server)
+      .get(
+        `/emergencies/${EM}/public/resources/nearby?lat=${ORIGIN_LAT}&lng=${ORIGIN_LNG}&radius=5000&limit=200`,
+      )
+      .expect(400);
+  });
+});

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -225,6 +225,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/emergencies/{emergencyId}/public/resources/nearby": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Find visible resources near a GPS point, ordered by distance */
+        get: operations["PublicController_nearby"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/emergencies/{emergencyId}/public/resources/facets": {
         parameters: {
             query?: never;
@@ -1440,7 +1457,10 @@ export interface components {
              * @example 2026-06-27T00:00:00.000Z
              */
             externalUpdatedAt: string | null;
-            /** @example VE */
+            /**
+             * @description Country string as stored by the ingestion source (e.g. full Spanish name "Venezuela"). NOT guaranteed to be an ISO 3166-1 alpha-2 code — value depends on the source `pais` field.
+             * @example Venezuela
+             */
             country: string | null;
             /** @example Caracas */
             city: string | null;
@@ -1454,6 +1474,75 @@ export interface components {
             /** @example 50 */
             limit: number;
         };
+        NearbyResourceViewDto: {
+            /**
+             * Format: uuid
+             * @example 3fa85f64-5717-4562-b3fc-2c963f66afa6
+             */
+            id: string;
+            /**
+             * @example collection_point
+             * @enum {string}
+             */
+            type: "collection_point" | "delivery_point" | "collection_and_delivery" | "warehouse" | "transport" | "supplier" | "venue";
+            /**
+             * @example origin
+             * @enum {string}
+             */
+            stage: "origin" | "intermediate" | "destination";
+            /** @example Cruz Roja Madrid */
+            name: string;
+            /** @example Centro de acopio principal */
+            description: string | null;
+            location: components["schemas"]["LocationViewDto"];
+            /**
+             * @example verified
+             * @enum {string}
+             */
+            verificationLevel: "unverified" | "verified" | "official";
+            /**
+             * @example active
+             * @enum {string}
+             */
+            publicStatus: "hidden" | "active" | "saturated" | "paused" | "closed";
+            /** Format: uuid */
+            ownerOrganizationId: string | null;
+            /**
+             * @example [
+             *       "water",
+             *       "food"
+             *     ]
+             */
+            accepts: string[];
+            /** @example +58 212 555 0000 */
+            contact: string | null;
+            /** @example Lun-Vie 08-18 */
+            schedule: string | null;
+            /** @example Juan Pérez */
+            manager: string | null;
+            /** @example acopiove.org */
+            sourceName: string | null;
+            /**
+             * @description ISO 8601 date string
+             * @example 2026-06-27T00:00:00.000Z
+             */
+            externalUpdatedAt: string | null;
+            /**
+             * @description Country string as stored by the ingestion source (e.g. full Spanish name "Venezuela"). NOT guaranteed to be an ISO 3166-1 alpha-2 code — value depends on the source `pais` field.
+             * @example Venezuela
+             */
+            country: string | null;
+            /** @example Caracas */
+            city: string | null;
+            /**
+             * @description Distance from query point in meters (rounded)
+             * @example 1234
+             */
+            distanceMeters: number;
+        };
+        NearbyResourcesResponseDto: {
+            items: components["schemas"]["NearbyResourceViewDto"][];
+        };
         ResourceFacetsDto: {
             /**
              * @example {
@@ -1463,9 +1552,10 @@ export interface components {
              */
             byCategory: Record<string, never>;
             /**
+             * @description Counts keyed by the stored `country` string. Values mirror the ingestion source `pais` field (full Spanish names, NOT ISO 3166-1 alpha-2 codes).
              * @example {
-             *       "VE": 3,
-             *       "CO": 2
+             *       "Venezuela": 3,
+             *       "Colombia": 2
              *     }
              */
             byCountry: Record<string, never>;
@@ -2856,6 +2946,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PagedResourcesDto"];
+                };
+            };
+        };
+    };
+    PublicController_nearby: {
+        parameters: {
+            query: {
+                /** @description Latitude between -90 and 90 */
+                lat: number;
+                /** @description Longitude between -180 and 180 */
+                lng: number;
+                /** @description Search radius in meters (max 100000) */
+                radius: number;
+                /** @description Max results (default 50, max 100) */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Emergency UUID */
+                emergencyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Resources within radius ordered by distance */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NearbyResourcesResponseDto"];
                 };
             };
         };


### PR DESCRIPTION
Closes #28.

Endpoint público `GET /emergencies/:id/public/resources/nearby?lat=&lng=&radius=&limit=` → recursos visibles dentro de radio R ordenados por distancia (con `distanceMeters`).

- **earthdistance** (contrib, sin PostGIS): `earth_box` pre-filtra vía el índice gist `resources_earth_gist` (migración 0019) + `earth_distance` para distancia exacta y orden.
- Validación lat/lng/radius(≤100km)/limit(≤100); solo visibles (active/saturated/paused).
- TDD: 5 unit + 2 int + 6 e2e. Gate local verde (api build/lint/prettier/test) + gen:api commiteado.

Necesidades/ofertas geo = follow-up.