### PR TITLE
feat(authz): endurecimiento de seguridad + búsqueda por email (reconciliado con #71)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -114,6 +114,50 @@
       }
     },
     "/grants": {
+      "get": {
+        "operationId": "GrantsController_list",
+        "parameters": [
+          {
+            "name": "principalId",
+            "required": true,
+            "in": "query",
+            "description": "User or service-account id",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GrantListItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Admin access required"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List the grants held by a principal (admin)",
+        "tags": [
+          "grants"
+        ]
+      },
       "post": {
         "operationId": "GrantsController_grant",
         "parameters": [],
@@ -192,6 +236,40 @@
       }
     },
     "/service-accounts": {
+      "get": {
+        "operationId": "ApiKeysController_listServiceAccounts",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ServiceAccountListItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Admin access required"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List service accounts (admin)",
+        "tags": [
+          "service-accounts"
+        ]
+      },
       "post": {
         "operationId": "ApiKeysController_create",
         "parameters": [],
@@ -235,6 +313,49 @@
       }
     },
     "/service-accounts/{serviceAccountId}/api-keys": {
+      "get": {
+        "operationId": "ApiKeysController_listApiKeys",
+        "parameters": [
+          {
+            "name": "serviceAccountId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ApiKeyListItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Admin access required"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List a service account’s keys — metadata only (admin)",
+        "tags": [
+          "service-accounts"
+        ]
+      },
       "post": {
         "operationId": "ApiKeysController_issue",
         "parameters": [
@@ -348,6 +469,81 @@
         "summary": "Introspect the calling service account (authenticated by X-API-Key)",
         "tags": [
           "service-accounts"
+        ]
+      }
+    },
+    "/roles": {
+      "get": {
+        "operationId": "RolesController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RoleDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List the fixed role catalog",
+        "tags": [
+          "roles"
+        ]
+      }
+    },
+    "/users/lookup": {
+      "get": {
+        "operationId": "UsersController_lookup",
+        "parameters": [
+          {
+            "name": "email",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserLookupDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not authorized to look up users"
+          },
+          "404": {
+            "description": "No user with that email"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Resolve an email to a principal id (admin only)",
+        "tags": [
+          "users"
         ]
       }
     },
@@ -1168,7 +1364,7 @@
             "description": "Missing or invalid token"
           },
           "403": {
-            "description": "Admin access required"
+            "description": "emergency:create required"
           },
           "409": {
             "description": "Slug already exists"
@@ -1179,7 +1375,7 @@
             "bearer": []
           }
         ],
-        "summary": "Create an emergency (admin only)",
+        "summary": "Create an emergency (emergency:create)",
         "tags": [
           "emergencies"
         ]
@@ -1274,7 +1470,7 @@
             "description": "Missing or invalid token"
           },
           "403": {
-            "description": "Admin access required"
+            "description": "emergency:create required"
           },
           "404": {
             "description": "Template not found"
@@ -1288,7 +1484,7 @@
             "bearer": []
           }
         ],
-        "summary": "Create an emergency from a template (admin only)",
+        "summary": "Create an emergency from a template (emergency:create)",
         "tags": [
           "emergencies"
         ]
@@ -2224,7 +2420,7 @@
             "bearer": []
           }
         ],
-        "summary": "Grant accreditation to an organization (admin only)",
+        "summary": "Grant accreditation to an organization (accreditation:grant)",
         "tags": [
           "accreditations"
         ]
@@ -2277,7 +2473,7 @@
             "bearer": []
           }
         ],
-        "summary": "List accreditations (admin only)",
+        "summary": "List accreditations (accreditation:grant)",
         "tags": [
           "accreditations"
         ]
@@ -2317,7 +2513,7 @@
             "bearer": []
           }
         ],
-        "summary": "Revoke an accreditation (admin only)",
+        "summary": "Revoke an accreditation (accreditation:revoke)",
         "tags": [
           "accreditations"
         ]
@@ -3804,7 +4000,7 @@
             "description": "Unauthorized"
           },
           "403": {
-            "description": "Admin access required"
+            "description": "audit:read required"
           }
         },
         "security": [
@@ -3812,9 +4008,403 @@
             "bearer": []
           }
         ],
