### PR TITLE
feat(web): destinatario final en la ficha de recurso + api-client regenerado (#60/#62)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1212,6 +1212,31 @@
         ]
       }
     },
+    "/recipient-types": {
+      "get": {
+        "operationId": "RecipientTypesController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Recipient types ordered by sort",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RecipientTypeDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List the recipient-type taxonomy for final recipients (extensible)",
+        "tags": [
+          "public"
+        ]
+      }
+    },
     "/templates": {
       "post": {
         "operationId": "TemplatesController_create",
@@ -1731,6 +1756,16 @@
                 "high",
                 "urgent"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "resourceId",
+            "required": false,
+            "in": "query",
+            "description": "Filter to needs linked to this resource / final recipient",
+            "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -5064,6 +5099,16 @@
             "type": "string",
             "example": "Caracas",
             "description": "City name"
+          },
+          "isFinalRecipient": {
+            "type": "boolean",
+            "example": true,
+            "description": "Mark this resource as a final recipient of aid (requires the destination stage)"
+          },
+          "recipientType": {
+            "type": "string",
+            "example": "hospital",
+            "description": "Recipient type slug (see the emergency recipient-type taxonomy)"
           }
         },
         "required": [
@@ -5244,6 +5289,17 @@
             "type": "string",
             "example": "Caracas",
             "nullable": true
+          },
+          "isFinalRecipient": {
+            "type": "boolean",
+            "example": false,
+            "description": "Whether this resource is a final recipient of aid"
+          },
+          "recipientType": {
+            "type": "string",
+            "example": "hospital",
+            "nullable": true,
+            "description": "Recipient type slug (see the emergency recipient-type taxonomy)"
           }
         },
         "required": [
@@ -5263,7 +5319,9 @@
           "sourceName",
           "externalUpdatedAt",
           "country",
-          "city"
+          "city",
+          "isFinalRecipient",
+          "recipientType"
         ]
       },
       "PagedResourcesDto": {
@@ -5409,6 +5467,17 @@
             "example": "Caracas",
             "nullable": true
           },
+          "isFinalRecipient": {
+            "type": "boolean",
+            "example": false,
+            "description": "Whether this resource is a final recipient of aid"
+          },
+          "recipientType": {
+            "type": "string",
+            "example": "hospital",
+            "nullable": true,
+            "description": "Recipient type slug (see the emergency recipient-type taxonomy)"
+          },
           "distanceMeters": {
             "type": "number",
             "example": 1234,
@@ -5433,6 +5502,8 @@
           "externalUpdatedAt",
           "country",
           "city",
+          "isFinalRecipient",
+          "recipientType",
           "distanceMeters"
         ]
       },
@@ -5491,6 +5562,33 @@
           "byCategory",
           "byCountry",
           "total"
