### PR TITLE
feat(resources): taxonomía extensible de tipos de destinatario (#62)

### DIFF
--- a/apps/api/drizzle/0024_recipient_types.sql
+++ b/apps/api/drizzle/0024_recipient_types.sql
@@ -1,0 +1,20 @@
+-- Taxonomía de tipos de destinatario final (EPIC #59 · #62).
+-- Catálogo extensible (slug PK + labels ES/EN + orden). Añadir un tipo nuevo
+-- es insertar una fila — sin tocar enums del dominio. Global por ahora; la
+-- configuración por emergencia queda como evolución futura (ver docs/features/14).
+CREATE TABLE recipient_types (
+  slug     text primary key,
+  label_es text not null,
+  label_en text not null,
+  sort     int  not null default 0
+);
+
+INSERT INTO recipient_types (slug, label_es, label_en, sort) VALUES
+  ('hospital',          'Hospital',         'Hospital',          10),
+  ('clinic',            'Clínica',          'Clinic',            20),
+  ('organization',      'Organización',     'Organization',      30),
+  ('company',           'Empresa',          'Company',           40),
+  ('collection_center', 'Centro de acopio', 'Collection center', 50),
+  ('individual',        'Particular',       'Individual',        60),
+  ('other',             'Otro',             'Other',             90)
+ON CONFLICT (slug) DO NOTHING;

--- a/apps/api/src/contexts/resources/application/list-recipient-types.spec.ts
+++ b/apps/api/src/contexts/resources/application/list-recipient-types.spec.ts
@@ -1,0 +1,19 @@
+import { ListRecipientTypes } from './list-recipient-types';
+import { RecipientTypeRepository } from '../domain/ports/recipient-type.repository';
+import { RecipientType } from '../domain/recipient-type';
+
+describe('ListRecipientTypes', () => {
+  it('returns the recipient types from the repository', async () => {
+    const types: RecipientType[] = [
+      { slug: 'hospital', labelEs: 'Hospital', labelEn: 'Hospital', sort: 10 },
+      { slug: 'other', labelEs: 'Otro', labelEn: 'Other', sort: 90 },
+    ];
+    const repo: RecipientTypeRepository = {
+      list: () => Promise.resolve(types),
+    };
+
+    const useCase = new ListRecipientTypes(repo);
+
+    await expect(useCase.execute()).resolves.toEqual(types);
+  });
+});

--- a/apps/api/src/contexts/resources/application/list-recipient-types.ts
+++ b/apps/api/src/contexts/resources/application/list-recipient-types.ts
@@ -1,0 +1,14 @@
+import { RecipientTypeRepository } from '../domain/ports/recipient-type.repository';
+import { RecipientType } from '../domain/recipient-type';
+
+/**
+ * Lists the recipient-type taxonomy (#62) so clients can offer a selector
+ * instead of hardcoding types. Read-only and public.
+ */
+export class ListRecipientTypes {
+  constructor(private readonly repo: RecipientTypeRepository) {}
+
+  execute(): Promise<RecipientType[]> {
+    return this.repo.list();
+  }
+}

--- a/apps/api/src/contexts/resources/domain/ports/recipient-type.repository.ts
+++ b/apps/api/src/contexts/resources/domain/ports/recipient-type.repository.ts
@@ -1,0 +1,8 @@
+import { RecipientType } from '../recipient-type';
+
+export const RECIPIENT_TYPE_REPOSITORY = Symbol('RECIPIENT_TYPE_REPOSITORY');
+
+export interface RecipientTypeRepository {
+  /** All recipient types ordered by `sort` ascending. */
+  list(): Promise<RecipientType[]>;
+}

--- a/apps/api/src/contexts/resources/domain/recipient-type.ts
+++ b/apps/api/src/contexts/resources/domain/recipient-type.ts
@@ -1,0 +1,10 @@
+/**
+ * Tipo de destinatario final (#62) — entrada de la taxonomía extensible.
+ * `slug` es el identificador estable que `Resource.recipientType` referencia.
+ */
+export interface RecipientType {
+  slug: string;
+  labelEs: string;
+  labelEn: string;
+  sort: number;
+}

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-recipient-type.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-recipient-type.repository.int-spec.ts
@@ -1,0 +1,39 @@
+import { createDb, Db } from '../../../../shared/db';
+import { DrizzleRecipientTypeRepository } from './drizzle-recipient-type.repository';
+import type { Pool } from 'pg';
+
+const URL =
+  process.env.DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub';
+
+// recipient_types is reference data seeded by migration 0024 — never truncated.
+describe('DrizzleRecipientTypeRepository (integration)', () => {
+  let db: Db;
+  let pool: Pool;
+  let repo: DrizzleRecipientTypeRepository;
+
+  beforeAll(() => {
+    ({ db, pool } = createDb(URL));
+    repo = new DrizzleRecipientTypeRepository(db);
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('lists the seeded recipient types, ordered by sort, with bilingual labels', async () => {
+    const types = await repo.list();
+    const slugs = types.map((t) => t.slug);
+
+    expect(slugs).toEqual(
+      expect.arrayContaining(['hospital', 'individual', 'other']),
+    );
+
+    // ordered by sort ascending
+    const sorts = types.map((t) => t.sort);
+    expect(sorts).toEqual([...sorts].sort((a, b) => a - b));
+
+    const hospital = types.find((t) => t.slug === 'hospital');
+    expect(hospital?.labelEs).toBe('Hospital');
+    expect(hospital?.labelEn).toBe('Hospital');
+  });
+});

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-recipient-type.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-recipient-type.repository.ts
@@ -1,0 +1,22 @@
+import { asc } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import { recipientTypesTable } from './recipient-types.schema';
+import { RecipientTypeRepository } from '../../domain/ports/recipient-type.repository';
+import { RecipientType } from '../../domain/recipient-type';
+
+export class DrizzleRecipientTypeRepository implements RecipientTypeRepository {
+  constructor(private readonly db: Db) {}
+
+  async list(): Promise<RecipientType[]> {
+    const rows = await this.db
+      .select()
+      .from(recipientTypesTable)
+      .orderBy(asc(recipientTypesTable.sort));
+    return rows.map((r) => ({
+      slug: r.slug,
+      labelEs: r.labelEs,
+      labelEn: r.labelEn,
+      sort: r.sort,
+    }));
+  }
+}

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/recipient-types.schema.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/recipient-types.schema.ts
@@ -1,0 +1,12 @@
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+
+/**
+ * Taxonomía extensible de tipos de destinatario final (#62).
+ * `slug` es la clave estable referenciada por `resources.recipient_type` (#60).
+ */
+export const recipientTypesTable = pgTable('recipient_types', {
+  slug: text('slug').primaryKey(),
+  labelEs: text('label_es').notNull(),
+  labelEn: text('label_en').notNull(),
+  sort: integer('sort').notNull().default(0),
+});

--- a/apps/api/src/contexts/resources/infrastructure/http/recipient-types.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/recipient-types.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiOkResponse,
+  ApiProperty,
+} from '@nestjs/swagger';
+import { ListRecipientTypes } from '../../application/list-recipient-types';
+import { RecipientType } from '../../domain/recipient-type';
+
+export class RecipientTypeDto {
+  @ApiProperty({ example: 'hospital' })
+  slug!: string;
+
+  @ApiProperty({ example: 'Hospital' })
+  labelEs!: string;
+
+  @ApiProperty({ example: 'Hospital' })
+  labelEn!: string;
+
+  @ApiProperty({ example: 10 })
+  sort!: number;
+}
+
+@ApiTags('public')
+@Controller()
+export class RecipientTypesController {
+  constructor(private readonly listRecipientTypes: ListRecipientTypes) {}
+
+  @Get('recipient-types')
+  @ApiOperation({
+    summary:
+      'List the recipient-type taxonomy for final recipients (extensible)',
+  })
+  @ApiOkResponse({
+    description: 'Recipient types ordered by sort',
+    type: [RecipientTypeDto],
+  })
+  list(): Promise<RecipientType[]> {
+    return this.listRecipientTypes.execute();
+  }
+}

--- a/apps/api/src/contexts/resources/infrastructure/resources.module.ts
+++ b/apps/api/src/contexts/resources/infrastructure/resources.module.ts
@@ -44,6 +44,13 @@ import {
   NotificationsPort,
 } from '../../notifications/domain/ports/notifications.port';
 import { NotificationsModule } from '../../notifications/infrastructure/notifications.module';
+import { RecipientTypesController } from './http/recipient-types.controller';
+import { ListRecipientTypes } from '../application/list-recipient-types';
+import {
+  RECIPIENT_TYPE_REPOSITORY,
+  RecipientTypeRepository,
+} from '../domain/ports/recipient-type.repository';
+import { DrizzleRecipientTypeRepository } from './drizzle/drizzle-recipient-type.repository';
 
 export const EVENT_QUEUE = Symbol('ResourcesEventQueue');
 
@@ -171,9 +178,27 @@ const getResourcesInBoundsProvider = {
   useFactory: (repo: ResourceRepository) => new GetResourcesInBounds(repo),
 };
 
+const recipientTypeRepositoryProvider = {
+  provide: RECIPIENT_TYPE_REPOSITORY,
+  inject: [DB],
+  useFactory: (db: Db): RecipientTypeRepository =>
+    new DrizzleRecipientTypeRepository(db),
+};
+
+const listRecipientTypesProvider = {
+  provide: ListRecipientTypes,
+  inject: [RECIPIENT_TYPE_REPOSITORY],
+  useFactory: (repo: RecipientTypeRepository) => new ListRecipientTypes(repo),
+};
+
 @Module({
   imports: [DatabaseModule, IdentityModule, NotificationsModule],
-  controllers: [ResourcesController, CoordinationController, PublicController],
+  controllers: [
+    ResourcesController,
+    CoordinationController,
+    PublicController,
+    RecipientTypesController,
+  ],
   providers: [
     eventQueueProvider,
     resourceRepositoryProvider,
@@ -191,6 +216,8 @@ const getResourcesInBoundsProvider = {
     updateStatusProvider,
     getMyResourcesProvider,
     getResourcesInBoundsProvider,
+    recipientTypeRepositoryProvider,
+    listRecipientTypesProvider,
   ],
 })
 export class ResourcesModule implements OnModuleDestroy {


### PR DESCRIPTION
Segundo incremento del núcleo del EPIC #59, sobre #60 (ya en `main`). Convierte `Resource.recipientType` en un **slug respaldado por una taxonomía extensible** en lugar de un enum hardcodeado: **añadir un tipo nuevo es insertar una fila**, sin tocar el dominio.

## Qué incluye

- **Migración `0024_recipient_types.sql`:** tabla `recipient_types` (`slug` PK + `label_es`/`label_en` + `sort`) con semilla base: hospital, clínica, organización, empresa, centro de acopio, particular, otro.
- **Dominio/infra:** `RecipientType` + puerto `RecipientTypeRepository` + `DrizzleRecipientTypeRepository`.
- **Aplicación:** `ListRecipientTypes` (solo lectura).
- **API:** `GET /recipient-types` (público) → `RecipientTypeDto[]` ordenado por `sort`.
- **Wiring** en `ResourcesModule` + **tests**: caso de uso (unit) e integración (lista la semilla, orden y labels bilingües).

## Diseño

- Calca el patrón del contexto `taxonomy` (categorías): `slug` como clave estable, labels ES/EN, repo-port puro.
- **Global por ahora** (como las categorías). La **configuración por emergencia** queda como evolución futura (ver `docs/features/14`, §8).
- **Validación dura** de `recipientType` contra la taxonomía: **pendiente a propósito**, consistente con cómo se tratan hoy los slugs de `accepts` (store-and-trust). El catálogo habilita el selector de la UI sin acoplar el registro.

## Verificación local

`pnpm --filter api build` (tsc) ✓ · `prettier --check` ✓ · `eslint --max-warnings=0` ✓. Los tests de integración (Postgres) corren en CI.

## Tracking

Parte de #59 · sub-issue #62. Siguientes: vínculo necesidad↔destinatario, ficha de recepciones (#67), y regenerar el `api-client` + UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV)_