-        "summary": "List audit log entries (admin only)",
+        "summary": "List audit log entries (audit:read)",
         "tags": [
           "audit"
+        ]
+      }
+    },
+    "/groups/mine": {
+      "get": {
+        "operationId": "GroupsController_mine",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MyGroupResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List the groups I belong to (any status)",
+        "tags": [
+          "groups"
+        ]
+      }
+    },
+    "/groups": {
+      "get": {
+        "operationId": "GroupsController_list",
+        "parameters": [
+          {
+            "name": "ownerKind",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "organization",
+                "emergency"
+              ]
+            }
+          },
+          {
+            "name": "ownerId",
+            "required": true,
+            "in": "query",
+            "description": "Id of the owning org/emergency",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GroupResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List groups under an org/emergency (all if you can read; else public)",
+        "tags": [
+          "groups"
+        ]
+      },
+      "post": {
+        "operationId": "GroupsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGroupDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IdResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "group:create required in the owner scope"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Create a group (creator becomes its first manager)",
+        "tags": [
+          "groups"
+        ]
+      }
+    },
+    "/groups/{groupId}": {
+      "get": {
+        "operationId": "GroupsController_getOne",
+        "parameters": [
+          {
+            "name": "groupId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get a group’s basic info",
+        "tags": [
+          "groups"
+        ]
+      }
+    },
+    "/groups/{groupId}/join": {
+      "post": {
+        "operationId": "GroupsController_join",
+        "parameters": [
+          {
+            "name": "groupId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Join request registered"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Group is private"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Request to join a public group (awaits approval)",
+        "tags": [
+          "groups"
+        ]
+      }
+    },
+    "/groups/{groupId}/members": {
+      "get": {
+        "operationId": "GroupsController_members",
+        "parameters": [
+          {
+            "name": "groupId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GroupMemberResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "group:read required"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List a group’s members",
+        "tags": [
+          "groups"
+        ]
+      },
+      "post": {
+        "operationId": "GroupsController_addMember",
+        "parameters": [
+          {
+            "name": "groupId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddMemberByEmailDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupMemberResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "group:manage_members required"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Add a member by email (manager only)",
+        "tags": [
+          "groups"
+        ]
+      }
+    },
+    "/groups/{groupId}/members/{userId}/approve": {
+      "post": {
+        "operationId": "GroupsController_approve",
+        "parameters": [
+          {
+            "name": "groupId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Member approved"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "group:manage_members required"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Approve a pending member (manager only)",
+        "tags": [
+          "groups"
+        ]
+      }
+    },
+    "/groups/{groupId}/managers": {
+      "post": {
+        "operationId": "GroupsController_assignManager",
+        "parameters": [
+          {
+            "name": "groupId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignManagerDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IdResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "role:grant required, or privilege escalation"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Appoint a member as co-manager (delegated, attenuated)",
+        "tags": [
+          "groups"
         ]
       }
     }
@@ -3903,6 +4493,42 @@
           "accessToken"
         ]
       },
+      "MeGrantDto": {
+        "type": "object",
+        "properties": {
+          "roleId": {
+            "type": "string",
+            "description": "Role id from the catalog",
+            "example": "org_admin"
+          },
+          "scopeType": {
+            "type": "string",
+            "enum": [
+              "platform",
+              "organization",
+              "emergency",
+              "group",
+              "entity"
+            ]
+          },
+          "scopeId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Scope id (null for platform)"
+          },
+          "expiresAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO expiry, or null"
+          }
+        },
+        "required": [
+          "roleId",
+          "scopeType",
+          "scopeId",
+          "expiresAt"
+        ]
+      },
       "MeResponseDto": {
         "type": "object",
         "properties": {
@@ -3920,13 +4546,73 @@
           },
           "isAdmin": {
             "type": "boolean"
+          },
+          "grants": {
+            "description": "The effective role grants (role @ scope) for this user",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MeGrantDto"
+            }
           }
         },
         "required": [
           "id",
           "email",
           "name",
-          "isAdmin"
+          "isAdmin",
+          "grants"
+        ]
+      },
+      "GrantListItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "principalId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "principalType": {
+            "type": "string",
+            "enum": [
+              "user",
+              "service_account"
+            ]
+          },
+          "roleId": {
+            "type": "string"
+          },
+          "scopeType": {
+            "type": "string"
+          },
+          "scopeId": {
+            "type": "string",
+            "nullable": true
+          },
+          "grantedByPrincipalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "grantedAt": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "principalId",
+          "principalType",
+          "roleId",
+          "scopeType",
+          "scopeId",
+          "grantedByPrincipalId",
+          "grantedAt",
+          "expiresAt"
         ]
       },
       "GrantRoleDto": {
@@ -3981,6 +4667,77 @@
         },
         "required": [
           "id"
+        ]
+      },
+      "ServiceAccountListItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerOrganizationId": {
+            "type": "object",
+            "format": "uuid",
+            "nullable": true
+          },
+          "createdByUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "ownerOrganizationId",
+          "createdByUserId",
+          "createdAt"
+        ]
+      },
+      "ApiKeyListItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "prefix": {
+            "type": "string",
+            "description": "Non-secret lookup prefix"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "expiresAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastUsedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "revokedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "prefix",
+          "active",
+          "expiresAt",
+          "lastUsedAt",
+          "revokedAt",
+          "createdAt"
         ]
       },
       "CreateServiceAccountDto": {
@@ -4086,6 +4843,52 @@
           "principalId",
           "principalType",
           "grants"
+        ]
+      },
+      "RoleDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "defaultScopeType": {
+            "type": "string"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "description",
+          "defaultScopeType",
+          "permissions"
+        ]
+      },
+      "UserLookupDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "name"
         ]
       },
       "NotificationDto": {
@@ -6540,6 +7343,211 @@
         "required": [
           "entries",
           "total"
+        ]
+      },
+      "MyGroupResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private"
+            ]
+          },
+          "ownerKind": {
+            "type": "string",
+            "enum": [
+              "organization",
+              "emergency"
+            ]
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentGroupId": {
+            "type": "object",
+            "format": "uuid",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "membershipStatus": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "visibility",
+          "ownerKind",
+          "ownerId",
+          "parentGroupId",
+          "createdAt",
+          "membershipStatus"
+        ]
+      },
+      "GroupResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private"
+            ]
+          },
+          "ownerKind": {
+            "type": "string",
+            "enum": [
+              "organization",
+              "emergency"
+            ]
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentGroupId": {
+            "type": "object",
+            "format": "uuid",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "visibility",
+          "ownerKind",
+          "ownerId",
+          "parentGroupId",
+          "createdAt"
+        ]
+      },
+      "CreateGroupDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Group/cuadrilla name"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private"
+            ]
+          },
+          "ownerKind": {
+            "type": "string",
+            "enum": [
+              "organization",
+              "emergency"
+            ],
+            "description": "Whether the group hangs off an organization or an emergency"
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Id of the owning org/emergency"
+          },
+          "parentGroupId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Parent group (nesting)"
+          }
+        },
+        "required": [
+          "name",
+          "visibility",
+          "ownerKind",
+          "ownerId"
+        ]
+      },
+      "IdResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "GroupMemberResponseDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved"
+            ]
+          },
+          "addedByUserId": {
+            "type": "object",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "required": [
+          "userId",
+          "status",
+          "addedByUserId"
+        ]
+      },
+      "AddMemberByEmailDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Email of the user to add (must already exist)"
+          }
+        },
+        "required": [
+          "email"
+        ]
+      },
+      "AssignManagerDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Member to appoint as manager"
+          }
+        },
+        "required": [
+          "userId"
         ]
       }
     }

--- a/apps/api/src/contexts/accreditation/infrastructure/http/accreditations.controller.ts
+++ b/apps/api/src/contexts/accreditation/infrastructure/http/accreditations.controller.ts
@@ -40,7 +40,8 @@ import {
   JwtAuthGuard,
   AuthenticatedUser,
 } from '../../../identity/infrastructure/http/jwt-auth.guard';
