### PR TITLE
feat: destinatarios finales — modelo (ficha 14) + rol "destinatario final" en el recurso (#59, #60)

### DIFF
--- a/apps/api/drizzle/0023_resource_recipient_role.sql
+++ b/apps/api/drizzle/0023_resource_recipient_role.sql
@@ -1,0 +1,7 @@
+-- Destinatario final (EPIC #59 · #60): rol "destinatario final" sobre un recurso
+-- en etapa de destino, con tipo de destinatario extensible (slug validado por la
+-- taxonomía por emergencia, #62). Ambos campos son aditivos y retrocompatibles.
+ALTER TABLE resources
+  ADD COLUMN is_final_recipient boolean NOT NULL DEFAULT false,
+  ADD COLUMN recipient_type text;
+CREATE INDEX resources_final_recipient ON resources(emergency_id) WHERE is_final_recipient;

--- a/apps/api/src/contexts/resources/application/ingest-external-resources.spec.ts
+++ b/apps/api/src/contexts/resources/application/ingest-external-resources.spec.ts
@@ -251,6 +251,8 @@ describe('IngestExternalResources', () => {
           externalUpdatedAt: null,
           raw: null,
         },
+        isFinalRecipient: false,
+        recipientType: null,
       });
       await repo.save(preExisting);
 

--- a/apps/api/src/contexts/resources/application/ingest-external-resources.ts
+++ b/apps/api/src/contexts/resources/application/ingest-external-resources.ts
@@ -84,6 +84,9 @@ export class IngestExternalResources {
           verificationLevel: existingSnap.verificationLevel,
           publicStatus: existingSnap.publicStatus,
           createdAt: existingSnap.createdAt,
+          // Preserved (local-owned recipient role — #60):
+          isFinalRecipient: existingSnap.isFinalRecipient,
+          recipientType: existingSnap.recipientType,
           // Preserved (structural — not changed by source):
           emergencyId: existingSnap.emergencyId,
           // Source-owned (updated):
@@ -131,6 +134,8 @@ export class IngestExternalResources {
           verificationLevel: VerificationLevel.Unverified,
           publicStatus: PublicStatus.Active,
           createdAt: new Date(),
+          isFinalRecipient: false,
+          recipientType: null,
           contact: mapped.contact,
           schedule: mapped.schedule,
           manager: mapped.manager,

--- a/apps/api/src/contexts/resources/application/register-resource.ts
+++ b/apps/api/src/contexts/resources/application/register-resource.ts
@@ -27,6 +27,9 @@ export interface RegisterResourceCommand {
   country?: string | null;
   city?: string | null;
   provenance?: Provenance | null;
+  // destinatario final (#60)
+  isFinalRecipient?: boolean;
+  recipientType?: string | null;
 }
 
 export class RegisterResource {
@@ -62,6 +65,8 @@ export class RegisterResource {
       country: cmd.country ?? null,
       city: cmd.city ?? null,
       provenance: cmd.provenance ?? null,
+      isFinalRecipient: cmd.isFinalRecipient ?? false,
+      recipientType: cmd.recipientType ?? null,
     });
     await this.repo.save(resource);
     await this.bus.publish(resource.pullDomainEvents());

--- a/apps/api/src/contexts/resources/application/resource-view.ts
+++ b/apps/api/src/contexts/resources/application/resource-view.ts
@@ -27,6 +27,9 @@ export interface ResourceView {
   /** Country string from the source's `pais` field — often a full Spanish name (e.g. "Venezuela"), NOT an ISO code. */
   country: string | null;
   city: string | null;
+  // destinatario final (#60)
+  isFinalRecipient: boolean;
+  recipientType: string | null;
 }
 
 export function toResourceView(r: Resource): ResourceView {
@@ -48,5 +51,7 @@ export function toResourceView(r: Resource): ResourceView {
     externalUpdatedAt: r.provenance?.externalUpdatedAt?.toISOString() ?? null,
     country: r.country,
     city: r.city,
+    isFinalRecipient: r.isFinalRecipient,
+    recipientType: r.recipientType,
   };
 }

--- a/apps/api/src/contexts/resources/domain/resource-errors.ts
+++ b/apps/api/src/contexts/resources/domain/resource-errors.ts
@@ -30,3 +30,9 @@ export class ResourceAlreadyPublishedError extends Error {
     this.name = 'ResourceAlreadyPublishedError';
   }
 }
+export class FinalRecipientMustBeDestinationError extends Error {
+  constructor(stage: string) {
+    super(`A final recipient must be at the destination stage; got "${stage}"`);
+    this.name = 'FinalRecipientMustBeDestinationError';
+  }
+}

--- a/apps/api/src/contexts/resources/domain/resource.spec.ts
+++ b/apps/api/src/contexts/resources/domain/resource.spec.ts
@@ -14,6 +14,7 @@ import {
   InvalidVerificationLevelError,
   InvalidPublicStatusTransitionError,
   ResourceNotPublishedError,
+  FinalRecipientMustBeDestinationError,
 } from './resource-errors';
 
 const makeLocation = () =>
@@ -286,6 +287,59 @@ describe('Resource', () => {
       expect(restored.provenance?.externalId).toBe('snap-ext-1');
       expect(restored.provenance?.externalUpdatedAt).toEqual(externalUpdatedAt);
       expect(restored.provenance?.raw).toEqual({ x: 42 });
+    });
+  });
+
+  describe('destinatario final (#60)', () => {
+    const makeRecipient = (recipientType: string | null = 'hospital') =>
+      Resource.register({
+        id: ResourceId.create(),
+        emergencyId: EmergencyId.fromString(
+          '11111111-1111-4111-8111-111111111111',
+        ),
+        type: ResourceType.Venue,
+        stage: ResourceStage.Destination,
+        name: 'Hospital Central',
+        location: makeLocation(),
+        ownerUserId: 'user-recipient',
+        isFinalRecipient: true,
+        recipientType,
+      });
+
+    it('marks a destination-stage resource as a final recipient with a type', () => {
+      const r = makeRecipient('hospital');
+      expect(r.isFinalRecipient).toBe(true);
+      expect(r.recipientType).toBe('hospital');
+    });
+
+    it('defaults isFinalRecipient to false and recipientType to null', () => {
+      const r = make();
+      expect(r.isFinalRecipient).toBe(false);
+      expect(r.recipientType).toBeNull();
+    });
+
+    it('rejects a final recipient that is not at the destination stage', () => {
+      expect(() =>
+        Resource.register({
+          id: ResourceId.create(),
+          emergencyId: EmergencyId.fromString(
+            '11111111-1111-4111-8111-111111111111',
+          ),
+          type: ResourceType.Venue,
+          stage: ResourceStage.Origin,
+          name: 'No-destino',
+          location: makeLocation(),
+          ownerUserId: 'user-bad',
+          isFinalRecipient: true,
+        }),
+      ).toThrow(FinalRecipientMustBeDestinationError);
+    });
+
+    it('toSnapshot / fromSnapshot round-trip preserves the recipient role', () => {
+      const r = makeRecipient('empresa');
+      const restored = Resource.fromSnapshot(r.toSnapshot());
+      expect(restored.isFinalRecipient).toBe(true);
+      expect(restored.recipientType).toBe('empresa');
     });
   });
 });