+        ]
+      },
+      "RecipientTypeDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "hospital"
+          },
+          "labelEs": {
+            "type": "string",
+            "example": "Hospital"
+          },
+          "labelEn": {
+            "type": "string",
+            "example": "Hospital"
+          },
+          "sort": {
+            "type": "number",
+            "example": 10
+          }
+        },
+        "required": [
+          "slug",
+          "labelEs",
+          "labelEn",
+          "sort"
         ]
       },
       "CreateTemplateDto": {
@@ -5863,6 +5961,13 @@
             "example": 3,
             "description": "How many personnel are needed (>= 1)",
             "nullable": true
+          },
+          "resourceId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "description": "Link this need to a resource / final recipient (#60). Optional.",
+            "nullable": true
           }
         },
         "required": [
@@ -6052,6 +6157,12 @@
             "example": 3,
             "nullable": true,
             "description": "Number of personnel needed"
+          },
+          "resourceId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "Linked resource / final recipient id (#60), or null if standalone."
           }
         },
         "required": [

--- a/apps/web/src/components/atoms/recipient-type-badge.tsx
+++ b/apps/web/src/components/atoms/recipient-type-badge.tsx
@@ -1,0 +1,28 @@
+/**
+ * RecipientTypeBadge — pill shown on a resource that is a "final recipient"
+ * of aid (#60), displaying its localised recipient type. Colour comes from
+ * `lib/recipient-types`; degrades gracefully for unknown/custom types.
+ */
+interface RecipientTypeBadgeProps {
+  /** Localised type label, e.g. "Hospital" (or the raw slug if unknown). */
+  label: string;
+  /** Tailwind colour classes from recipientTypeColor(). */
+  colorClass: string;
+  /** Full aria label, e.g. "Destinatario final: Hospital". */
+  ariaLabel: string;
+}
+
+export function RecipientTypeBadge({
+  label,
+  colorClass,
+  ariaLabel,
+}: RecipientTypeBadgeProps) {
+  return (
+    <span
+      aria-label={ariaLabel}
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${colorClass}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/components/organisms/public-resource-card.tsx
+++ b/apps/web/src/components/organisms/public-resource-card.tsx
@@ -6,6 +6,11 @@ import { Card } from '@/components/atoms/card';
 import type { Messages } from '@/i18n/messages/es';
 import type { Locale } from '@/i18n';
 import { categoryLabel, categoryColor } from '@/lib/categories';
+import {
+  recipientTypeLabel,
+  recipientTypeColor,
+} from '@/lib/recipient-types';
+import { RecipientTypeBadge } from '@/components/atoms/recipient-type-badge';
 
 type ResourceViewDto = components['schemas']['ResourceViewDto'];
 
@@ -56,6 +61,12 @@ export function PublicResourceCard({
   if (locationParts.length > 0) subtitleParts.push(locationParts.join(', '));
   const subtitle = subtitleParts.join(' · ');
 
+  // Destinatario final (#60): show a type chip when the point is a recipient.
+  const recipientTypeText =
+    resource.recipientType != null
+      ? recipientTypeLabel(resource.recipientType, locale)
+      : null;
+
   return (
     <Card
       as="article"
@@ -66,6 +77,21 @@ export function PublicResourceCard({
       <div className="flex flex-wrap items-center gap-2">
         <VerificationBadge level={resource.verificationLevel} t={tVerification} />
         <StatusLight status={resource.publicStatus} t={tStatusLight} />
+        {resource.isFinalRecipient && (
+          <RecipientTypeBadge
+            label={recipientTypeText ?? t.final_recipient_label}
+            colorClass={
+              resource.recipientType != null
+                ? recipientTypeColor(resource.recipientType)
+                : 'bg-navy text-white'
+            }
+            ariaLabel={
+              recipientTypeText != null
+                ? `${t.final_recipient_label}: ${recipientTypeText}`
+                : t.final_recipient_label
+            }
+          />
+        )}
       </div>
 
       {/* ── Name ────────────────────────────────────────────────────────── */}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -292,6 +292,8 @@ export const en = {
     meta_source: 'Source:',
     // aria-label for the card article element
     aria_label: 'Active point: {name}',
+    // Final recipient (#60)
+    final_recipient_label: 'Final recipient',
   },
 
   resource_list: {

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -308,6 +308,8 @@ export const es = {
     meta_source: 'Fuente:',
     // aria-label for the card article element
     aria_label: 'Punto activo: {name}',
+    // Destinatario final (#60)
+    final_recipient_label: 'Destinatario final',
   },
 
   // ── ResourceList ──────────────────────────────────────────────────────────

--- a/apps/web/src/lib/recipient-types.ts
+++ b/apps/web/src/lib/recipient-types.ts
@@ -1,0 +1,70 @@
+/**
+ * Recipient-type metadata for a resource's `recipientType` slug (#62).
+ *
+ * Mirrors `lib/categories`: a static map of the seeded base types with
+ * localised labels + chip colours. The type taxonomy is extensible on the
+ * backend (GET /recipient-types), so the helpers fall back gracefully — label
+ * to the slug itself, colour to neutral — for any slug not listed here.
+ */
+
+export interface RecipientTypeMeta {
+  labelEs: string;
+  labelEn: string;
+  /** Tailwind utility classes for the chip background + text colour */
+  color: string;
+}
+
+const RECIPIENT_TYPE_MAP: Record<string, RecipientTypeMeta> = {
+  hospital: {
+    labelEs: 'Hospital',
+    labelEn: 'Hospital',
+    color: 'bg-red-100 text-red-800',
+  },
+  clinic: {
+    labelEs: 'Clínica',
+    labelEn: 'Clinic',
+    color: 'bg-rose-100 text-rose-800',
+  },
+  organization: {
+    labelEs: 'Organización',
+    labelEn: 'Organization',
+    color: 'bg-indigo-100 text-indigo-800',
+  },
+  company: {
+    labelEs: 'Empresa',
+    labelEn: 'Company',
+    color: 'bg-blue-100 text-blue-800',
+  },
+  collection_center: {
+    labelEs: 'Centro de acopio',
+    labelEn: 'Collection center',
+    color: 'bg-amber-100 text-amber-800',
+  },
+  individual: {
+    labelEs: 'Particular',
+    labelEn: 'Individual',
+    color: 'bg-emerald-100 text-emerald-800',
+  },
+  other: {
+    labelEs: 'Otro',
+    labelEn: 'Other',
+    color: 'bg-gray-100 text-gray-700',
+  },
+};
+
+const FALLBACK_COLOR = 'bg-gray-100 text-gray-700';
+
+/**
+ * Localised label for a recipient-type slug. Falls back to the slug itself
+ * when unknown, so custom/extensible types still render something meaningful.
+ */
+export function recipientTypeLabel(slug: string, locale: 'es' | 'en'): string {
+  const meta = RECIPIENT_TYPE_MAP[slug];
+  if (!meta) return slug;
+  return locale === 'en' ? meta.labelEn : meta.labelEs;
+}
+
+/** Tailwind chip colour for a recipient-type slug; neutral fallback when unknown. */
+export function recipientTypeColor(slug: string): string {
+  return RECIPIENT_TYPE_MAP[slug]?.color ?? FALLBACK_COLOR;
+}

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -415,6 +415,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/recipient-types": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the recipient-type taxonomy for final recipients (extensible) */
+        get: operations["RecipientTypesController_list"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/templates": {
         parameters: {
             query?: never;
@@ -1641,6 +1658,16 @@ export interface components {
              * @example Caracas
              */
             city?: string;
+            /**
+             * @description Mark this resource as a final recipient of aid (requires the destination stage)
+             * @example true
+             */
+            isFinalRecipient?: boolean;
+            /**
+             * @description Recipient type slug (see the emergency recipient-type taxonomy)
+             * @example hospital
+             */
+            recipientType?: string;
         };
         RegisterResourceResponseDto: {
             /**
@@ -1726,6 +1753,16 @@ export interface components {
             country: string | null;
             /** @example Caracas */
             city: string | null;
+            /**
+             * @description Whether this resource is a final recipient of aid
+             * @example false
+             */
+            isFinalRecipient: boolean;
+            /**
+             * @description Recipient type slug (see the emergency recipient-type taxonomy)
+             * @example hospital
+             */
+            recipientType: string | null;
         };
         PagedResourcesDto: {
             items: components["schemas"]["ResourceViewDto"][];
@@ -1797,6 +1834,16 @@ export interface components {
             /** @example Caracas */
             city: string | null;
             /**
+             * @description Whether this resource is a final recipient of aid
+             * @example false
+             */
+            isFinalRecipient: boolean;
+            /**
+             * @description Recipient type slug (see the emergency recipient-type taxonomy)
+             * @example hospital
+             */
+            recipientType: string | null;
+            /**
              * @description Distance from query point in meters (rounded)
              * @example 1234
              */
@@ -1826,6 +1873,16 @@ export interface components {
             byCountry: Record<string, never>;
             /** @example 8 */
             total: number;
+        };
+        RecipientTypeDto: {
+            /** @example hospital */
+            slug: string;
+            /** @example Hospital */
+            labelEs: string;
+            /** @example Hospital */
+            labelEn: string;
+            /** @example 10 */
+            sort: number;
         };
         CreateTemplateDto: {
             /** @example Terremoto básico */
@@ -2003,6 +2060,12 @@ export interface components {
              * @example 3
              */
             requestedCount?: number | null;
+            /**
+             * Format: uuid
+             * @description Link this need to a resource / final recipient (#60). Optional.
+             * @example 3fa85f64-5717-4562-b3fc-2c963f66afa6
+             */
+            resourceId?: string | null;
         };
         CreateNeedResponseDto: {
             /**
@@ -2091,6 +2154,11 @@ export interface components {
              * @example 3
              */
             requestedCount?: number | null;
+            /**
+             * Format: uuid
+             * @description Linked resource / final recipient id (#60), or null if standalone.
+             */
+            resourceId?: string | null;
         };
         AssignNeedManagerDto: {
             /**
@@ -3627,6 +3695,26 @@ export interface operations {
             };
         };
     };
+    RecipientTypesController_list: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Recipient types ordered by sort */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecipientTypeDto"][];
+                };
+            };
+        };
+    };
     TemplatesController_list: {
         parameters: {
             query?: never;
@@ -4107,6 +4195,8 @@ export interface operations {
                 category?: "hygiene" | "water" | "food" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel";
                 /** @description Filter by need priority */
                 priority?: "low" | "medium" | "high" | "urgent";
+                /** @description Filter to needs linked to this resource / final recipient */
+                resourceId?: string;
             };
             header?: never;
             path: {


### PR DESCRIPTION
**Cierra el bucle** del núcleo de destinatarios finales (EPIC #59): el backend (#60/#62, ya en `main`) ahora se ve y se usa en la web.

## Qué incluye

- **api-client regenerado** (`pnpm gen:api`): `apps/api/openapi.json` + `packages/api-client/src/schema.ts` ahora incluyen `isFinalRecipient`, `recipientType`, `needs.resourceId` y el endpoint `GET /recipient-types`. Sin esto la web no tenía tipos para los campos nuevos.
- **UI — chip "destinatario final · tipo"** en `PublicResourceCard`: cuando un punto es destinatario final, muestra una pastilla con su tipo (Hospital, Empresa, Organización…), junto a los pills de confianza/estado.
  - `lib/recipient-types.ts` — mapa de etiquetas/colores calcando `lib/categories.ts`, con **fallback al slug** para tipos personalizados (la taxonomía es extensible).
  - `atoms/recipient-type-badge.tsx` — pastilla reutilizable.
  - i18n **ES/EN** (`final_recipient_label`).

## Verificación local

`pnpm --filter web lint` ✓ · `pnpm --filter web build` (next build, typecheck) ✓ · `pnpm --filter @reliefhub/api-client build` ✓. El `next build` confirma que el `ResourceViewDto` regenerado trae los campos y que ES/EN cuadran con `Messages`.

> Esta vez Vercel **sí** despliega preview (cambia `apps/web`): se puede ver el chip en un punto marcado como destinatario.

## Siguiente (Fase 2, opcional)

Mostrar **"necesidades de este destinatario"** (lista filtrada por `?resourceId=`) en una vista de detalle del recurso — hoy no existe página de detalle, así que sería un componente/ruta nueva. Lo dejo propuesto.

## Tracking

Parte de #59 (#60/#62). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV)_