### PR TITLE
feat(needs): presentación de ítems médicos (ampolla/EV) (#61)

### DIFF
--- a/apps/api/drizzle/0026_need_item_presentation.sql
+++ b/apps/api/drizzle/0026_need_item_presentation.sql
@@ -1,0 +1,5 @@
+-- Presentación / vía de administración de un ítem de necesidad (EPIC #59 · #61).
+-- Distingue ampolla / EV / inhalador de pastilla / jarabe — clave para saber si
+-- un medicamento sirve para uso hospitalario directo. Columna nullable y libre
+-- (extensible), igual que `unit`.
+ALTER TABLE need_items ADD COLUMN presentation text;

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5942,6 +5942,11 @@
               "medical_personnel"
             ],
             "example": "water"
+          },
+          "presentation": {
+            "type": "string",
+            "example": "ampolla",
+            "description": "Presentation / route of administration: ampolla, EV (intravenoso), inhalador, pastilla, jarabe, oxígeno… Optional, free-form (#61)."
           }
         },
         "required": [
@@ -6098,6 +6103,12 @@
               "medical_personnel"
             ],
             "example": "water"
+          },
+          "presentation": {
+            "type": "string",
+            "example": "ampolla",
+            "nullable": true,
+            "description": "Presentation / route of administration (ampolla, EV, inhalador…) — #61."
           }
         },
         "required": [

--- a/apps/api/src/contexts/needs/application/create-need.ts
+++ b/apps/api/src/contexts/needs/application/create-need.ts
@@ -17,6 +17,8 @@ export interface CreateNeedItemCommand {
   quantity: number;
   unit: string | null;
   category: NeedCategory;
+  /** Presentation / route of administration (#61). Optional. */
+  presentation?: string | null;
 }
 
 export interface CreateNeedLocationCommand {
@@ -70,6 +72,7 @@ export class CreateNeed {
         quantity: i.quantity,
         unit: i.unit,
         category: i.category,
+        presentation: i.presentation ?? null,
       }),
     );
 

--- a/apps/api/src/contexts/needs/domain/need-item.spec.ts
+++ b/apps/api/src/contexts/needs/domain/need-item.spec.ts
@@ -103,4 +103,35 @@ describe('NeedItem value object', () => {
     expect(restored.unit).toBe('kits');
     expect(restored.category).toBe(NeedCategory.Medical);
   });
+
+  it('stores presentation and defaults it to null (#61)', () => {
+    const withPres = NeedItem.create({
+      name: 'Clindamicina',
+      quantity: 10,
+      unit: 'amp',
+      category: NeedCategory.Medicines,
+      presentation: 'EV/ampolla',
+    });
+    expect(withPres.presentation).toBe('EV/ampolla');
+
+    const withoutPres = NeedItem.create({
+      name: 'Agua',
+      quantity: 1,
+      unit: null,
+      category: NeedCategory.Water,
+    });
+    expect(withoutPres.presentation).toBeNull();
+  });
+
+  it('round-trip preserves presentation (#61)', () => {
+    const original = NeedItem.create({
+      name: 'Budesonida',
+      quantity: 5,
+      unit: null,
+      category: NeedCategory.Medicines,
+      presentation: 'inhalador',
+    });
+    const restored = NeedItem.fromSnapshot(original.toSnapshot());
+    expect(restored.presentation).toBe('inhalador');
+  });
 });

