### PR TITLE
feat(needs): vínculo necesidad → destinatario final (1‑a‑N) (#60)

### DIFF
--- a/apps/api/drizzle/0025_need_resource_link.sql
+++ b/apps/api/drizzle/0025_need_resource_link.sql
@@ -1,0 +1,6 @@
+-- Vínculo opcional necesidad → recurso / destinatario final (EPIC #59 · #60).
+-- Habilita el registro 1‑a‑N de un destinatario y sus necesidades. Columna
+-- nullable y sin FK por ahora, consistente con emergency_id (que tampoco
+-- declara FK en este esquema); puede endurecerse a FK más adelante.
+ALTER TABLE needs ADD COLUMN resource_id uuid;
+CREATE INDEX needs_resource ON needs(resource_id) WHERE resource_id IS NOT NULL;

--- a/apps/api/src/contexts/needs/application/create-need.ts
+++ b/apps/api/src/contexts/needs/application/create-need.ts
@@ -38,6 +38,8 @@ export interface CreateNeedCommand {
   requiredSkill?: PersonnelSkill | null;
   skillSpecialty?: string | null;
   requestedCount?: number | null;
+  /** Optional link to the resource / final recipient (#60). */
+  resourceId?: string | null;
 }
 
 export class CreateNeed {
@@ -93,6 +95,7 @@ export class CreateNeed {
       requiredSkill: cmd.requiredSkill ?? null,
       skillSpecialty: cmd.skillSpecialty ?? null,
       requestedCount: cmd.requestedCount ?? null,
+      resourceId: cmd.resourceId ?? null,
     });
 
     await this.repo.save(need);

--- a/apps/api/src/contexts/needs/application/get-public-needs.ts
+++ b/apps/api/src/contexts/needs/application/get-public-needs.ts
@@ -7,6 +7,8 @@ export interface GetPublicNeedsQuery {
   emergencyId: string;
   category?: NeedCategory;
   priority?: Priority;
+  /** Filter to needs linked to a specific resource / final recipient (#60). */
+  resourceId?: string;
 }
 
 export class GetPublicNeeds {
@@ -16,6 +18,7 @@ export class GetPublicNeeds {
     const filters: NeedFilters = {};
     if (q.category !== undefined) filters.category = q.category;
     if (q.priority !== undefined) filters.priority = q.priority;
+    if (q.resourceId !== undefined) filters.resourceId = q.resourceId;
 
     const validated = await this.repo.findValidatedByEmergency(
       EmergencyId.fromString(q.emergencyId),

--- a/apps/api/src/contexts/needs/application/need-view.ts
+++ b/apps/api/src/contexts/needs/application/need-view.ts
@@ -23,6 +23,8 @@ export interface NeedView {
   /** F05: personnel-need fields — skillSpecialty omitted from public view */
   requiredSkill: PersonnelSkill | null;
   requestedCount: number | null;
+  /** Optional link to the resource / final recipient (#60). */
+  resourceId: string | null;
 }
 
 /** F05: Coordinator view includes the sensitive skillSpecialty field */
@@ -77,6 +79,7 @@ export function toPublicNeedView(n: Need): NeedView {
     // skillSpecialty deliberately excluded from public view (sensitive)
     requiredSkill: n.requiredSkill,
     requestedCount: n.requestedCount,
+    resourceId: n.resourceId,
   };
 }
 
@@ -105,6 +108,7 @@ export function toCoordinatorNeedView(n: Need): CoordinatorNeedView {
     requiredSkill: n.requiredSkill,
     skillSpecialty: n.skillSpecialty,
     requestedCount: n.requestedCount,
+    resourceId: n.resourceId,
   };
 }
 

--- a/apps/api/src/contexts/needs/domain/need.ts
+++ b/apps/api/src/contexts/needs/domain/need.ts
@@ -36,6 +36,8 @@ export interface CreateNeedProps {
   requiredSkill?: PersonnelSkill | null;
   skillSpecialty?: string | null;
   requestedCount?: number | null;
+  /** Optional link to the resource / final recipient this need belongs to (#60). */
+  resourceId?: string | null;
 }
 
 export interface NeedSnapshot {
@@ -59,6 +61,8 @@ export interface NeedSnapshot {
   requiredSkill?: PersonnelSkill | null;
   skillSpecialty?: string | null;
   requestedCount?: number | null;
+  /** Optional (legacy-safe) link to the resource / final recipient (#60). */
+  resourceId?: string | null;
 }
 
 export class Need {
@@ -84,6 +88,7 @@ export class Need {
     public readonly requiredSkill: PersonnelSkill | null,
     public readonly skillSpecialty: string | null,
     public readonly requestedCount: number | null,
+    public readonly resourceId: string | null,
   ) {}
 
   static create(props: CreateNeedProps): Need {
@@ -117,6 +122,7 @@ export class Need {
       props.requiredSkill ?? null,
       props.skillSpecialty ?? null,
       props.requestedCount ?? null,
+      props.resourceId ?? null,
     );
     need.events.push(
       new NeedCreated(need.id.value, {
@@ -148,6 +154,7 @@ export class Need {
       (s.requiredSkill as PersonnelSkill) ?? null,
       s.skillSpecialty ?? null,
       s.requestedCount ?? null,
+      s.resourceId ?? null,
     );
   }
 
@@ -243,6 +250,7 @@ export class Need {
       requiredSkill: this.requiredSkill,
       skillSpecialty: this.skillSpecialty,
       requestedCount: this.requestedCount,
+      resourceId: this.resourceId,
     };
   }
 

--- a/apps/api/src/contexts/needs/domain/ports/need.repository.ts
+++ b/apps/api/src/contexts/needs/domain/ports/need.repository.ts
@@ -8,6 +8,8 @@ export const NEED_REPOSITORY = Symbol('NeedRepository');
 export interface NeedFilters {
   category?: NeedCategory;
   priority?: Priority;
+  /** Filter by linked resource / final recipient (#60). */
+  resourceId?: string | null;
 }
 
 export interface NeedRepository {

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.int-spec.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.int-spec.ts
@@ -92,6 +92,59 @@ describe('DrizzleNeedRepository (integration)', () => {
     expect(found!.items[0].category).toBe(NeedCategory.Water);
   });
 
+  it('round-trips the resourceId link to a final recipient (#60)', async () => {
+    const resourceId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    const need = Need.create({
+      id: NeedId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      title: 'Linked to recipient',
+      description: null,
+      location: makeLocation(),
+      priority: Priority.High,
+      requesterUserId: USER_ID,
+      requesterOrganizationId: null,
+      items: makeItems(),
+      resourceId,
+    });
+    await repo.save(need);
+    const found = await repo.findById(need.id);
+    expect(found!.resourceId).toBe(resourceId);
+  });
+
+  it('defaults resourceId to null when not provided', async () => {
+    const need = makeNeed();
+    await repo.save(need);
+    const found = await repo.findById(need.id);
+    expect(found!.resourceId).toBeNull();
+  });
+
+  it('filters needs by resourceId (1-a-N per recipient)', async () => {
+    const recipientA = 'aaaaaaaa-1111-4aaa-8aaa-aaaaaaaaaaaa';
+    const recipientB = 'bbbbbbbb-2222-4bbb-8bbb-bbbbbbbbbbbb';
+    const mk = (resourceId: string, title: string) =>
+      Need.create({
+        id: NeedId.create(),
+        emergencyId: EmergencyId.fromString(EM),
+        title,
+        description: null,
+        location: makeLocation(),
+        priority: Priority.High,
+        requesterUserId: USER_ID,
+        requesterOrganizationId: null,
+        items: makeItems(),
+        resourceId,
+      });
+    await repo.save(mk(recipientA, 'For A'));
+    await repo.save(mk(recipientB, 'For B'));
+
+    const forA = await repo.findPendingByEmergency(EmergencyId.fromString(EM), {
+      resourceId: recipientA,
+    });
+    expect(forA).toHaveLength(1);
+    expect(forA[0].title).toBe('For A');
+    expect(forA[0].resourceId).toBe(recipientA);
+  });
+
   it('round-trips need with multiple items', async () => {
     const need = Need.create({
       id: NeedId.create(),

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.ts
@@ -64,6 +64,7 @@ function rowToSnapshot(row: NeedsRow, items: ItemsRow[]): NeedSnapshot {
     requiredSkill: (row.requiredSkill as PersonnelSkill) ?? null,
     skillSpecialty: row.skillSpecialty ?? null,
     requestedCount: row.requestedCount ?? null,
+    resourceId: row.resourceId ?? null,
   };
 }
 
@@ -96,6 +97,7 @@ export class DrizzleNeedRepository implements NeedRepository {
           requiredSkill: s.requiredSkill ?? null,
           skillSpecialty: s.skillSpecialty ?? null,
           requestedCount: s.requestedCount ?? null,
+          resourceId: s.resourceId ?? null,
         })
         .onConflictDoUpdate({
           target: needsTable.id,
@@ -244,6 +246,10 @@ export class DrizzleNeedRepository implements NeedRepository {
             ),
         ),
       );
+    }
+
+    if (filters?.resourceId !== undefined && filters.resourceId !== null) {
+      conditions.push(eq(needsTable.resourceId, filters.resourceId));
     }
 
     const rows = await this.db

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/schema.ts
@@ -28,6 +28,8 @@ export const needsTable = pgTable('needs', {
   requiredSkill: text('required_skill'),
   skillSpecialty: text('skill_specialty'),
   requestedCount: integer('requested_count'),
+  /** Optional link to the resource / final recipient (#60). */
+  resourceId: uuid('resource_id'),
 });
 
 export const needItemsTable = pgTable('need_items', {

--- a/apps/api/src/contexts/needs/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/dto.ts
@@ -141,6 +141,18 @@ export class CreateNeedDto {
   @IsInt()
   @Min(1)
   requestedCount?: number;
+
+  @ApiPropertyOptional({
+    format: 'uuid',
+    example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+    description:
+      'Link this need to a resource / final recipient (#60). Optional.',
+    nullable: true,
+    type: String,
+  })
+  @IsOptional()
+  @IsUUID()
+  resourceId?: string;
 }
 
 export class AssignNeedManagerDto {

--- a/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
@@ -112,6 +112,7 @@ export class NeedsController {
       requiredSkill: dto.requiredSkill ?? null,
       skillSpecialty: dto.skillSpecialty ?? null,
       requestedCount: dto.requestedCount ?? null,
+      resourceId: dto.resourceId ?? null,
     });
   }
 
@@ -135,6 +136,12 @@ export class NeedsController {
     required: false,
     description: 'Filter by need priority',
   })
+  @ApiQuery({
+    name: 'resourceId',
+    required: false,
+    format: 'uuid',
+    description: 'Filter to needs linked to this resource / final recipient',
+  })
   @ApiOkResponse({
     description: 'List of validated needs',
     type: [NeedViewDto],
@@ -143,6 +150,7 @@ export class NeedsController {
     @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
     @Query('category') category?: string,
     @Query('priority') priority?: string,
+    @Query('resourceId') resourceId?: string,
   ): Promise<NeedView[]> {
     const validCategory = Object.values(NeedCategory).includes(
       category as NeedCategory,
@@ -157,6 +165,7 @@ export class NeedsController {
       emergencyId,
       ...(validCategory !== undefined && { category: validCategory }),
       ...(validPriority !== undefined && { priority: validPriority }),
+      ...(resourceId !== undefined && { resourceId }),
     });
   }
 

--- a/apps/api/src/contexts/needs/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/response.dto.ts
@@ -129,6 +129,15 @@ export class NeedViewDto {
     description: 'Number of personnel needed',
   })
   requestedCount!: number | null;
+
+  @ApiPropertyOptional({
+    format: 'uuid',
+    nullable: true,
+    type: String,
+    description:
+      'Linked resource / final recipient id (#60), or null if standalone.',
+  })
+  resourceId!: string | null;
 }
 
 /** Extended DTO for coordinator views — includes the sensitive skillSpecialty field. */

--- a/apps/api/src/contexts/needs/infrastructure/in-memory-need.repository.ts
+++ b/apps/api/src/contexts/needs/infrastructure/in-memory-need.repository.ts
@@ -40,6 +40,12 @@ export class InMemoryNeedRepository implements NeedRepository {
           !s.items.some((i) => i.category === filters.category)
         )
           return false;
+        if (
+          filters?.resourceId !== undefined &&
+          filters.resourceId !== null &&
+          (s.resourceId ?? null) !== filters.resourceId
+        )
+          return false;
         return true;
       })
       .map((s) => Need.fromSnapshot(s));
@@ -64,6 +70,12 @@ export class InMemoryNeedRepository implements NeedRepository {
           !s.items.some((i) => i.category === filters.category)
         )
           return false;
+        if (
+          filters?.resourceId !== undefined &&
+          filters.resourceId !== null &&
+          (s.resourceId ?? null) !== filters.resourceId
+        )
+          return false;
         return true;
       })
       .map((s) => Need.fromSnapshot(s));
@@ -83,6 +95,12 @@ export class InMemoryNeedRepository implements NeedRepository {
         if (
           filters?.category !== undefined &&
           !s.items.some((i) => i.category === filters.category)
+        )
+          return false;
+        if (
+          filters?.resourceId !== undefined &&
+          filters.resourceId !== null &&
+          (s.resourceId ?? null) !== filters.resourceId
         )
           return false;
         return true;


### PR DESCRIPTION
Tercer incremento del núcleo del EPIC #59, sobre #60/#62 (ya en `main`). Permite el **registro 1‑a‑N** de un destinatario y sus necesidades — el *"registro 1 a N hospitales→solicitudes"* del parte de campo.

## Qué incluye

- **Dominio:** `resourceId` (opcional, *legacy-safe*) en `Need` — `CreateNeedProps`, `NeedSnapshot`, constructor, `create`, `fromSnapshot`, `toSnapshot`.
- **Persistencia:** columna `needs.resource_id` (**migración `0025`**, índice parcial) + mapeo en el repo Drizzle (`rowToSnapshot`, insert) y **filtro `resourceId`** en `_findByEmergencyAndStatus` (lo heredan las consultas públicas/queue); repo in-memory actualizado para mantener la misma semántica.
- **API:**
  - opcional al crear: `POST /emergencies/:id/needs` acepta `resourceId`.
  - **listar las necesidades de un destinatario:** `GET /emergencies/:id/public/needs?resourceId=…`.
  - expuesto en `NeedView` / `NeedViewDto` (y por herencia en la vista de coordinación).
- **Tests:** integración — round-trip del vínculo, default a `null`, y filtro 1‑a‑N por destinatario.

## Notas de diseño

- `resourceId` es **nullable y sin FK dura** por ahora, **consistente con `emergency_id`** (que tampoco declara FK en este esquema). Puede endurecerse a FK más adelante.
- Filtro **store-and-trust** (como `category`/`priority`): no se valida que el `resourceId` exista; eso lo resolverá la UI con el catálogo/recursos.

## Verificación local

`pnpm --filter api build` (tsc) ✓ · `prettier --check` ✓ · `eslint --max-warnings=0` ✓. Integración (Postgres) en CI.

## Tracking

Completa la parte de "vínculo necesidad↔destinatario" de #60 (EPIC #59). Siguientes: #67 ficha + recepciones, #64 contacto, vertical sanitario #61/#63, y regenerar `api-client` + UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV)_