### PR TITLE
fix(deploy): reconciliar el stack en cada arranque de la EC2 (systemd oneshot)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Deploy on EC2 via SSM
         run: |
           set -euo pipefail
-          CMD='cd /opt/responsegrid && git fetch origin && git reset --hard origin/main && docker compose -f deploy/docker-compose.prod.yml up -d --build && docker compose -f deploy/docker-compose.prod.yml ps'
+          CMD='cd /opt/responsegrid && git fetch origin && git reset --hard origin/main && bash deploy/install-reconcile.sh && docker compose -f deploy/docker-compose.prod.yml up -d --build && docker compose -f deploy/docker-compose.prod.yml ps'
           PARAMS=$(jq -n --arg c "$CMD" '{commands: [$c]}')
           CID=$(aws ssm send-command \
             --instance-ids i-0f5979080ad5da6e5 \

--- a/deploy/install-reconcile.sh
+++ b/deploy/install-reconcile.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Install (or refresh) the systemd unit that reconciles the compose stack on
+# every boot — see deploy/responsegrid.service for the why.
+#
+# Idempotent: safe to run on every deploy. Needs root (systemctl / writing to
+# /etc/systemd/system). Run from anywhere; paths are resolved from this script.
+#   sudo bash deploy/install-reconcile.sh
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNIT=responsegrid.service
+
+install -m 0644 "$DIR/$UNIT" "/etc/systemd/system/$UNIT"
+systemctl daemon-reload
+systemctl enable "$UNIT"
+
+echo "Installed and enabled $UNIT (reconciles the stack on every boot)."

--- a/deploy/responsegrid.service
+++ b/deploy/responsegrid.service
@@ -1,0 +1,41 @@
+# ResponseGrid — reconcile the full prod stack on every boot.
+#
+# Why this exists: on start, the Docker daemon only re-applies each container's
+# own `restart:` policy — it does NOT re-run `docker compose up`. The `migrate`
+# service is one-shot (restart: no) and `api` depends on it
+# (service_completed_successfully), so after an EC2 stop/start the daemon brings
+# back postgres/redis/caddy/datadog but NOT migrate, and `api` therefore stays
+# down → Caddy returns 502 until someone runs `docker compose up -d` by hand.
+#
+# This oneshot unit runs exactly that command once, after Docker is up, on every
+# boot. It reconciles the compose desired state: migrate re-runs (idempotent),
+# then api starts. RemainAfterExit keeps the unit "active (exited)" afterwards.
+#
+# Source of truth for the unit. Installed by:
+#   - deploy/user-data.sh           (fresh instances — written inline, repo not cloned yet)
+#   - deploy/install-reconcile.sh   (existing instances + every CI deploy — copies THIS file)
+# Keep the inline copy in deploy/user-data.sh in sync with this file.
+#
+# Manual install (from the repo root, e.g. /opt/responsegrid):
+#   sudo bash deploy/install-reconcile.sh
+
+[Unit]
+Description=ResponseGrid stack (docker compose up -d) — reconcile on every boot
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+# Skip cleanly (not fail) on a brand-new box before the repo/.env exist.
+ConditionPathExists=/opt/responsegrid/deploy/docker-compose.prod.yml
+ConditionPathExists=/opt/responsegrid/deploy/.env
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/responsegrid
+ExecStart=/usr/bin/docker compose -f deploy/docker-compose.prod.yml up -d
+# Cold boot needs to wait for postgres health + the one-shot migrate to finish
+# (compose honours depends_on conditions even with -d), so allow generous time.
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/user-data.sh
+++ b/deploy/user-data.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# EC2 user-data — paste this when launching the t3.micro (Ubuntu 22.04/24.04).
-# Installs Docker + Compose, adds swap (the instance has only 1 GiB RAM) and git.
+# EC2 user-data — paste this when launching the instance (t3.micro/t3.small, Ubuntu 22.04/24.04).
+# Installs Docker + Compose, adds swap (the t3.micro has only 1 GiB RAM), git, and
+# a systemd unit that reconciles the compose stack on every boot.
 # After it runs you SSH in and clone + deploy (see docs/deploy/aws-free-tier.md).
 set -euxo pipefail
 
@@ -27,5 +28,36 @@ apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin do
 # Let the default user run docker without sudo.
 usermod -aG docker ubuntu || true
 systemctl enable --now docker
+
+# ── Reconcile-on-boot unit ────────────────────────────────────────────────────
+# The Docker daemon only re-applies per-container restart policies on start; it
+# never re-runs `docker compose up`. The one-shot `migrate` service (restart: no)
+# is then not restarted and `api` (which depends on it) stays down after an EC2
+# stop/start. This oneshot unit runs `docker compose up -d` once per boot to
+# reconcile the whole stack. Written inline because the repo isn't cloned yet;
+# the deploy refreshes it from deploy/responsegrid.service (keep both in sync).
+cat > /etc/systemd/system/responsegrid.service <<'UNIT'
+[Unit]
+Description=ResponseGrid stack (docker compose up -d) — reconcile on every boot
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+ConditionPathExists=/opt/responsegrid/deploy/docker-compose.prod.yml
+ConditionPathExists=/opt/responsegrid/deploy/.env
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/responsegrid
+ExecStart=/usr/bin/docker compose -f deploy/docker-compose.prod.yml up -d
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+# enable only (not --now): the repo/.env don't exist yet, the ConditionPathExists
+# guards make it a clean no-op until the first deploy, then it runs every boot.
+systemctl enable responsegrid.service
 
 echo "Provisioning done. SSH in and follow docs/deploy/aws-free-tier.md."

--- a/docs/deploy/aws-free-tier.md
+++ b/docs/deploy/aws-free-tier.md
@@ -103,6 +103,41 @@ docker compose -f deploy/docker-compose.prod.yml up -d --build
 ```
 (Las migraciones nuevas se aplican solas en el arranque.)
 
+## G. Arranque automático tras stop/start (reconciliación en cada boot)
+
+El daemon de Docker, al arrancar, solo reaplica la política `restart:` de cada
+contenedor; **no** vuelve a ejecutar `docker compose up`. Como `migrate` es
+one-shot (`restart: no`) y `api` depende de él (`service_completed_successfully`),
+tras un **stop/start** de la EC2 vuelven `postgres/redis/caddy/datadog` pero
+`migrate` no, así que `api` se queda caída y Caddy responde **502** hasta que
+alguien lanza `docker compose up -d` a mano.
+
+Para evitarlo, un servicio **systemd oneshot** ([`deploy/responsegrid.service`](../../deploy/responsegrid.service))
+ejecuta `docker compose -f deploy/docker-compose.prod.yml up -d` una vez por
+arranque (tras `docker.service`), reconciliando todo el stack (migra de forma
+idempotente y luego levanta `api`).
+
+- **Instancias nuevas:** lo instala y habilita [`deploy/user-data.sh`](../../deploy/user-data.sh) (unit escrita inline; sobrevive a recreaciones).
+- **Instancia ya creada / cada deploy:** lo (re)instala desde el fichero versionado [`deploy/install-reconcile.sh`](../../deploy/install-reconcile.sh), que invoca el workflow de deploy en cada push a `main`.
+
+Instalación/refresco manual (desde la raíz del repo, p. ej. `/opt/responsegrid`):
+
+```bash
+sudo bash deploy/install-reconcile.sh
+systemctl status responsegrid.service        # 'enabled'; tras un boot, 'active (exited)'
+```
+
+**Verificar** (stop/start real de la instancia):
+
+```bash
+# parar/arrancar la EC2 y esperar a que vuelva
+aws ec2 stop-instances  --instance-ids i-0f5979080ad5da6e5
+aws ec2 start-instances --instance-ids i-0f5979080ad5da6e5
+# sin tocar nada más, comprobar que el stack vuelve solo:
+docker compose -f deploy/docker-compose.prod.yml ps   # api/postgres/redis/caddy/datadog Up
+curl -fsS -o /dev/null -w '%{http_code}\n' https://api.responsegrid.app/docs   # 200
+```
+
 ---
 
 ## Notas / límites del free tier


### PR DESCRIPTION
## Problema

Tras un **stop/start** de la EC2 (`i-0f5979080ad5da6e5`), el contenedor `api` no vuelve solo y Caddy responde **502** hasta que alguien ejecuta a mano `docker compose -f deploy/docker-compose.prod.yml up -d`.

Causa: al arrancar, el daemon de Docker solo reaplica la política `restart:` de cada contenedor; **no** vuelve a ejecutar `docker compose up`. Como `migrate` es one-shot (`restart: no`) y `api` depende de él (`service_completed_successfully`), vuelven `postgres/redis/caddy/datadog` pero **no** `migrate`, y por tanto `api` se queda caída. (Se observó al subir de t3.micro a t3.small.)

## Solución

Un servicio **systemd oneshot** que ejecuta `docker compose -f deploy/docker-compose.prod.yml up -d` una vez por arranque (tras `docker.service`), reconciliando todo el stack: `migrate` se vuelve a ejecutar de forma idempotente y luego arranca `api`. `RemainAfterExit=yes` mantiene la unit como `active (exited)`.

Opción (a) del enunciado, la recomendada.

## Cambios

- **`deploy/responsegrid.service`** — unit canónica (fuente de verdad). `Type=oneshot`, `RemainAfterExit=yes`, `Requires=/After=docker.service`, `WantedBy=multi-user.target`. `ConditionPathExists` sobre el compose y `.env` para que en una instancia recién creada (sin repo/.env todavía) sea un no-op limpio en vez de fallar.
- **`deploy/install-reconcile.sh`** — instalador idempotente que copia la unit a `/etc/systemd/system/`, hace `daemon-reload` y `enable`. Reutilizable.
- **`deploy/user-data.sh`** — escribe la unit **inline** y la habilita en instancias nuevas (el repo aún no está clonado en el primer boot, así que **sobrevive a recreaciones**).
- **`.github/workflows/deploy.yml`** — el deploy por SSM ahora ejecuta `bash deploy/install-reconcile.sh`, así que **al hacer merge la unit queda instalada en la instancia actual** (que se provisionó con el user-data antiguo) sin intervención manual, y se mantiene alineada con el fichero versionado en cada deploy.
- **`docs/deploy/aws-free-tier.md`** — nueva sección **G** explicando el mecanismo y cómo verificar con un stop/start real.

## Verificación

`bash -n` OK en ambos scripts; YAML del workflow válido. La verificación en vivo (stop/start de la EC2 + `curl https://api.responsegrid.app/docs` → 200) se hace por SSM sobre la instancia; ver la sección G de la doc. Al mergear, el deploy instala la unit en la instancia actual automáticamente.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Be4qbPAijs2Z9GsgJFEfM2)_