--- a/apps/api/src/contexts/needs/domain/need-item.ts
+++ b/apps/api/src/contexts/needs/domain/need-item.ts
@@ -5,6 +5,8 @@ export interface NeedItemProps {
   quantity: number;
   unit: string | null;
   category: NeedCategory;
+  /** Presentation / route of administration (ampolla, EV, inhalador…). Optional. */
+  presentation?: string | null;
 }
 
 export interface NeedItemSnapshot {
@@ -12,6 +14,8 @@ export interface NeedItemSnapshot {
   quantity: number;
   unit: string | null;
   category: NeedCategory;
+  /** Optional (legacy-safe) presentation / route of administration (#61). */
+  presentation?: string | null;
 }
 
 export class NeedItemValidationError extends Error {
@@ -26,12 +30,14 @@ export class NeedItem {
   readonly quantity: number;
   readonly unit: string | null;
   readonly category: NeedCategory;
+  readonly presentation: string | null;
 
   private constructor(props: NeedItemProps) {
     this.name = props.name;
     this.quantity = props.quantity;
     this.unit = props.unit;
     this.category = props.category;
+    this.presentation = props.presentation ?? null;
   }
 
   static create(props: NeedItemProps): NeedItem {
@@ -48,6 +54,7 @@ export class NeedItem {
       quantity: props.quantity,
       unit: props.unit ?? null,
       category: props.category,
+      presentation: props.presentation ?? null,
     });
   }
 
@@ -61,6 +68,7 @@ export class NeedItem {
       quantity: this.quantity,
       unit: this.unit,
       category: this.category,
+      presentation: this.presentation,
     };
   }
 }

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.int-spec.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.int-spec.ts
@@ -145,6 +145,31 @@ describe('DrizzleNeedRepository (integration)', () => {
     expect(forA[0].resourceId).toBe(recipientA);
   });
 
+  it('round-trips a need item presentation, ampolla/EV (#61)', async () => {
+    const need = Need.create({
+      id: NeedId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      title: 'Clindamicina EV',
+      description: null,
+      location: makeLocation(),
+      priority: Priority.High,
+      requesterUserId: USER_ID,
+      requesterOrganizationId: null,
+      items: [
+        NeedItem.create({
+          name: 'Clindamicina',
+          quantity: 20,
+          unit: 'amp',
+          category: NeedCategory.Medicines,
+          presentation: 'EV/ampolla',
+        }),
+      ],
+    });
+    await repo.save(need);
+    const found = await repo.findById(need.id);
+    expect(found!.items[0].presentation).toBe('EV/ampolla');
+  });
+
   it('round-trips need with multiple items', async () => {
     const need = Need.create({
       id: NeedId.create(),

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.ts
@@ -55,6 +55,7 @@ function rowToSnapshot(row: NeedsRow, items: ItemsRow[]): NeedSnapshot {
         quantity: i.quantity,
         unit: i.unit ?? null,
         category: i.category as NeedCategory,
+        presentation: i.presentation ?? null,
       }),
     ),
     status: row.status as NeedStatus,
@@ -124,6 +125,7 @@ export class DrizzleNeedRepository implements NeedRepository {
             quantity: item.quantity,
             unit: item.unit,
             category: item.category,
+            presentation: item.presentation ?? null,
           })),
         );
       }

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/schema.ts
@@ -41,4 +41,6 @@ export const needItemsTable = pgTable('need_items', {
   quantity: integer('quantity').notNull(),
   unit: text('unit'),
   category: text('category').notNull(),
+  /** Presentation / route of administration of a medical item (#61). */
+  presentation: text('presentation'),
 });

--- a/apps/api/src/contexts/needs/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/dto.ts
@@ -49,6 +49,15 @@ export class NeedItemDto {
   @ApiProperty({ enum: NeedCategory, example: NeedCategory.Water })
   @IsEnum(NeedCategory)
   category!: NeedCategory;
+
+  @ApiPropertyOptional({
+    example: 'ampolla',
+    description:
+      'Presentation / route of administration: ampolla, EV (intravenoso), inhalador, pastilla, jarabe, oxígeno… Optional, free-form (#61).',
+  })
+  @IsOptional()
+  @IsString()
+  presentation?: string;
 }
 
 export class NeedLocationDto {

--- a/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
@@ -108,6 +108,7 @@ export class NeedsController {
         quantity: i.quantity,
         unit: i.unit ?? null,
         category: i.category,
+        presentation: i.presentation ?? null,
       })),
       requiredSkill: dto.requiredSkill ?? null,
       skillSpecialty: dto.skillSpecialty ?? null,

