### PR TITLE
feat(web): contacto oficial verificado / "sin contacto oficial" en la ficha (#64)

### DIFF
--- a/apps/web/src/components/organisms/public-resource-card.tsx
+++ b/apps/web/src/components/organisms/public-resource-card.tsx
@@ -126,7 +126,11 @@ export function PublicResourceCard({
         <dl className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted">
           {resource.contact != null && (
             <div className="flex items-center gap-1">
-              <dt className="font-medium text-muted-soft">{t.meta_contact}</dt>
+              <dt className="font-medium text-muted-soft">
+                {resource.verificationLevel === 'official'
+                  ? t.meta_contact_official
+                  : t.meta_contact}
+              </dt>
               <dd>{resource.contact}</dd>
             </div>
           )}
@@ -143,6 +147,13 @@ export function PublicResourceCard({
             </div>
           )}
         </dl>
+      )}
+
+      {/* ── Sin contacto oficial (#64) ──────────────────────────────────── */}
+      {resource.contact == null && (
+        <p className="text-xs italic text-muted-soft">
+          {t.no_official_contact}
+        </p>
       )}
 
       {/* ── Freshness indicator ─────────────────────────────────────────── */}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -295,6 +295,9 @@ export const en = {
     aria_label: 'Active point: {name}',
     // Final recipient (#60)
     final_recipient_label: 'Final recipient',
+    // Official contact (#64)
+    meta_contact_official: 'Official contact:',
+    no_official_contact: 'No official contact',
   },
 
   resource_list: {

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -311,6 +311,9 @@ export const es = {
     aria_label: 'Punto activo: {name}',
     // Destinatario final (#60)
     final_recipient_label: 'Destinatario final',
+    // Contacto oficial (#64)
+    meta_contact_official: 'Contacto oficial:',
+    no_official_contact: 'Sin contacto oficial',
   },
 
   // ── ResourceList ──────────────────────────────────────────────────────────


### PR DESCRIPTION
EPIC #59 · #64. Hace visible el estado del **contacto oficial** de un punto/destinatario, **derivándolo de datos que ya existen** (`contact` + `verificationLevel`) — justo como pide el issue (*"vinculado a `VerificationLevel`/acreditación"*), sin nuevo backend ni migración.

## Qué incluye (solo web)

- En `PublicResourceCard`:
  - Cuando el punto es **`official`** (acreditado) y tiene contacto → la etiqueta pasa de "Contacto:" a **"Contacto oficial:"**.
  - Cuando **no hay contacto** (`contact == null`) → se muestra un marcador explícito **"Sin contacto oficial"** (antes la fila de contacto se omitía en silencio). Esto da visibilidad al cuello de botella del parte de campo y conecta con **#58** (esos puntos se ordenan al final).
- i18n **ES/EN** (`meta_contact_official`, `no_official_contact`).

## Decisión de diseño

- **Derivado, no nuevo campo:** el issue plantea como decisión abierta si añadir un flag explícito vs derivar; al decir "vinculado a `VerificationLevel`", derivar es el enfoque fiel y el más ligero. Si más adelante quieres una **acción de verificación de contacto** explícita (flag `contactVerified` puesto por coordinación), es el follow-up natural.

## Verificación local

`pnpm --filter web lint` ✓ · `pnpm --filter web build` ✓.

## Tracking

Parte de #59 · #64. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV)_