### PR TITLE
docs: alinear README + índice de features con el estado real (todas las sesiones)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ResponseGrid
 
-**Plataforma de coordinación de ayuda en emergencias.** Conecta a ciudadanía, organizaciones y coordinación durante una catástrofe: publica los puntos logísticos verificados, recoge y valida necesidades, casa ofertas de material con quien las pide, organiza voluntariado y partes de campo, y mantiene todo en un mapa en tiempo real — minimizando el ruido y los desplazamientos inútiles.
+**Plataforma de coordinación de ayuda material y logística en emergencias.** Conecta a ciudadanía, organizaciones y coordinación durante una catástrofe: publica los puntos logísticos verificados, recoge y valida necesidades, casa ofertas de material con quien las pide, organiza voluntariado y partes de campo, y mantiene todo en un mapa en tiempo real — minimizando el ruido y los desplazamientos inútiles.
 
-> Producto de la organización **GlobalEmergency**. Multi-emergencia, multilingüe (ES/EN), con privacidad por diseño.
+> Producto de la organización **Global Emergency**. Multi-emergencia, multilingüe (ES/EN), con privacidad por diseño.
 
 ---
 
@@ -11,13 +11,14 @@
 | Dominio | Capacidades |
 |---|---|
 | **Emergencias** | Multi-emergencia con estados (activa / en pausa), **kill-switch** (corta altas cuando no está activa), comunicado oficial, **plantillas** (p. ej. "Emergencia sanitaria") y lista de "qué NO llevar ahora". |
-| **Puntos logísticos** | Ficha del punto (almacén/transporte…), rol origen→intermedio→destino, **nivel de confianza** (verificado / oficial vía acreditación), **semáforo de estado** (operativo/saturado/en pausa/cerrado) y autoservicio del responsable. |
+| **Puntos logísticos** | Ficha del punto (almacén/transporte…), rol origen→intermedio→destino (incl. **destinatario final** como receptor del recurso destino), **nivel de confianza** (verificado / oficial vía acreditación), **semáforo de estado** (operativo/saturado/en pausa/cerrado) y autoservicio del responsable. |
 | **Necesidades** | Ciclo crear→validar→público, categorías (incl. **sanitarias**: medicamentos, equipos, insumos, personal), prioridad, ítems con cantidad, **caducidad/frescura** (48 h, "verifica antes de actuar"), y **personal sanitario ↔ matching con el roster de voluntarios**. |
 | **Ofertas de material** | Oferta general o dirigida a una necesidad concreta + matching oferta↔necesidad desde coordinación. |
 | **Voluntariado** | Roster con skills / disponibilidad / vehículo + **tareas** con asignación y check-in/out. |
 | **Partes de campo** | Partes de campo (incidencia/stock/estado) con fotos, prioridad y punto logístico relacionado; cola de revisión en coordinación. |