--- a/apps/api/src/contexts/needs/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/response.dto.ts
@@ -38,6 +38,15 @@ export class NeedItemResponseDto {
 
   @ApiProperty({ enum: NeedCategory, example: NeedCategory.Water })
   category!: NeedCategory;
+
+  @ApiPropertyOptional({
+    example: 'ampolla',
+    nullable: true,
+    type: String,
+    description:
+      'Presentation / route of administration (ampolla, EV, inhalador…) — #61.',
+  })
+  presentation!: string | null;
 }
 
 export class NeedViewDto {

--- a/apps/web/src/components/molecules/need-card.tsx
+++ b/apps/web/src/components/molecules/need-card.tsx
@@ -45,6 +45,11 @@ export function NeedCard({ need, te, slug, active }: NeedCardProps) {
       </div>
       <h3 className="text-[15px] font-bold leading-tight text-ink">{need.title}</h3>
       {detail !== '' && <p className="text-[12.5px] text-muted">{detail}</p>}
+      {item?.presentation != null && (
+        <p className="text-[12.5px] font-semibold text-ink">
+          {item.presentation}
+        </p>
+      )}
       {approximate && <PrivacyLocationNotice text={te.privacy_approximate_location} />}
       {active && (
         <Link

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -2041,6 +2041,11 @@ export interface components {
              * @enum {string}
              */
             category: "hygiene" | "water" | "food" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel";
+            /**
+             * @description Presentation / route of administration: ampolla, EV (intravenoso), inhalador, pastilla, jarabe, oxígeno… Optional, free-form (#61).
+             * @example ampolla
+             */
+            presentation?: string;
         };
         CreateNeedDto: {
             /** @example Alimentos para 50 familias */
@@ -2111,6 +2116,11 @@ export interface components {
              * @enum {string}
              */
             category: "hygiene" | "water" | "food" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel";
+            /**
+             * @description Presentation / route of administration (ampolla, EV, inhalador…) — #61.
+             * @example ampolla
+             */
+            presentation?: string | null;
         };
         NeedViewDto: {
             /**


### PR DESCRIPTION
EPIC #59 · #61 — **la idea central del parte de campo**: que una necesidad de medicamento indique su **presentación / vía** (ampolla · EV/intravenoso · inhalador vs pastilla · jarabe), clave para saber si sirve para **uso hospitalario directo**.

## Qué incluye

- **Dominio:** `presentation` (opcional, *free-form*) en el value object `NeedItem` — mismo patrón que `unit`, por tanto extensible y sin romper fixtures.
- **Persistencia:** columna `need_items.presentation` (**migración `0026`**) + mapeo en el repo Drizzle (rowToSnapshot + insert).
- **API:** opcional al crear (`NeedItemDto`) y expuesto en `NeedItemResponseDto` (y en `NeedView` por el snapshot del ítem). **api-client regenerado** (`schema.ts`/`openapi.json`).
- **Web:** línea de **presentación destacada** en `NeedCard` (p. ej. "EV/ampolla" en negrita bajo el título).
- **Tests:** dominio (default a null + round-trip) e integración (round-trip de "EV/ampolla").

## Notas

- **Free-form** (string) en lugar de enum: máxima extensibilidad y consistencia con `unit`. La UI puede ofrecer un desplegable de valores conocidos (ampolla/EV/inhalador/…) en una iteración posterior; de momento se muestra el valor tal cual y es *settable* vía API.
- El **catálogo curado** de ítems médicos (oxígeno, Gerdex, fármacos EV…) que también menciona #61 queda como pieza aparte.

## Verificación local

api: `build` (tsc) ✓ · `prettier --check` ✓ · `eslint` ✓. web: `lint` ✓ · `next build` ✓. api-client: `build` ✓. Integración (Postgres) en CI.

## Tracking

Parte de #59 · #61. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV)_