### PR TITLE
feat(deploy): agente Datadog lean (servidor + bbdd + servicios, sitio EU)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -40,3 +40,12 @@ FACEBOOK_APP_SECRET=
 # ── Caddy (automatic HTTPS) ────────────────────────────────────────────────────
 # Domain pointing at the EC2 Elastic IP (A record). Caddy gets a TLS cert for it.
 API_DOMAIN=api.yourdomain.com
+
+# ── Datadog Agent (observability) ──────────────────────────────────────────────
+# Lean agent: host + containers + Postgres + Redis + logs (see deploy/datadog.md).
+# The API key is a SECRET — never commit deploy/.env.
+DD_API_KEY=CHANGE_ME_datadog_api_key
+DD_SITE=datadoghq.eu
+# Password for the read-only "datadog" Postgres monitoring role (pg_monitor).
+# Generate: openssl rand -hex 24 — must match the role created on the DB.
+DD_POSTGRES_PASSWORD=CHANGE_ME_run_openssl_rand_hex_24

--- a/deploy/datadog.md
+++ b/deploy/datadog.md
@@ -1,0 +1,63 @@
+# Datadog en producción (EC2 all-in-one)
+
+Agente Datadog **lean** para depurar el servidor, la base de datos y los servicios.
+Corre como un servicio más del stack (`datadog` en `deploy/docker-compose.prod.yml`).
+
+## Qué monitoriza
+
+- **Host** — CPU, RAM, disco, carga, red (la EC2 t3.small).
+- **Contenedores** — CPU/memoria/estado de cada contenedor (vía `/var/run/docker.sock`).
+- **Postgres** — conexiones, locks, tamaño de BD, transacciones (integración `postgres` por Autodiscovery; usuario de solo lectura `datadog` con rol `pg_monitor`).
+- **Redis** — memoria, ops, clientes (integración `redisdb` por Autodiscovery).
+- **Logs** — de **todos** los contenedores (API, Postgres, Redis, Caddy) → ver errores en vivo.
+
+## Decisiones (caja pequeña)
+
+- **Sitio: EU** (`DD_SITE=datadoghq.eu`).
+- **APM y process-agent desactivados** (`DD_APM_ENABLED=false`, `DD_PROCESS_AGENT_ENABLED=false`) para no cargar la instancia. `mem_limit: 512m`.
+- **DBM (query-level)**: pendiente como paso 2 — requiere `shared_preload_libraries=pg_stat_statements` (reinicio de Postgres) + esquema `datadog`. Ver más abajo.
+
+## Secretos (nunca en git)
+
+Van en `deploy/.env` del servidor (modo 600), inyectados al agente con `env_file: .env`:
+
+- `DD_API_KEY` — API key de Datadog.
+- `DD_SITE=datadoghq.eu`.
+- `DD_POSTGRES_PASSWORD` — contraseña del rol `datadog` de Postgres.
+
+Las labels de Autodiscovery leen la contraseña/BD con `%%env_DD_POSTGRES_PASSWORD%%` y
+`%%env_POSTGRES_DB%%` (el agente las tiene por `env_file`), así el compose **no** lleva secretos.
+
+## Usuario de Postgres (una vez)
+
+```sql
+CREATE ROLE datadog LOGIN PASSWORD '<DD_POSTGRES_PASSWORD>';
+GRANT pg_monitor TO datadog;
+```
+
+## Verificar
+
+```bash
+# en la EC2
+docker compose -f deploy/docker-compose.prod.yml ps          # 'datadog' Up
+docker exec deploy-datadog-1 agent status                    # checks postgres/redisdb/docker OK
+docker exec deploy-datadog-1 agent health                    # Agent health: PASS
+```
+En Datadog (EU): **Infrastructure → Host map** (host `responsegrid-prod`), **Integrations → Postgres/Redis**, **Logs**.
+
+## Activar DBM (paso 2, opcional)
+
+1. En el servicio `postgres` del compose añadir:
+   `command: ["postgres","-c","shared_preload_libraries=pg_stat_statements","-c","track_activity_query_size=4096","-c","pg_stat_statements.track=all"]`
+2. Desplegar (recrea Postgres, ~10 s de corte) y luego:
+   ```sql
+   CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+   CREATE SCHEMA IF NOT EXISTS datadog;
+   GRANT USAGE ON SCHEMA datadog TO datadog;
+   CREATE OR REPLACE FUNCTION datadog.explain_statement(l_query text, OUT explain JSON)
+     RETURNS SETOF JSON AS $$ DECLARE curs REFCURSOR; plan JSON; BEGIN
+     OPEN curs FOR EXECUTE pg_catalog.concat('EXPLAIN (FORMAT JSON) ', l_query);
+     FETCH curs INTO plan; CLOSE curs; RETURN QUERY SELECT plan; END; $$
+     LANGUAGE plpgsql RETURNS NULL ON NULL INPUT SECURITY DEFINER;
+   ```
+3. Añadir `"dbm":true` a la instancia `postgres` de la label de Autodiscovery.

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -20,6 +20,9 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    labels:
+      com.datadoghq.ad.checks: |
+        {"postgres":{"init_config":{},"instances":[{"host":"%%host%%","port":5432,"username":"datadog","password":"%%env_DD_POSTGRES_PASSWORD%%","dbname":"%%env_POSTGRES_DB%%"}]}}
 
   redis:
     image: redis:7
