### PR TITLE
feat: página de detalle del recurso con sus necesidades (1‑a‑N) (#59)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1311,6 +1311,52 @@
         ]
       }
     },
+    "/emergencies/{emergencyId}/public/resources/{resourceId}": {
+      "get": {
+        "operationId": "PublicController_getOne",
+        "parameters": [
+          {
+            "name": "emergencyId",
+            "required": true,
+            "in": "path",
+            "description": "Emergency UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "resourceId",
+            "required": true,
+            "in": "path",
+            "description": "Resource UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The published resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceViewDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not public"
+          }
+        },
+        "summary": "Get a single published resource by id",
+        "tags": [
+          "public"
+        ]
+      }
+    },
     "/recipient-types": {
       "get": {
         "operationId": "RecipientTypesController_list",

--- a/apps/api/src/contexts/resources/application/get-public-resource.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-public-resource.spec.ts
@@ -1,0 +1,89 @@
+import { GetPublicResource } from './get-public-resource';
+import { Resource, ResourceSnapshot } from '../domain/resource';
+import { ResourceId } from '../domain/resource-id';
+import { ResourceRepository } from '../domain/ports/resource.repository';
+import {
+  ResourceType,
+  ResourceStage,
+  PublicStatus,
+  VerificationLevel,
+} from '../domain/resource-enums';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const OTHER_EM = '22222222-2222-4222-8222-222222222222';
+
+function snapshot(
+  overrides: Partial<ResourceSnapshot> & { id: string },
+): ResourceSnapshot {
+  return {
+    id: overrides.id,
+    emergencyId: overrides.emergencyId ?? EM,
+    type: ResourceType.Venue,
+    stage: ResourceStage.Destination,
+    name: 'Hospital Central',
+    description: null,
+    location: { address: 'Calle 1', latitude: 10.4, longitude: -66.9 },
+    ownerUserId: 'owner-1',
+    ownerOrganizationId: null,
+    verificationLevel: VerificationLevel.Official,
+    publicStatus: overrides.publicStatus ?? PublicStatus.Active,
+    createdAt: new Date('2026-06-01T00:00:00Z'),
+    contact: null,
+    schedule: null,
+    manager: null,
+    accepts: [],
+    country: null,
+    city: null,
+    provenance: null,
+    isFinalRecipient: true,
+    recipientType: 'hospital',
+    ...overrides,
+  };
+}
+
+function repoWith(...resources: Resource[]): ResourceRepository {
+  const store = new Map(resources.map((r) => [r.id.value, r]));
+  return {
+    findById: (id: ResourceId) => Promise.resolve(store.get(id.value) ?? null),
+  } as unknown as ResourceRepository;
+}
+
+describe('GetPublicResource', () => {
+  const ID = '33333333-3333-4333-8333-333333333333';
+
+  it('returns the view for a visible resource in the emergency', async () => {
+    const resource = Resource.fromSnapshot(snapshot({ id: ID }));
+    const useCase = new GetPublicResource(repoWith(resource));
+
+    const view = await useCase.execute({ emergencyId: EM, resourceId: ID });
+
+    expect(view).not.toBeNull();
+    expect(view!.id).toBe(ID);
+    expect(view!.isFinalRecipient).toBe(true);
+    expect(view!.recipientType).toBe('hospital');
+  });
+
+  it('returns null when the resource does not exist', async () => {
+    const useCase = new GetPublicResource(repoWith());
+    const view = await useCase.execute({ emergencyId: EM, resourceId: ID });
+    expect(view).toBeNull();
+  });
+
+  it('returns null when the resource belongs to another emergency', async () => {
+    const resource = Resource.fromSnapshot(
+      snapshot({ id: ID, emergencyId: OTHER_EM }),
+    );
+    const useCase = new GetPublicResource(repoWith(resource));
+    const view = await useCase.execute({ emergencyId: EM, resourceId: ID });
+    expect(view).toBeNull();
+  });
+
+  it('returns null when the resource is not publicly visible', async () => {
+    const hidden = Resource.fromSnapshot(
+      snapshot({ id: ID, publicStatus: PublicStatus.Hidden }),
+    );
+    const useCase = new GetPublicResource(repoWith(hidden));
+    const view = await useCase.execute({ emergencyId: EM, resourceId: ID });
+    expect(view).toBeNull();
+  });
+});

--- a/apps/api/src/contexts/resources/application/get-public-resource.ts
+++ b/apps/api/src/contexts/resources/application/get-public-resource.ts
@@ -1,0 +1,33 @@
+import { ResourceRepository } from '../domain/ports/resource.repository';
+import { ResourceId } from '../domain/resource-id';
+import { PublicStatus } from '../domain/resource-enums';
+import { ResourceView, toResourceView } from './resource-view';
+
+const VISIBLE = [
+  PublicStatus.Active,
+  PublicStatus.Saturated,
+  PublicStatus.Paused,
+];
+
+/**
+ * Fetch a single published resource by id, scoped to an emergency.
+ * Returns null when the resource does not exist, belongs to another emergency,
+ * or is not publicly visible (Hidden/Closed). Powers the public resource
+ * detail page (#59 — "necesidades de este destinatario").
+ */
+export class GetPublicResource {
+  constructor(private readonly repo: ResourceRepository) {}
+
+  async execute(q: {
+    emergencyId: string;
+    resourceId: string;
+  }): Promise<ResourceView | null> {
+    const resource = await this.repo.findById(
+      ResourceId.fromString(q.resourceId),
+    );
+    if (resource === null) return null;
+    if (resource.emergencyId.value !== q.emergencyId) return null;
+    if (!VISIBLE.includes(resource.publicStatus)) return null;
+    return toResourceView(resource);
+  }
+}

--- a/apps/api/src/contexts/resources/infrastructure/http/public.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/public.controller.ts
@@ -1,19 +1,30 @@
-import { Controller, Get, Param, ParseUUIDPipe, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseUUIDPipe,
+  Query,
+} from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiParam,
   ApiOkResponse,
+  ApiNotFoundResponse,
 } from '@nestjs/swagger';
 import { GetPublicResources } from '../../application/get-public-resources';
 import { GetResourceFacets } from '../../application/get-resource-facets';
 import { GetNearbyResources } from '../../application/get-nearby-resources';
 import { GetResourcesInBounds } from '../../application/get-resources-in-bounds';
+import { GetPublicResource } from '../../application/get-public-resource';
+import { ResourceView } from '../../application/resource-view';
 import {
   PagedResourcesDto,
   ResourceFacetsDto,
   NearbyResourcesResponseDto,
   InBoundsResourcesDto,
+  ResourceViewDto,
 } from './response.dto';
 import {
   PublicResourcesQueryDto,
@@ -29,6 +40,7 @@ export class PublicController {
     private readonly getResourceFacets: GetResourceFacets,
     private readonly getNearbyResources: GetNearbyResources,
     private readonly getResourcesInBounds: GetResourcesInBounds,
+    private readonly getPublicResource: GetPublicResource,
   ) {}
 
   @Get('emergencies/:emergencyId/public/resources')
@@ -130,5 +142,38 @@ export class PublicController {
     @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
   ): Promise<ResourceFacetsDto> {
     return this.getResourceFacets.execute({ emergencyId });
+  }
+
+  // Declared AFTER the static nearby/in-bounds/facets routes so those match
+  // first; this param route catches the remaining resource ids.
+  @Get('emergencies/:emergencyId/public/resources/:resourceId')
+  @ApiOperation({ summary: 'Get a single published resource by id' })
+  @ApiParam({
+    name: 'emergencyId',
+    description: 'Emergency UUID',
+    format: 'uuid',
+  })
+  @ApiParam({
+    name: 'resourceId',
+    description: 'Resource UUID',
+    format: 'uuid',
+  })
+  @ApiOkResponse({
+    description: 'The published resource',
+    type: ResourceViewDto,
+  })
+  @ApiNotFoundResponse({ description: 'Resource not found or not public' })
+  async getOne(
+    @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
+    @Param('resourceId', ParseUUIDPipe) resourceId: string,
+  ): Promise<ResourceView> {
+    const resource = await this.getPublicResource.execute({
+      emergencyId,
+      resourceId,
+    });
+    if (resource === null) {
+      throw new NotFoundException('Resource not found');
+    }
+    return resource;
   }
 }

--- a/apps/api/src/contexts/resources/infrastructure/resources.module.ts
+++ b/apps/api/src/contexts/resources/infrastructure/resources.module.ts
@@ -12,6 +12,7 @@ import { GetPublicResources } from '../application/get-public-resources';
 import { GetResourceFacets } from '../application/get-resource-facets';
 import { GetNearbyResources } from '../application/get-nearby-resources';
 import { GetResourcesInBounds } from '../application/get-resources-in-bounds';
+import { GetPublicResource } from '../application/get-public-resource';
 import { GetMyResources } from '../application/get-my-resources';
 import { VerifyResource } from '../application/verify-resource';
 import { PublishResource } from '../application/publish-resource';
@@ -178,6 +179,12 @@ const getResourcesInBoundsProvider = {
   useFactory: (repo: ResourceRepository) => new GetResourcesInBounds(repo),
 };
 
+const getPublicResourceProvider = {
+  provide: GetPublicResource,
+  inject: [RESOURCE_REPOSITORY],
+  useFactory: (repo: ResourceRepository) => new GetPublicResource(repo),
+};
+
 const recipientTypeRepositoryProvider = {
   provide: RECIPIENT_TYPE_REPOSITORY,
   inject: [DB],
@@ -216,6 +223,7 @@ const listRecipientTypesProvider = {
     updateStatusProvider,
     getMyResourcesProvider,
     getResourcesInBoundsProvider,
+    getPublicResourceProvider,
     recipientTypeRepositoryProvider,
     listRecipientTypesProvider,
   ],

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -238,6 +238,7 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
             <h2 id="points-heading" className={sectionTitle}>{te.points_heading}</h2>
             <ResourceList
               emergencyId={emergencyId}
+              slug={slug}
               initialItems={activeResources}
               total={resourcesTotal}
               facetsByCategory={facetsByCategory}

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
@@ -1,0 +1,99 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { api } from '@/lib/api';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { PublicResourceCard } from '@/components/organisms/public-resource-card';
+import { NeedCard } from '@/components/molecules/need-card';
+import { EmptyState } from '@/components/molecules/empty-state';
+import { getT } from '@/i18n/server';
+
+export const dynamic = 'force-dynamic';
+
+type Props = {
+  params: Promise<{ slug: string; resourceId: string }>;
+};
+
+/**
+ * Public detail page for a single resource / final recipient: its ficha plus
+ * the list of needs linked to it (1‑a‑N, via ?resourceId=). EPIC #59.
+ */
+export default async function RecipientResourcePage({ params }: Props) {
+  const { slug, resourceId } = await params;
+  const emergency = await getEmergencyBySlug(slug);
+  const { t, locale } = await getT();
+
+  if (!emergency) {
+    notFound();
+  }
+
+  const emergencyId = emergency.id;
+  const isActive = emergency.status === 'active';
+
+  const [{ data: resource }, { data: needs }] = await Promise.all([
+    api.GET('/emergencies/{emergencyId}/public/resources/{resourceId}', {
+      params: { path: { emergencyId, resourceId } },
+    }),
+    api.GET('/emergencies/{emergencyId}/public/needs', {
+      params: { path: { emergencyId }, query: { resourceId } },
+    }),
+  ]);
+
+  if (!resource) {
+    notFound();
+  }
+
+  const te = t.emergency;
+  const td = t.resource_detail;
+  const recipientNeeds = needs ?? [];
+
+  return (
+    <main className="flex-1 bg-surface">
+      <div className="mx-auto w-full max-w-md bg-surface lg:max-w-3xl">
+        <div className="flex flex-col gap-5 px-4 pb-12 pt-5 lg:gap-6 lg:px-8">
+          <Link
+            href={`/e/${slug}`}
+            className="w-fit text-sm font-semibold text-navy hover:underline"
+          >
+            ← {td.back}
+          </Link>
+
+          <PublicResourceCard
+            resource={resource}
+            t={t.resource_card}
+            tVerification={t.verification_badge}
+            tStatusLight={t.status_light}
+            locale={locale}
+          />
+
+          <section
+            aria-labelledby="recipient-needs-heading"
+            className="flex flex-col gap-3"
+          >
+            <h2
+              id="recipient-needs-heading"
+              className="font-display text-base font-bold text-navy"
+            >
+              {td.needs_heading}
+            </h2>
+            {recipientNeeds.length === 0 ? (
+              <EmptyState title={td.needs_empty} />
+            ) : (
+              <ul className="flex flex-col gap-2.5" role="list">
+                {recipientNeeds.map((need) => (
+                  <li key={need.id}>
+                    <NeedCard
+                      need={need}
+                      te={te}
+                      slug={slug}
+                      active={isActive}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/organisms/public-resource-card.tsx
+++ b/apps/web/src/components/organisms/public-resource-card.tsx
@@ -1,4 +1,5 @@
 import type { components } from '@reliefhub/api-client';
+import Link from 'next/link';
 import { VerificationBadge } from '@/components/atoms/verification-badge';
 import { StatusLight } from '@/components/atoms/status-light';
 import { FreshnessIndicator } from '@/components/atoms/freshness-indicator';
@@ -20,6 +21,8 @@ interface PublicResourceCardProps {
   tVerification: Messages['verification_badge'];
   tStatusLight: Messages['status_light'];
   locale?: Locale;
+  /** When set, the card name links to the resource detail page (#59). */
+  slug?: string;
 }
 
 /**
@@ -36,6 +39,7 @@ export function PublicResourceCard({
   tVerification,
   tStatusLight,
   locale = 'es',
+  slug,
 }: PublicResourceCardProps) {
   const typeLabels: Record<ResourceViewDto['type'], string> = {
     collection_point: t.type_collection_point,
@@ -96,7 +100,16 @@ export function PublicResourceCard({
 
       {/* ── Name ────────────────────────────────────────────────────────── */}
       <h3 className="text-[15px] font-bold leading-tight text-ink">
-        {resource.name}
+        {slug != null ? (
+          <Link
+            href={`/e/${slug}/recursos/${resource.id}`}
+            className="hover:underline"
+          >
+            {resource.name}
+          </Link>
+        ) : (
+          resource.name
+        )}
       </h3>
 
       {/* ── Subtitle: type · stage · city, country ──────────────────────── */}

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -58,6 +58,8 @@ interface ResourceListProps {
   tNearby: Messages['nearby_points'];
   tEmpty: { title: string; description?: string };
   locale: Locale;
+  /** Emergency slug — enables linking each card to its resource detail page. */
+  slug?: string;
 }
 
 export function ResourceList({
@@ -74,6 +76,7 @@ export function ResourceList({
   tNearby,
   tEmpty,
   locale,
+  slug,
 }: ResourceListProps) {
   // ── Filter state (category/country) → triggers re-fetch ──────────────────
   const [activeCategory, setActiveCategory] = useState('');
@@ -231,6 +234,7 @@ export function ResourceList({
                   tVerification={tVerification}
                   tStatusLight={tStatusLight}
                   locale={locale}
+                  slug={slug}
                 />
                 <div className="mt-1 flex justify-end px-1">
                   <DistanceBadge distanceMeters={item.distanceMeters} locale={locale} />
@@ -364,6 +368,7 @@ export function ResourceList({
                       tVerification={tVerification}
                       tStatusLight={tStatusLight}
                       locale={locale}
+                      slug={slug}
                     />
                   </li>
                 ))}
@@ -389,6 +394,7 @@ export function ResourceList({
                       tVerification={tVerification}
                       tStatusLight={tStatusLight}
                       locale={locale}
+                      slug={slug}
                     />
                   </li>
                 ))}
@@ -414,6 +420,7 @@ export function ResourceList({
                       tVerification={tVerification}
                       tStatusLight={tStatusLight}
                       locale={locale}
+                      slug={slug}
                     />
                   </li>
                 ))}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -300,6 +300,12 @@ export const en = {
     no_official_contact: 'No official contact',
   },
 
+  resource_detail: {
+    back: 'Back to the emergency',
+    needs_heading: 'Needs of this recipient',
+    needs_empty: 'This recipient has no published needs.',
+  },
+
   resource_list: {
     aria_label: 'Verified active points',
     showing: 'Showing {shown} of {total}',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -316,6 +316,12 @@ export const es = {
     no_official_contact: 'Sin contacto oficial',
   },
 
+  resource_detail: {
+    back: 'Volver a la emergencia',
+    needs_heading: 'Necesidades de este destinatario',
+    needs_empty: 'Este destinatario no tiene necesidades publicadas.',
+  },
+
   // ── ResourceList ──────────────────────────────────────────────────────────
   resource_list: {
     aria_label: 'Puntos activos verificados',

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -449,6 +449,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/emergencies/{emergencyId}/public/resources/{resourceId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a single published resource by id */
+        get: operations["PublicController_getOne"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/recipient-types": {
         parameters: {
             query?: never;
@@ -3812,6 +3829,38 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ResourceFacetsDto"];
                 };
+            };
+        };
+    };
+    PublicController_getOne: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Emergency UUID */
+                emergencyId: string;
+                /** @description Resource UUID */
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The published resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceViewDto"];
+                };
+            };
+            /** @description Resource not found or not public */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
**Fase 2** del núcleo de destinatarios finales (EPIC #59): una **página pública de detalle** de un recurso/destinatario que muestra su ficha + las **necesidades vinculadas (1‑a‑N)**.

## Qué incluye

- **Backend:** `GetPublicResource` + endpoint **`GET /emergencies/:id/public/resources/:resourceId`** (404 si no existe / no es público). Declarado **después** de las rutas estáticas (`nearby`/`in-bounds`/`facets`) para no taparlas. **api-client regenerado**.
- **Web — nueva ruta `/e/[slug]/recursos/[resourceId]`:** ficha del destinatario (`PublicResourceCard`) + sección **"Necesidades de este destinatario"** (lista filtrada por `?resourceId=`, reutiliza `NeedCard`) + enlace de vuelta.
- **Navegación:** el **nombre de cada card** de la lista de puntos ahora **enlaza** a su detalle (threading de `slug` por `ResourceList` → `PublicResourceCard`).
- **i18n ES/EN** (`resource_detail`).
- **Tests:** use-case `GetPublicResource` (visible / otra emergencia / oculto / no encontrado).

## Verificación local

api: `prettier --check` ✓ · `eslint` ✓ · `build` ✓. web: `lint` ✓ · `next build` ✓. api-client: `build` ✓. Integración en CI.

## Cómo verlo en el preview

Abre la lista de puntos de una emergencia y pulsa el **nombre** de cualquier punto → su página de detalle con sus necesidades.

## Con esto

Se completa el recorrido del feedback: destinatario final → tipo extensible → presentación de ítems → **registro 1‑a‑N navegable** (lista de necesidades por destinatario). Queda pendiente solo **#67 (ficha + recepciones)**, que depende de inventario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV)_