### PR TITLE
fix(resources): nearby endpoint 500 — coerce raw-SQL date columns to Date

### DIFF
--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
@@ -749,6 +749,66 @@ describe('DrizzleResourceRepository (integration)', () => {
       }
     });
 
+    it('regression: findNearbyVisible maps externalUpdatedAt string to Date (fixes 500)', async () => {
+      // This test reproduces the prod 500: db.execute() returns timestamptz columns
+      // as strings; rawRowToSnapshot must coerce them to Date so toISOString() works.
+      const externalUpdatedAt = new Date('2026-06-15T12:00:00.000Z');
+      const r = Resource.fromSnapshot({
+        ...Resource.register({
+          id: ResourceId.create(),
+          emergencyId: EmergencyId.fromString(GEO_EM),
+          type: ResourceType.CollectionPoint,
+          stage: ResourceStage.Origin,
+          name: 'Provenance Nearby',
+          location: Location.create({
+            address: 'Near addr',
+            latitude: GEO_LAT,
+            longitude: GEO_LNG,
+          }),
+          ownerUserId: OWNER_ID,
+          accepts: ['water'],
+          provenance: {
+            sourceName: 'test-source',
+            externalId: 'ext-nearby-1',
+            externalUpdatedAt,
+            raw: { x: 1 },
+          },
+        }).toSnapshot(),
+        verificationLevel: VerificationLevel.Verified,
+        publicStatus: PublicStatus.Active,
+        createdAt: new Date(),
+      });
+      await repo.save(r);
+
+      const results = await repo.findNearbyVisible(
+        EmergencyId.fromString(GEO_EM),
+        { lat: GEO_LAT, lng: GEO_LNG, radiusMeters: 500, limit: 10 },
+      );
+
+      expect(results).toHaveLength(1);
+      const found = results[0].resource;
+
+      // provenance.externalUpdatedAt must be a Date, not a string
+      expect(found.provenance?.externalUpdatedAt).toBeInstanceOf(Date);
+      // And it must serialise cleanly — this is what toResourceView() calls;
+      // if the value is still a string this throws: "not a function"
+      expect(() =>
+        found.provenance?.externalUpdatedAt?.toISOString(),
+      ).not.toThrow();
+      expect(found.provenance?.externalUpdatedAt?.toISOString()).toBe(
+        '2026-06-15T12:00:00.000Z',
+      );
+
+      // createdAt must also be a Date
+      expect(found.createdAt).toBeInstanceOf(Date);
+
+      // accepts must be a proper array (not a raw PG literal like {water})
+      expect(found.accepts).toEqual(['water']);
+
+      // distanceMeters must be a finite number
+      expect(results[0].distanceMeters).toBeLessThan(10);
+    });
+
     it('with radiusMeters=2000 returns only resources within 2km', async () => {
       const r1 = makeGeoResource(
         'R1 origin',

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
@@ -14,7 +14,12 @@ import {
 
 type Row = typeof resourcesTable.$inferSelect;
 
-/** Raw snake_case row returned by db.execute() (no Drizzle camelCase mapping). */
+/**
+ * Raw snake_case row returned by db.execute() (no Drizzle camelCase mapping).
+ * NOTE: the `pg` driver returns timestamptz columns as strings and
+ * double-precision columns as strings when going through raw SQL, so we use
+ * `unknown` / loose types here and coerce in rawRowToSnapshot().
+ */
 type RawRow = {
   id: string;
   emergency_id: string;
@@ -23,31 +28,66 @@ type RawRow = {
   name: string;
   description: string | null;
   address: string;
-  latitude: number;
-  longitude: number;
+  latitude: unknown;
+  longitude: unknown;
   owner_user_id: string;
   owner_organization_id: string | null;
   verification_level: string;
   public_status: string;
-  created_at: Date;
+  created_at: unknown;
   contact: string | null;
   schedule: string | null;
   manager: string | null;
-  accepts: string[] | null;
+  accepts: unknown;
   source_name: string | null;
   external_id: string | null;
-  external_updated_at: Date | null;
+  external_updated_at: unknown;
   country: string | null;
   city: string | null;
   raw: unknown;
 };
+
+/**
+ * Coerce a raw value from db.execute() to a Date.
+ * The pg driver may return timestamptz as a string or already as a Date.
+ */
+function toDate(value: unknown): Date {
+  if (value instanceof Date) return value;
+  return new Date(value as string);
+}
+
+function toDateOrNull(value: unknown): Date | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value;
+  return new Date(value as string);
+}
+
+/**
+ * Parse the PostgreSQL text-array literal returned by the pg driver for
+ * raw SQL queries (e.g. `{water,food}`) into a JS string array.
+ * If the driver already returned a proper JS array, it is returned as-is.
+ */
+function toStringArray(value: unknown): string[] {
+  if (value == null) return [];
+  if (Array.isArray(value)) return value as string[];
+  // PostgreSQL array literal: `{val1,val2}` — strip braces and split.
+  const str = (value as string).trim();
+  if (str === '{}') return [];
+  if (str.startsWith('{') && str.endsWith('}')) {
+    return str
+      .slice(1, -1)
+      .split(',')
+      .map((s) => s.trim());
+  }
+  return [];
+}
 
 function rawRowToSnapshot(row: RawRow): ResourceSnapshot {
   const provenance: Provenance | null = row.source_name
     ? {
         sourceName: row.source_name,
         externalId: row.external_id as string,
-        externalUpdatedAt: row.external_updated_at ?? null,
+        externalUpdatedAt: toDateOrNull(row.external_updated_at),
         raw: row.raw ?? null,
       }
     : null;
@@ -60,18 +100,18 @@ function rawRowToSnapshot(row: RawRow): ResourceSnapshot {
     description: row.description ?? null,
     location: {
       address: row.address,
-      latitude: row.latitude,
-      longitude: row.longitude,
+      latitude: Number(row.latitude),
+      longitude: Number(row.longitude),
     },
     ownerUserId: row.owner_user_id,
     ownerOrganizationId: row.owner_organization_id ?? null,
     verificationLevel: row.verification_level as VerificationLevel,
     publicStatus: row.public_status as PublicStatus,
-    createdAt: row.created_at,
+    createdAt: toDate(row.created_at),
     contact: row.contact ?? null,
     schedule: row.schedule ?? null,
     manager: row.manager ?? null,
-    accepts: row.accepts ?? [],
+    accepts: toStringArray(row.accepts),
     country: row.country ?? null,
     city: row.city ?? null,
     provenance,


### PR DESCRIPTION
Arregla el 500 en `GET /public/resources/nearby` (endpoint de #28). El path de raw SQL (`db.execute(SELECT *)`) devolvía las columnas timestamptz (`external_updated_at`, `created_at`) como **strings**, así que `provenance.externalUpdatedAt` no era Date y `toISOString()` petaba. `rawRowToSnapshot` ahora coacciona fechas/números/arrays (helpers `toDate`/`toStringArray`; este último cubre literales pg `{water,food}`). **Test de regresión** que reproduce el error exacto (falla antes, pasa después). Gate local verde (build/lint/prettier/722 tests). Detectado en prod tras mergear #28; el endpoint es nuevo y sin uso en frontend, sin impacto en vivo.