### PR TITLE
feat(admin): panel de administración role-aware (todos los ámbitos)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -113,6 +113,60 @@
         ]
       }
     },
+    "/grants/at-scope": {
+      "get": {
+        "operationId": "GrantsController_listAtScope",
+        "parameters": [
+          {
+            "name": "scopeType",
+            "required": true,
+            "in": "query",
+            "description": "platform | organization | emergency | group",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scopeId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GrantListItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not authorized to administer this scope"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List the grants made AT a scope (scoped administrator)",
+        "tags": [
+          "grants"
+        ]
+      }
+    },
     "/grants": {
       "get": {
         "operationId": "GrantsController_list",
@@ -1207,6 +1261,31 @@
           }
         },
         "summary": "Get facets (counts by category and country) for visible resources",
+        "tags": [
+          "public"
+        ]
+      }
+    },
+    "/recipient-types": {
+      "get": {
+        "operationId": "RecipientTypesController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Recipient types ordered by sort",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RecipientTypeDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List the recipient-type taxonomy for final recipients (extensible)",
         "tags": [
           "public"
         ]
@@ -5064,6 +5143,16 @@
             "type": "string",
             "example": "Caracas",
             "description": "City name"
+          },
+          "isFinalRecipient": {
+            "type": "boolean",
+            "example": true,
+            "description": "Mark this resource as a final recipient of aid (requires the destination stage)"
+          },
+          "recipientType": {
+            "type": "string",
+            "example": "hospital",
+            "description": "Recipient type slug (see the emergency recipient-type taxonomy)"
           }
         },
         "required": [
@@ -5244,6 +5333,17 @@
             "type": "string",
             "example": "Caracas",
             "nullable": true
+          },
+          "isFinalRecipient": {
+            "type": "boolean",
+            "example": false,
+            "description": "Whether this resource is a final recipient of aid"
+          },
+          "recipientType": {
+            "type": "string",
+            "example": "hospital",
+            "nullable": true,
+            "description": "Recipient type slug (see the emergency recipient-type taxonomy)"
           }
         },
         "required": [
@@ -5263,7 +5363,9 @@
           "sourceName",
           "externalUpdatedAt",
           "country",
-          "city"
+          "city",
+          "isFinalRecipient",
+          "recipientType"
         ]
       },
       "PagedResourcesDto": {
@@ -5409,6 +5511,17 @@
             "example": "Caracas",
             "nullable": true
           },
+          "isFinalRecipient": {
+            "type": "boolean",
+            "example": false,
+            "description": "Whether this resource is a final recipient of aid"
+          },
+          "recipientType": {
+            "type": "string",
+            "example": "hospital",
+            "nullable": true,
+            "description": "Recipient type slug (see the emergency recipient-type taxonomy)"
+          },
           "distanceMeters": {
             "type": "number",
             "example": 1234,
@@ -5433,6 +5546,8 @@
           "externalUpdatedAt",
           "country",
           "city",
+          "isFinalRecipient",
+          "recipientType",
           "distanceMeters"
         ]
       },
@@ -5491,6 +5606,33 @@
           "byCategory",
           "byCountry",
           "total"