@@ -27,6 +30,9 @@ services:
     command: ['redis-server', '--save', '60', '1']
     volumes:
       - redisdata:/data
+    labels:
+      com.datadoghq.ad.checks: |
+        {"redisdb":{"init_config":{},"instances":[{"host":"%%host%%","port":6379}]}}
 
   # One-shot, idempotent migration runner: applies apps/api/drizzle/*.sql once
   # each (tracked in a _migrations table), then exits.
@@ -72,8 +78,35 @@ services:
       - caddydata:/data
       - caddyconfig:/config
 
+  # Datadog Agent (lean): host metrics + containers + Postgres + Redis + logs.
+  # EU site and secrets (DD_API_KEY, DD_SITE, DD_POSTGRES_PASSWORD) come from
+  # deploy/.env via env_file (never committed). APM and process-agent are off
+  # to stay light on the box; see deploy/datadog.md.
+  datadog:
+    image: datadog/agent:7
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      - DD_HOSTNAME=responsegrid-prod
+      - DD_TAGS=env:prod
+      - DD_LOGS_ENABLED=true
+      - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
+      - DD_PROCESS_AGENT_ENABLED=false
+      - DD_APM_ENABLED=false
+      - DD_CONTAINER_EXCLUDE=name:datadog
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+      - dd-run:/opt/datadog-agent/run:rw
+    mem_limit: 512m
+    depends_on:
+      - postgres
+      - redis
+
 volumes:
   pgdata:
   redisdata:
   caddydata:
   caddyconfig:
+  dd-run:


### PR DESCRIPTION
Anade el agente Datadog como servicio del stack de produccion para depurar servidor, base de datos y servicios. Lean para caber en la instancia: host + contenedores (via docker.sock) + Postgres (Autodiscovery, rol de solo lectura datadog con pg_monitor) + Redis + logs de todos los contenedores. Sitio EU (DD_SITE=datadoghq.eu). APM y process-agent desactivados, mem_limit 512m. Secretos (DD_API_KEY, DD_POSTGRES_PASSWORD) en deploy/.env del servidor via env_file, nunca en git; las labels de Autodiscovery leen la contrasena/BD con %%env_*%%. Incluye deploy/.env.example actualizado y el runbook deploy/datadog.md (con el paso 2 para activar DBM query-level). La instancia se subio de t3.micro a t3.small para dar holgura de RAM. Al mergear, el deploy (git reset + compose up -d --build) levanta el agente automaticamente con los secretos ya presentes en .env.