-| **Mapa** | Leaflet con capas (puntos, necesidades), **privacidad de ubicación** (coordenadas aproximadas para entidades sensibles, "tu ubicación no se publica"). |
-| **Plataforma** | Identidad JWT + OAuth (Google/Facebook), acreditación de organizaciones, notificaciones in-app, **auditoría** de acciones, métricas, geocodificación (Nominatim), almacenamiento de ficheros, **i18n ES/EN**, **PWA** (manifest + service worker + autoguardado de borradores) y seguridad (Helmet, rate-limit, CORS). |
+| **Mapa** | Leaflet con capas (puntos, necesidades), **clustering** de marcadores, **carga por viewport (bounding-box)** (`/in-bounds`), **búsqueda server-side** (`?q=`, pg_trgm), **proximidad geo** ("puntos cerca de ti", `/nearby`) y **privacidad de ubicación** (coordenadas aproximadas para entidades sensibles, "tu ubicación no se publica"). |
+| **Acceso / Autorización** | Roles/permisos/**grants** con jerarquía de scopes, delegación con atenuación, **grupos/cuadrillas** con managers, **API keys** para integraciones automáticas y consola de administración (UI admin/manager/user). |
+| **Plataforma** | Identidad JWT + OAuth (Google/Facebook), acreditación de organizaciones, notificaciones in-app, **auditoría** de acciones, métricas, geocodificación (Nominatim), almacenamiento de ficheros, **i18n ES/EN**, **PWA** (manifest + service worker + autoguardado de borradores), **API pública de solo-lectura con portal `/docs` para desarrolladores** y seguridad (Helmet, rate-limit, CORS). |
 
 ---
 
@@ -35,7 +36,7 @@ ResponseGrid/
 └─ docs/        Especificaciones, fichas de feature y planes
 ```
 
-**15 bounded contexts** en `apps/api/src/contexts/`: `emergencies`, `resources`, `needs`, `offers`, `volunteers`, `reports`, `identity`, `organizations`, `accreditation`, `templates`, `notifications`, `audit`, `metrics`, `geocoding`, `files`. Cada uno con `domain` (agregados, value objects, puertos), `application` (casos de uso) e `infrastructure` (HTTP, Drizzle, adaptadores).
+**16 bounded contexts** en `apps/api/src/contexts/`: `emergencies`, `resources`, `needs`, `offers`, `volunteers`, `reports`, `identity`, `organizations`, `accreditation`, `templates`, `notifications`, `audit`, `metrics`, `geocoding`, `files`, `taxonomy`. La autorización completa (grants, groups, service-accounts, API keys) vive dentro de `identity`.
 
 **Stack:** NestJS 11 · Next.js 16 · React 19 · TypeScript · Drizzle ORM · PostgreSQL 16 · Redis 7 (BullMQ) · Tailwind · Leaflet · Jest · ESLint + Prettier.
 
@@ -84,6 +85,7 @@ pnpm --filter api test:e2e       # end-to-end (requiere Postgres/Redis)
 pnpm --filter api lint           # ESLint
 pnpm --filter web lint
 pnpm --filter web build
+pnpm --filter api build          # nest build — gate de CI
 ```
 
 Desarrollo guiado por **TDD**; Clean Code, SOLID y DDD en el backend, Atomic Design en el frontend.
@@ -92,9 +94,23 @@ Desarrollo guiado por **TDD**; Clean Code, SOLID y DDD en el backend, Atomic Des
 
 ## 🗺️ Estado y roadmap
 
-**Implementado y verificado:** ciclo de vida de emergencia + kill-switch, confianza/acreditación, semáforo de puntos, voluntariado + tareas, partes de campo + fotos, plantillas, notificaciones, auditoría, PWA, i18n, métricas, y las features capturadas del análisis competitivo: categorías sanitarias, caducidad de necesidades, privacidad de ubicación y matching personal↔voluntarios.
+**Implementado y verificado:** ciclo de vida de emergencia + kill-switch, confianza/acreditación, semáforo de puntos, voluntariado + tareas, partes de campo + fotos, plantillas, notificaciones, auditoría, PWA, i18n, métricas; categorías sanitarias, caducidad de necesidades, privacidad de ubicación, matching personal↔voluntarios; **autorización completa** (roles/permisos/grants/grupos/cuadrillas/API keys); **operativo escalable** (taxonomía como datos, recursos enriquecidos con accepts/contact/schedule/manager/provenance, paginación/filtros/facets, clustering, fichas ricas); **búsqueda server-side** (`?q=`, pg_trgm); **proximidad geo** (`/nearby` + UX "puntos cerca de ti"); **mapa por bounding-box** (`/in-bounds`); **API pública + portal `/docs`** para desarrolladores; **destinatarios finales** (rol en recurso destino); rebranding **Global Emergency** (marca, footer, páginas SEO, icono).
 
-**Backlog (en `docs/features/`):** necesidades nominales por beneficiario, oferta como compromiso de entrega, cercanía/rutas, cola offline real, directorio de servicios gratuitos, CTA de emergencia nacional, e **inventario y logística de punto de acopio** (existencias, lotes/cajas, traslados e indicadores de impacto).
+**Backlog (en `docs/features/`):** necesidades nominales por beneficiario, oferta como compromiso de entrega, **rutas/isócronas** (la cercanía puntual ya está), cola offline real, directorio de servicios gratuitos, CTA de emergencia nacional, **inventario y logística de punto de acopio** (existencias, lotes/cajas, traslados e indicadores de impacto), **ingesta multi-fuente** (enchufar fuentes externas como acopiove/REDH).
+
+---
+
+## 🤝 Cómo contribuir
+
+Consulta **[`AGENTS.md`](AGENTS.md)** como guía canónica de convenciones, bounded contexts y patrones del proyecto.
+
+Flujo de trabajo:
+1. Crea una rama desde `main` (`feat/`, `fix/`, `docs/`, …).
+2. Abre un PR con `Closes #NN` en la descripción.
+3. Asegúrate de que CI pase: format → lint → **`pnpm --filter api build`** (nest build) → test.
+4. Squash-merge cuando el PR esté aprobado y verde.
+
+**No se hace push directo a `main`** (branch protection activa).
 
 ---
 

--- a/docs/features/00-indice.md
+++ b/docs/features/00-indice.md
@@ -1,41 +1,41 @@
-# Casos de uso capturados de REDH — backlog de features (ReliefHub)
+# Casos de uso capturados de REDH — backlog de features (ResponseGrid)
 
 > Origen: análisis de **REDH (Red de Ayuda Hospitalaria)** — plataforma de coordinación de emergencias del sector salud desplegada para el sismo de Venezuela (Caracas/La Guaira/Miranda). Cada feature es un **entregable independiente y abordable por separado**, agrupado por dominio.
 >
-> Plantilla común de cada ficha: **Origen (qué hace REDH) · Problema/valor · Propuesta (DDD + API + Atomic + encaje con ReliefHub) · Alcance (MVP/futuro) · Dependencias · Privacidad/GDPR · Esfuerzo · Decisiones abiertas**.
+> Plantilla común de cada ficha: **Origen (qué hace REDH) · Problema/valor · Propuesta (DDD + API + Atomic + encaje con ResponseGrid) · Alcance (MVP/futuro) · Dependencias · Privacidad/GDPR · Esfuerzo · Decisiones abiertas**.
 
 ## Dominio 1 — Personas
-| # | Feature | Resumen | Prioridad |
-|---|---------|---------|-----------|
-| [02](02-necesidades-nominales-beneficiario.md) | **Necesidades nominales (beneficiario concreto)** | Necesidad ligada a una persona albergada y su medicación, con privacidad | 🟡 Media |
+| # | Feature | Resumen | Prioridad | Estado |
+|---|---------|---------|-----------|--------|
+| [02](02-necesidades-nominales-beneficiario.md) | **Necesidades nominales (beneficiario concreto)** | Necesidad ligada a una persona albergada y su medicación, con privacidad | 🟡 Media | ⏳ Pendiente |
 
 ## Dominio 2 — Vertical sanitario
-| # | Feature | Resumen | Prioridad |
-|---|---------|---------|-----------|
-| [04](04-plantilla-y-categorias-sanitarias.md) | **Plantilla y categorías sanitarias** | Plantilla "Sismo/Sanitario" con categorías médicas (medicamentos, equipos, personal) y "qué NO llevar" sanitario | 🔴 Alta |
-| [05](05-personal-como-necesidad-y-voluntarios.md) | **Personal como necesidad ↔ voluntarios** | Una necesidad de "personal con skill X" se casa con el roster de voluntarios | 🟡 Media |
+| # | Feature | Resumen | Prioridad | Estado |
+|---|---------|---------|-----------|--------|
+| [04](04-plantilla-y-categorias-sanitarias.md) | **Plantilla y categorías sanitarias** | Plantilla "Sismo/Sanitario" con categorías médicas (medicamentos, equipos, personal) y "qué NO llevar" sanitario | 🔴 Alta | ✅ Hecho |
+| [05](05-personal-como-necesidad-y-voluntarios.md) | **Personal como necesidad ↔ voluntarios** | Una necesidad de "personal con skill X" se casa con el roster de voluntarios | 🟡 Media | ✅ Hecho |
 
 ## Dominio 3 — Núcleo de necesidades y ofertas
-| # | Feature | Resumen | Prioridad |
-|---|---------|---------|-----------|
-| [06](06-caducidad-frescura-necesidades.md) | **Caducidad / frescura de necesidades** | Vigencia (p. ej. 48 h), aviso "verifica antes de actuar" y auto-archivado | 🔴 Alta |
-| [07](07-oferta-compromiso-entrega.md) | **Oferta como compromiso de entrega** | La oferta evoluciona a "promesa" con fecha/método de entrega y seguimiento | 🟡 Media |
-| [14](14-destinatarios-finales.md) | **Destinatarios finales (ficha · peticiones 1‑a‑N · recepciones)** | Receptor final genérico con tipo extensible (empresa/organización/particular/hospital…); vertical sanitario como primer caso. EPIC #59 | 🔴 Alta |
+| # | Feature | Resumen | Prioridad | Estado |
+|---|---------|---------|-----------|--------|
+| [06](06-caducidad-frescura-necesidades.md) | **Caducidad / frescura de necesidades** | Vigencia (p. ej. 48 h), aviso "verifica antes de actuar" y auto-archivado | 🔴 Alta | ✅ Hecho |
+| [07](07-oferta-compromiso-entrega.md) | **Oferta como compromiso de entrega** | La oferta evoluciona a "promesa" con fecha/método de entrega y seguimiento | 🟡 Media | ⏳ Pendiente |
+| [14](14-destinatarios-finales.md) | **Destinatarios finales (ficha · peticiones 1‑a‑N · recepciones)** | Receptor final genérico con tipo extensible (empresa/organización/particular/hospital…); vertical sanitario como primer caso. EPIC #59 | 🔴 Alta | ✅ Hecho |
 
 ## Dominio 4 — Mapa y geolocalización
-| # | Feature | Resumen | Prioridad |
-|---|---------|---------|-----------|
-| [08](08-cercania-y-rutas.md) | **Cercanía y rutas** | Ordenar puntos/necesidades por distancia al usuario + enlace a ruta | 🟡 Media |
-| [09](09-privacidad-de-ubicacion.md) | **Privacidad de ubicación** | Coordenadas aproximadas en puntos sensibles, "no publicamos tu ubicación", "verifica por teléfono" | 🔴 Alta |
+| # | Feature | Resumen | Prioridad | Estado |
+|---|---------|---------|-----------|--------|
+| [08](08-cercania-y-rutas.md) | **Cercanía y rutas** | Ordenar puntos/necesidades por distancia al usuario (`/nearby` ✅) + enlace a ruta/isócrona ⏳ | 🟡 Media | ⏳ Parcial |
+| [09](09-privacidad-de-ubicacion.md) | **Privacidad de ubicación** | Coordenadas aproximadas en puntos sensibles, "no publicamos tu ubicación", "verifica por teléfono" | 🔴 Alta | ✅ Hecho |
 
 ## Dominio 5 — Plataforma y acceso
-| # | Feature | Resumen | Prioridad |
-|---|---------|---------|-----------|
-| [10](10-cola-offline-real.md) | **Cola offline real (IndexedDB + sync)** | Enviar formularios sin conexión y sincronizar al volver la señal (completa la PWA) | 🟡 Media |
-| [11](11-directorio-servicios-gratis.md) | **Directorio de servicios gratis** | Jornadas/exámenes/servicios gratuitos validados, filtrables por ciudad/cercanía | 🟢 Baja |
-| [12](12-cta-emergencia-nacional.md) | **CTA de emergencia nacional** | Número de emergencia por país/emergencia siempre visible (banner + llamar) | 🟢 Baja |
-| [13](13-roles-permisos-y-autenticacion.md) | **Roles, permisos y autenticación** | Rediseño fundacional de autorización: principal/permiso/rol/grant + jerarquía de scopes, delegación con atenuación, grupos/managers, API keys | 🔴 Alta |
+| # | Feature | Resumen | Prioridad | Estado |
+|---|---------|---------|-----------|--------|
+| [10](10-cola-offline-real.md) | **Cola offline real (IndexedDB + sync)** | Enviar formularios sin conexión y sincronizar al volver la señal (completa la PWA) | 🟡 Media | ⏳ Pendiente |
+| [11](11-directorio-servicios-gratis.md) | **Directorio de servicios gratis** | Jornadas/exámenes/servicios gratuitos validados, filtrables por ciudad/cercanía | 🟢 Baja | ⏳ Pendiente |
+| [12](12-cta-emergencia-nacional.md) | **CTA de emergencia nacional** | Número de emergencia por país/emergencia siempre visible (banner + llamar) | 🟢 Baja | ⏳ Pendiente |
+| [13](13-roles-permisos-y-autenticacion.md) | **Roles, permisos y autenticación** | Rediseño fundacional de autorización: principal/permiso/rol/grant + jerarquía de scopes, delegación con atenuación, grupos/managers, API keys | 🔴 Alta | ✅ Hecho |
 
 ---
 
-**Orden sugerido de abordaje:** 04 (plantilla sanitaria) y 06 (caducidad) son rápidos y de alto valor; 09 (privacidad de ubicación) es transversal y debería entrar pronto.
+**Orden sugerido de abordaje:** 04 (plantilla sanitaria), 05 (personal↔voluntarios), 06 (caducidad), 09 (privacidad de ubicación), 13 (roles/permisos) y 14 (destinatarios finales) ya están implementados ✅. Próximos de alto valor: 07 (oferta-compromiso) y la parte de rutas/isócronas de 08 (la cercanía puntual ya está vía `/nearby`).


### PR DESCRIPTION
Actualiza README.md y docs/features/00-indice.md para reflejar TODAS las decisiones de TODAS las sesiones, no solo una. README: intro a ayuda MATERIAL + logística y marca Global Emergency; tabla Que hace con mapa (clustering/bounding-box/busqueda server-side/proximidad), nueva fila Acceso/Autorizacion (grants/grupos/API keys/consola), destinatario final, y API publica + /docs; 16 bounded contexts (+taxonomy, authz dentro de identity); roadmap Implementado ampliado con authz, operativo escalable, busqueda, proximidad, mapa por bbox, API publica/docs, destinatarios finales, rebranding; backlog depurado (cercania ya hecha) + rutas/isocronas e ingesta multi-fuente; nueva seccion Como contribuir -> AGENTS.md + flujo de PR; nest build anadido al gate. Indice: ReliefHub -> ResponseGrid, ficha 14 destinatarios finales, columna Estado (hechas: 04/05/06/09/13/14; parcial 08), nota de orden actualizada.