+        ]
+      },
+      "RecipientTypeDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "hospital"
+          },
+          "labelEs": {
+            "type": "string",
+            "example": "Hospital"
+          },
+          "labelEn": {
+            "type": "string",
+            "example": "Hospital"
+          },
+          "sort": {
+            "type": "number",
+            "example": 10
+          }
+        },
+        "required": [
+          "slug",
+          "labelEs",
+          "labelEn",
+          "sort"
         ]
       },
       "CreateTemplateDto": {

--- a/apps/api/src/contexts/identity/application/find-user-by-email.spec.ts
+++ b/apps/api/src/contexts/identity/application/find-user-by-email.spec.ts
@@ -1,6 +1,5 @@
 import { FindUserByEmail } from './find-user-by-email';
 import { InMemoryUserRepository } from '../infrastructure/in-memory-user.repository';
-import { LocalAccessControl } from '../domain/authorization/local-access-control';
 import { AuthorizationContext } from '../domain/authorization/access-control';
 import { Grant } from '../domain/authorization/grant';
 import { ScopeRef } from '../domain/authorization/scope-ref';
@@ -9,29 +8,22 @@ import { User } from '../domain/user';
 import { UserId } from '../domain/user-id';
 import { Email } from '../domain/email';
 
-const PLATFORM_ADMIN = '11111111-1111-4111-8111-111111111111';
 const ALICE = '33333333-3333-4333-8333-333333333333';
 
-function platformAdmin(): AuthorizationContext {
-  return {
-    principalId: PLATFORM_ADMIN,
-    grants: [
-      Grant.create({
-        id: 'g',
-        principalId: PLATFORM_ADMIN,
-        roleId: 'platform_admin',
-        scope: ScopeRef.platform(),
-      }).toSnapshot(),
-    ],
-  };
+function actorWith(...held: Grant[]): AuthorizationContext {
+  return { principalId: 'actor', grants: held.map((g) => g.toSnapshot()) };
 }
 
-function outsider(): AuthorizationContext {
-  return { principalId: ALICE, grants: [] };
+function grant(roleId: string, scope: ScopeRef): Grant {
+  return Grant.create({
+    id: `g-${roleId}`,
+    principalId: 'actor',
+    roleId,
+    scope,
+  });
 }
 
 describe('FindUserByEmail', () => {
-  const access = new LocalAccessControl();
   let users: InMemoryUserRepository;
 
   beforeEach(async () => {
@@ -47,9 +39,9 @@ describe('FindUserByEmail', () => {
     );
   });
 
-  it('resolves an email to a principal id for a platform admin', async () => {
-    const result = await new FindUserByEmail(users, access).execute({
-      actor: platformAdmin(),
+  it('resolves an email for a platform admin', async () => {
+    const result = await new FindUserByEmail(users).execute({
+      actor: actorWith(grant('platform_admin', ScopeRef.platform())),
       email: 'alice@example.org',
     });
     expect(result).toEqual({
@@ -59,28 +51,38 @@ describe('FindUserByEmail', () => {
     });
   });
 
-  it('is case/space-insensitive (email is normalized)', async () => {
-    const result = await new FindUserByEmail(users, access).execute({
-      actor: platformAdmin(),
+  it('resolves an email for an org admin (scoped manager, not just platform)', async () => {
+    const result = await new FindUserByEmail(users).execute({
+      actor: actorWith(grant('org_admin', ScopeRef.organization('o1'))),
       email: '  ALICE@example.org ',
     });
     expect(result?.id).toBe(ALICE);
   });
 
   it('returns null for an unknown or malformed email', async () => {
-    const uc = new FindUserByEmail(users, access);
+    const uc = new FindUserByEmail(users);
+    const admin = actorWith(grant('platform_admin', ScopeRef.platform()));
     expect(
-      await uc.execute({ actor: platformAdmin(), email: 'nobody@example.org' }),
+      await uc.execute({ actor: admin, email: 'nobody@example.org' }),
     ).toBeNull();
     expect(
-      await uc.execute({ actor: platformAdmin(), email: 'not-an-email' }),
+      await uc.execute({ actor: admin, email: 'not-an-email' }),
     ).toBeNull();
   });
 
-  it('forbids lookup without role:grant or user:read at platform', async () => {
+  it('forbids a non-manager (e.g. a plain org member)', async () => {
     await expect(
-      new FindUserByEmail(users, access).execute({
-        actor: outsider(),
+      new FindUserByEmail(users).execute({
+        actor: actorWith(grant('org_member', ScopeRef.organization('o1'))),
+        email: 'alice@example.org',
+      }),
+    ).rejects.toThrow(NotAuthorizedToReadError);
+  });
+
+  it('forbids a principal with no grants', async () => {
+    await expect(
+      new FindUserByEmail(users).execute({
+        actor: { principalId: 'nobody', grants: [] },
         email: 'alice@example.org',
       }),
     ).rejects.toThrow(NotAuthorizedToReadError);

--- a/apps/api/src/contexts/identity/application/find-user-by-email.ts
+++ b/apps/api/src/contexts/identity/application/find-user-by-email.ts
@@ -1,10 +1,9 @@
 import { UserRepository } from '../domain/ports/user.repository';
 import { Email } from '../domain/email';
-import {
-  AccessControl,
-  AuthorizationContext,
-} from '../domain/authorization/access-control';
-import { ancestorChain } from '../domain/authorization/scope-ref';
+import { AuthorizationContext } from '../domain/authorization/access-control';
+import { Grant } from '../domain/authorization/grant';
+import { permissionsForRole } from '../domain/authorization/role-catalog';
+import { Permission } from '../domain/authorization/permission';
 import { NotAuthorizedToReadError } from '../domain/authorization/errors';
 
 export interface FindUserByEmailCommand {
@@ -19,23 +18,28 @@ export interface FoundUser {
 }
 
 /**
- * Resolves an email to a principal id so the access console can grant roles by
- * email instead of by raw UUID. A thin admin directory lookup: requires
- * `role:grant` or `user:read` at the platform scope. Returns `null` when the
- * email is malformed or unknown (callers map that to 404).
+ * Holding any of these — at ANY scope — makes a principal an administrator who
+ * may resolve a user by email (to invite them or grant them a role). Scoped to
+ * directory-relevant capabilities so an ordinary member can't enumerate users.
+ */
+const DIRECTORY_PERMISSIONS: readonly Permission[] = [
+  'role:grant',
+  'user:invite',
+  'user:read',
+];
+
+/**
+ * Resolves an email to a principal id so an admin console can grant roles or
+ * invite by email instead of by raw UUID. Authorized for any principal that
+ * administers *some* scope (platform, org, group…), not only platform admins —
+ * the per-scope attenuation on the actual grant still applies (docs/features/13
+ * §5). Returns `null` for a malformed or unknown email.
  */
 export class FindUserByEmail {
-  constructor(
-    private readonly users: UserRepository,
-    private readonly access: AccessControl,
-  ) {}
+  constructor(private readonly users: UserRepository) {}
 
   async execute(cmd: FindUserByEmailCommand): Promise<FoundUser | null> {
-    const perms = await this.access.effectivePermissions(
-      cmd.actor,
-      ancestorChain({ type: 'platform' }),
-    );
-    if (!perms.has('role:grant') && !perms.has('user:read')) {
+    if (!this.administersSomeScope(cmd.actor)) {
       throw new NotAuthorizedToReadError('users');
     }
 
@@ -49,5 +53,15 @@ export class FindUserByEmail {
     const user = await this.users.findByEmail(email);
     if (!user) return null;
     return { id: user.id.value, email: user.email.value, name: user.name };
+  }
+
+  /** True if any active grant confers a directory permission. */
+  private administersSomeScope(actor: AuthorizationContext): boolean {
+    const now = new Date();
+    return actor.grants.some((snapshot) => {
+      if (!Grant.fromSnapshot(snapshot).isActive(now)) return false;
+      const perms = permissionsForRole(snapshot.roleId);
+      return DIRECTORY_PERMISSIONS.some((p) => perms.includes(p));
+    });
   }
 }

--- a/apps/api/src/contexts/identity/application/list-grants-at-scope.spec.ts
+++ b/apps/api/src/contexts/identity/application/list-grants-at-scope.spec.ts
@@ -1,0 +1,103 @@
+import { ListGrantsAtScope } from './list-grants-at-scope';
+import { InMemoryGrantRepository } from '../infrastructure/in-memory-grant.repository';
+import { LocalAccessControl } from '../domain/authorization/local-access-control';
+import { AuthorizationContext } from '../domain/authorization/access-control';
+import { Grant } from '../domain/authorization/grant';
+import { ScopeRef } from '../domain/authorization/scope-ref';
+import { NotAuthorizedToReadError } from '../domain/authorization/errors';
+
+const PLATFORM_ADMIN = '11111111-1111-4111-8111-111111111111';
+const ORG_ADMIN = '22222222-2222-4222-8222-222222222222';
+const MEMBER = '33333333-3333-4333-8333-333333333333';
+const ORG = 'org-1';
+const OTHER_ORG = 'org-2';
+
+function ctx(principalId: string, ...held: Grant[]): AuthorizationContext {
+  return { principalId, grants: held.map((g) => g.toSnapshot()) };
+}
+
+describe('ListGrantsAtScope', () => {
+  const access = new LocalAccessControl();
+  let repo: InMemoryGrantRepository;
+
+  beforeEach(async () => {
+    repo = new InMemoryGrantRepository();
+    // A member with org_member at ORG, plus the org admin's own grant at ORG.
+    await repo.save(
+      Grant.create({
+        id: 'm1',
+        principalId: MEMBER,
+        roleId: 'org_member',
+        scope: ScopeRef.organization(ORG),
+      }),
+    );
+    await repo.save(
+      Grant.create({
+        id: 'oa',
+        principalId: ORG_ADMIN,
+        roleId: 'org_admin',
+        scope: ScopeRef.organization(ORG),
+      }),
+    );
+  });
+
+  function orgAdmin(): AuthorizationContext {
+    return ctx(
+      ORG_ADMIN,
+      Grant.create({
+        id: 'oa',
+        principalId: ORG_ADMIN,
+        roleId: 'org_admin',
+        scope: ScopeRef.organization(ORG),
+      }),
+    );
+  }
+
+  function platformAdmin(): AuthorizationContext {
+    return ctx(
+      PLATFORM_ADMIN,
+      Grant.create({
+        id: 'pa',
+        principalId: PLATFORM_ADMIN,
+        roleId: 'platform_admin',
+        scope: ScopeRef.platform(),
+      }),
+    );
+  }
+
+  it('lets an org admin list the grants at their own organization', async () => {
+    const result = await new ListGrantsAtScope(repo, access).execute({
+      actor: orgAdmin(),
+      scope: ScopeRef.organization(ORG).toPlain(),
+    });
+    expect(result.map((g) => g.principalId).sort()).toEqual(
+      [MEMBER, ORG_ADMIN].sort(),
+    );
+  });
+
+  it('lets a platform admin list grants at any organization', async () => {
+    const result = await new ListGrantsAtScope(repo, access).execute({
+      actor: platformAdmin(),
+      scope: ScopeRef.organization(ORG).toPlain(),
+    });
+    expect(result).toHaveLength(2);
+  });
+
+  it('forbids an org admin from listing a different organization', async () => {
+    await expect(
+      new ListGrantsAtScope(repo, access).execute({
+        actor: orgAdmin(),
+        scope: ScopeRef.organization(OTHER_ORG).toPlain(),
+      }),
+    ).rejects.toThrow(NotAuthorizedToReadError);
+  });
+
+  it('forbids a principal with no admin permission at the scope', async () => {
+    await expect(
+      new ListGrantsAtScope(repo, access).execute({
+        actor: ctx(MEMBER),
+        scope: ScopeRef.organization(ORG).toPlain(),
+      }),
+    ).rejects.toThrow(NotAuthorizedToReadError);
+  });
+});

--- a/apps/api/src/contexts/identity/application/list-grants-at-scope.ts
+++ b/apps/api/src/contexts/identity/application/list-grants-at-scope.ts
@@ -1,0 +1,57 @@
+import { GrantSnapshot } from '../domain/authorization/grant';
+import { GrantRepository } from '../domain/ports/grant.repository';
+import {
+  AccessControl,
+  AuthorizationContext,
+} from '../domain/authorization/access-control';
+import { Permission } from '../domain/authorization/permission';
+import {
+  ScopeRefProps,
+  ancestorChain,
+} from '../domain/authorization/scope-ref';
+import { NotAuthorizedToReadError } from '../domain/authorization/errors';
+
+/**
+ * Permissions that make a principal an *administrator* of a scope — any of them
+ * lets you see who holds roles there (the read side of scoped administration).
+ */
+const ADMIN_READ_PERMISSIONS: readonly Permission[] = [
+  'role:grant',
+  'user:read',
+  'user:invite',
+  'group:manage_members',
+];
+
+export interface ListGrantsAtScopeCommand {
+  actor: AuthorizationContext;
+  scope: ScopeRefProps;
+}
+
+/**
+ * Lists the grants made AT a scope (who has which role here) so a scoped
+ * administrator — platform admin, org admin, group manager, emergency
+ * coordinator — can manage their own area. Authorization reuses the PDP: the
+ * actor must hold an admin-read permission at the scope (or an ancestor), so an
+ * org admin sees only their org and a platform admin sees any scope, with no
+ * special-casing per role (docs/features/13 §3, §5).
+ */
+export class ListGrantsAtScope {
+  constructor(
+    private readonly grants: GrantRepository,
+    private readonly access: AccessControl,
+  ) {}
+
+  async execute(cmd: ListGrantsAtScopeCommand): Promise<GrantSnapshot[]> {
+    const perms = await this.access.effectivePermissions(
+      cmd.actor,
+      ancestorChain(cmd.scope),
+    );
+    if (!ADMIN_READ_PERMISSIONS.some((p) => perms.has(p))) {
+      throw new NotAuthorizedToReadError('grants at this scope');
+    }
+
+    const scopeId = cmd.scope.type === 'platform' ? null : cmd.scope.id;
+    const grants = await this.grants.findByScope(cmd.scope.type, scopeId);
+    return grants.map((g) => g.toSnapshot());
+  }
+}

--- a/apps/api/src/contexts/identity/domain/ports/grant.repository.ts
+++ b/apps/api/src/contexts/identity/domain/ports/grant.repository.ts
@@ -5,6 +5,11 @@ export const GRANT_REPOSITORY = Symbol('GrantRepository');
 export interface GrantRepository {
   /** All grants held by a principal (across every scope). */
   findByPrincipal(principalId: string): Promise<Grant[]>;
+  /**
+   * All grants made AT a given scope (who holds a role here) — the read side of
+   * scoped administration. `scopeId` is null for the platform scope.
+   */
+  findByScope(scopeType: string, scopeId: string | null): Promise<Grant[]>;
   findById(id: string): Promise<Grant | null>;
   save(grant: Grant): Promise<void>;
   deleteById(id: string): Promise<void>;

--- a/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-grant.repository.ts
+++ b/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-grant.repository.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { Db } from '../../../../shared/db';
 import { grantsTable } from './schema';
 import { GrantRepository } from '../../domain/ports/grant.repository';
@@ -101,6 +101,24 @@ export class DrizzleGrantRepository implements GrantRepository {
       .select()
       .from(grantsTable)
       .where(eq(grantsTable.principalId, principalId));
+    return rows.map(rowToGrant);
+  }
+
+  async findByScope(
+    scopeType: string,
+    scopeId: string | null,
+  ): Promise<Grant[]> {
+    const rows = await this.db
+      .select()
+      .from(grantsTable)
+      .where(
+        and(
+          eq(grantsTable.scopeType, scopeType),
+          scopeId === null
+            ? isNull(grantsTable.scopeId)
+            : eq(grantsTable.scopeId, scopeId),
+        ),
+      );
     return rows.map(rowToGrant);
   }
 

--- a/apps/api/src/contexts/identity/infrastructure/http/grants.controller.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/grants.controller.ts
@@ -29,7 +29,9 @@ import {
 import { Request } from 'express';
 import { GrantRole } from '../../application/grant-role';
 import { RevokeGrant } from '../../application/revoke-grant';
+import { ListGrantsAtScope } from '../../application/list-grants-at-scope';
 import { ScopeRefProps } from '../../domain/authorization/scope-ref';
+import { GrantSnapshot } from '../../domain/authorization/grant';
 import { GRANT_REPOSITORY } from '../../domain/ports/grant.repository';
 import type { GrantRepository } from '../../domain/ports/grant.repository';
 import { GrantRoleDto } from './grants-dto';
@@ -98,6 +100,41 @@ function buildScope(dto: GrantRoleDto): ScopeRefProps {
   }
 }
 
+/** Build a scope from `?scopeType=&scopeId=` for the scoped-listing endpoint. */
+function buildScopeFromQuery(
+  scopeType: string,
+  scopeId?: string,
+): ScopeRefProps {
+  if (scopeType === 'platform') return { type: 'platform' };
+  if (
+    scopeType === 'organization' ||
+    scopeType === 'emergency' ||
+    scopeType === 'group'
+  ) {
+    if (!scopeId) {
+      throw new BadRequestException(
+        `scopeId is required for scope '${scopeType}'`,
+      );
+    }
+    return { type: scopeType, id: scopeId };
+  }
+  throw new BadRequestException(`unsupported scopeType '${scopeType}'`);
+}
+
+function toGrantListItem(s: GrantSnapshot): GrantListItemDto {
+  return {
+    id: s.id,
+    principalId: s.principalId,
+    principalType: s.principalType,
+    roleId: s.roleId,
+    scopeType: s.scope.type,
+    scopeId: 'id' in s.scope ? s.scope.id : null,
+    grantedByPrincipalId: s.grantedByPrincipalId,
+    grantedAt: s.grantedAt,
+    expiresAt: s.expiresAt,
+  };
+}
+
 @ApiTags('grants')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -107,8 +144,37 @@ export class GrantsController {
   constructor(
     private readonly grantRole: GrantRole,
     private readonly revokeGrant: RevokeGrant,
+    private readonly listGrantsAtScope: ListGrantsAtScope,
     @Inject(GRANT_REPOSITORY) private readonly grants: GrantRepository,
   ) {}
+
+  @Get('at-scope')
+  @ApiOperation({
+    summary: 'List the grants made AT a scope (scoped administrator)',
+  })
+  @ApiQuery({
+    name: 'scopeType',
+    required: true,
+    description: 'platform | organization | emergency | group',
+  })
+  @ApiQuery({ name: 'scopeId', required: false })
+  @ApiOkResponse({ type: [GrantListItemDto] })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({
+    description: 'Not authorized to administer this scope',
+  })
+  async listAtScope(
+    @Query('scopeType') scopeType: string,
+    @Req() req: Request & { user?: AuthenticatedUser },
+    @Query('scopeId') scopeId?: string,
+  ): Promise<GrantListItemDto[]> {
+    const user = req.user!;
+    const grants = await this.listGrantsAtScope.execute({
+      actor: { principalId: user.id, grants: user.grants },
+      scope: buildScopeFromQuery(scopeType, scopeId),
+    });
+    return grants.map(toGrantListItem);
+  }
 
   @Get()
   @UseGuards(RequireAdminGuard)
@@ -128,20 +194,7 @@ export class GrantsController {
       throw new BadRequestException('principalId query param is required');
     }
     const grants = await this.grants.findByPrincipal(principalId);
-    return grants.map((g) => {
-      const s = g.toSnapshot();
-      return {
-        id: s.id,
-        principalId: s.principalId,
-        principalType: s.principalType,
-        roleId: s.roleId,
-        scopeType: s.scope.type,
-        scopeId: 'id' in s.scope ? s.scope.id : null,
-        grantedByPrincipalId: s.grantedByPrincipalId,
-        grantedAt: s.grantedAt,
-        expiresAt: s.expiresAt,
-      };
-    });
+    return grants.map((g) => toGrantListItem(g.toSnapshot()));
   }
 
   @Post()

--- a/apps/api/src/contexts/identity/infrastructure/identity.module.ts
+++ b/apps/api/src/contexts/identity/infrastructure/identity.module.ts
@@ -19,6 +19,7 @@ import { CreateServiceAccount } from '../application/create-service-account';
 import { IssueApiKey } from '../application/issue-api-key';
 import { RevokeApiKey } from '../application/revoke-api-key';
 import { FindUserByEmail } from '../application/find-user-by-email';
+import { ListGrantsAtScope } from '../application/list-grants-at-scope';
 import {
   USER_REPOSITORY,
   UserRepository,
@@ -141,9 +142,15 @@ const revokeGrantProvider = {
 
 const findUserByEmailProvider = {
   provide: FindUserByEmail,
-  inject: [USER_REPOSITORY, ACCESS_CONTROL],
-  useFactory: (users: UserRepository, access: AccessControl) =>
-    new FindUserByEmail(users, access),
+  inject: [USER_REPOSITORY],
+  useFactory: (users: UserRepository) => new FindUserByEmail(users),
+};
+
+const listGrantsAtScopeProvider = {
+  provide: ListGrantsAtScope,
+  inject: [GRANT_REPOSITORY, ACCESS_CONTROL],
+  useFactory: (grants: GrantRepository, access: AccessControl) =>
+    new ListGrantsAtScope(grants, access),
 };
 
 const serviceAccountRepositoryProvider = {
@@ -310,6 +317,7 @@ const authenticateWithProviderProvider = {
     grantRoleProvider,
     revokeGrantProvider,
     findUserByEmailProvider,
+    listGrantsAtScopeProvider,
     serviceAccountRepositoryProvider,
     apiKeyRepositoryProvider,
     createServiceAccountProvider,

--- a/apps/api/src/contexts/identity/infrastructure/in-memory-grant.repository.ts
+++ b/apps/api/src/contexts/identity/infrastructure/in-memory-grant.repository.ts
@@ -16,6 +16,17 @@ export class InMemoryGrantRepository implements GrantRepository {
     return Promise.resolve(result);
   }
 
+  findByScope(scopeType: string, scopeId: string | null): Promise<Grant[]> {
+    const result = [...this.store.values()]
+      .filter((s) => {
+        if (s.scope.type !== scopeType) return false;
+        if (s.scope.type === 'platform') return scopeId === null;
+        return 'id' in s.scope && s.scope.id === scopeId;
+      })
+      .map((s) => Grant.fromSnapshot(s));
+    return Promise.resolve(result);
+  }
+
   findById(id: string): Promise<Grant | null> {
     const snapshot = this.store.get(id);
     return Promise.resolve(snapshot ? Grant.fromSnapshot(snapshot) : null);

--- a/apps/web/src/app/administracion/organizacion/[id]/actions.ts
+++ b/apps/web/src/app/administracion/organizacion/[id]/actions.ts
@@ -1,0 +1,160 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+
+export interface RoleView {
+  id: string;
+  description: string;
+  defaultScopeType: string;
+  permissions: string[];
+}
+
+export interface ScopeGrant {
+  id: string;
+  principalId: string;
+  principalType: string;
+  roleId: string;
+  scopeType: string;
+  scopeId: string | null;
+  grantedByPrincipalId: string | null;
+  grantedAt: string;
+  expiresAt: string | null;
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function loginPath(orgId: string): string {
+  return `/login?next=/administracion/organizacion/${orgId}`;
+}
+
+export async function fetchRoles(): Promise<RoleView[]> {
+  const token = await getToken();
+  if (!token) return [];
+  const { data, error } = await api.GET('/roles', {
+    headers: authHeaders(token),
+  });
+  if (error !== undefined) return [];
+  return (data ?? []) as RoleView[];
+}
+
+/** Members of an organization = the grants made at its scope. */
+export async function fetchOrgGrants(orgId: string): Promise<ScopeGrant[]> {
+  const token = await getToken();
+  if (!token) return [];
+  const { data, error } = await api.GET('/grants/at-scope', {
+    params: { query: { scopeType: 'organization', scopeId: orgId } },
+    headers: authHeaders(token),
+  });
+  if (error !== undefined) return [];
+  return (data ?? []) as ScopeGrant[];
+}
+
+export type ActionResult =
+  | { status: 'idle' }
+  | { status: 'success'; message?: string }
+  | { status: 'error'; message: string };
+
+async function resolvePrincipalId(
+  token: string,
+  input: string,
+): Promise<string | null> {
+  const query = input.trim();
+  if (!query) return null;
+  if (UUID_RE.test(query)) return query;
+  const { data, error } = await api.GET('/users/lookup', {
+    params: { query: { email: query } },
+    headers: authHeaders(token),
+  });
+  if (error !== undefined || !data) return null;
+  return data.id;
+}
+
+/** Grant a catalog role to a user (by email or id) within this organization. */
+export async function grantOrgRoleAction(
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  const orgId = String(formData.get('orgId') ?? '').trim();
+  const token = await getToken();
+  if (!token) redirect(loginPath(orgId));
+
+  const principalInput = String(formData.get('principal') ?? '').trim();
+  const roleId = String(formData.get('roleId') ?? '').trim();
+  if (!orgId || !principalInput || !roleId) {
+    return { status: 'error', message: 'Indica el usuario y el rol.' };
+  }
+
+  const principalId = await resolvePrincipalId(token, principalInput);
+  if (!principalId) {
+    return {
+      status: 'error',
+      message: 'No se encontró ningún usuario con ese email o ID.',
+    };
+  }
+
+  const { error, response } = await api.POST('/grants', {
+    body: {
+      principalId,
+      roleId,
+      scopeType: 'organization',
+      scopeId: orgId,
+    },
+    headers: authHeaders(token),
+  });
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(loginPath(orgId));
+    }
+    if (response.status === 403) {
+      return {
+        status: 'error',
+        message:
+          'No puedes conceder ese rol aquí: requiere permisos que tú no tienes en esta organización (atenuación).',
+      };
+    }
+    if (response.status === 400) {
+      return { status: 'error', message: 'Datos inválidos. Revisa el rol.' };
+    }
+    return { status: 'error', message: 'No se pudo conceder el rol.' };
+  }
+
+  revalidatePath(`/administracion/organizacion/${orgId}`);
+  return { status: 'success', message: 'Rol concedido.' };
+}
+
+/** Revoke a grant within this organization. */
+export async function revokeOrgGrantAction(
+  grantId: string,
+  orgId: string,
+): Promise<ActionResult> {
+  const token = await getToken();
+  if (!token) redirect(loginPath(orgId));
+
+  const { error, response } = await api.DELETE('/grants/{id}', {
+    params: { path: { id: grantId } },
+    headers: authHeaders(token),
+  });
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(loginPath(orgId));
+    }
+    if (response.status === 403) {
+      return {
+        status: 'error',
+        message: 'No tienes permiso para revocar este rol.',
+      };
+    }
+    return { status: 'error', message: 'No se pudo revocar el rol.' };
+  }
+
+  revalidatePath(`/administracion/organizacion/${orgId}`);
+  return { status: 'success' };
+}

--- a/apps/web/src/app/administracion/organizacion/[id]/grant-org-role-form.tsx
+++ b/apps/web/src/app/administracion/organizacion/[id]/grant-org-role-form.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useActionState } from 'react';
+import { Button } from '@/components/atoms/button';
+import { Input } from '@/components/atoms/input';
+import { Select } from '@/components/atoms/select';
+import { FormField } from '@/components/molecules/form-field';
+import { ErrorMessage } from '@/components/atoms/error-message';
+import {
+  grantOrgRoleAction,
+  type ActionResult,
+  type RoleView,
+} from './actions';
+
+const INITIAL: ActionResult = { status: 'idle' };
+
+export function GrantOrgRoleForm({
+  orgId,
+  roles,
+}: {
+  orgId: string;
+  roles: RoleView[];
+}) {
+  const [state, formAction, pending] = useActionState(
+    grantOrgRoleAction,
+    INITIAL,
+  );
+
+  return (
+    <form action={formAction} className="flex flex-col gap-5">
+      <input type="hidden" name="orgId" value={orgId} />
+
+      {state.status === 'error' && <ErrorMessage message={state.message} />}
+      {state.status === 'success' && (
+        <p
+          role="status"
+          className="rounded-md border border-green-500 bg-green-50 px-4 py-3 text-sm font-medium text-green-800"
+        >
+          {state.message ?? 'Rol concedido.'}
+        </p>
+      )}
+
+      <FormField htmlFor="principal" label="Usuario (email o ID)">
+        <Input
+          id="principal"
+          name="principal"
+          type="text"
+          placeholder="persona@ejemplo.org o UUID"
+          required
+          autoComplete="off"
+        />
+      </FormField>
+
+      <FormField htmlFor="roleId" label="Rol">
+        <Select id="roleId" name="roleId" required defaultValue="">
+          <option value="" disabled>
+            Elige un rol…
+          </option>
+          {roles.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.id} — {r.description}
+            </option>
+          ))}
+        </Select>
+      </FormField>
+
+      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-300 rounded px-3 py-2">
+        Solo puedes conceder roles cuyos permisos tú ya tengas en esta
+        organización (atenuación). El servidor lo verifica.
+      </p>
+
+      <Button type="submit" size="md" disabled={pending}>
+        {pending ? 'Concediendo…' : 'Conceder rol'}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/app/administracion/organizacion/[id]/page.tsx
+++ b/apps/web/src/app/administracion/organizacion/[id]/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { PageShell } from '@/components/molecules/page-shell';
+import { EmptyState } from '@/components/molecules/empty-state';
+import { shortId } from '@/lib/permissions';
+import { administrableScopes } from '@/lib/admin-scopes';
+import { fetchRoles, fetchOrgGrants } from './actions';
+import { GrantOrgRoleForm } from './grant-org-role-form';
+import { RevokeGrantButton } from './revoke-grant-button';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Administrar organización — ResponseGrid',
+  description: 'Gestiona los usuarios y roles de tu organización.',
+};
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function OrganizacionAdminPage({ params }: PageProps) {
+  const { id: orgId } = await params;
+  const next = `/administracion/organizacion/${orgId}`;
+
+  const token = await getToken();
+  if (!token) redirect(`/login?next=${next}`);
+
+  const [meRes, roles] = await Promise.all([
+    api.GET('/auth/me', { headers: authHeaders(token) }),
+    fetchRoles(),
+  ]);
+  const me = meRes.data;
+  if (meRes.response.status === 401 || !me) redirect(`/login?next=${next}`);
+
+  // Authorize: the caller must actually administer THIS organization.
+  const administers = administrableScopes(me.grants ?? [], roles).some(
+    (s) => s.scopeType === 'organization' && s.scopeId === orgId,
+  );
+  if (!administers) redirect('/administracion');
+
+  const grants = await fetchOrgGrants(orgId);
+
+  return (
+    <PageShell>
+      <header className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/administracion"
+            className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors"
+          >
+            ← Administración
+          </Link>
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+          Organización
+        </h1>
+        <p className="font-mono text-xs text-gray-400 break-all">{orgId}</p>
+        <p className="text-base text-gray-600">
+          Usuarios y roles de esta organización. Asigna o revoca roles del
+          catálogo; los cambios respetan la atenuación de tus propios permisos.
+        </p>
+      </header>
+
+      {/* ── MIEMBROS / ROLES ─────────────────────────────────────────────── */}
+      <section aria-labelledby="members-heading" className="flex flex-col gap-4">
+        <h2 id="members-heading" className="text-xl font-bold text-gray-900">
+          Roles concedidos ({grants.length})
+        </h2>
+        {grants.length === 0 ? (
+          <EmptyState
+            title="Aún no hay roles en esta organización."
+            description="Concede el primero con el formulario de abajo."
+          />
+        ) : (
+          <ul className="flex flex-col gap-2" role="list">
+            {grants.map((g) => (
+              <li
+                key={g.id}
+                className="flex flex-wrap items-start justify-between gap-3 rounded-lg border border-gray-300 bg-white p-3"
+              >
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  <span className="text-sm font-bold text-gray-900">
+                    {g.roleId}
+                  </span>
+                  <span className="font-mono text-xs text-gray-500 break-all">
+                    {g.principalType === 'service_account'
+                      ? 'cuenta de servicio · '
+                      : ''}
+                    {shortId(g.principalId)}
+                    {g.principalId === me.id ? ' (tú)' : ''}
+                  </span>
+                  {g.expiresAt && (
+                    <span className="text-xs text-amber-700">
+                      caduca{' '}
+                      <time dateTime={g.expiresAt} suppressHydrationWarning>
+                        {new Date(g.expiresAt).toLocaleDateString('es-ES')}
+                      </time>
+                    </span>
+                  )}
+                </div>
+                <RevokeGrantButton grantId={g.id} orgId={orgId} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <hr className="border-gray-200" />
+
+      {/* ── CONCEDER ROL ─────────────────────────────────────────────────── */}
+      <section aria-labelledby="grant-heading" className="flex flex-col gap-4">
+        <h2 id="grant-heading" className="text-xl font-bold text-gray-900">
+          Asignar un rol
+        </h2>
+        <GrantOrgRoleForm orgId={orgId} roles={roles} />
+      </section>
+    </PageShell>
+  );
+}

--- a/apps/web/src/app/administracion/organizacion/[id]/revoke-grant-button.tsx
+++ b/apps/web/src/app/administracion/organizacion/[id]/revoke-grant-button.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Button } from '@/components/atoms/button';
+import { ErrorMessage } from '@/components/atoms/error-message';
+import { revokeOrgGrantAction } from './actions';
+
+export function RevokeGrantButton({
+  grantId,
+  orgId,
+}: {
+  grantId: string;
+  orgId: string;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleRevoke() {
+    setError(null);
+    startTransition(async () => {
+      const result = await revokeOrgGrantAction(grantId, orgId);
+      if (result.status === 'error') setError(result.message);
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        type="button"
+        variant="danger-outline"
+        size="sm"
+        disabled={pending}
+        onClick={handleRevoke}
+      >
+        {pending ? 'Revocando…' : 'Revocar'}
+      </Button>
+      {error && <ErrorMessage message={error} />}
+    </div>
+  );
+}

--- a/apps/web/src/app/administracion/page.tsx
+++ b/apps/web/src/app/administracion/page.tsx
@@ -1,0 +1,190 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { PageShell } from '@/components/molecules/page-shell';
+import { shortId } from '@/lib/permissions';
+import {
+  administrableScopes,
+  sortAdminScopes,
+  type AdminScope,
+} from '@/lib/admin-scopes';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Administración — ResponseGrid',
+  description:
+    'Panel de administración: gestiona los usuarios, roles y accesos de los ámbitos que administras.',
+};
+
+function capChips(scope: AdminScope): string[] {
+  const chips: string[] = [];
+  if (scope.canGrantRoles) chips.push('Roles');
+  if (scope.canInvite) chips.push('Invitar');
+  if (scope.canManageMembers) chips.push('Miembros');
+  if (scope.canManageKeys) chips.push('API keys');
+  return chips;
+}
+
+export default async function AdministracionPage() {
+  const token = await getToken();
+  if (!token) redirect('/login?next=/administracion');
+
+  const [meRes, rolesRes, emergenciesRes] = await Promise.all([
+    api.GET('/auth/me', { headers: authHeaders(token) }),
+    api.GET('/roles', { headers: authHeaders(token) }),
+    api.GET('/emergencies', { headers: authHeaders(token) }),
+  ]);
+
+  const me = meRes.data;
+  if (meRes.response.status === 401 || !me) redirect('/login?next=/administracion');
+
+  const roles = (rolesRes.data ?? []) as { id: string; permissions: string[] }[];
+  const scopes = sortAdminScopes(administrableScopes(me.grants ?? [], roles));
+
+  // Anyone who can't administer anything has no business here.
+  if (scopes.length === 0) redirect('/');
+
+  // Resolve emergency ids → slugs for deep links into coordination.
+  const emergencies = (emergenciesRes.data ?? []) as {
+    id: string;
+    slug: string;
+    name: string;
+  }[];
+  const slugById = new Map(emergencies.map((e) => [e.id, e.slug]));
+  const nameById = new Map(emergencies.map((e) => [e.id, e.name]));
+
+  return (
+    <PageShell>
+      <header className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/"
+            className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors"
+          >
+            ← Inicio
+          </Link>
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+          Administración
+        </h1>
+        <p className="text-base text-gray-600">
+          Estos son los ámbitos que administras. Entra en cualquiera para
+          gestionar sus usuarios, roles y accesos. Solo ves lo que tus permisos
+          te permiten.
+        </p>
+      </header>
+
+      <section aria-labelledby="scopes-heading" className="flex flex-col gap-4">
+        <h2 id="scopes-heading" className="text-xl font-bold text-gray-900">
+          Ámbitos que administras ({scopes.length})
+        </h2>
+        <ul className="flex flex-col gap-3" role="list">
+          {scopes.map((scope) => (
+            <li key={scope.key}>
+              <ScopeCard
+                scope={scope}
+                emergencyName={
+                  scope.scopeId ? nameById.get(scope.scopeId) : undefined
+                }
+                emergencySlug={
+                  scope.scopeId ? slugById.get(scope.scopeId) : undefined
+                }
+              />
+            </li>
+          ))}
+        </ul>
+      </section>
+    </PageShell>
+  );
+}
+
+function ScopeCard({
+  scope,
+  emergencyName,
+  emergencySlug,
+}: {
+  scope: AdminScope;
+  emergencyName?: string;
+  emergencySlug?: string;
+}) {
+  const chips = capChips(scope);
+
+  // Each scope type routes to the right management surface.
+  let title: string;
+  let subtitle: string;
+  let href: string | null;
+  let cta: string;
+
+  switch (scope.scopeType) {
+    case 'platform':
+      title = 'Plataforma (global)';
+      subtitle = 'Roles, permisos y cuentas de servicio de toda la plataforma.';
+      href = '/admin/permisos';
+      cta = 'Roles y permisos';
+      break;
+    case 'organization':
+      title = 'Organización';
+      subtitle = `ID ${shortId(scope.scopeId ?? '')} · gestiona sus miembros y roles.`;
+      href = `/administracion/organizacion/${scope.scopeId}`;
+      cta = 'Gestionar organización';
+      break;
+    case 'group':
+      title = 'Grupo / cuadrilla';
+      subtitle = `ID ${shortId(scope.scopeId ?? '')} · miembros y asignaciones.`;
+      href = `/grupos/${scope.scopeId}`;
+      cta = 'Gestionar grupo';
+      break;
+    case 'emergency':
+      title = emergencyName ?? 'Emergencia';
+      subtitle = `ID ${shortId(scope.scopeId ?? '')} · coordinación y miembros.`;
+      href = emergencySlug ? `/e/${emergencySlug}/coordinacion` : null;
+      cta = 'Ir a coordinación';
+      break;
+    default:
+      title = scope.scopeType;
+      subtitle = scope.scopeId ?? '';
+      href = null;
+      cta = '';
+  }
+
+  const inner = (
+    <div className="flex flex-col gap-2 rounded-lg border-2 border-gray-900 bg-white p-4 transition-colors hover:bg-gray-50">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <span className="text-base font-bold text-gray-900">
+          {title}
+          {href ? ' →' : ''}
+        </span>
+        <div className="flex flex-wrap gap-1">
+          {chips.map((c) => (
+            <span
+              key={c}
+              className="rounded-full border border-gray-300 bg-gray-50 px-2 py-0.5 text-[11px] font-semibold text-gray-600"
+            >
+              {c}
+            </span>
+          ))}
+        </div>
+      </div>
+      <span className="text-sm text-gray-600">{subtitle}</span>
+      {scope.scopeType === 'platform' && (
+        <Link
+          href="/admin/api-keys"
+          className="text-xs font-medium text-gray-500 underline underline-offset-2 hover:text-gray-900"
+        >
+          Cuentas de servicio y API keys →
+        </Link>
+      )}
+    </div>
+  );
+
+  return href ? (
+    <Link href={href} aria-label={`${cta}: ${title}`}>
+      {inner}
+    </Link>
+  ) : (
+    inner
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import { getToken, authHeaders } from '@/lib/auth';
 import { SiteHeaderBand } from '@/components/organisms/site-header-band';
 import { EmergencyDirectoryCard } from '@/components/organisms/emergency-directory-card';
 import { AccountNav } from '@/components/molecules/account-nav';
+import { hasManagerRole } from '@/lib/admin-scopes';
 import { HowItWorksStep } from '@/components/molecules/how-it-works-step';
 import { TrustLevelsCard } from '@/components/molecules/trust-levels-card';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -29,6 +30,7 @@ export default async function HomePage() {
   const token = await getToken();
   let notificationUnreadCount = 0;
   let isAdmin = false;
+  let canAdminister = false;
   if (token != null) {
     const [notifResult, meResult] = await Promise.all([
       api.GET('/notifications/mine', { headers: authHeaders(token) }),
@@ -39,6 +41,7 @@ export default async function HomePage() {
     }
     if (meResult.data != null) {
       isAdmin = meResult.data.isAdmin === true;
+      canAdminister = isAdmin || hasManagerRole(meResult.data.grants ?? []);
     }
   }
 
@@ -150,6 +153,7 @@ export default async function HomePage() {
             t={th}
             authed={token !== null}
             isAdmin={isAdmin}
+            canAdminister={canAdminister}
             notificationUnreadCount={notificationUnreadCount}
           />
         </div>

--- a/apps/web/src/components/molecules/account-nav.tsx
+++ b/apps/web/src/components/molecules/account-nav.tsx
@@ -10,13 +10,21 @@ interface AccountNavProps {
   t: Messages['home'];
   authed: boolean;
   isAdmin: boolean;
+  /** Can administer at least one scope (platform, org, group, emergency). */
+  canAdminister?: boolean;
   notificationUnreadCount: number;
 }
 
 const linkClass =
   'text-sm font-medium text-muted underline underline-offset-2 transition-colors hover:text-navy focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 rounded';
 
-export function AccountNav({ t, authed, isAdmin, notificationUnreadCount }: AccountNavProps) {
+export function AccountNav({
+  t,
+  authed,
+  isAdmin,
+  canAdminister = false,
+  notificationUnreadCount,
+}: AccountNavProps) {
   return (
     <nav
       aria-label={t.aria_secondary_nav}
@@ -26,6 +34,9 @@ export function AccountNav({ t, authed, isAdmin, notificationUnreadCount }: Acco
         {t.account_heading}
       </span>
       <Link href="/organizaciones" className={linkClass}>{t.my_orgs}</Link>
+      {authed && canAdminister && (
+        <Link href="/administracion" className={linkClass}>{t.administration}</Link>
+      )}
       {authed && (
         <>
           <Link href="/grupos" className={linkClass}>{t.groups}</Link>

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -57,6 +57,7 @@ export const en = {
     no_emergencies_description: 'When an emergency is activated it will appear here.',
     emergency_status_active: 'Active',
     my_orgs: 'My organizations',
+    administration: 'Administration',
     notifications: 'Notifications',
     notifications_with_count: 'Notifications ({count})',
     coordination_access: 'Coordination access',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -57,6 +57,7 @@ export const es = {
     no_emergencies_description: 'Cuando se active una emergencia aparecerá aquí.',
     emergency_status_active: 'Activa',
     my_orgs: 'Mis organizaciones',
+    administration: 'Administración',
     notifications: 'Notificaciones',
     notifications_with_count: 'Notificaciones ({count})',
     coordination_access: 'Acceso coordinación',

--- a/apps/web/src/lib/admin-scopes.test.ts
+++ b/apps/web/src/lib/admin-scopes.test.ts
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  administrableScopes,
+  canAdminister,
+  sortAdminScopes,
+} from './admin-scopes.ts';
+
+const ROLES = [
+  { id: 'platform_admin', permissions: ['role:grant', 'apikey:create', 'user:invite', 'group:manage_members'] },
+  { id: 'org_admin', permissions: ['user:invite', 'role:grant', 'apikey:create', 'group:manage_members', 'org:read'] },
+  { id: 'org_member', permissions: ['org:read'] },
+  { id: 'group_manager', permissions: ['group:manage_members', 'role:grant', 'user:invite'] },
+  { id: 'viewer', permissions: ['org:read'] },
+];
+
+test('org_admin administers their organization with full caps', () => {
+  const scopes = administrableScopes(
+    [{ roleId: 'org_admin', scopeType: 'organization', scopeId: 'o1' }],
+    ROLES,
+  );
+  assert.equal(scopes.length, 1);
+  assert.equal(scopes[0].scopeType, 'organization');
+  assert.equal(scopes[0].scopeId, 'o1');
+  assert.equal(scopes[0].canGrantRoles, true);
+  assert.equal(scopes[0].canManageKeys, true);
+  assert.equal(scopes[0].canManageMembers, true);
+});
+
+test('a plain org_member administers nothing', () => {
+  const grants = [{ roleId: 'org_member', scopeType: 'organization', scopeId: 'o1' }];
+  assert.equal(administrableScopes(grants, ROLES).length, 0);
+  assert.equal(canAdminister(grants, ROLES), false);
+});
+
+test('expired grants are ignored', () => {
+  const scopes = administrableScopes(
+    [
+      {
+        roleId: 'org_admin',
+        scopeType: 'organization',
+        scopeId: 'o1',
+        expiresAt: '2000-01-01T00:00:00.000Z',
+      },
+    ],
+    ROLES,
+  );
+  assert.equal(scopes.length, 0);
+});
+
+test('caps from multiple roles at the same scope are unioned and deduped', () => {
+  const scopes = administrableScopes(
+    [
+      { roleId: 'group_manager', scopeType: 'group', scopeId: 'g1' },
+      { roleId: 'group_manager', scopeType: 'group', scopeId: 'g1' },
+    ],
+    ROLES,
+  );
+  assert.equal(scopes.length, 1);
+  assert.deepEqual(scopes[0].roleIds, ['group_manager']);
+  assert.equal(scopes[0].canManageMembers, true);
+  assert.equal(scopes[0].canManageKeys, false);
+});
+
+test('unknown roleId contributes nothing', () => {
+  const scopes = administrableScopes(
+    [{ roleId: 'wizard', scopeType: 'platform', scopeId: null }],
+    ROLES,
+  );
+  assert.equal(scopes.length, 0);
+});
+
+test('sortAdminScopes orders platform → organization → group', () => {
+  const scopes = administrableScopes(
+    [
+      { roleId: 'group_manager', scopeType: 'group', scopeId: 'g1' },
+      { roleId: 'platform_admin', scopeType: 'platform', scopeId: null },
+      { roleId: 'org_admin', scopeType: 'organization', scopeId: 'o1' },
+    ],
+    ROLES,
+  );
+  const sorted = sortAdminScopes(scopes).map((s) => s.scopeType);
+  assert.deepEqual(sorted, ['platform', 'organization', 'group']);
+});

--- a/apps/web/src/lib/admin-scopes.ts
+++ b/apps/web/src/lib/admin-scopes.ts
@@ -1,0 +1,127 @@
+/**
+ * Derives, from a principal's effective grants and the role catalog, the set of
+ * scopes they can ADMINISTER and what they can do in each. Pure and
+ * framework-free so it works in Server and Client Components and is unit-tested.
+ *
+ * This is the heart of the role-aware admin hub: instead of special-casing each
+ * role, we read the permissions each grant confers and group management
+ * capabilities by scope (docs/features/13 §3, §5).
+ */
+
+/** Permissions that make a principal an administrator of a scope. */
+export const MANAGEMENT_PERMISSIONS = [
+  'role:grant',
+  'user:invite',
+  'apikey:create',
+  'group:manage_members',
+] as const;
+
+export interface MeGrant {
+  roleId: string;
+  scopeType: string;
+  scopeId: string | null;
+  expiresAt?: string | null;
+}
+
+export interface RoleCatalogEntry {
+  id: string;
+  permissions: string[];
+}
+
+export interface AdminScope {
+  /** Stable key `${scopeType}:${scopeId ?? ''}`. */
+  key: string;
+  scopeType: string;
+  scopeId: string | null;
+  /** Roles the principal holds at this scope that grant management power. */
+  roleIds: string[];
+  canGrantRoles: boolean;
+  canInvite: boolean;
+  canManageKeys: boolean;
+  canManageMembers: boolean;
+}
+
+/** The scopes a principal can administer, with their capabilities, deduped. */
+export function administrableScopes(
+  grants: MeGrant[],
+  roles: RoleCatalogEntry[],
+  now: number = Date.now(),
+): AdminScope[] {
+  const permsByRole = new Map(
+    roles.map((r) => [r.id, new Set(r.permissions)]),
+  );
+  const byScope = new Map<string, AdminScope>();
+
+  for (const g of grants) {
+    if (g.expiresAt && new Date(g.expiresAt).getTime() <= now) continue;
+    const perms = permsByRole.get(g.roleId);
+    if (!perms) continue;
+    if (!MANAGEMENT_PERMISSIONS.some((p) => perms.has(p))) continue;
+
+    const key = `${g.scopeType}:${g.scopeId ?? ''}`;
+    const scope = byScope.get(key) ?? {
+      key,
+      scopeType: g.scopeType,
+      scopeId: g.scopeId,
+      roleIds: [],
+      canGrantRoles: false,
+      canInvite: false,
+      canManageKeys: false,
+      canManageMembers: false,
+    };
+    if (!scope.roleIds.includes(g.roleId)) scope.roleIds.push(g.roleId);
+    scope.canGrantRoles = scope.canGrantRoles || perms.has('role:grant');
+    scope.canInvite = scope.canInvite || perms.has('user:invite');
+    scope.canManageKeys = scope.canManageKeys || perms.has('apikey:create');
+    scope.canManageMembers =
+      scope.canManageMembers || perms.has('group:manage_members');
+    byScope.set(key, scope);
+  }
+
+  return [...byScope.values()];
+}
+
+/**
+ * Role ids that confer management capability — a cheap signal for nav
+ * visibility without loading the full role catalog. The hub itself does the
+ * precise, catalog-driven check via {@link administrableScopes}.
+ */
+export const MANAGER_ROLE_IDS = [
+  'platform_admin',
+  'org_admin',
+  'group_manager',
+  'emergency_coordinator',
+] as const;
+
+/** Cheap check (no catalog) for whether to surface the admin entry in nav. */
+export function hasManagerRole(grants: MeGrant[], now: number = Date.now()): boolean {
+  const ids = MANAGER_ROLE_IDS as readonly string[];
+  return grants.some((g) => {
+    if (g.expiresAt && new Date(g.expiresAt).getTime() <= now) return false;
+    return ids.includes(g.roleId);
+  });
+}
+
+/** Whether a principal can administer at least one scope. */
+export function canAdminister(
+  grants: MeGrant[],
+  roles: RoleCatalogEntry[],
+  now: number = Date.now(),
+): boolean {
+  return administrableScopes(grants, roles, now).length > 0;
+}
+
+const SCOPE_ORDER: Record<string, number> = {
+  platform: 0,
+  organization: 1,
+  emergency: 2,
+  group: 3,
+  entity: 4,
+};
+
+/** Stable display ordering: platform first, then org, emergency, group. */
+export function sortAdminScopes(scopes: AdminScope[]): AdminScope[] {
+  return [...scopes].sort(
+    (a, b) => (SCOPE_ORDER[a.scopeType] ?? 9) - (SCOPE_ORDER[b.scopeType] ?? 9),
+  );
+}

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -55,6 +55,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/grants/at-scope": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the grants made AT a scope (scoped administrator) */
+        get: operations["GrantsController_listAtScope"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/grants": {
         parameters: {
             query?: never;
@@ -407,6 +424,23 @@ export interface paths {
         };
         /** Get facets (counts by category and country) for visible resources */
         get: operations["PublicController_facets"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/recipient-types": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the recipient-type taxonomy for final recipients (extensible) */
+        get: operations["RecipientTypesController_list"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1641,6 +1675,16 @@ export interface components {
              * @example Caracas
              */
             city?: string;
+            /**
+             * @description Mark this resource as a final recipient of aid (requires the destination stage)
+             * @example true
+             */
+            isFinalRecipient?: boolean;
+            /**
+             * @description Recipient type slug (see the emergency recipient-type taxonomy)
+             * @example hospital
+             */
+            recipientType?: string;
         };
         RegisterResourceResponseDto: {
             /**
@@ -1726,6 +1770,16 @@ export interface components {
             country: string | null;
             /** @example Caracas */
             city: string | null;
+            /**
+             * @description Whether this resource is a final recipient of aid
+             * @example false
+             */
+            isFinalRecipient: boolean;
+            /**
+             * @description Recipient type slug (see the emergency recipient-type taxonomy)
+             * @example hospital
+             */
+            recipientType: string | null;
         };
         PagedResourcesDto: {
             items: components["schemas"]["ResourceViewDto"][];
@@ -1797,6 +1851,16 @@ export interface components {
             /** @example Caracas */
             city: string | null;
             /**
+             * @description Whether this resource is a final recipient of aid
+             * @example false
+             */
+            isFinalRecipient: boolean;
+            /**
+             * @description Recipient type slug (see the emergency recipient-type taxonomy)
+             * @example hospital
+             */
+            recipientType: string | null;
+            /**
              * @description Distance from query point in meters (rounded)
              * @example 1234
              */
@@ -1826,6 +1890,16 @@ export interface components {
             byCountry: Record<string, never>;
             /** @example 8 */
             total: number;
+        };
+        RecipientTypeDto: {
+            /** @example hospital */
+            slug: string;
+            /** @example Hospital */
+            labelEs: string;
+            /** @example Hospital */
+            labelEn: string;
+            /** @example 10 */
+            sort: number;
         };
         CreateTemplateDto: {
             /** @example Terremoto básico */
@@ -2764,6 +2838,43 @@ export interface operations {
             };
         };
     };
+    GrantsController_listAtScope: {
+        parameters: {
+            query: {
+                /** @description platform | organization | emergency | group */
+                scopeType: string;
+                scopeId?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GrantListItemDto"][];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authorized to administer this scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     GrantsController_list: {
         parameters: {
             query: {
@@ -3623,6 +3734,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ResourceFacetsDto"];
+                };
+            };
+        };
+    };
+    RecipientTypesController_list: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Recipient types ordered by sort */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecipientTypeDto"][];
                 };
             };
         };


### PR DESCRIPTION
## Resumen

Páginas de administración **accesibles e intuitivas** no solo para admins de plataforma, sino para **cualquier usuario con capacidad de gestión** en su ámbito (p. ej. un admin de organización). El diseño es **genérico sobre el modelo de grants/atenuación** (un panel por ámbito que administras, con las acciones que tus permisos permiten) en vez de casos especiales por rol — alineado con feature-13.

## Backend (DDD + TDD)

- **`GrantRepository.findByScope(scopeType, scopeId)`** (drizzle + in-memory) — usa el índice `(scope_type, scope_id)`.
- **`ListGrantsAtScope`** — lista quién tiene roles en un ámbito. Autorizado por el **PDP**: el actor necesita `role:grant` / `user:read` / `user:invite` / `group:manage_members` en ese ámbito (o un ancestro), sin casos especiales por rol → un `org_admin` solo ve **su** organización, un `platform_admin` ve cualquiera.
- **`GET /grants/at-scope?scopeType=&scopeId=`**.
- **`/users/lookup`** ahora vale para managers de **cualquier** ámbito (antes solo plataforma), para conceder/invitar por email.

## Frontend (Atomic Design)

- **`lib/admin-scopes`** — deriva de los grants + catálogo los ámbitos que administras y sus capacidades (`role:grant`/`user:invite`/`apikey:create`/`group:manage_members`). Con tests `node:test`.
- **`/administracion`** — hub role-aware: tarjetas por ámbito (plataforma, organización, grupo, emergencia) con enlaces a su gestión (la org abre su panel; grupo → `/grupos/[id]`; emergencia → coordinación; plataforma → `/admin/permisos` y `/admin/api-keys`).
- **`/administracion/organizacion/[id]`** — gestiona miembros y roles de la organización: lookup por **email o UUID**, conceder y revocar roles del catálogo con **atenuación** verificada en el servidor.
- Enlace **"Administración"** en la navegación visible para cualquier manager (no solo `isAdmin`).

## Pruebas

- **797** unit/integración api + **12** web (`node:test`) + **261** e2e en verde.
- `api`/`web` build, lint (`--max-warnings=0`) y prettier OK. Cliente tipado regenerado.

## Seguimiento (fuera de alcance de esta PR)

- **Cuentas de servicio scoped por organización** en el panel de org (hoy el hub enlaza a `/admin/api-keys` para plataforma; el `POST` ya respeta `apikey:create` en el ámbito de la org).
- **Enriquecer la lista de miembros** con email/nombre (hoy muestra `id` + rol; falta una resolución en bloque de principales).
- Paneles dedicados de grupo/emergencia (hoy se enlaza a las superficies existentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnU5GA4cPpCAq4AWRwubiK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnU5GA4cPpCAq4AWRwubiK)_