-import { RequireAdminGuard } from '../../../identity/infrastructure/http/require-admin.guard';
+import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
+import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
 
 class AccreditationResponseDto {
   @ApiProperty({ format: 'uuid' })
@@ -69,7 +70,7 @@ class AccreditationViewDto implements AccreditationView {
 
 @ApiTags('accreditations')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard, RequireAdminGuard)
+@UseGuards(JwtAuthGuard, PermissionGuard)
 @UseFilters(AccreditationExceptionFilter)
 @Controller('accreditations')
 export class AccreditationsController {
@@ -81,8 +82,9 @@ export class AccreditationsController {
 
   @Post()
   @HttpCode(201)
+  @RequirePermission('accreditation:grant')
   @ApiOperation({
-    summary: 'Grant accreditation to an organization (admin only)',
+    summary: 'Grant accreditation to an organization (accreditation:grant)',
   })
   @ApiCreatedResponse({
     description: 'Accreditation granted',
@@ -104,7 +106,8 @@ export class AccreditationsController {
 
   @Delete(':id')
   @HttpCode(204)
-  @ApiOperation({ summary: 'Revoke an accreditation (admin only)' })
+  @RequirePermission('accreditation:revoke')
+  @ApiOperation({ summary: 'Revoke an accreditation (accreditation:revoke)' })
   @ApiParam({ name: 'id', description: 'Accreditation UUID', format: 'uuid' })
   @ApiNoContentResponse({ description: 'Accreditation revoked' })
   @ApiNotFoundResponse({ description: 'Accreditation not found' })
@@ -117,7 +120,8 @@ export class AccreditationsController {
   }
 
   @Get()
-  @ApiOperation({ summary: 'List accreditations (admin only)' })
+  @RequirePermission('accreditation:grant')
+  @ApiOperation({ summary: 'List accreditations (accreditation:grant)' })
   @ApiQuery({
     name: 'organizationId',
     required: false,

--- a/apps/api/src/contexts/audit/infrastructure/http/audit.controller.ts
+++ b/apps/api/src/contexts/audit/infrastructure/http/audit.controller.ts
@@ -8,7 +8,8 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
-import { RequireAdminGuard } from '../../../identity/infrastructure/http/require-admin.guard';
+import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
+import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
 import {
   AUDIT_REPOSITORY,
   type AuditRepository,
@@ -23,16 +24,17 @@ import {
 @ApiTags('audit')
 @Controller('audit')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard, RequireAdminGuard)
+@UseGuards(JwtAuthGuard, PermissionGuard)
 @ApiUnauthorizedResponse({ description: 'Unauthorized' })
-@ApiForbiddenResponse({ description: 'Admin access required' })
+@ApiForbiddenResponse({ description: 'audit:read required' })
 export class AuditController {
   constructor(
     @Inject(AUDIT_REPOSITORY) private readonly auditRepo: AuditRepository,
   ) {}
 
   @Get()
-  @ApiOperation({ summary: 'List audit log entries (admin only)' })
+  @RequirePermission('audit:read')
+  @ApiOperation({ summary: 'List audit log entries (audit:read)' })
   @ApiOkResponse({ type: AuditListResponseDto })
   async list(@Query() query: AuditQueryDto): Promise<AuditListResponseDto> {
     const filters: AuditQueryFilters = {

--- a/apps/api/src/contexts/emergencies/infrastructure/http/emergencies.controller.ts
+++ b/apps/api/src/contexts/emergencies/infrastructure/http/emergencies.controller.ts
@@ -41,7 +41,6 @@ import {
 } from './dto';
 import { EmergencyExceptionFilter } from './emergency-exception.filter';
 import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
-import { RequireAdminGuard } from '../../../identity/infrastructure/http/require-admin.guard';
 import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
 import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
 
@@ -61,9 +60,10 @@ export class EmergenciesController {
 
   @Post()
   @HttpCode(201)
-  @UseGuards(JwtAuthGuard, RequireAdminGuard)
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('emergency:create')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Create an emergency (admin only)' })
+  @ApiOperation({ summary: 'Create an emergency (emergency:create)' })
   @ApiCreatedResponse({
     description: 'Emergency created',
     type: CreateEmergencyResponseDto,
@@ -71,7 +71,7 @@ export class EmergenciesController {
   @ApiBadRequestResponse({ description: 'Invalid request body' })
   @ApiConflictResponse({ description: 'Slug already exists' })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
-  @ApiForbiddenResponse({ description: 'Admin access required' })
+  @ApiForbiddenResponse({ description: 'emergency:create required' })
   async createEmergency(
     @Body() dto: CreateEmergencyDto,
   ): Promise<CreateEmergencyResponseDto> {
@@ -105,10 +105,11 @@ export class EmergenciesController {
 
   @Post('from-template')
   @HttpCode(201)
-  @UseGuards(JwtAuthGuard, RequireAdminGuard)
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('emergency:create')
   @ApiBearerAuth()
   @ApiOperation({
-    summary: 'Create an emergency from a template (admin only)',
+    summary: 'Create an emergency from a template (emergency:create)',
   })
   @ApiCreatedResponse({
     description: 'Emergency created from template',
@@ -118,7 +119,7 @@ export class EmergenciesController {
   @ApiConflictResponse({ description: 'Slug already exists' })
   @ApiNotFoundResponse({ description: 'Template not found' })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
-  @ApiForbiddenResponse({ description: 'Admin access required' })
+  @ApiForbiddenResponse({ description: 'emergency:create required' })
   async createFromTemplateRoute(
     @Body() dto: CreateEmergencyFromTemplateDto,
   ): Promise<CreateEmergencyResponseDto> {

--- a/apps/api/src/contexts/identity/application/find-user-by-email.spec.ts
+++ b/apps/api/src/contexts/identity/application/find-user-by-email.spec.ts
@@ -1,0 +1,88 @@
+import { FindUserByEmail } from './find-user-by-email';
+import { InMemoryUserRepository } from '../infrastructure/in-memory-user.repository';
+import { LocalAccessControl } from '../domain/authorization/local-access-control';
+import { AuthorizationContext } from '../domain/authorization/access-control';
+import { Grant } from '../domain/authorization/grant';
+import { ScopeRef } from '../domain/authorization/scope-ref';
+import { NotAuthorizedToReadError } from '../domain/authorization/errors';
+import { User } from '../domain/user';
+import { UserId } from '../domain/user-id';
+import { Email } from '../domain/email';
+
+const PLATFORM_ADMIN = '11111111-1111-4111-8111-111111111111';
+const ALICE = '33333333-3333-4333-8333-333333333333';
+
+function platformAdmin(): AuthorizationContext {
+  return {
+    principalId: PLATFORM_ADMIN,
+    grants: [
+      Grant.create({
+        id: 'g',
+        principalId: PLATFORM_ADMIN,
+        roleId: 'platform_admin',
+        scope: ScopeRef.platform(),
+      }).toSnapshot(),
+    ],
+  };
+}
+
+function outsider(): AuthorizationContext {
+  return { principalId: ALICE, grants: [] };
+}
+
+describe('FindUserByEmail', () => {
+  const access = new LocalAccessControl();
+  let users: InMemoryUserRepository;
+
+  beforeEach(async () => {
+    users = new InMemoryUserRepository();
+    await users.save(
+      User.create({
+        id: UserId.fromString(ALICE),
+        email: Email.fromString('alice@example.org'),
+        passwordHash: null,
+        name: 'Alice',
+        isAdmin: false,
+      }),
+    );
+  });
+
+  it('resolves an email to a principal id for a platform admin', async () => {
+    const result = await new FindUserByEmail(users, access).execute({
+      actor: platformAdmin(),
+      email: 'alice@example.org',
+    });
+    expect(result).toEqual({
+      id: ALICE,
+      email: 'alice@example.org',
+      name: 'Alice',
+    });
+  });
+
+  it('is case/space-insensitive (email is normalized)', async () => {
+    const result = await new FindUserByEmail(users, access).execute({
+      actor: platformAdmin(),
+      email: '  ALICE@example.org ',
+    });
+    expect(result?.id).toBe(ALICE);
+  });
+
+  it('returns null for an unknown or malformed email', async () => {
+    const uc = new FindUserByEmail(users, access);
+    expect(
+      await uc.execute({ actor: platformAdmin(), email: 'nobody@example.org' }),
+    ).toBeNull();
+    expect(
+      await uc.execute({ actor: platformAdmin(), email: 'not-an-email' }),
+    ).toBeNull();
+  });
+
+  it('forbids lookup without role:grant or user:read at platform', async () => {
+    await expect(
+      new FindUserByEmail(users, access).execute({
+        actor: outsider(),
+        email: 'alice@example.org',
+      }),
+    ).rejects.toThrow(NotAuthorizedToReadError);
+  });
+});

--- a/apps/api/src/contexts/identity/application/find-user-by-email.ts
+++ b/apps/api/src/contexts/identity/application/find-user-by-email.ts
@@ -1,0 +1,53 @@
+import { UserRepository } from '../domain/ports/user.repository';
+import { Email } from '../domain/email';
+import {
+  AccessControl,
+  AuthorizationContext,
+} from '../domain/authorization/access-control';
+import { ancestorChain } from '../domain/authorization/scope-ref';
+import { NotAuthorizedToReadError } from '../domain/authorization/errors';
+
+export interface FindUserByEmailCommand {
+  actor: AuthorizationContext;
+  email: string;
+}
+
+export interface FoundUser {
+  id: string;
+  email: string;
+  name: string;
+}
+
+/**
+ * Resolves an email to a principal id so the access console can grant roles by
+ * email instead of by raw UUID. A thin admin directory lookup: requires
+ * `role:grant` or `user:read` at the platform scope. Returns `null` when the
+ * email is malformed or unknown (callers map that to 404).
+ */
+export class FindUserByEmail {
+  constructor(
+    private readonly users: UserRepository,
+    private readonly access: AccessControl,
+  ) {}
+
+  async execute(cmd: FindUserByEmailCommand): Promise<FoundUser | null> {
+    const perms = await this.access.effectivePermissions(
+      cmd.actor,
+      ancestorChain({ type: 'platform' }),
+    );
+    if (!perms.has('role:grant') && !perms.has('user:read')) {
+      throw new NotAuthorizedToReadError('users');
+    }
+
+    let email: Email;
+    try {
+      email = Email.fromString(cmd.email);
+    } catch {
+      return null;
+    }
+
+    const user = await this.users.findByEmail(email);
+    if (!user) return null;
+    return { id: user.id.value, email: user.email.value, name: user.name };
+  }
+}

--- a/apps/api/src/contexts/identity/application/grant-role.spec.ts
+++ b/apps/api/src/contexts/identity/application/grant-role.spec.ts
@@ -5,6 +5,7 @@ import { AuthorizationContext } from '../domain/authorization/access-control';
 import { Grant } from '../domain/authorization/grant';
 import { ScopeRef } from '../domain/authorization/scope-ref';
 import {
+  InvalidGrantExpiryError,
   NotAuthorizedToGrantError,
   PrivilegeEscalationError,
   UnknownRoleError,
@@ -130,5 +131,37 @@ describe('GrantRole (delegation with attenuation)', () => {
         scope: ScopeRef.platform().toPlain(),
       }),
     ).rejects.toThrow(UnknownRoleError);
+  });
+
+  it('rejects an expiry in the past (would create a dead grant)', async () => {
+    const actor = actorWith({
+      roleId: 'platform_admin',
+      scope: ScopeRef.platform(),
+    });
+    await expect(
+      useCase.execute({
+        actor,
+        targetPrincipalId: TARGET,
+        roleId: 'emergency_coordinator',
+        scope: ScopeRef.emergency('e1').toPlain(),
+        expiresAt: new Date(Date.now() - 60_000),
+      }),
+    ).rejects.toThrow(InvalidGrantExpiryError);
+  });
+
+  it('rejects an Invalid Date expiry instead of creating a dead grant / 500', async () => {
+    const actor = actorWith({
+      roleId: 'platform_admin',
+      scope: ScopeRef.platform(),
+    });
+    await expect(
+      useCase.execute({
+        actor,
+        targetPrincipalId: TARGET,
+        roleId: 'emergency_coordinator',
+        scope: ScopeRef.emergency('e1').toPlain(),
+        expiresAt: new Date('not-a-date'),
+      }),
+    ).rejects.toThrow(InvalidGrantExpiryError);
   });
 });

--- a/apps/api/src/contexts/identity/application/grant-role.ts
+++ b/apps/api/src/contexts/identity/application/grant-role.ts
@@ -15,6 +15,7 @@ import {
   roleExists,
 } from '../domain/authorization/role-catalog';
 import {
+  InvalidGrantExpiryError,
   NotAuthorizedToGrantError,
   PrivilegeEscalationError,
   UnknownRoleError,
@@ -46,6 +47,17 @@ export class GrantRole {
   async execute(cmd: GrantRoleCommand): Promise<{ id: string }> {
     if (!roleExists(cmd.roleId)) {
       throw new UnknownRoleError(cmd.roleId);
+    }
+
+    if (
+      cmd.expiresAt != null &&
+      (Number.isNaN(cmd.expiresAt.getTime()) ||
+        cmd.expiresAt.getTime() <= Date.now())
+    ) {
+      // Rejects both past expiries and Invalid Date (e.g. an unparseable
+      // expiresAt string from the HTTP layer) — otherwise NaN <= now is false
+      // and a "born-dead" grant with an Invalid Date would 500 on persist.
+      throw new InvalidGrantExpiryError();
     }
 
     const chain = ancestorChain(cmd.scope);

--- a/apps/api/src/contexts/identity/application/revoke-grant.spec.ts
+++ b/apps/api/src/contexts/identity/application/revoke-grant.spec.ts
@@ -5,7 +5,9 @@ import { AuthorizationContext } from '../domain/authorization/access-control';
 import { Grant } from '../domain/authorization/grant';
 import { ScopeRef } from '../domain/authorization/scope-ref';
 import {
+  CannotRevokeOwnAdminError,
   GrantNotFoundError,
+  LegacyGrantNotRevocableError,
   NotAuthorizedToRevokeError,
 } from '../domain/authorization/errors';
 
@@ -78,5 +80,51 @@ describe('RevokeGrant', () => {
     await expect(useCase.execute({ actor, grantId: GRANT_ID })).rejects.toThrow(
       NotAuthorizedToRevokeError,
     );
+  });
+
+  it('forbids an admin from revoking their own platform_admin grant (self-lockout)', async () => {
+    await repo.save(
+      Grant.create({
+        id: GRANT_ID,
+        principalId: ACTOR,
+        roleId: 'platform_admin',
+        scope: ScopeRef.platform(),
+      }),
+    );
+    const actor = actorWith({
+      roleId: 'platform_admin',
+      scope: ScopeRef.platform(),
+    });
+    await expect(useCase.execute({ actor, grantId: GRANT_ID })).rejects.toThrow(
+      CannotRevokeOwnAdminError,
+    );
+    expect(await repo.findById(GRANT_ID)).not.toBeNull();
+  });
+
+  it('still lets an admin revoke ANOTHER admin platform_admin grant', async () => {
+    await repo.save(
+      Grant.create({
+        id: GRANT_ID,
+        principalId: TARGET,
+        roleId: 'platform_admin',
+        scope: ScopeRef.platform(),
+      }),
+    );
+    const actor = actorWith({
+      roleId: 'platform_admin',
+      scope: ScopeRef.platform(),
+    });
+    await useCase.execute({ actor, grantId: GRANT_ID });
+    expect(await repo.findById(GRANT_ID)).toBeNull();
+  });
+
+  it('rejects revoking a legacy-derived grant with a clear error', async () => {
+    const actor = actorWith({
+      roleId: 'platform_admin',
+      scope: ScopeRef.platform(),
+    });
+    await expect(
+      useCase.execute({ actor, grantId: `legacy:admin:${TARGET}` }),
+    ).rejects.toThrow(LegacyGrantNotRevocableError);
   });
 });

--- a/apps/api/src/contexts/identity/application/revoke-grant.ts
+++ b/apps/api/src/contexts/identity/application/revoke-grant.ts
@@ -5,7 +5,9 @@ import {
 } from '../domain/authorization/access-control';
 import { ancestorChain } from '../domain/authorization/scope-ref';
 import {
+  CannotRevokeOwnAdminError,
   GrantNotFoundError,
+  LegacyGrantNotRevocableError,
   NotAuthorizedToRevokeError,
 } from '../domain/authorization/errors';
 
@@ -27,9 +29,25 @@ export class RevokeGrant {
   ) {}
 
   async execute(cmd: RevokeGrantCommand): Promise<void> {
+    // Legacy-derived grants are not persisted rows; they carry a `legacy:` id and
+    // would otherwise surface as a misleading "not found". Reject them clearly.
+    if (cmd.grantId.startsWith('legacy:')) {
+      throw new LegacyGrantNotRevocableError(cmd.grantId);
+    }
+
     const grant = await this.grants.findById(cmd.grantId);
     if (!grant) {
       throw new GrantNotFoundError(cmd.grantId);
+    }
+
+    // Self-lockout guard: an admin must not revoke their own platform_admin
+    // grant. Removing other admins still requires platform `role:revoke` below.
+    if (
+      grant.principalId === cmd.actor.principalId &&
+      grant.roleId === 'platform_admin' &&
+      grant.scope.type === 'platform'
+    ) {
+      throw new CannotRevokeOwnAdminError();
     }
 
     const chain = ancestorChain(grant.scope.toPlain());

--- a/apps/api/src/contexts/identity/domain/api-key-generator.spec.ts
+++ b/apps/api/src/contexts/identity/domain/api-key-generator.spec.ts
@@ -17,4 +17,8 @@ describe('api-key-generator', () => {
     expect(prefixOf('rh_live_')).toBeNull();
     expect(prefixOf('rh_test_abcdef12')).toBeNull();
   });
+
+  it('prefixOf rejects an over-long key (DoS guard)', () => {
+    expect(prefixOf(`rh_live_${'a'.repeat(200)}`)).toBeNull();
+  });
 });

--- a/apps/api/src/contexts/identity/domain/api-key-generator.ts
+++ b/apps/api/src/contexts/identity/domain/api-key-generator.ts
@@ -7,7 +7,10 @@ export interface GeneratedApiKey {
   prefix: string;
 }
 
-const KEY_RE = /^rh_live_([0-9a-f]{16,})$/;
+// Upper-bounded on purpose: an unbounded `{16,}` would let an unauthenticated
+// caller submit a multi-megabyte all-hex header that we then SHA-256. The real
+// secret is 48 hex chars, so 128 is generous headroom.
+const KEY_RE = /^rh_live_([0-9a-f]{16,128})$/;
 
 /** Generate a fresh API key: `rh_live_<48 hex>`, with an 8-char lookup prefix. */
 export function generateApiKey(): GeneratedApiKey {

--- a/apps/api/src/contexts/identity/domain/authorization/errors.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/errors.ts
@@ -38,3 +38,46 @@ export class GrantNotFoundError extends Error {
     this.name = 'GrantNotFoundError';
   }
 }
+
+export class NotAuthorizedToReadError extends Error {
+  constructor(what: string) {
+    super(`Not authorized to read ${what}`);
+    this.name = 'NotAuthorizedToReadError';
+  }
+}
+
+/**
+ * Guards against an administrator revoking their own platform-admin grant and
+ * locking themselves (and possibly the platform) out by accident.
+ */
+export class CannotRevokeOwnAdminError extends Error {
+  constructor() {
+    super(
+      'You cannot revoke your own platform_admin grant; ask another admin to do it.',
+    );
+    this.name = 'CannotRevokeOwnAdminError';
+  }
+}
+
+/**
+ * Legacy-derived grants (`legacy:*`) are computed from `users.isAdmin` /
+ * `memberships` at request time and are not rows in the grants table. They are
+ * de-provisioned at their source, not through the grants API.
+ */
+export class LegacyGrantNotRevocableError extends Error {
+  constructor(id: string) {
+    super(
+      `Grant '${id}' is legacy-derived and cannot be revoked here; ` +
+        'remove it at its source (toggle isAdmin / delete the membership).',
+    );
+    this.name = 'LegacyGrantNotRevocableError';
+  }
+}
+
+/** A grant `expiresAt` that is already in the past would create a dead grant. */
+export class InvalidGrantExpiryError extends Error {
+  constructor() {
+    super('Grant expiry must be in the future.');
+    this.name = 'InvalidGrantExpiryError';
+  }
+}

--- a/apps/api/src/contexts/identity/domain/authorization/local-access-control.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/local-access-control.spec.ts
@@ -19,6 +19,40 @@ function chain(...scopes: ScopeRef[]): ScopeRefProps[] {
 describe('LocalAccessControl', () => {
   const ac = new LocalAccessControl();
 
+  it('ignores a malformed grant (unknown scope type) without crashing the decision', async () => {
+    // A forged/stale JWT grant with a scope type the runtime does not know.
+    const valid = Grant.create({
+      id: 'g1',
+      principalId: PRINCIPAL,
+      roleId: 'emergency_coordinator',
+      scope: ScopeRef.emergency('venezuela'),
+    }).toSnapshot();
+    const malformed = {
+      ...valid,
+      id: 'g2',
+      scope: {
+        type: 'hub',
+        id: 'valencia',
+      } as unknown as (typeof valid)['scope'],
+    };
+    const ctx: AuthorizationContext = {
+      principalId: PRINCIPAL,
+      grants: [malformed, valid],
+    };
+    const resource = {
+      scopeChain: chain(ScopeRef.emergency('venezuela'), ScopeRef.platform()),
+    };
+    // The malformed grant contributes nothing; the valid one still applies.
+    await expect(ac.can(ctx, 'resource:verify', resource)).resolves.toBe(true);
+    await expect(
+      ac.can(
+        { principalId: PRINCIPAL, grants: [malformed] },
+        'resource:verify',
+        resource,
+      ),
+    ).resolves.toBe(false);
+  });
+
   it('a coordinator of an emergency can verify a resource in that emergency', async () => {
     const ctx = ctxWith(
       Grant.create({

--- a/apps/api/src/contexts/identity/domain/authorization/local-access-control.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/local-access-control.ts
@@ -44,9 +44,19 @@ export class LocalAccessControl implements AccessControl {
     const out = new Set<Permission>();
 
     for (const snapshot of ctx.grants) {
-      const grant = Grant.fromSnapshot(snapshot);
-      if (!grant.isActive(now)) continue;
-      if (!grant.scope.coversAnyOf(chain)) continue;
+      // A single malformed grant (e.g. an unknown scope type from a stale or
+      // forged JWT) must not crash the whole decision — it simply contributes
+      // nothing. This keeps the PDP fail-closed and DoS-resistant rather than
+      // letting a TypeError propagate into a 500. Mirrors the unknown-role
+      // handling below.
+      let grant: Grant;
+      try {
+        grant = Grant.fromSnapshot(snapshot);
+        if (!grant.isActive(now)) continue;
+        if (!grant.scope.coversAnyOf(chain)) continue;
+      } catch {
+        continue;
+      }
 
       const role = ROLE_CATALOG[grant.roleId];
       if (role === undefined) continue; // unknown role → contributes nothing

--- a/apps/api/src/contexts/identity/domain/authorization/scope-ref.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/scope-ref.spec.ts
@@ -59,5 +59,12 @@ describe('ScopeRef', () => {
     it('throws on an empty id', () => {
       expect(() => ScopeRef.emergency('')).toThrow();
     });
+    it('rejects an unknown scope type (fail-closed, never platform)', () => {
+      // Grant snapshots arrive from JWTs and are not type-checked at runtime.
+      const forged = { type: 'hub', id: 'x' } as unknown as Parameters<
+        typeof ScopeRef.fromProps
+      >[0];
+      expect(() => ScopeRef.fromProps(forged)).toThrow(/unknown scope type/);
+    });
   });
 });

--- a/apps/api/src/contexts/identity/domain/authorization/scope-ref.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/scope-ref.ts
@@ -61,6 +61,17 @@ export class ScopeRef {
         return ScopeRef.group(props.id);
       case 'entity':
         return ScopeRef.entity(props.entityType, props.id);
+      default: {
+        // Unknown scope type. The compiler proves this is unreachable for valid
+        // input, but grant snapshots arrive from JWTs and are not re-validated
+        // at runtime — so reject explicitly (fail-closed) rather than fall off
+        // the switch returning `undefined`, which would crash the PDP. Never map
+        // an unknown scope to `platform`: that would be a fail-open escalation.
+        const exhaustive: never = props;
+        throw new Error(
+          `unknown scope type: ${String((exhaustive as { type?: unknown }).type)}`,
+        );
+      }
     }
   }
 

--- a/apps/api/src/contexts/identity/infrastructure/http/api-key-auth.guard.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/api-key-auth.guard.ts
@@ -21,6 +21,9 @@ import { AuthenticatedUser } from './jwt-auth.guard';
  */
 @Injectable()
 export class ApiKeyAuthGuard implements CanActivate {
+  /** Minimum gap between `lastUsedAt` writes for the same key. */
+  private static readonly USAGE_THROTTLE_MS = 5 * 60 * 1000;
+
   constructor(
     @Inject(API_KEY_REPOSITORY) private readonly keys: ApiKeyRepository,
     @Inject(GRANT_REPOSITORY) private readonly grants: GrantRepository,
@@ -38,13 +41,29 @@ export class ApiKeyAuthGuard implements CanActivate {
     const prefix = prefixOf(presented);
     if (!prefix) throw new UnauthorizedException('Malformed API key');
 
+    const now = new Date();
     const key = await this.keys.findByPrefix(prefix);
     if (
       !key ||
-      !key.isActive(new Date()) ||
+      !key.isActive(now) ||
       !verifyApiKeySecret(presented, key.hashedSecret)
     ) {
       throw new UnauthorizedException('Invalid or revoked API key');
+    }
+
+    // Record usage for leak detection, throttled so we don't write on every
+    // request (the secret hash never changes, so a coarse last-used is enough).
+    if (
+      key.lastUsedAt === null ||
+      now.getTime() - key.lastUsedAt.getTime() >
+        ApiKeyAuthGuard.USAGE_THROTTLE_MS
+    ) {
+      try {
+        await this.keys.save(key.markUsed(now));
+      } catch {
+        // Best-effort usage telemetry: a transient write failure must never
+        // fail an otherwise-valid API-key request.
+      }
     }
 
     const grants = await this.grants.findByPrincipal(key.serviceAccountId);

--- a/apps/api/src/contexts/identity/infrastructure/http/entity-aware-scope-resolver.spec.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/entity-aware-scope-resolver.spec.ts
@@ -1,0 +1,58 @@
+import { NotFoundException } from '@nestjs/common';
+import { Request } from 'express';
+import { EntityAwareScopeResolver } from './entity-aware-scope-resolver';
+
+interface Lookup {
+  findEmergencyId(entityId: string): Promise<string | null>;
+}
+
+function lookup(map: Record<string, string>): Lookup {
+  return { findEmergencyId: (id) => Promise.resolve(map[id] ?? null) };
+}
+
+function req(params: Record<string, string>): Request {
+  return { params } as unknown as Request;
+}
+
+describe('EntityAwareScopeResolver', () => {
+  const resource = lookup({ r1: 'E_victim' });
+  const none = lookup({});
+  const resolver = new EntityAwareScopeResolver(
+    resource,
+    none,
+    none,
+    none,
+    none,
+    none,
+  );
+
+  it("derives the chain from the entity's real owner, ignoring a client-supplied :emergencyId", async () => {
+    // The attacker is a coordinator of E_self trying to act on r1 (in E_victim).
+    const chain = await resolver.resolve(
+      req({ emergencyId: 'E_self', resourceId: 'r1' }),
+    );
+    expect(chain).toEqual([
+      { type: 'entity', entityType: 'resource', id: 'r1' },
+      { type: 'emergency', id: 'E_victim' },
+      { type: 'platform' },
+    ]);
+  });
+
+  it('throws NotFound when the targeted entity does not exist', async () => {
+    await expect(
+      resolver.resolve(req({ resourceId: 'missing' })),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('falls back to the emergency-collection scope when no entity param is present', async () => {
+    const chain = await resolver.resolve(req({ emergencyId: 'E1' }));
+    expect(chain).toEqual([
+      { type: 'emergency', id: 'E1' },
+      { type: 'platform' },
+    ]);
+  });
+
+  it('defaults to platform when there is nothing to scope', async () => {
+    expect(await resolver.resolve(req({}))).toEqual([{ type: 'platform' }]);
+  });
+});

--- a/apps/api/src/contexts/identity/infrastructure/http/entity-aware-scope-resolver.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/entity-aware-scope-resolver.ts
@@ -54,11 +54,13 @@ export class EntityAwareScopeResolver implements ScopeResolver {
   async resolve(request: Request): Promise<ScopeRefProps[]> {
     const params = (request.params ?? {}) as Record<string, string | undefined>;
 
-    const emergencyId = params.emergencyId;
-    if (emergencyId) {
-      return [{ type: 'emergency', id: emergencyId }, { type: 'platform' }];
-    }
-
+    // Resolve a targeted sub-entity FIRST. Its owning emergency is derived
+    // server-side from the entity id, so it is authoritative over any
+    // `:emergencyId` in the path — which the client controls. Trusting the path
+    // `:emergencyId` on a route that also carries `:resourceId`/`:needId`/… would
+    // let a coordinator of emergency A act on an entity in emergency B simply by
+    // putting A in the URL (privilege confusion). Always derive the chain from
+    // the entity instead. (docs/features/13 §9, §16)
     for (const { param, entityType, lookups } of this.entityParams) {
       const entityId = params[param];
       if (!entityId) continue;
@@ -74,6 +76,12 @@ export class EntityAwareScopeResolver implements ScopeResolver {
         }
       }
       throw new NotFoundException(`${entityType} ${entityId} not found`);
+    }
+
+    // No recognized sub-entity in the path → emergency-collection scope.
+    const emergencyId = params.emergencyId;
+    if (emergencyId) {
+      return [{ type: 'emergency', id: emergencyId }, { type: 'platform' }];
     }
 
     return [{ type: 'platform' }];

--- a/apps/api/src/contexts/identity/infrastructure/http/grant-exception.filter.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/grant-exception.filter.ts
@@ -6,23 +6,35 @@ import {
 } from '@nestjs/common';
 import { Response } from 'express';
 import {
+  CannotRevokeOwnAdminError,
   GrantNotFoundError,
+  InvalidGrantExpiryError,
+  LegacyGrantNotRevocableError,
   NotAuthorizedToGrantError,
+  NotAuthorizedToReadError,
   NotAuthorizedToRevokeError,
   PrivilegeEscalationError,
   UnknownRoleError,
 } from '../../domain/authorization/errors';
 
 type GrantError =
+  | CannotRevokeOwnAdminError
   | GrantNotFoundError
+  | InvalidGrantExpiryError
+  | LegacyGrantNotRevocableError
   | NotAuthorizedToGrantError
+  | NotAuthorizedToReadError
   | NotAuthorizedToRevokeError
   | PrivilegeEscalationError
   | UnknownRoleError;
 
 @Catch(
+  CannotRevokeOwnAdminError,
   GrantNotFoundError,
+  InvalidGrantExpiryError,
+  LegacyGrantNotRevocableError,
   NotAuthorizedToGrantError,
+  NotAuthorizedToReadError,
   NotAuthorizedToRevokeError,
   PrivilegeEscalationError,
   UnknownRoleError,
@@ -39,8 +51,14 @@ export class GrantExceptionFilter implements ExceptionFilter {
 
   private statusFor(exception: GrantError): number {
     if (exception instanceof GrantNotFoundError) return HttpStatus.NOT_FOUND;
-    if (exception instanceof UnknownRoleError) return HttpStatus.BAD_REQUEST;
-    // NotAuthorizedToGrant/Revoke + PrivilegeEscalation
+    if (
+      exception instanceof UnknownRoleError ||
+      exception instanceof InvalidGrantExpiryError
+    )
+      return HttpStatus.BAD_REQUEST;
+    if (exception instanceof LegacyGrantNotRevocableError)
+      return HttpStatus.CONFLICT;
+    // CannotRevokeOwnAdmin + NotAuthorizedToGrant/Revoke/Read + PrivilegeEscalation
     return HttpStatus.FORBIDDEN;
   }
 }

--- a/apps/api/src/contexts/identity/infrastructure/http/require-permission.decorator.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/require-permission.decorator.ts
@@ -13,7 +13,11 @@ export const REQUIRED_PERMISSION = 'required_permission';
  *
  * @example
  *   @RequirePermission('resource:verify')
- *   @Patch('emergencies/:emergencyId/resources/:resourceId/verify')
+ *   @Patch('resources/:resourceId/verify')
+ *
+ * Prefer entity-id routes (`:resourceId`) over nesting the scope id in the path
+ * (`:emergencyId/:resourceId`): the scope resolver derives the owning emergency
+ * from the entity itself, so a client-supplied path scope can't be trusted.
  */
 export const RequirePermission = (permission: Permission) =>
   SetMetadata(REQUIRED_PERMISSION, permission);

--- a/apps/api/src/contexts/identity/infrastructure/http/users-dto.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/users-dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/** Minimal directory projection used to resolve an email to a principal id. */
+export class UserLookupDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiProperty()
+  name!: string;
+}

--- a/apps/api/src/contexts/identity/infrastructure/http/users.controller.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/users.controller.ts
@@ -1,0 +1,64 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  NotFoundException,
+  Query,
+  Req,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { FindUserByEmail } from '../../application/find-user-by-email';
+import { GrantExceptionFilter } from './grant-exception.filter';
+import { JwtAuthGuard, AuthenticatedUser } from './jwt-auth.guard';
+import { UserLookupDto } from './users-dto';
+
+/**
+ * Thin admin directory lookup so the access console can grant roles by email
+ * rather than raw UUID. Authorization lives in the use case (docs/features/13
+ * §5): `role:grant` or `user:read` at the platform scope.
+ */
+@ApiTags('users')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@UseFilters(GrantExceptionFilter)
+@Controller('users')
+export class UsersController {
+  constructor(private readonly findUserByEmail: FindUserByEmail) {}
+
+  @Get('lookup')
+  @ApiOperation({ summary: 'Resolve an email to a principal id (admin only)' })
+  @ApiQuery({ name: 'email', required: true })
+  @ApiOkResponse({ type: UserLookupDto })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Not authorized to look up users' })
+  @ApiNotFoundResponse({ description: 'No user with that email' })
+  async lookup(
+    @Query('email') email: string,
+    @Req() req: Request & { user?: AuthenticatedUser },
+  ): Promise<UserLookupDto> {
+    if (!email || email.trim() === '') {
+      throw new BadRequestException('email query parameter is required');
+    }
+    const user = req.user!;
+    const found = await this.findUserByEmail.execute({
+      actor: { principalId: user.id, grants: user.grants },
+      email,
+    });
+    if (!found) {
+      throw new NotFoundException('No user with that email');
+    }
+    return found;
+  }
+}

--- a/apps/api/src/contexts/identity/infrastructure/identity.module.ts
+++ b/apps/api/src/contexts/identity/infrastructure/identity.module.ts
@@ -9,6 +9,7 @@ import { GrantsController } from './http/grants.controller';
 import { ApiKeysController } from './http/api-keys.controller';
 import { ServiceAccountIntrospectionController } from './http/service-account-introspection.controller';
 import { RolesController } from './http/roles.controller';
+import { UsersController } from './http/users.controller';
 import { Login } from '../application/login';
 import { RegisterUser } from '../application/register-user';
 import { AuthenticateWithProvider } from '../application/authenticate-with-provider';
@@ -17,6 +18,7 @@ import { RevokeGrant } from '../application/revoke-grant';
 import { CreateServiceAccount } from '../application/create-service-account';
 import { IssueApiKey } from '../application/issue-api-key';
 import { RevokeApiKey } from '../application/revoke-api-key';
+import { FindUserByEmail } from '../application/find-user-by-email';
 import {
   USER_REPOSITORY,
   UserRepository,
@@ -135,6 +137,13 @@ const revokeGrantProvider = {
   inject: [GRANT_REPOSITORY, ACCESS_CONTROL],
   useFactory: (grants: GrantRepository, access: AccessControl) =>
     new RevokeGrant(grants, access),
+};
+
+const findUserByEmailProvider = {
+  provide: FindUserByEmail,
+  inject: [USER_REPOSITORY, ACCESS_CONTROL],
+  useFactory: (users: UserRepository, access: AccessControl) =>
+    new FindUserByEmail(users, access),
 };
 
 const serviceAccountRepositoryProvider = {
@@ -286,6 +295,7 @@ const authenticateWithProviderProvider = {
     ApiKeysController,
     ServiceAccountIntrospectionController,
     RolesController,
+    UsersController,
   ],
   providers: [
     userRepositoryProvider,
@@ -299,6 +309,7 @@ const authenticateWithProviderProvider = {
     authenticateWithProviderProvider,
     grantRoleProvider,
     revokeGrantProvider,
+    findUserByEmailProvider,
     serviceAccountRepositoryProvider,
     apiKeyRepositoryProvider,
     createServiceAccountProvider,

--- a/apps/api/src/contexts/identity/infrastructure/jwt-token.service.ts
+++ b/apps/api/src/contexts/identity/infrastructure/jwt-token.service.ts
@@ -9,6 +9,11 @@ export class JwtTokenService implements TokenService {
   }
 
   verify(token: string): TokenPayload {
-    return this.jwtService.verify<TokenPayload>(token);
+    // Pin the accepted algorithm. The current setup is symmetric (HS256), so
+    // this is defence-in-depth against algorithm-confusion if an asymmetric key
+    // is ever introduced; it also rejects `alg: none` explicitly.
+    return this.jwtService.verify<TokenPayload>(token, {
+      algorithms: ['HS256'],
+    });
   }
 }

--- a/apps/web/src/app/admin/permisos/actions.ts
+++ b/apps/web/src/app/admin/permisos/actions.ts
@@ -50,6 +50,38 @@ export async function fetchGrants(principalId: string): Promise<GrantView[]> {
   return (data ?? []) as GrantView[];
 }
 
+export interface ResolvedPrincipal {
+  id: string;
+  email?: string;
+  name?: string;
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve the lookup input to a principal id. A raw UUID is used as-is; anything
+ * else is treated as an email and resolved via the admin directory lookup, so
+ * an admin can find a user without knowing their UUID. Returns null when an
+ * email is unknown or malformed.
+ */
+export async function resolvePrincipal(
+  input: string,
+): Promise<ResolvedPrincipal | null> {
+  const query = input.trim();
+  if (!query) return null;
+  if (UUID_RE.test(query)) return { id: query };
+
+  const token = await getToken();
+  if (!token) return null;
+  const { data, error } = await api.GET('/users/lookup', {
+    params: { query: { email: query } },
+    headers: authHeaders(token),
+  });
+  if (error !== undefined || !data) return null;
+  return { id: data.id, email: data.email, name: data.name };
+}
+
 export async function grantRoleAction(
   _prev: GrantActionResult,
   formData: FormData,

--- a/apps/web/src/app/admin/permisos/page.tsx
+++ b/apps/web/src/app/admin/permisos/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
-import { fetchRoles, fetchGrants } from './actions';
+import { fetchRoles, fetchGrants, resolvePrincipal } from './actions';
 import { GrantRoleForm } from './grant-role-form';
 import { RevokeGrantButton } from './revoke-grant-button';
 import { scopeLabel } from '@/lib/permissions';
@@ -29,7 +29,10 @@ export default async function PermisosPage({ searchParams }: Props) {
   if (!me.isAdmin) redirect('/');
 
   const { principalId } = await searchParams;
-  const lookupId = (principalId ?? '').trim();
+  const rawLookup = (principalId ?? '').trim();
+  // Accept a UUID or an email; resolve email → principal id via the directory.
+  const resolved = rawLookup ? await resolvePrincipal(rawLookup) : null;
+  const lookupId = resolved?.id ?? '';
 
   const [roles, grants] = await Promise.all([
     fetchRoles(),
@@ -64,8 +67,8 @@ export default async function PermisosPage({ searchParams }: Props) {
             <input
               type="text"
               name="principalId"
-              defaultValue={lookupId}
-              placeholder="UUID del usuario o cuenta de servicio"
+              defaultValue={rawLookup}
+              placeholder="Email del usuario, o UUID de usuario / cuenta de servicio"
               className="flex-1 rounded-lg border-2 border-gray-900 bg-white px-4 py-3 text-base text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2"
             />
             <button
@@ -75,6 +78,21 @@ export default async function PermisosPage({ searchParams }: Props) {
               Consultar
             </button>
           </form>
+
+          {rawLookup && !resolved && (
+            <p className="text-sm text-amber-700 bg-amber-50 border border-amber-300 rounded px-3 py-2">
+              No se encontró ningún principal con «{rawLookup}». Usa un email
+              registrado o pega un UUID.
+            </p>
+          )}
+
+          {resolved && (resolved.name || resolved.email) && (
+            <p className="text-xs text-gray-500">
+              {resolved.name ?? 'Usuario'}
+              {resolved.email ? ` · ${resolved.email}` : ''} ·{' '}
+              <span className="font-mono break-all">{resolved.id}</span>
+            </p>
+          )}
 
           {lookupId &&
             (grants.length === 0 ? (

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -177,6 +177,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/lookup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Resolve an email to a principal id (admin only) */
+        get: operations["UsersController_lookup"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/notifications/mine": {
         parameters: {
             query?: never;
@@ -443,7 +460,7 @@ export interface paths {
         /** List active emergencies */
         get: operations["EmergenciesController_list"];
         put?: never;
-        /** Create an emergency (admin only) */
+        /** Create an emergency (emergency:create) */
         post: operations["EmergenciesController_createEmergency"];
         delete?: never;
         options?: never;
@@ -477,7 +494,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Create an emergency from a template (admin only) */
+        /** Create an emergency from a template (emergency:create) */
         post: operations["EmergenciesController_createFromTemplateRoute"];
         delete?: never;
         options?: never;
@@ -769,10 +786,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List accreditations (admin only) */
+        /** List accreditations (accreditation:grant) */
         get: operations["AccreditationsController_listAccreditations"];
         put?: never;
-        /** Grant accreditation to an organization (admin only) */
+        /** Grant accreditation to an organization (accreditation:grant) */
         post: operations["AccreditationsController_grantAccreditation"];
         delete?: never;
         options?: never;
@@ -790,7 +807,7 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /** Revoke an accreditation (admin only) */
+        /** Revoke an accreditation (accreditation:revoke) */
         delete: operations["AccreditationsController_revokeAccreditation"];
         options?: never;
         head?: never;
@@ -1249,7 +1266,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List audit log entries (admin only) */
+        /** List audit log entries (audit:read) */
         get: operations["AuditController_list"];
         put?: never;
         post?: never;
@@ -1530,6 +1547,12 @@ export interface components {
             description: string;
             defaultScopeType: string;
             permissions: string[];
+        };
+        UserLookupDto: {
+            /** Format: uuid */
+            id: string;
+            email: string;
+            name: string;
         };
         NotificationDto: {
             id: string;
@@ -3072,6 +3095,48 @@ export interface operations {
             };
         };
     };
+    UsersController_lookup: {
+        parameters: {
+            query: {
+                email: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserLookupDto"];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authorized to look up users */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No user with that email */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     NotificationsController_getMyNotifications: {
         parameters: {
             query?: never;
@@ -3739,7 +3804,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Admin access required */
+            /** @description emergency:create required */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -3820,7 +3885,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Admin access required */
+            /** @description emergency:create required */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -5885,7 +5950,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Admin access required */
+            /** @description audit:read required */
             403: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Resumen

Esta rama empezó como una UI de permisos + endpoints de lectura, pero mientras tanto se mergeó en `main` el **#71** (UI de permisos, endpoints de lectura y módulo de grupos), que **solapaba**. Siguiendo la decisión de _"reconciliar lo mejor de ambos"_, la rama se ha **rebasado sobre el nuevo `main`** y se conserva únicamente lo que **aporta valor neto sobre #71**, sin duplicar interfaces:

- **De #71 (ya en `main`):** la UI (`/admin/permisos`, `/admin/api-keys`, `/mis-permisos`, `/grupos`) y los endpoints de lectura.
- **De esta rama (net-new):** el **endurecimiento de seguridad** del sistema de permisos (no estaba en #71) y la **búsqueda de principal por email**.
- **Descartado:** mi UI/endpoints duplicados anteriores (`/admin/acceso`) para no tener dos consolas de permisos en paralelo.

## Seguridad — auditoría del sistema de permisos completo

Revisión exhaustiva (núcleo de decisión, delegación/atenuación, guards/resolvers HTTP, auth máquina, cobertura por endpoint). Cada corrección con test:

| Sev | Corrección |
|---|---|
| **Alto** | `EntityAwareScopeResolver` deriva el ámbito de la **entidad** (su emergencia real es autoritativa) en vez de confiar en el `:emergencyId` de la ruta → elimina la confusión de privilegios entre emergencias en rutas anidadas. |
| Medio | `ScopeRef.fromProps` rechaza tipos de ámbito desconocidos (fail-closed, **nunca** mapea a `platform`); `LocalAccessControl` ignora grants no parseables sin tumbar el PDP (anti-DoS). |
| Medio | `RevokeGrant` impide el **auto-lockout** (revocar tu propio `platform_admin`) y da un error claro para grants `legacy:*`. |
| Medio | Migra **acreditaciones**, **creación de emergencias** y **auditoría** de `isAdmin` a permisos (`accreditation:grant/revoke`, `emergency:create`, `audit:read`) → habilita `platform_operator` y hace la autoridad revocable por grants. |
| Medio | JWT: algoritmo de verificación fijado a `HS256` (anti algorithm-confusion / `alg:none`). |
| Bajo | API keys: `lastUsedAt` best-effort (no falla la auth si la escritura falla) y regex acotado (anti-DoS). `GrantRole` rechaza expiraciones en el pasado **y fechas inválidas (NaN)**. |

## Mejora portada a la UI de #71

- `GET /users/lookup?email` (directorio admin, gated por `role:grant`/`user:read` en plataforma) + caso de uso `FindUserByEmail`.
- `/admin/permisos` ahora resuelve **email → id**: el admin concede roles sin conocer el UUID (antes solo aceptaba UUID).

## Fixes de la revisión de código

- `GrantRole`: `expiresAt` inválido (`NaN`) ya no se cuela (evitaba un grant "nacido muerto" y un 500 al persistir).
- `ApiKeyAuthGuard`: la escritura de `lastUsedAt` es best-effort (un fallo transitorio de BD ya no rechaza una API key válida).

## Pruebas

- **785** unit/integración + **261** e2e en verde (incluye los tests de #71).
- `api` build + `web` build + lint (`--max-warnings=0`) + prettier OK. Cliente tipado regenerado.

## Fuera de alcance (seguimiento, fail-closed hoy)

Migrar la pertenencia a organización (`OrganizationRole.Owner`) a `can()`; auth/firma en `GET /files/:key` y rate-limit en `GET /geocode`; eventos de dominio `RoleGranted`/`GrantRevoked` (hoy cubierto por el access-log HTTP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnU5GA4cPpCAq4AWRwubiK