### PR TITLE
fix(deploy): auto-arranque del stack en reboot (systemd)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Deploy on EC2 via SSM
         run: |
           set -euo pipefail
-          CMD='cd /opt/responsegrid && git fetch origin && git reset --hard origin/main && docker compose -f deploy/docker-compose.prod.yml up -d --build && docker compose -f deploy/docker-compose.prod.yml ps'
+          CMD='cd /opt/responsegrid && git fetch origin && git reset --hard origin/main && install -m 644 deploy/responsegrid.service /etc/systemd/system/responsegrid.service && systemctl daemon-reload && systemctl enable responsegrid.service && docker compose -f deploy/docker-compose.prod.yml up -d --build && docker compose -f deploy/docker-compose.prod.yml ps'
           PARAMS=$(jq -n --arg c "$CMD" '{commands: [$c]}')
           CID=$(aws ssm send-command \
             --instance-ids i-0f5979080ad5da6e5 \

--- a/deploy/responsegrid.service
+++ b/deploy/responsegrid.service
@@ -1,0 +1,19 @@
+# systemd unit that brings the whole stack up on every boot.
+# Installed + enabled by the deploy (see .github/workflows/deploy.yml).
+# Needed because the `api` container depends on the one-shot `migrate` service,
+# so Docker's restart policies alone don't reliably reconcile the stack on reboot.
+[Unit]
+Description=ResponseGrid stack (docker compose up on boot)
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+ConditionPathExists=/opt/responsegrid/deploy/docker-compose.prod.yml
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/responsegrid
+ExecStart=/usr/bin/docker compose -f deploy/docker-compose.prod.yml up -d
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/user-data.sh
+++ b/deploy/user-data.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# EC2 user-data — paste this when launching the t3.micro (Ubuntu 22.04/24.04).
-# Installs Docker + Compose, adds swap (the instance has only 1 GiB RAM) and git.
+# EC2 user-data — paste this when launching the instance (Ubuntu 22.04/24.04).
+# Production runs on t3.small (2 GiB); t3.micro also works for a minimal deploy.
+# Installs Docker + Compose, 2 GB swap, and git. (The deploy installs a systemd
+# unit — deploy/responsegrid.service — that brings the stack up on every boot.)
 # After it runs you SSH in and clone + deploy (see docs/deploy/aws-free-tier.md).
 set -euxo pipefail
 


### PR DESCRIPTION
Corrige que tras un reinicio de la EC2 el contenedor api no volviera solo (depende del servicio one-shot migrate, y las politicas restart de Docker no reconcilian el stack en el arranque). Anade deploy/responsegrid.service: una unidad systemd oneshot (RemainAfterExit, ConditionPathExists sobre el compose) que ejecuta 'docker compose up -d' en cada boot. La instala y habilita el propio deploy (.github/workflows/deploy.yml: install + daemon-reload + systemctl enable, idempotente), por el canal autorizado del pipeline; user-data.sh queda solo con el provisioning base. Al mergear, el deploy instala y habilita la unidad en la instancia actual. Verificado: el 'compose up' que ejecuta la unidad es idempotente.