--- a/apps/api/src/contexts/resources/domain/resource.ts
+++ b/apps/api/src/contexts/resources/domain/resource.ts
@@ -13,6 +13,7 @@ import {
   ResourceAlreadyPublishedError,
   ResourceNotPublishedError,
   ResourceNotVerifiedError,
+  FinalRecipientMustBeDestinationError,
 } from './resource-errors';
 import { DomainEvent } from './events/domain-event';
 import { ResourceRegistered } from './events/resource-registered';
@@ -44,6 +45,9 @@ export interface RegisterResourceProps {
   country?: string | null;
   city?: string | null;
   provenance?: Provenance | null;
+  // destinatario final (#60)
+  isFinalRecipient?: boolean;
+  recipientType?: string | null;
 }
 
 // Snapshot used by repositories to rehydrate without going through register().
@@ -68,6 +72,8 @@ export interface ResourceSnapshot {
   country: string | null;
   city: string | null;
   provenance: Provenance | null;
+  isFinalRecipient: boolean;
+  recipientType: string | null;
 }
 
 export class Resource {
@@ -93,9 +99,17 @@ export class Resource {
     public readonly country: string | null,
     public readonly city: string | null,
     public readonly provenance: Provenance | null,
+    public readonly isFinalRecipient: boolean,
+    public readonly recipientType: string | null,
   ) {}
 
   static register(props: RegisterResourceProps): Resource {
+    if (
+      (props.isFinalRecipient ?? false) &&
+      props.stage !== ResourceStage.Destination
+    ) {
+      throw new FinalRecipientMustBeDestinationError(props.stage);
+    }
     const r = new Resource(
       props.id,
       props.emergencyId,
@@ -116,6 +130,8 @@ export class Resource {
       props.country ?? null,
       props.city ?? null,
       props.provenance ?? null,
+      props.isFinalRecipient ?? false,
+      props.recipientType ?? null,
     );
     r.events.push(
       new ResourceRegistered(r.id.value, {
@@ -149,6 +165,8 @@ export class Resource {
       s.country ?? null,
       s.city ?? null,
       s.provenance ?? null,
+      s.isFinalRecipient ?? false,
+      s.recipientType ?? null,
     );
   }
 
@@ -227,6 +245,8 @@ export class Resource {
       country: this.country,
       city: this.city,
       provenance: this.provenance,
+      isFinalRecipient: this.isFinalRecipient,
+      recipientType: this.recipientType,
     };
   }
 

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
@@ -347,6 +347,27 @@ describe('DrizzleResourceRepository (integration)', () => {
     expect(found!.provenance?.raw).toEqual({ x: 1 });
   });
 
+  it('round-trips the final-recipient role through Postgres (#60)', async () => {
+    const r = Resource.register({
+      id: ResourceId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      type: ResourceType.Venue,
+      stage: ResourceStage.Destination,
+      name: 'Hospital Central',
+      location: baseLocation,
+      ownerUserId: OWNER_ID,
+      isFinalRecipient: true,
+      recipientType: 'hospital',
+    });
+
+    await repo.save(r);
+    const found = await repo.findById(r.id);
+
+    expect(found).not.toBeNull();
+    expect(found!.isFinalRecipient).toBe(true);
+    expect(found!.recipientType).toBe('hospital');
+  });
+
   it('round-trips resource with no enriched fields (defaults)', async () => {
     const r = Resource.register({
       id: ResourceId.create(),

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
@@ -45,6 +45,8 @@ type RawRow = {
   country: string | null;
   city: string | null;
   raw: unknown;
+  is_final_recipient: boolean | null;
+  recipient_type: string | null;
 };
 
 /**
@@ -115,6 +117,8 @@ function rawRowToSnapshot(row: RawRow): ResourceSnapshot {
     country: row.country ?? null,
     city: row.city ?? null,
     provenance,
+    isFinalRecipient: row.is_final_recipient ?? false,
+    recipientType: row.recipient_type ?? null,
   };
 }
 
@@ -155,6 +159,8 @@ function rowToSnapshot(row: Row): ResourceSnapshot {
     country: row.country ?? null,
     city: row.city ?? null,
     provenance: rowToProvenance(row),
+    isFinalRecipient: row.isFinalRecipient ?? false,
+    recipientType: row.recipientType ?? null,
   };
 }
 
@@ -190,6 +196,8 @@ export class DrizzleResourceRepository implements ResourceRepository {
         externalId: s.provenance?.externalId ?? null,
         externalUpdatedAt: s.provenance?.externalUpdatedAt ?? null,
         raw: s.provenance?.raw ?? null,
+        isFinalRecipient: s.isFinalRecipient,
+        recipientType: s.recipientType,
       })
       .onConflictDoUpdate({
         target: resourcesTable.id,
@@ -207,6 +215,8 @@ export class DrizzleResourceRepository implements ResourceRepository {
           externalId: s.provenance?.externalId ?? null,
           externalUpdatedAt: s.provenance?.externalUpdatedAt ?? null,
           raw: s.provenance?.raw ?? null,
+          isFinalRecipient: s.isFinalRecipient,
+          recipientType: s.recipientType,
         },
       });
   }

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/schema.ts
@@ -5,6 +5,7 @@ import {
   timestamp,
   doublePrecision,
   jsonb,
+  boolean,
 } from 'drizzle-orm/pg-core';
 
 export const resourcesTable = pgTable('resources', {
@@ -33,4 +34,7 @@ export const resourcesTable = pgTable('resources', {
   country: text('country'),
   city: text('city'),
   raw: jsonb('raw'),
+  // destinatario final (0023_resource_recipient_role)
+  isFinalRecipient: boolean('is_final_recipient').notNull().default(false),
+  recipientType: text('recipient_type'),
 });

--- a/apps/api/src/contexts/resources/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/dto.ts
@@ -9,6 +9,7 @@ import {
   Max,
   ValidateNested,
   IsArray,
+  IsBoolean,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -122,6 +123,24 @@ export class RegisterResourceDto {
   @IsOptional()
   @IsString()
   city?: string;
+
+  @ApiPropertyOptional({
+    example: true,
+    description:
+      'Mark this resource as a final recipient of aid (requires the destination stage)',
+  })
+  @IsOptional()
+  @IsBoolean()
+  isFinalRecipient?: boolean;
+
+  @ApiPropertyOptional({
+    example: 'hospital',
+    description:
+      'Recipient type slug (see the emergency recipient-type taxonomy)',
+  })
+  @IsOptional()
+  @IsString()
+  recipientType?: string;
 }
 
 /**

--- a/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
@@ -94,6 +94,8 @@ export class ResourcesController {
       accepts: dto.accepts ?? [],
       country: dto.country ?? null,
       city: dto.city ?? null,
+      isFinalRecipient: dto.isFinalRecipient ?? false,
+      recipientType: dto.recipientType ?? null,
     });
   }
 

--- a/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
@@ -97,6 +97,23 @@ export class ResourceViewDto {
 
   @ApiProperty({ example: 'Caracas', nullable: true, type: String })
   city!: string | null;
+
+  // ── destinatario final (#60) ──────────────────────────────────────────────
+
+  @ApiProperty({
+    example: false,
+    description: 'Whether this resource is a final recipient of aid',
+  })
+  isFinalRecipient!: boolean;
+
+  @ApiProperty({
+    example: 'hospital',
+    nullable: true,
+    type: String,
+    description:
+      'Recipient type slug (see the emergency recipient-type taxonomy)',
+  })
+  recipientType!: string | null;
 }
 
 export class NearbyResourceViewDto extends ResourceViewDto {

--- a/docs/features/00-indice.md
+++ b/docs/features/00-indice.md
@@ -20,6 +20,7 @@
 |---|---------|---------|-----------|
 | [06](06-caducidad-frescura-necesidades.md) | **Caducidad / frescura de necesidades** | Vigencia (p. ej. 48 h), aviso "verifica antes de actuar" y auto-archivado | 🔴 Alta |
 | [07](07-oferta-compromiso-entrega.md) | **Oferta como compromiso de entrega** | La oferta evoluciona a "promesa" con fecha/método de entrega y seguimiento | 🟡 Media |
+| [14](14-destinatarios-finales.md) | **Destinatarios finales (ficha · peticiones 1‑a‑N · recepciones)** | Receptor final genérico con tipo extensible (empresa/organización/particular/hospital…); vertical sanitario como primer caso. EPIC #59 | 🔴 Alta |
 
 ## Dominio 4 — Mapa y geolocalización
 | # | Feature | Resumen | Prioridad |

--- a/docs/features/14-destinatarios-finales.md
+++ b/docs/features/14-destinatarios-finales.md
@@ -1,0 +1,197 @@
+# 14 · Destinatarios finales — Dominio: Núcleo de necesidades / Logística de destino
+
+> Caso de uso capturado de un **parte de campo** (La Guaira, 27‑jun; hospitales Domingo Luciani, Clínico Universitario y Militar Carlos Arvelo) y consolidado tras revisión de producto. Entregable abordable por fases. Tracking en el EPIC #59 y sub-issues #60, #62, #67, #64 (núcleo genérico) + #61, #63 (vertical sanitario).
+
+---
+
+## 1. Origen (qué se observó en campo)
+
+Durante la respuesta al sismo, los **centros de salud** reportan que reciben **demasiadas donaciones sin clasificar**: medicamentos en pastillas/jarabes que no sirven para uso hospitalario directo (se necesitan **ampollas / EV / inhaladores**), alimentos que ahora mismo no se requieren, etc. La información de **qué necesita cada centro** está dispersa y es difícil de centralizar; conseguir un **contacto oficial** del centro es el principal cuello de botella.
+
+La observación clave de modelado es que **un centro de salud no es un tipo especial de punto**, sino una instancia de un concepto más general: el **destinatario final** de la ayuda. Es como un nodo en la etapa de **destino** (cf. `ResourceStage.Destination`), pero en lugar de ser un punto genérico "donde la gente va a recoger" (`DeliveryPoint`/`CollectionPoint`), es el **receptor último**. Puede ser de **varios tipos extensibles**: empresa, organización, particular, hospital… *o cualquier otra cosa*. Y necesita **ficha propia** con **seguimiento de lo que ha recibido** (qué, cuánto, cuándo, de quién).
+
+---
+
+## 2. Problema / valor para ResponseGrid
+
+**Problema actual:**
+- `ResourceType` (`apps/api/src/contexts/resources/domain/resource-enums.ts`) modela puntos logísticos (`CollectionPoint`, `DeliveryPoint`, `Warehouse`, `Transport`, `Supplier`, `Venue`), pero **no** el rol de **destinatario final**. Un hospital hoy cae en `Venue` genérico.
+- Las **necesidades** son autónomas: la tabla `needs` **no** referencia ningún punto/destinatario (no hay `resourceId`). No se puede ver "las necesidades **de** este destinatario" como una lista **1‑a‑N**.
+- No existe una **taxonomía de tipos de destinatario** (empresa/organización/particular/hospital…), ni una **ficha de recepciones** que agregue lo que un receptor ha recibido.
+
+**Valor:** un modelo **genérico y escalable** de destinatario final permite:
+- Centralizar las peticiones **por receptor** (un hospital, una empresa, una familia… tienen su lista 1‑a‑N).
+- Dirigir donaciones al destinatario correcto y reducir el material inservible acumulado.
+- Reutilizar el mismo modelo para cualquier vertical (sanitario como **primer caso**, pero no el único).
+- Dar trazabilidad **centrada en el receptor** ("qué ha recibido este centro y cuándo").
+
+---
+
+## 3. Propuesta
+
+### 3.1 Modelo (DDD / Hexagonal)
+
+El **destinatario final** es un **rol** sobre un recurso en `Destination`, no un nuevo `ResourceType`. Lo "que es" (hospital, empresa, particular…) lo aporta una **taxonomía configurable**, no un enum cerrado.
+
+```
+Resource (contexto resources, ya existe)
+  ├── stage: ResourceStage            // origin | intermediate | destination
+  ├── isFinalRecipient: boolean       // NUEVO — rol "destinatario final" (solo con stage = destination)
+  ├── recipientType: string | null    // NUEVO — slug de la taxonomía (ver EmergencyRecipientType)
+  └── contact / manager / …           // ficha ya existente (se reutiliza)
+
+EmergencyRecipientType (taxonomía extensible, patrón de EmergencyNeedCategory — ficha 04)
+  ├── emergencyId: EmergencyId
+  ├── slug: string                    // "hospital" | "empresa" | "organizacion" | "particular" | "acopio" | …
+  ├── label: string                   // etiqueta localizable
+  └── sortOrder: number
+
+Need (contexto needs, ya existe)
+  └── resourceId: ResourceId | null   // NUEVO — vincula la necesidad a su destinatario (1‑a‑N)
+
+Receipt (recepción — proyección/registro centrado en el receptor)
+  ├── resourceId: ResourceId          // destinatario que recibe
+  ├── item / quantity / unit / presentation
+  ├── receivedAt: Date
+  ├── sourceName: string | null       // origen/donante
+  └── needId / transferId / offerId   // procedencia (traslado #11 u oferta entregada #25)
+```
+
+**Invariantes:**
+- `isFinalRecipient = true` ⇒ `stage = destination`.
+- `recipientType` (si se informa) debe ser un `slug` válido para esa emergencia.
+- Un `Receipt` siempre apunta a un `resourceId` con rol destinatario.
+- `Need.resourceId` es **opcional**: una necesidad puede no estar ligada a un destinatario (compatibilidad hacia atrás).
+
+> **Destinatario "particular":** una persona/familia puede ser destinatario **sin** ficha pública de recurso. En ese caso se modela vía **necesidades nominales** (ficha `02`) con privacidad, no como `resource` visible. El modelo admite ambos caminos (ver §8).
+
+### 3.2 Casos de uso
+
+| Caso de uso | Contexto | Descripción |
+|---|---|---|
+| `MarkResourceAsFinalRecipient` | `resources` | Marca un recurso en destino como destinatario y le asigna `recipientType` |
+| `ListRecipientTypesForEmergency` | `resources`/`needs` | Devuelve la taxonomía de tipos configurada (o base) |
+| `LinkNeedToRecipient` | `needs` | Asocia (o crea) una necesidad ligada a un `resourceId` |
+| `ListNeedsByRecipient` | `needs` | Lista 1‑a‑N de necesidades de un destinatario |
+| `RecordReceipt` / `ProjectReceipts` | `inventory`/`resources` | Registra o deriva recepciones desde traslados (#11) / ofertas entregadas (#25) |
+| `GetRecipientReceipts` | `resources` | Historial de recepciones de un destinatario + resumen agregado |
+| `CreateEmergencyFromTemplate` | `templates` | Extender para precargar `recipientTypes` (como ya hace con `dontBringList`) |
+
+### 3.3 API
+
+```
+# Taxonomía de tipos de destinatario
+GET  /emergencies/:id/recipient-types
+     → RecipientTypeDto[] { slug, label, sortOrder }
+
+# Destinatario ↔ necesidades (1‑a‑N)
+GET  /emergencies/:id/public/resources/:resourceId/needs
+     → NeedView[]
+POST /emergencies/:id/needs
+     body: { ..., resourceId?: string }     // vínculo opcional al destinatario
+
+# Recepciones (ficha del destinatario)
+GET  /emergencies/:id/resources/:resourceId/receipts
+     → { items: ReceiptDto[], summary: { byCategory, byItem } }
+```
+
+Migraciones Drizzle (aplicar a dev y test vía psql — drizzle-kit cuelga en Windows):
+```sql
+ALTER TABLE resources ADD COLUMN is_final_recipient BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE resources ADD COLUMN recipient_type TEXT;            -- slug, nullable
+ALTER TABLE needs     ADD COLUMN resource_id UUID REFERENCES resources(id);
+
+CREATE TABLE emergency_recipient_types (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  emergency_id UUID NOT NULL REFERENCES emergencies(id) ON DELETE CASCADE,
+  slug         TEXT NOT NULL,
+  label        TEXT NOT NULL,
+  sort_order   INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (emergency_id, slug)
+);
+-- receipts: tabla propia o proyección de eventos de traslado/oferta (ver §8)
+```
+
+### 3.4 Frontend (Atomic Design)
+
+| Capa | Componente | Descripción |
+|---|---|---|
+| Átomo | `RecipientTypeBadge` | Pastilla con el tipo de destinatario (hospital, empresa…) |
+| Molécula | `RecipientTypeSelector` | Carga la taxonomía vía `GET /emergencies/:id/recipient-types` |
+| Molécula | `ReceiptTimelineItem` | Una entrada del historial de recepciones (qué, cuánto, cuándo, de quién) |
+| Organismo | `RecipientNeedsList` | Lista 1‑a‑N de necesidades en la ficha del destinatario |
+| Organismo | `RecipientReceiptsPanel` | Sección "Recepciones" en la ficha (timeline + resumen agregado) |
+| Página | Ficha del recurso/destinatario | Integra necesidades, recepciones y contacto verificado |
+
+### 3.5 Encaje con lo existente
+
+- **`resources`:** reutiliza `Resource`, su ficha (`PublicResourceCard`), `ResourceStage` y `VerificationLevel` (para el contacto oficial verificado, #64). Solo añade `isFinalRecipient` + `recipientType`.
+- **`needs`:** añade `resourceId` opcional; `GET public/needs` y filtros siguen funcionando.
+- **`templates`:** la taxonomía de tipos se precarga desde plantilla, igual que `dontBringList` y `defaultAnnouncement`.
+- **`inventory`/`offers` (EPIC #1, #25):** las recepciones se **derivan** de traslados confirmados y ofertas entregadas; no se duplica el registro.
+- **Vertical sanitario (#61, #63):** la **presentación** de ítems (ampolla/EV/inhalador) y el "qué SÍ/NO llevar" se construyen **encima** de este núcleo, como primer caso de uso.
+
+---
+
+## 4. Alcance
+
+### Primer corte (MVP)
+- `isFinalRecipient` + `recipientType` en `resources` + taxonomía `emergency_recipient_types`.
+- `resourceId` opcional en `needs` + endpoint `…/resources/:resourceId/needs`.
+- Selector de tipo + lista de necesidades en la ficha del destinatario.
+- Recepciones derivadas de traslados/ofertas existentes (solo lectura) + resumen agregado.
+- Plantilla precarga los tipos base (empresa · organización · particular · hospital · acopio · otro).
+- Tests de dominio (TDD) + integración de endpoints.
+
+### Futuro
+- Registro **manual** de recepción (donación directa sin traslado formal).
+- Editor de taxonomía de tipos por emergencia (admin) sin plantilla previa.
+- Tipos jerárquicos / sub-uso dentro de un destinatario (p. ej. "pacientes" vs "personal" de un hospital).
+- Métricas de impacto por destinatario (kilos/cajas recibidas) integradas en `metrics`.
+- Matching por cercanía necesidad↔destinatario (enlaza con EPIC #4 y #57).
+
+---
+
+## 5. Dependencias
+
+| Dependencia | Estado |
+|---|---|
+| Contexto `resources` (`Resource`, `ResourceStage`, ficha) | ✅ Existe |
+| Contexto `needs` (`Need`, `NeedItem`) | ✅ Existe |
+| Patrón de taxonomía configurable (`EmergencyNeedCategory`, ficha 04) | 🔜 Referencia de diseño |
+| Traslados con recepción confirmada (#11) y oferta→entregada (#25) | 🔜 Backlog (para recepciones derivadas) |
+| Necesidades nominales / privacidad (ficha 02) | 🔜 Para destinatarios "particulares" |
+| `pnpm gen:api` tras nuevos endpoints | Obligatorio |
+| Migraciones Drizzle vía psql (dev + test) | Obligatorio |
+
+---
+
+## 6. Privacidad / seguridad / GDPR
+
+- Los destinatarios **tipo organización/empresa/hospital** son entidades públicas; su ficha y recepciones agregadas pueden ser públicas (igual que los puntos hoy).
+- Los destinatarios **tipo particular** son personas: **no** llevan ficha pública. Se modelan con necesidades nominales (ficha 02), datos mínimos, consentimiento y sin exponer identidad en vistas públicas.
+- El **historial de recepciones** puede revelar carencias/capacidades de un centro: limitar el desglose fino a coordinación; exponer al público solo agregados no sensibles.
+- Respeta la **privacidad de ubicación** existente (coordenadas aproximadas para entidades sensibles, ficha 09).
+
+---
+
+## 7. Esfuerzo estimado
+
+**L (grande) — abordar por fases**
+
+- Núcleo destinatario + taxonomía (#60, #62): **M** (~3‑4 días).
+- Vínculo necesidad↔destinatario 1‑a‑N (#60): incluido arriba.
+- Ficha + recepciones derivadas (#67): **M**, depende de #11/#25 — si aún no existen, empezar por recepción manual.
+- Contacto oficial verificado (#64): **S** (~1 día), reutiliza `VerificationLevel`.
+- Vertical sanitario (#61, #63): fichas independientes.
+
+---
+
+## 8. Decisiones abiertas (para PM)
+
+1. **¿Destinatario = rol sobre `resource`, o agregado propio `Recipient`?** Propuesta: rol sobre `resource` (máximo reuso de ficha/estado/verificación). Un agregado propio solo si aparecen destinatarios sin nodo logístico.
+2. **¿`recipientType` como taxonomía configurable (recomendado) o enum base?** Recomendado configurable (patrón ficha 04), por el "*o cualquier otra cosa*".
+3. **¿Las recepciones se derivan de traslados/ofertas (proyección de eventos) o se registran a mano?** Probablemente ambos; el MVP puede empezar por lo que ya exista.
+4. **¿Un "particular" es `resource` con privacidad o siempre necesidad nominal (ficha 02)?** Define el límite entre este modelo y el de beneficiario nominal.
+5. **¿Sub-uso dentro de un destinatario** (p. ej. "pacientes" vs "personal" de un hospital) entra en alcance o se pospone?
+6. **¿`Need.resourceId` obligatorio para algún tipo** (p. ej. necesidades sanitarias) **o siempre opcional?**


### PR DESCRIPTION
EPIC #59. Arranca el **núcleo genérico** de destinatarios finales: la documentación del modelo y el **primer incremento de implementación** (#60).

## 1. Documentación — `docs/features/14-destinatarios-finales.md`

Consolida el modelo **genérico y escalable**: el "destinatario final" es un **rol** sobre un recurso en `ResourceStage.Destination` (no un `ResourceType` hardcodeado), con **tipo extensible** (empresa · organización · particular · hospital · …), necesidades vinculadas 1‑a‑N y ficha con historial de recepciones. El vertical sanitario es el primer caso de uso. (+ entrada en el índice.)

## 2. Implementación — #60 · rol "destinatario final" en `Resource`

Primer incremento del núcleo. **No hardcodea "hospital"**: un hospital es solo un `recipientType`.

- **Dominio:** `isFinalRecipient` + `recipientType` en `Resource` (props, snapshot, constructor, `register`, `fromSnapshot`, `toSnapshot`) e **invariante** "destinatario ⇒ etapa destino" (`FinalRecipientMustBeDestinationError`).
- **Persistencia:** columnas `is_final_recipient` / `recipient_type` (**migración `0023`**, índice parcial) + mapeo en el repositorio Drizzle (insert/upsert y los dos mappers de fila).
- **API:** opcional al registrar (`RegisterResourceDto`) y expuesto en `ResourceView` / `ResourceViewDto` (todos los listados de recursos). El ingest externo **preserva** el rol en update y lo deja en `false` al insertar.
- **Tests:** dominio (invariante + round‑trip) e integración (round‑trip en Postgres); fixture de ingest actualizado.

## Verificación local

`pnpm --filter api build` (tsc) ✓ · `prettier --check` ✓ · `eslint --max-warnings=0` ✓. Los tests de integración (Postgres) corren en CI.

## Pendiente (próximos incrementos del EPIC)

- #62 Taxonomía extensible de `recipientType` (validación por emergencia) — ahora es slug libre.
- Vínculo necesidad ↔ destinatario (1‑a‑N) y ficha de recepciones (#67).
- Regenerar el `api-client` tipado y la UI (web no consume aún los campos nuevos).

## Tracking

Sub‑issues de #59: #60 (este), #62, #67, #64, #61, #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV