### PR TITLE
feat(web): puntos cerca de ti — geolocated nearest points (#30)

### DIFF
--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -279,6 +279,7 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
               tStatusLight={t.status_light}
               tList={t.resource_list}
               tFilter={t.resource_filter}
+              tNearby={t.nearby_points}
               tEmpty={{
                 title: te.points_empty_title,
                 description: te.points_empty_description,

--- a/apps/web/src/components/atoms/distance-badge.tsx
+++ b/apps/web/src/components/atoms/distance-badge.tsx
@@ -1,0 +1,35 @@
+import type { Locale } from '@/i18n';
+
+interface DistanceBadgeProps {
+  distanceMeters: number;
+  locale: Locale;
+  /** i18n prefix word, defaults to "a" */
+  label?: string;
+}
+
+/**
+ * DistanceBadge — shows a human-friendly distance from the citizen's queried location.
+ *
+ * - <1000 m → "a 850 m"
+ * - ≥1000 m → "a 2,3 km" (es) / "a 2.3 km" (en)
+ */
+export function DistanceBadge({ distanceMeters, locale, label = 'a' }: DistanceBadgeProps) {
+  let text: string;
+
+  if (distanceMeters < 1000) {
+    text = `${label} ${Math.round(distanceMeters)} m`;
+  } else {
+    const km = distanceMeters / 1000;
+    const formatted = km.toLocaleString(locale === 'es' ? 'es-ES' : 'en-US', {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
+    text = `${label} ${formatted} km`;
+  }
+
+  return (
+    <span className="text-xs font-semibold text-blue-700 bg-blue-50 rounded-full px-2 py-0.5">
+      {text}
+    </span>
+  );
+}

--- a/apps/web/src/components/molecules/nearby-button.tsx
+++ b/apps/web/src/components/molecules/nearby-button.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+/**
+ * NearbyButton — triggers geolocation and fetches nearby resources.
+ *
+ * Privacy: coordinates are ephemeral — passed as query params to one API call
+ * and never stored. They are obtained from navigator.geolocation.getCurrentPosition,
+ * used immediately in the API call, and discarded once the call resolves.
+ * Coordinates are NEVER written to localStorage, sessionStorage, cookies,
+ * or any persistent React state.
+ */
+
+import { useState } from 'react';
+import { createResponseGridClient } from '@reliefhub/api-client';
+import type { components } from '@reliefhub/api-client';
+import type { Messages } from '@/i18n/messages/es';
+
+type NearbyResourceViewDto = components['schemas']['NearbyResourceViewDto'];
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+interface NearbyButtonProps {
+  emergencyId: string;
+  tNearby: Messages['nearby_points'];
+  onNearbyResults: (items: NearbyResourceViewDto[], clear: () => void) => void;
+  onGeoError: () => void;
+  active: boolean;
+}
+
+export function NearbyButton({
+  emergencyId,
+  tNearby,
+  onNearbyResults,
+  onGeoError,
+  active,
+}: NearbyButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  /**
+   * Clears nearby mode by signalling the parent with an empty items array.
+   * The parent's onNearbyResults handler detects the empty array and sets
+   * nearbyItems to null.
+   */
+  function clearNearby() {
+    onNearbyResults([], clearNearby);
+  }
+
+  function handleFind() {
+    if (!navigator.geolocation) {
+      onGeoError();
+      return;
+    }
+
+    setLoading(true);
+
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        // Coordinates are ephemeral — used only for this one API call.
+        const lat = position.coords.latitude;
+        const lng = position.coords.longitude;
+
+        try {
+          const client = createResponseGridClient(API_URL);
+          const { data } = await client.GET(
+            '/emergencies/{emergencyId}/public/resources/nearby',
+            {
+              params: {
+                path: { emergencyId },
+                query: { lat, lng, radius: 50000, limit: 50 },
+              },
+            },
+          );
+
+          if (data != null) {
+            onNearbyResults(data.items, clearNearby);
+          } else {
+            onGeoError();
+          }
+        } catch {
+          onGeoError();
+        } finally {
+          setLoading(false);
+          // lat / lng go out of scope here — never persisted.
+        }
+      },
+      () => {
+        // Geolocation denied or unavailable
+        setLoading(false);
+        onGeoError();
+      },
+    );
+  }
+
+  if (active) {
+    return (
+      <button
+        type="button"
+        onClick={clearNearby}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-blue-300 bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+      >
+        {tNearby.button_clear}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleFind}
+      disabled={loading}
+      className="inline-flex items-center gap-1.5 rounded-lg border border-blue-300 bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-colors"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className="h-4 w-4 flex-shrink-0"
+      >
+        <path
+          d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+          fill="currentColor"
+        />
+      </svg>
+      {loading ? tNearby.loading : tNearby.button_find}
+    </button>
+  );
+}

--- a/apps/web/src/components/molecules/nearby-button.tsx
+++ b/apps/web/src/components/molecules/nearby-button.tsx
@@ -22,7 +22,8 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
 interface NearbyButtonProps {
   emergencyId: string;
   tNearby: Messages['nearby_points'];
-  onNearbyResults: (items: NearbyResourceViewDto[], clear: () => void) => void;
+  onNearbyResults: (items: NearbyResourceViewDto[]) => void;
+  onClear: () => void;
   onGeoError: () => void;
   active: boolean;
 }
@@ -31,19 +32,11 @@ export function NearbyButton({
   emergencyId,
   tNearby,
   onNearbyResults,
+  onClear,
   onGeoError,
   active,
 }: NearbyButtonProps) {
   const [loading, setLoading] = useState(false);
-
-  /**
-   * Clears nearby mode by signalling the parent with an empty items array.
-   * The parent's onNearbyResults handler detects the empty array and sets
-   * nearbyItems to null.
-   */
-  function clearNearby() {
-    onNearbyResults([], clearNearby);
-  }
 
   function handleFind() {
     if (!navigator.geolocation) {
@@ -72,7 +65,7 @@ export function NearbyButton({
           );
 
           if (data != null) {
-            onNearbyResults(data.items, clearNearby);
+            onNearbyResults(data.items);
           } else {
             onGeoError();
           }
@@ -95,7 +88,7 @@ export function NearbyButton({
     return (
       <button
         type="button"
-        onClick={clearNearby}
+        onClick={onClear}
         className="inline-flex items-center gap-1.5 rounded-lg border border-blue-300 bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
       >
         {tNearby.button_clear}

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -314,7 +314,7 @@ export function ResourceList({
             type="button"
             onClick={() => setGeoError(false)}
             className="ml-1 underline hover:no-underline focus:outline-none"
-            aria-label="Cerrar"
+            aria-label={tNearby.geo_error_dismiss}
           >
             ✕
           </button>

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -12,16 +12,25 @@
  *    accumulated items whenever they change.
  *  - Client-side text search over the already-loaded items.
  *  - Geographic grouping: Venezuela first, diaspora/others after.
+ *  - Nearby mode: citizen geolocates and sees nearest points, ordered by
+ *    distance. Filter bar, load-more and geographic grouping are hidden in
+ *    this mode.
  */
 
 import { useState, useTransition, useEffect, useMemo, useRef } from 'react';
 import { createResponseGridClient } from '@reliefhub/api-client';
+import type { components } from '@reliefhub/api-client';
 import { groupByCountry, type ResourceViewDto } from '@/lib/group-by-country';
 import { PublicResourceCard } from '@/components/organisms/public-resource-card';
 import { ResourceFilterBar } from '@/components/molecules/resource-filter-bar';
 import { EmptyState } from '@/components/molecules/empty-state';
+import { NearbyButton } from '@/components/molecules/nearby-button';
+import { DistanceBadge } from '@/components/atoms/distance-badge';
+import { PrivacyLocationNotice } from '@/components/atoms/privacy-location-notice';
 import type { Messages } from '@/i18n/messages/es';
 import type { Locale } from '@/i18n';
+
+type NearbyResourceViewDto = components['schemas']['NearbyResourceViewDto'];
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
 if (!API_URL) {
@@ -46,6 +55,7 @@ interface ResourceListProps {
   tStatusLight: Messages['status_light'];
   tList: Messages['resource_list'];
   tFilter: Messages['resource_filter'];
+  tNearby: Messages['nearby_points'];
   tEmpty: { title: string; description?: string };
   locale: Locale;
 }
@@ -61,6 +71,7 @@ export function ResourceList({
   tStatusLight,
   tList,
   tFilter,
+  tNearby,
   tEmpty,
   locale,
 }: ResourceListProps) {
@@ -77,6 +88,10 @@ export function ResourceList({
   const [page, setPage] = useState(1);
   const [isPending, startTransition] = useTransition();
   const [loadMoreError, setLoadMoreError] = useState(false);
+
+  // ── Nearby mode state ─────────────────────────────────────────────────────
+  const [nearbyItems, setNearbyItems] = useState<NearbyResourceViewDto[] | null>(null);
+  const [geoError, setGeoError] = useState(false);
 
   // ── Re-fetch page 1 whenever category or country changes ──────────────────
   const firstRun = useRef(true);
@@ -154,6 +169,20 @@ export function ResourceList({
     });
   }
 
+  /**
+   * Callback for NearbyButton:
+   * - items.length > 0 → activate nearby mode with the results.
+   * - items.length === 0 (clearNearby signal) → exit nearby mode.
+   */
+  function handleNearbyResults(nearbyResults: NearbyResourceViewDto[], _clear: () => void) {
+    if (nearbyResults.length === 0) {
+      setNearbyItems(null);
+    } else {
+      setNearbyItems(nearbyResults);
+      setGeoError(false);
+    }
+  }
+
   // ── Client-side search filter ─────────────────────────────────────────────
   const filteredItems = useMemo(() => {
     if (searchQuery.trim() === '') return items;
@@ -175,9 +204,80 @@ export function ResourceList({
   const isSearching = searchQuery.trim() !== '';
   const hasMore = !isSearching && items.length < total;
 
+  // ── Nearby mode rendering ─────────────────────────────────────────────────
+  if (nearbyItems !== null) {
+    return (
+      <div className="flex flex-col gap-4">
+        {/* NearbyButton in active state (shows "Volver a la lista") */}
+        <NearbyButton
+          emergencyId={emergencyId}
+          tNearby={tNearby}
+          onNearbyResults={handleNearbyResults}
+          onGeoError={() => setGeoError(true)}
+          active
+        />
+
+        {/* Summary */}
+        <p className="text-xs text-gray-500">
+          {tNearby.showing_nearby.replace('{n}', String(nearbyItems.length))}
+        </p>
+
+        {/* Privacy notice */}
+        <PrivacyLocationNotice text={tNearby.privacy_note} />
+
+        {/* Nearby items list */}
+        <ul className="flex flex-col gap-3" role="list">
+          {nearbyItems.map((item) => (
+            <li key={item.id}>
+              <div className="relative">
+                <PublicResourceCard
+                  resource={item as unknown as ResourceViewDto}
+                  t={t}
+                  tVerification={tVerification}
+                  tStatusLight={tStatusLight}
+                  locale={locale}
+                />
+                <div className="mt-1 flex justify-end px-1">
+                  <DistanceBadge distanceMeters={item.distanceMeters} locale={locale} />
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  // ── Normal mode rendering ─────────────────────────────────────────────────
+
   if (items.length === 0 && !isPending) {
     return (
       <div className="flex flex-col gap-4">
+        {/* NearbyButton above filter bar */}
+        <NearbyButton
+          emergencyId={emergencyId}
+          tNearby={tNearby}
+          onNearbyResults={handleNearbyResults}
+          onGeoError={() => setGeoError(true)}
+          active={false}
+        />
+
+        {/* Geo error alert */}
+        {geoError && (
+          <p role="alert" className="rounded-card border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            {tNearby.geo_error}
+            {' '}
+            <button
+              type="button"
+              onClick={() => setGeoError(false)}
+              className="ml-1 underline hover:no-underline focus:outline-none"
+              aria-label="Cerrar"
+            >
+              ✕
+            </button>
+          </p>
+        )}
+
         <ResourceFilterBar
           byCategory={facetsByCategory}
           byCountry={facetsByCountry}
@@ -197,6 +297,31 @@ export function ResourceList({
 
   return (
     <div className="flex flex-col gap-4">
+      {/* ── NearbyButton above filter bar ───────────────────────────────── */}
+      <NearbyButton
+        emergencyId={emergencyId}
+        tNearby={tNearby}
+        onNearbyResults={handleNearbyResults}
+        onGeoError={() => setGeoError(true)}
+        active={nearbyItems !== null}
+      />
+
+      {/* ── Geo error alert ──────────────────────────────────────────────── */}
+      {geoError && nearbyItems === null && (
+        <p role="alert" className="rounded-card border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          {tNearby.geo_error}
+          {' '}
+          <button
+            type="button"
+            onClick={() => setGeoError(false)}
+            className="ml-1 underline hover:no-underline focus:outline-none"
+            aria-label="Cerrar"
+          >
+            ✕
+          </button>
+        </p>
+      )}
+
       {/* ── Filter bar ──────────────────────────────────────────────────── */}
       <ResourceFilterBar
         byCategory={facetsByCategory}

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -257,7 +257,7 @@ export function ResourceList({
           onNearbyResults={handleNearbyResults}
           onClear={() => setNearbyItems(null)}
           onGeoError={() => setGeoError(true)}
-          active={false}
+          active={nearbyItems !== null}
         />
 
         {/* Geo error alert */}

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -170,17 +170,13 @@ export function ResourceList({
   }
 
   /**
-   * Callback for NearbyButton:
-   * - items.length > 0 → activate nearby mode with the results.
-   * - items.length === 0 (clearNearby signal) → exit nearby mode.
+   * Callback for NearbyButton: activates nearby mode with the API results.
+   * An empty array means 0 results within range — still shows nearby mode.
+   * Clearing nearby mode is handled by onClear → setNearbyItems(null).
    */
-  function handleNearbyResults(nearbyResults: NearbyResourceViewDto[], _clear: () => void) {
-    if (nearbyResults.length === 0) {
-      setNearbyItems(null);
-    } else {
-      setNearbyItems(nearbyResults);
-      setGeoError(false);
-    }
+  function handleNearbyResults(nearbyResults: NearbyResourceViewDto[]) {
+    setNearbyItems(nearbyResults);
+    setGeoError(false);
   }
 
   // ── Client-side search filter ─────────────────────────────────────────────
@@ -213,6 +209,7 @@ export function ResourceList({
           emergencyId={emergencyId}
           tNearby={tNearby}
           onNearbyResults={handleNearbyResults}
+          onClear={() => setNearbyItems(null)}
           onGeoError={() => setGeoError(true)}
           active
         />
@@ -258,6 +255,7 @@ export function ResourceList({
           emergencyId={emergencyId}
           tNearby={tNearby}
           onNearbyResults={handleNearbyResults}
+          onClear={() => setNearbyItems(null)}
           onGeoError={() => setGeoError(true)}
           active={false}
         />
@@ -271,7 +269,7 @@ export function ResourceList({
               type="button"
               onClick={() => setGeoError(false)}
               className="ml-1 underline hover:no-underline focus:outline-none"
-              aria-label="Cerrar"
+              aria-label={tNearby.geo_error_dismiss}
             >
               ✕
             </button>
@@ -302,6 +300,7 @@ export function ResourceList({
         emergencyId={emergencyId}
         tNearby={tNearby}
         onNearbyResults={handleNearbyResults}
+        onClear={() => setNearbyItems(null)}
         onGeoError={() => setGeoError(true)}
         active={nearbyItems !== null}
       />

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -327,6 +327,7 @@ export const en = {
     button_clear: 'Back to list',
     loading: 'Looking for nearby points…',
     geo_error: 'Could not get your location. Check your browser permissions.',
+    geo_error_dismiss: 'Dismiss',
     showing_nearby: '{n} nearby points',
     privacy_note: 'Your location is only used in your browser to sort by proximity; it is never stored.',
   },

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -321,6 +321,16 @@ export const en = {
     group_other: 'Other',
   },
 
+  // ── Nearby points ─────────────────────────────────────────────────────────
+  nearby_points: {
+    button_find: 'Find points near me',
+    button_clear: 'Back to list',
+    loading: 'Looking for nearby points…',
+    geo_error: 'Could not get your location. Check your browser permissions.',
+    showing_nearby: '{n} nearby points',
+    privacy_note: 'Your location is only used in your browser to sort by proximity; it is never stored.',
+  },
+
   verification_badge: {
     official: 'Official',
     verified: 'Verified',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -339,6 +339,16 @@ export const es = {
     group_other: 'Otros',
   },
 
+  // ── Nearby points ("Puntos cerca de ti") ─────────────────────────────────
+  nearby_points: {
+    button_find: 'Ver puntos cerca de mí',
+    button_clear: 'Volver a la lista',
+    loading: 'Buscando puntos cercanos…',
+    geo_error: 'No pudimos obtener tu ubicación. Comprueba los permisos del navegador.',
+    showing_nearby: '{n} puntos cercanos',
+    privacy_note: 'Tu ubicación solo se usa en tu navegador para ordenar por cercanía; no se guarda.',
+  },
+
   // ── VerificationBadge ─────────────────────────────────────────────────────
   verification_badge: {
     official: 'Oficial',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -345,6 +345,7 @@ export const es = {
     button_clear: 'Volver a la lista',
     loading: 'Buscando puntos cercanos…',
     geo_error: 'No pudimos obtener tu ubicación. Comprueba los permisos del navegador.',
+    geo_error_dismiss: 'Cerrar',
     showing_nearby: '{n} puntos cercanos',
     privacy_note: 'Tu ubicación solo se usa en tu navegador para ordenar por cercanía; no se guarda.',
   },


### PR DESCRIPTION
Closes #30.

UX de cercanía en el operativo, encima del endpoint `/nearby` (#28). Botón 'Ver puntos cerca de mí' → Geolocation API del navegador → llama a `/public/resources/nearby` (radio 50km) → lista plana ordenada por distancia con `DistanceBadge` por ficha. Reusa `PublicResourceCard`.

**Privacidad (aceptación de #30):** la ubicación del ciudadano vive solo en variables locales del callback de geolocalización — se pasa una vez a la API y se descarta. Nada en localStorage/cookie/estado. `PrivacyLocationNotice` visible en modo cercanía. Manejo de denegación/error sin romper.

Atomic Design (átomo DistanceBadge + molécula NearbyButton) + i18n es/en. Web build + lint verde (cambio solo-web; jobs de api intactos).