### PR TITLE
feat: necesidades cercanas (#57) y orden "sin contacto" al final (#58)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1936,6 +1936,79 @@
         ]
       }
     },
+    "/emergencies/{emergencyId}/public/needs/nearby": {
+      "get": {
+        "operationId": "NeedsController_listNearby",
+        "parameters": [
+          {
+            "name": "emergencyId",
+            "required": true,
+            "in": "path",
+            "description": "Emergency UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "lat",
+            "required": true,
+            "in": "query",
+            "description": "Latitude between -90 and 90",
+            "schema": {
+              "example": 10.4806,
+              "type": "number"
+            }
+          },
+          {
+            "name": "lng",
+            "required": true,
+            "in": "query",
+            "description": "Longitude between -180 and 180",
+            "schema": {
+              "example": -66.9036,
+              "type": "number"
+            }
+          },
+          {
+            "name": "radius",
+            "required": true,
+            "in": "query",
+            "description": "Search radius in meters (max 100000)",
+            "schema": {
+              "example": 5000,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Max results (default 50, max 100)",
+            "schema": {
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Validated needs within radius ordered by distance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NearbyNeedsResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "List validated needs near a GPS point, ordered by distance (public, #57)",
+        "tags": [
+          "needs"
+        ]
+      }
+    },
     "/emergencies/{emergencyId}/needs/queue": {
       "get": {
         "operationId": "NeedsController_listQueue",
@@ -6343,6 +6416,151 @@
           "items",
           "status",
           "createdAt"
+        ]
+      },
+      "NearbyNeedViewDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          },
+          "emergencyId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "11111111-1111-4111-8111-111111111111"
+          },
+          "title": {
+            "type": "string",
+            "example": "Alimentos para 50 familias"
+          },
+          "description": {
+            "type": "string",
+            "example": "Descripción detallada",
+            "nullable": true
+          },
+          "location": {
+            "$ref": "#/components/schemas/NeedLocationResponseDto"
+          },
+          "locationSensitivity": {
+            "type": "string",
+            "enum": [
+              "public",
+              "approximate"
+            ],
+            "example": "approximate",
+            "description": "When \"approximate\", the coordinates in location are jittered for privacy. Coordinators always receive exact coordinates regardless of this value."
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "urgent"
+            ],
+            "example": "high"
+          },
+          "requesterOrganizationId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "managingOrganizationId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NeedItemResponseDto"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "validated",
+              "rejected",
+              "fulfilled"
+            ],
+            "example": "pending"
+          },
+          "createdAt": {
+            "type": "string",
+            "example": "2024-01-01T00:00:00.000Z"
+          },
+          "expiresAt": {
+            "type": "string",
+            "example": "2024-01-03T00:00:00.000Z",
+            "nullable": true,
+            "description": "Timestamp when the need expires (48 h after validation). Null for legacy needs."
+          },
+          "lastVerifiedAt": {
+            "type": "string",
+            "example": "2024-01-01T12:00:00.000Z",
+            "nullable": true,
+            "description": "Timestamp when the need was last verified by a coordinator."
+          },
+          "requiredSkill": {
+            "type": "string",
+            "enum": [
+              "driving",
+              "medical",
+              "logistics",
+              "cooking",
+              "languages",
+              "admin",
+              "general"
+            ],
+            "nullable": true,
+            "description": "Required volunteer skill (personnel needs only)"
+          },
+          "requestedCount": {
+            "type": "number",
+            "example": 3,
+            "nullable": true,
+            "description": "Number of personnel needed"
+          },
+          "resourceId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "Linked resource / final recipient id (#60), or null if standalone."
+          },
+          "distanceMeters": {
+            "type": "number",
+            "example": 1850,
+            "description": "Distance in meters from the queried location to the (public) need location."
+          }
+        },
+        "required": [
+          "id",
+          "emergencyId",
+          "title",
+          "location",
+          "locationSensitivity",
+          "priority",
+          "items",
+          "status",
+          "createdAt",
+          "distanceMeters"
+        ]
+      },
+      "NearbyNeedsResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NearbyNeedViewDto"
+            }
+          }
+        },
+        "required": [
+          "items"
         ]
       },
       "AssignNeedManagerDto": {

--- a/apps/api/src/contexts/needs/application/get-nearby-needs.spec.ts
+++ b/apps/api/src/contexts/needs/application/get-nearby-needs.spec.ts
@@ -1,0 +1,189 @@
+import { InMemoryNeedRepository } from '../infrastructure/in-memory-need.repository';
+import { GetNearbyNeeds } from './get-nearby-needs';
+import { Need } from '../domain/need';
+import { NeedId } from '../domain/need-id';
+import { NeedItem } from '../domain/need-item';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { Priority, NeedCategory } from '../domain/need-enums';
+import { Location } from '../../../shared/domain/location';
+import { LocationSensitivity } from '../../../shared/domain/location-sensitivity';
+
+const EM = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const USER_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+// Caracas origin point
+const ORIGIN_LAT = 10.4806;
+const ORIGIN_LNG = -66.9036;
+
+function makeValidated(
+  title: string,
+  lat: number,
+  lng: number,
+  sensitivity: LocationSensitivity = LocationSensitivity.Public,
+): Need {
+  const need = Need.create({
+    id: NeedId.create(),
+    emergencyId: EmergencyId.fromString(EM),
+    title,
+    description: null,
+    location: Location.create({
+      address: `${title} address`,
+      latitude: lat,
+      longitude: lng,
+    }),
+    priority: Priority.High,
+    requesterUserId: USER_ID,
+    requesterOrganizationId: null,
+    locationSensitivity: sensitivity,
+    items: [
+      NeedItem.create({
+        name: 'Water',
+        quantity: 10,
+        unit: 'liters',
+        category: NeedCategory.Water,
+      }),
+    ],
+  });
+  need.validate();
+  return need;
+}
+
+describe('GetNearbyNeeds', () => {
+  it('returns validated needs within radius, each with a distanceMeters', async () => {
+    const repo = new InMemoryNeedRepository();
+    const useCase = new GetNearbyNeeds(repo);
+
+    await repo.save(makeValidated('At origin', ORIGIN_LAT, ORIGIN_LNG));
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 5000,
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].title).toBe('At origin');
+    expect(typeof result.items[0].distanceMeters).toBe('number');
+    expect(result.items[0].distanceMeters).toBeGreaterThanOrEqual(0);
+    expect(result.items[0].items).toHaveLength(1);
+  });
+
+  it('orders needs by ascending distance', async () => {
+    const repo = new InMemoryNeedRepository();
+    const useCase = new GetNearbyNeeds(repo);
+
+    await repo.save(makeValidated('Medium', 10.49, -66.903)); // ~1.3 km
+    await repo.save(makeValidated('Near', ORIGIN_LAT, ORIGIN_LNG)); // ~0 km
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 10000,
+      limit: 10,
+    });
+
+    expect(result.items.map((n) => n.title)).toEqual(['Near', 'Medium']);
+    expect(result.items[0].distanceMeters).toBeLessThanOrEqual(
+      result.items[1].distanceMeters,
+    );
+  });
+
+  it('returns empty array when no needs are within radius', async () => {
+    const repo = new InMemoryNeedRepository();
+    const useCase = new GetNearbyNeeds(repo);
+
+    await repo.save(makeValidated('Far', 10.8, -66.9)); // ~35 km
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 5000,
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(0);
+  });
+
+  it('excludes needs that are not validated (e.g. pending)', async () => {
+    const repo = new InMemoryNeedRepository();
+    const useCase = new GetNearbyNeeds(repo);
+
+    // validated → included
+    await repo.save(makeValidated('Validated', ORIGIN_LAT, ORIGIN_LNG));
+    // pending (no validate()) → excluded
+    const pending = Need.create({
+      id: NeedId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      title: 'Pending',
+      description: null,
+      location: Location.create({
+        address: 'Pending address',
+        latitude: ORIGIN_LAT,
+        longitude: ORIGIN_LNG,
+      }),
+      priority: Priority.High,
+      requesterUserId: USER_ID,
+      requesterOrganizationId: null,
+      items: [
+        NeedItem.create({
+          name: 'Water',
+          quantity: 10,
+          unit: 'liters',
+          category: NeedCategory.Water,
+        }),
+      ],
+    });
+    await repo.save(pending);
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 5000,
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].title).toBe('Validated');
+  });
+
+  it('does NOT expose an exact distance for approximate-location needs (privacy)', async () => {
+    const repo = new InMemoryNeedRepository();
+    const useCase = new GetNearbyNeeds(repo);
+
+    // A sensitive need located EXACTLY at the query point. Because its public
+    // view jitters the coordinates, the exposed distance is derived from the
+    // jittered point and must therefore be strictly greater than 0.
+    await repo.save(
+      makeValidated(
+        'Sensitive',
+        ORIGIN_LAT,
+        ORIGIN_LNG,
+        LocationSensitivity.Approximate,
+      ),
+    );
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      lat: ORIGIN_LAT,
+      lng: ORIGIN_LNG,
+      radiusMeters: 5000,
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(1);
+    const item = result.items[0];
+    expect(item.locationSensitivity).toBe('approximate');
+    // Exposed distance comes from the jittered point (≤ 300 m jitter radius).
+    expect(item.distanceMeters).toBeGreaterThan(0);
+    expect(item.distanceMeters).toBeLessThanOrEqual(350);
+    // The exposed coordinates are not the exact origin.
+    const movedLat = item.location.latitude !== ORIGIN_LAT;
+    const movedLng = item.location.longitude !== ORIGIN_LNG;
+    expect(movedLat || movedLng).toBe(true);
+  });
+});

--- a/apps/api/src/contexts/needs/application/get-nearby-needs.ts
+++ b/apps/api/src/contexts/needs/application/get-nearby-needs.ts
@@ -1,0 +1,51 @@
+import { NeedRepository } from '../domain/ports/need.repository';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { haversineMeters } from '../../../shared/domain/geo-distance';
+import { NeedView, toPublicNeedView } from './need-view';
+
+export interface NearbyNeedView extends NeedView {
+  distanceMeters: number;
+}
+
+export interface GetNearbyNeedsQuery {
+  emergencyId: string;
+  lat: number;
+  lng: number;
+  radiusMeters: number;
+  limit: number;
+}
+
+/**
+ * Returns validated needs near a citizen's (ephemeral) location, ordered by
+ * proximity (#57).
+ *
+ * Privacy: the repository filters and orders by the exact stored coordinates
+ * (efficient, correct "nearby" gate), but the distance EXPOSED to the public is
+ * recomputed from the public view coordinates — which are jittered when the
+ * need's locationSensitivity is "approximate". This prevents the exact location
+ * of a sensitive requester from being triangulated from an exact distance.
+ */
+export class GetNearbyNeeds {
+  constructor(private readonly repo: NeedRepository) {}
+
+  async execute(q: GetNearbyNeedsQuery): Promise<{ items: NearbyNeedView[] }> {
+    const results = await this.repo.findNearbyValidated(
+      EmergencyId.fromString(q.emergencyId),
+      { lat: q.lat, lng: q.lng, radiusMeters: q.radiusMeters, limit: q.limit },
+    );
+    return {
+      items: results.map((r) => {
+        const view = toPublicNeedView(r.need);
+        const distanceMeters = Math.round(
+          haversineMeters(
+            q.lat,
+            q.lng,
+            view.location.latitude,
+            view.location.longitude,
+          ),
+        );
+        return { ...view, distanceMeters };
+      }),
+    };
+  }
+}

--- a/apps/api/src/contexts/needs/domain/ports/need.repository.ts
+++ b/apps/api/src/contexts/needs/domain/ports/need.repository.ts
@@ -19,6 +19,15 @@ export interface NeedRepository {
     emergencyId: EmergencyId,
     filters?: NeedFilters,
   ): Promise<Need[]>;
+  /**
+   * Returns validated (non-expired) needs within `radiusMeters` of the given
+   * point, ordered by ascending distance, each annotated with its distance in
+   * meters. Powers the "needs near me" view (#57).
+   */
+  findNearbyValidated(
+    emergencyId: EmergencyId,
+    q: { lat: number; lng: number; radiusMeters: number; limit: number },
+  ): Promise<Array<{ need: Need; distanceMeters: number }>>;
   /** Returns validated needs that have expired (expiresAt IS NOT NULL AND expiresAt <= now). */
   findExpiredByEmergency(
     emergencyId: EmergencyId,

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.int-spec.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.int-spec.ts
@@ -521,4 +521,95 @@ describe('DrizzleNeedRepository (integration)', () => {
     );
     expect(counts[NeedStatus.Pending]).toBe(1);
   });
+
+  // #57 — needs near me
+  describe('findNearbyValidated', () => {
+    const ORIGIN_LAT = 10.4806;
+    const ORIGIN_LNG = -66.9036;
+
+    const makeAt = (title: string, lat: number, lng: number) =>
+      Need.create({
+        id: NeedId.create(),
+        emergencyId: EmergencyId.fromString(EM),
+        title,
+        description: null,
+        location: Location.create({
+          address: `${title} address`,
+          latitude: lat,
+          longitude: lng,
+        }),
+        priority: Priority.High,
+        requesterUserId: USER_ID,
+        requesterOrganizationId: null,
+        items: makeItems(),
+      });
+
+    it('returns validated needs within radius ordered by distance', async () => {
+      const near = makeAt('Near', ORIGIN_LAT, ORIGIN_LNG); // ~0 m
+      near.validate();
+      const medium = makeAt('Medium', 10.49, -66.903); // ~1.3 km
+      medium.validate();
+      const far = makeAt('Far', 10.8, -66.9); // ~35 km
+      far.validate();
+
+      await repo.save(near);
+      await repo.save(medium);
+      await repo.save(far);
+
+      const result = await repo.findNearbyValidated(
+        EmergencyId.fromString(EM),
+        { lat: ORIGIN_LAT, lng: ORIGIN_LNG, radiusMeters: 10000, limit: 50 },
+      );
+
+      expect(result.map((r) => r.need.title)).toEqual(['Near', 'Medium']);
+      expect(result[0].distanceMeters).toBeLessThanOrEqual(
+        result[1].distanceMeters,
+      );
+      expect(result[0].distanceMeters).toBeGreaterThanOrEqual(0);
+      // items are hydrated for each need
+      expect(result[0].need.items).toHaveLength(1);
+    });
+
+    it('excludes pending needs', async () => {
+      const validated = makeAt('Validated', ORIGIN_LAT, ORIGIN_LNG);
+      validated.validate();
+      const pending = makeAt('Pending', ORIGIN_LAT, ORIGIN_LNG); // not validated
+
+      await repo.save(validated);
+      await repo.save(pending);
+
+      const result = await repo.findNearbyValidated(
+        EmergencyId.fromString(EM),
+        { lat: ORIGIN_LAT, lng: ORIGIN_LNG, radiusMeters: 5000, limit: 50 },
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].need.title).toBe('Validated');
+    });
+
+    it('excludes expired needs', async () => {
+      const fresh = makeAt('Fresh', ORIGIN_LAT, ORIGIN_LNG);
+      fresh.validate();
+      const expired = makeAt('Expired', ORIGIN_LAT, ORIGIN_LNG);
+      expired.validate();
+
+      await repo.save(fresh);
+      await repo.save(expired);
+
+      const pastExpiry = new Date(Date.now() - 1000 * 60 * 60); // 1 h ago
+      await db
+        .update(needsTable)
+        .set({ expiresAt: pastExpiry })
+        .where(eq(needsTable.id, expired.id.value));
+
+      const result = await repo.findNearbyValidated(
+        EmergencyId.fromString(EM),
+        { lat: ORIGIN_LAT, lng: ORIGIN_LNG, radiusMeters: 5000, limit: 50 },
+      );
+
+      const titles = result.map((r) => r.need.title);
+      expect(titles).toContain('Fresh');
+      expect(titles).not.toContain('Expired');
+    });
+  });
 });

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.ts
@@ -8,6 +8,7 @@ import {
   isNull,
   lt,
   or,
+  sql,
   SQL,
 } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
@@ -164,6 +165,64 @@ export class DrizzleNeedRepository implements NeedRepository {
       filters,
       [notExpired],
     );
+  }
+
+  async findNearbyValidated(
+    emergencyId: EmergencyId,
+    q: { lat: number; lng: number; radiusMeters: number; limit: number },
+  ): Promise<Array<{ need: Need; distanceMeters: number }>> {
+    const now = new Date();
+    // Geo filter + ordering via the cube/earthdistance index (migration 0019),
+    // mirroring findNearbyVisible for resources. Only the id + distance are
+    // selected here; the full aggregates (with items) are loaded below.
+    const result = await this.db.execute<{ id: string; dist: number }>(sql`
+      SELECT id,
+        earth_distance(ll_to_earth(${q.lat}, ${q.lng}), ll_to_earth(latitude, longitude)) AS dist
+      FROM needs
+      WHERE emergency_id = ${emergencyId.value}
+        AND status = ${NeedStatus.Validated}
+        AND (expires_at IS NULL OR expires_at > ${now})
+        AND earth_box(ll_to_earth(${q.lat}, ${q.lng}), ${q.radiusMeters}) @> ll_to_earth(latitude, longitude)
+        AND earth_distance(ll_to_earth(${q.lat}, ${q.lng}), ll_to_earth(latitude, longitude)) <= ${q.radiusMeters}
+      ORDER BY dist ASC
+      LIMIT ${q.limit}
+    `);
+
+    const ranked = result.rows;
+    if (ranked.length === 0) return [];
+
+    const ids = ranked.map((r) => r.id);
+    const distById = new Map(ranked.map((r) => [r.id, Number(r.dist)]));
+
+    const [needRows, allItems] = await Promise.all([
+      this.db.select().from(needsTable).where(inArray(needsTable.id, ids)),
+      this.db
+        .select()
+        .from(needItemsTable)
+        .where(inArray(needItemsTable.needId, ids)),
+    ]);
+
+    const itemsByNeedId = new Map<string, ItemsRow[]>();
+    for (const item of allItems) {
+      const bucket = itemsByNeedId.get(item.needId) ?? [];
+      bucket.push(item);
+      itemsByNeedId.set(item.needId, bucket);
+    }
+    const needRowById = new Map(needRows.map((r) => [r.id, r]));
+
+    // Preserve the distance ordering from the ranked query.
+    return ids
+      .map((id) => {
+        const row = needRowById.get(id);
+        if (row === undefined) return null;
+        return {
+          need: Need.fromSnapshot(
+            rowToSnapshot(row, itemsByNeedId.get(id) ?? []),
+          ),
+          distanceMeters: Math.round(distById.get(id) ?? 0),
+        };
+      })
+      .filter((x): x is { need: Need; distanceMeters: number } => x !== null);
   }
 
   async findExpiredByEmergency(

--- a/apps/api/src/contexts/needs/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/dto.ts
@@ -11,7 +11,9 @@ import {
   MinLength,
   ValidateNested,
   IsInt,
+  IsNumber,
   Min,
+  Max,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -162,6 +164,46 @@ export class CreateNeedDto {
   @IsOptional()
   @IsUUID()
   resourceId?: string;
+}
+
+export class NearbyNeedsQueryDto {
+  @ApiProperty({ example: 10.4806, description: 'Latitude between -90 and 90' })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat!: number;
+
+  @ApiProperty({
+    example: -66.9036,
+    description: 'Longitude between -180 and 180',
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lng!: number;
+
+  @ApiProperty({
+    example: 5000,
+    description: 'Search radius in meters (max 100000)',
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100000)
+  radius!: number;
+
+  @ApiPropertyOptional({
+    example: 50,
+    description: 'Max results (default 50, max 100)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
 }
 
 export class AssignNeedManagerDto {

--- a/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
@@ -27,6 +27,10 @@ import {
 import { CreateNeed } from '../../application/create-need';
 import { ValidateNeed } from '../../application/validate-need';
 import { GetPublicNeeds } from '../../application/get-public-needs';
+import {
+  GetNearbyNeeds,
+  NearbyNeedView,
+} from '../../application/get-nearby-needs';
 import { GetNeedsQueue } from '../../application/get-needs-queue';
 import { AssignNeedManager } from '../../application/assign-need-manager';
 import { RenewNeed, GetExpiredNeeds } from '../../application/renew-need';
@@ -38,10 +42,12 @@ import {
   CreateNeedDto,
   AssignNeedManagerDto,
   CreateTaskFromNeedDto,
+  NearbyNeedsQueryDto,
 } from './dto';
 import {
   CreateNeedResponseDto,
   NeedViewDto,
+  NearbyNeedsResponseDto,
   VolunteerSuggestionDto,
   CreatedTaskFromNeedDto,
 } from './response.dto';
@@ -60,6 +66,7 @@ export class NeedsController {
     private readonly createNeed: CreateNeed,
     private readonly validateNeed: ValidateNeed,
     private readonly getPublicNeeds: GetPublicNeeds,
+    private readonly getNearbyNeeds: GetNearbyNeeds,
     private readonly getNeedsQueue: GetNeedsQueue,
     private readonly assignNeedManager: AssignNeedManager,
     private readonly renewNeed: RenewNeed,
@@ -167,6 +174,33 @@ export class NeedsController {
       ...(validCategory !== undefined && { category: validCategory }),
       ...(validPriority !== undefined && { priority: validPriority }),
       ...(resourceId !== undefined && { resourceId }),
+    });
+  }
+
+  @Get('emergencies/:emergencyId/public/needs/nearby')
+  @ApiOperation({
+    summary:
+      'List validated needs near a GPS point, ordered by distance (public, #57)',
+  })
+  @ApiParam({
+    name: 'emergencyId',
+    description: 'Emergency UUID',
+    format: 'uuid',
+  })
+  @ApiOkResponse({
+    description: 'Validated needs within radius ordered by distance',
+    type: NearbyNeedsResponseDto,
+  })
+  async listNearby(
+    @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
+    @Query() query: NearbyNeedsQueryDto,
+  ): Promise<{ items: NearbyNeedView[] }> {
+    return this.getNearbyNeeds.execute({
+      emergencyId,
+      lat: query.lat,
+      lng: query.lng,
+      radiusMeters: query.radius,
+      limit: query.limit ?? 50,
     });
   }
 

--- a/apps/api/src/contexts/needs/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/response.dto.ts
@@ -149,6 +149,22 @@ export class NeedViewDto {
   resourceId!: string | null;
 }
 
+/** A validated need annotated with its distance from the queried point (#57). */
+export class NearbyNeedViewDto extends NeedViewDto {
+  @ApiProperty({
+    example: 1850,
+    description:
+      'Distance in meters from the queried location to the (public) need location.',
+  })
+  distanceMeters!: number;
+}
+
+/** Response wrapper for the "needs near me" endpoint (#57). */
+export class NearbyNeedsResponseDto {
+  @ApiProperty({ type: [NearbyNeedViewDto] })
+  items!: NearbyNeedViewDto[];
+}
+
 /** Extended DTO for coordinator views — includes the sensitive skillSpecialty field. */
 export class CoordinatorNeedViewDto extends NeedViewDto {
   @ApiPropertyOptional({

--- a/apps/api/src/contexts/needs/infrastructure/in-memory-need.repository.ts
+++ b/apps/api/src/contexts/needs/infrastructure/in-memory-need.repository.ts
@@ -3,6 +3,7 @@ import { Need, NeedSnapshot } from '../domain/need';
 import { NeedId } from '../domain/need-id';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
 import { NeedStatus } from '../domain/need-enums';
+import { haversineMeters } from '../../../shared/domain/geo-distance';
 
 export class InMemoryNeedRepository implements NeedRepository {
   private store = new Map<string, NeedSnapshot>();
@@ -49,6 +50,42 @@ export class InMemoryNeedRepository implements NeedRepository {
         return true;
       })
       .map((s) => Need.fromSnapshot(s));
+    return Promise.resolve(result);
+  }
+
+  findNearbyValidated(
+    emergencyId: EmergencyId,
+    q: { lat: number; lng: number; radiusMeters: number; limit: number },
+  ): Promise<Array<{ need: Need; distanceMeters: number }>> {
+    const now = new Date();
+    const result = [...this.store.values()]
+      .filter((s) => {
+        if (s.emergencyId !== emergencyId.value) return false;
+        if (s.status !== NeedStatus.Validated) return false;
+        if (
+          s.expiresAt !== null &&
+          s.expiresAt !== undefined &&
+          s.expiresAt <= now
+        )
+          return false;
+        return true;
+      })
+      .map((s) => ({
+        snap: s,
+        dist: haversineMeters(
+          q.lat,
+          q.lng,
+          s.location.latitude,
+          s.location.longitude,
+        ),
+      }))
+      .filter(({ dist }) => dist <= q.radiusMeters)
+      .sort((a, b) => a.dist - b.dist)
+      .slice(0, q.limit)
+      .map(({ snap, dist }) => ({
+        need: Need.fromSnapshot(snap),
+        distanceMeters: Math.round(dist),
+      }));
     return Promise.resolve(result);
   }
 

--- a/apps/api/src/contexts/needs/infrastructure/needs.module.ts
+++ b/apps/api/src/contexts/needs/infrastructure/needs.module.ts
@@ -7,6 +7,7 @@ import { NeedsController } from './http/needs.controller';
 import { CreateNeed } from '../application/create-need';
 import { ValidateNeed } from '../application/validate-need';
 import { GetPublicNeeds } from '../application/get-public-needs';
+import { GetNearbyNeeds } from '../application/get-nearby-needs';
 import { GetNeedsQueue } from '../application/get-needs-queue';
 import { AssignNeedManager } from '../application/assign-need-manager';
 import { RenewNeed, GetExpiredNeeds } from '../application/renew-need';
@@ -103,6 +104,12 @@ const getPublicNeedsProvider = {
   useFactory: (repo: NeedRepository) => new GetPublicNeeds(repo),
 };
 
+const getNearbyNeedsProvider = {
+  provide: GetNearbyNeeds,
+  inject: [NEED_REPOSITORY],
+  useFactory: (repo: NeedRepository) => new GetNearbyNeeds(repo),
+};
+
 const getNeedsQueueProvider = {
   provide: GetNeedsQueue,
   inject: [NEED_REPOSITORY],
@@ -180,6 +187,7 @@ const createTaskFromNeedProvider = {
     createNeedProvider,
     validateNeedProvider,
     getPublicNeedsProvider,
+    getNearbyNeedsProvider,
     getNeedsQueueProvider,
     assignNeedManagerProvider,
     renewNeedProvider,

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
@@ -521,6 +521,50 @@ describe('DrizzleResourceRepository (integration)', () => {
       expect(total).toBe(5);
     });
 
+    it('orders points without contact to the end (#58)', async () => {
+      const makeWithContact = (name: string, contact: string | null) =>
+        Resource.fromSnapshot({
+          ...Resource.register({
+            id: ResourceId.create(),
+            emergencyId: EmergencyId.fromString(EM),
+            type: ResourceType.CollectionPoint,
+            stage: ResourceStage.Origin,
+            name,
+            location: baseLocation,
+            ownerUserId: OWNER_ID,
+            contact,
+          }).toSnapshot(),
+          verificationLevel: VerificationLevel.Verified,
+          publicStatus: PublicStatus.Active,
+          createdAt: new Date(),
+        });
+
+      // Insert in an order that is NOT the desired output order.
+      await repo.save(makeWithContact('Zeta sin contacto', null));
+      await repo.save(makeWithContact('Alfa con contacto', '+58 212 555 0001'));
+      await repo.save(makeWithContact('Beta sin contacto', null));
+      await repo.save(
+        makeWithContact('Gamma con contacto', '+58 212 555 0002'),
+      );
+
+      const { items } = await repo.findVisiblePaged(
+        EmergencyId.fromString(EM),
+        {
+          page: 1,
+          limit: 10,
+        },
+      );
+
+      const names = items.map((r) => r.name);
+      // Points with contact come first (sorted by name), then the ones without.
+      expect(names).toEqual([
+        'Alfa con contacto',
+        'Gamma con contacto',
+        'Beta sin contacto',
+        'Zeta sin contacto',
+      ]);
+    });
+
     it('filters by category (accepts @> ARRAY[category])', async () => {
       const withWater = Resource.fromSnapshot({
         ...Resource.register({

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
@@ -1,4 +1,4 @@
-import { and, between, count, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, between, count, eq, inArray, sql } from 'drizzle-orm';
 import { Db } from '../../../../shared/db';
 import { resourcesTable } from './schema';
 import { ResourceRepository } from '../../domain/ports/resource.repository';
@@ -353,6 +353,15 @@ export class DrizzleResourceRepository implements ResourceRepository {
         .select()
         .from(resourcesTable)
         .where(whereClause)
+        // Deterministic order (#58): points WITHOUT contact data sink to the
+        // bottom (they help the citizen less — there is nobody to call). Within
+        // each group, order by name, then id as a stable tiebreaker so paging is
+        // consistent across pages.
+        .orderBy(
+          asc(sql`(${resourcesTable.contact} IS NULL)`),
+          asc(resourcesTable.name),
+          asc(resourcesTable.id),
+        )
         .limit(q.limit)
         .offset(offset),
       this.db.select({ cnt: count() }).from(resourcesTable).where(whereClause),

--- a/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
@@ -150,6 +150,15 @@ export class InMemoryResourceRepository implements ResourceRepository {
           (s.city != null && s.city.toLowerCase().includes(term)),
       );
     }
+    // Deterministic order (#58): points without contact sink to the bottom,
+    // then by name, then id — mirrors the SQL ORDER BY in the Drizzle repo.
+    all.sort((a, b) => {
+      const aNoContact = a.contact == null ? 1 : 0;
+      const bNoContact = b.contact == null ? 1 : 0;
+      if (aNoContact !== bNoContact) return aNoContact - bNoContact;
+      if (a.name !== b.name) return a.name < b.name ? -1 : 1;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
     const total = all.length;
     const offset = (q.page - 1) * q.limit;
     const items = all

--- a/apps/api/src/shared/domain/geo-distance.ts
+++ b/apps/api/src/shared/domain/geo-distance.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared Kernel — great-circle distance helper.
+ *
+ * Pure function with no framework or I/O dependency. Computes the distance in
+ * meters between two WGS84 coordinates using the haversine formula. Used by
+ * in-memory repositories (test parity with the Postgres `earth_distance`
+ * geo index) and by application use cases that need to derive a display
+ * distance from the *public* (possibly approximated) coordinates of a need.
+ */
+
+const EARTH_RADIUS_METERS = 6_371_000;
+
+export function haversineMeters(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number {
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return EARTH_RADIUS_METERS * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -7,12 +7,11 @@ import { OfficialHeaderBand } from '@/components/organisms/official-header-band'
 import { ResourceList } from '@/components/organisms/resource-list';
 import { EmergencyMapWrapper } from '@/components/organisms/emergency-map-wrapper';
 import { NeedsFilter } from '@/components/molecules/needs-filter';
-import { EmptyState } from '@/components/molecules/empty-state';
 import { MetricCard } from '@/components/molecules/metric-card';
 import { StatusBanner } from '@/components/molecules/status-banner';
 import { AnnouncementCard } from '@/components/molecules/announcement-card';
 import { HelpActionRow } from '@/components/molecules/help-action-row';
-import { NeedCard } from '@/components/molecules/need-card';
+import { NeedsList } from '@/components/organisms/needs-list';
 import { EmergencyQuickLinks } from '@/components/molecules/emergency-quick-links';
 import type { MapPoint } from '@/components/organisms/emergency-map';
 import { getT } from '@/i18n/server';
@@ -261,17 +260,16 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
           <section aria-labelledby="needs-heading" className="flex flex-col gap-3">
             <h2 id="needs-heading" className={sectionTitle}>{te.needs_heading}</h2>
             <NeedsFilter t={t.needs_filter} te={t.emergency} />
-            {validatedNeeds.length === 0 ? (
-              <EmptyState title={te.needs_empty_title} />
-            ) : (
-              <ul className="flex flex-col gap-2.5" role="list" aria-label={te.needs_aria_label}>
-                {validatedNeeds.map((need) => (
-                  <li key={need.id}>
-                    <NeedCard need={need} te={te} slug={slug} active={isActive} />
-                  </li>
-                ))}
-              </ul>
-            )}
+            <NeedsList
+              emergencyId={emergencyId}
+              slug={slug}
+              initialItems={validatedNeeds}
+              te={te}
+              tNearby={t.nearby_needs}
+              emptyTitle={te.needs_empty_title}
+              active={isActive}
+              locale={locale}
+            />
           </section>
           </div>
 

--- a/apps/web/src/components/molecules/nearby-button.tsx
+++ b/apps/web/src/components/molecules/nearby-button.tsx
@@ -1,37 +1,37 @@
 'use client';
 
 /**
- * NearbyButton — triggers geolocation and fetches nearby resources.
+ * NearbyButton — triggers browser geolocation and hands the ephemeral
+ * coordinates to the parent via `onLocate`. It is intentionally agnostic about
+ * what is fetched (resources, needs, …); the parent decides.
  *
- * Privacy: coordinates are ephemeral — passed as query params to one API call
- * and never stored. They are obtained from navigator.geolocation.getCurrentPosition,
- * used immediately in the API call, and discarded once the call resolves.
- * Coordinates are NEVER written to localStorage, sessionStorage, cookies,
+ * Privacy: coordinates are ephemeral — obtained from
+ * navigator.geolocation.getCurrentPosition, passed once to `onLocate`, and then
+ * discarded. They are NEVER written to localStorage, sessionStorage, cookies,
  * or any persistent React state.
  */
 
 import { useState } from 'react';
-import { createResponseGridClient } from '@reliefhub/api-client';
-import type { components } from '@reliefhub/api-client';
 import type { Messages } from '@/i18n/messages/es';
 
-type NearbyResourceViewDto = components['schemas']['NearbyResourceViewDto'];
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
-
 interface NearbyButtonProps {
-  emergencyId: string;
+  /**
+   * Labels for the button. Structurally compatible with both `nearby_points`
+   * and `nearby_needs` message blocks (only button_find / button_clear /
+   * loading are read here).
+   */
   tNearby: Messages['nearby_points'];
-  onNearbyResults: (items: NearbyResourceViewDto[]) => void;
+  /** Called with the ephemeral coordinates. May be async (the button stays in
+   * its loading state until it settles). Throwing triggers onGeoError. */
+  onLocate: (coords: { lat: number; lng: number }) => Promise<void> | void;
   onClear: () => void;
   onGeoError: () => void;
   active: boolean;
 }
 
 export function NearbyButton({
-  emergencyId,
   tNearby,
-  onNearbyResults,
+  onLocate,
   onClear,
   onGeoError,
   active,
@@ -48,27 +48,12 @@ export function NearbyButton({
 
     navigator.geolocation.getCurrentPosition(
       async (position) => {
-        // Coordinates are ephemeral — used only for this one API call.
+        // Coordinates are ephemeral — used only for this one call.
         const lat = position.coords.latitude;
         const lng = position.coords.longitude;
 
         try {
-          const client = createResponseGridClient(API_URL);
-          const { data } = await client.GET(
-            '/emergencies/{emergencyId}/public/resources/nearby',
-            {
-              params: {
-                path: { emergencyId },
-                query: { lat, lng, radius: 50000, limit: 50 },
-              },
-            },
-          );
-
-          if (data != null) {
-            onNearbyResults(data.items);
-          } else {
-            onGeoError();
-          }
+          await onLocate({ lat, lng });
         } catch {
           onGeoError();
         } finally {

--- a/apps/web/src/components/organisms/needs-list.tsx
+++ b/apps/web/src/components/organisms/needs-list.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+/**
+ * NeedsList — public list of validated needs with an optional "near me" mode.
+ *
+ * By default it renders the `initialItems` fetched server-side (already
+ * filtered by category/priority via the URL). When the citizen activates the
+ * NearbyButton, their ephemeral location is sent to the needs/nearby endpoint
+ * and the list is replaced by the nearest validated needs, each annotated with
+ * a DistanceBadge. Clearing returns to the default (filtered) list.
+ *
+ * Location privacy: the coordinates never leave the browser except as the
+ * query of a single API call, and the distances shown for needs flagged as
+ * "approximate" are derived server-side from the jittered point (see
+ * GetNearbyNeeds), so an exact position is never exposed.
+ */
+
+import { useState } from 'react';
+import { createResponseGridClient } from '@reliefhub/api-client';
+import type { components } from '@reliefhub/api-client';
+import { NeedCard } from '@/components/molecules/need-card';
+import { NearbyButton } from '@/components/molecules/nearby-button';
+import { DistanceBadge } from '@/components/atoms/distance-badge';
+import { PrivacyLocationNotice } from '@/components/atoms/privacy-location-notice';
+import { EmptyState } from '@/components/molecules/empty-state';
+import type { Messages } from '@/i18n/messages/es';
+import type { Locale } from '@/i18n';
+
+type NeedViewDto = components['schemas']['NeedViewDto'];
+type NearbyNeedViewDto = components['schemas']['NearbyNeedViewDto'];
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+if (!API_URL) {
+  console.error(
+    '[NeedsList] NEXT_PUBLIC_API_URL is not set — ' +
+      '"nearby needs" will fail. Set this env var in your deployment.',
+  );
+}
+
+const RADIUS_METERS = 50000;
+
+interface NeedsListProps {
+  emergencyId: string;
+  slug: string;
+  initialItems: NeedViewDto[];
+  te: Messages['emergency'];
+  tNearby: Messages['nearby_needs'];
+  emptyTitle: string;
+  active: boolean;
+  locale: Locale;
+}
+
+export function NeedsList({
+  emergencyId,
+  slug,
+  initialItems,
+  te,
+  tNearby,
+  emptyTitle,
+  active,
+  locale,
+}: NeedsListProps) {
+  const [nearby, setNearby] = useState<NearbyNeedViewDto[] | null>(null);
+  const [geoError, setGeoError] = useState(false);
+
+  async function handleLocate({ lat, lng }: { lat: number; lng: number }) {
+    const client = createResponseGridClient(API_URL);
+    const { data } = await client.GET(
+      '/emergencies/{emergencyId}/public/needs/nearby',
+      {
+        params: {
+          path: { emergencyId },
+          query: { lat, lng, radius: RADIUS_METERS, limit: 50 },
+        },
+      },
+    );
+    if (data == null) throw new Error('nearby needs request failed');
+    setNearby(data.items);
+    setGeoError(false);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <NearbyButton
+          tNearby={tNearby}
+          onLocate={handleLocate}
+          onClear={() => setNearby(null)}
+          onGeoError={() => setGeoError(true)}
+          active={nearby !== null}
+        />
+      </div>
+
+      {geoError && nearby === null && (
+        <p
+          role="alert"
+          className="rounded-card border border-warning bg-warning-soft px-3 py-2 text-xs text-warning"
+        >
+          {tNearby.geo_error}{' '}
+          <button
+            type="button"
+            onClick={() => setGeoError(false)}
+            className="ml-1 underline hover:no-underline focus:outline-none"
+            aria-label={tNearby.geo_error_dismiss}
+          >
+            ✕
+          </button>
+        </p>
+      )}
+
+      {nearby !== null ? (
+        <>
+          <p className="text-xs text-muted">
+            {tNearby.showing_nearby.replace('{n}', String(nearby.length))}
+          </p>
+          <PrivacyLocationNotice text={tNearby.privacy_note} />
+          {nearby.length === 0 ? (
+            <EmptyState title={emptyTitle} />
+          ) : (
+            <ul
+              className="flex flex-col gap-2.5"
+              role="list"
+              aria-label={te.needs_aria_label}
+            >
+              {nearby.map((need) => (
+                <li key={need.id}>
+                  <div className="relative">
+                    <NeedCard
+                      need={need}
+                      te={te}
+                      slug={slug}
+                      active={active}
+                    />
+                    <div className="mt-1 flex justify-end px-1">
+                      <DistanceBadge
+                        distanceMeters={need.distanceMeters}
+                        locale={locale}
+                      />
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      ) : initialItems.length === 0 ? (
+        <EmptyState title={emptyTitle} />
+      ) : (
+        <ul
+          className="flex flex-col gap-2.5"
+          role="list"
+          aria-label={te.needs_aria_label}
+        >
+          {initialItems.map((need) => (
+            <li key={need.id}>
+              <NeedCard need={need} te={te} slug={slug} active={active} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -192,6 +192,31 @@ export function ResourceList({
     setGeoError(false);
   }
 
+  /**
+   * Fetches nearby resources for the ephemeral coordinates provided by
+   * NearbyButton. Throws on failure so the button surfaces the geo error.
+   */
+  async function handleNearbyLocate({
+    lat,
+    lng,
+  }: {
+    lat: number;
+    lng: number;
+  }) {
+    const client = createResponseGridClient(API_URL);
+    const { data } = await client.GET(
+      '/emergencies/{emergencyId}/public/resources/nearby',
+      {
+        params: {
+          path: { emergencyId },
+          query: { lat, lng, radius: 50000, limit: 50 },
+        },
+      },
+    );
+    if (data == null) throw new Error('nearby request failed');
+    handleNearbyResults(data.items);
+  }
+
   // ── Geographic grouping ───────────────────────────────────────────────────
   const { venezuela, diaspora, other } = useMemo(
     () => groupByCountry(items),
@@ -207,9 +232,8 @@ export function ResourceList({
       <div className="flex flex-col gap-4">
         {/* NearbyButton in active state (shows "Volver a la lista") */}
         <NearbyButton
-          emergencyId={emergencyId}
           tNearby={tNearby}
-          onNearbyResults={handleNearbyResults}
+          onLocate={handleNearbyLocate}
           onClear={() => setNearbyItems(null)}
           onGeoError={() => setGeoError(true)}
           active
@@ -254,9 +278,8 @@ export function ResourceList({
       <div className="flex flex-col gap-4">
         {/* NearbyButton above filter bar */}
         <NearbyButton
-          emergencyId={emergencyId}
           tNearby={tNearby}
-          onNearbyResults={handleNearbyResults}
+          onLocate={handleNearbyLocate}
           onClear={() => setNearbyItems(null)}
           onGeoError={() => setGeoError(true)}
           active={nearbyItems !== null}
@@ -299,9 +322,8 @@ export function ResourceList({
     <div className="flex flex-col gap-4">
       {/* ── NearbyButton above filter bar ───────────────────────────────── */}
       <NearbyButton
-        emergencyId={emergencyId}
         tNearby={tNearby}
-        onNearbyResults={handleNearbyResults}
+        onLocate={handleNearbyLocate}
         onClear={() => setNearbyItems(null)}
         onGeoError={() => setGeoError(true)}
         active={nearbyItems !== null}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -342,6 +342,17 @@ export const en = {
     privacy_note: 'Your location is only used in your browser to sort by proximity; it is never stored.',
   },
 
+  // ── Nearby needs (#57) ────────────────────────────────────────────────────
+  nearby_needs: {
+    button_find: 'Find needs near me',
+    button_clear: 'Back to list',
+    loading: 'Looking for nearby needs…',
+    geo_error: 'Could not get your location. Check your browser permissions.',
+    geo_error_dismiss: 'Dismiss',
+    showing_nearby: '{n} nearby needs',
+    privacy_note: 'Your location is only used in your browser to sort by proximity; it is never stored.',
+  },
+
   verification_badge: {
     official: 'Official',
     verified: 'Verified',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -359,6 +359,17 @@ export const es = {
     privacy_note: 'Tu ubicación solo se usa en tu navegador para ordenar por cercanía; no se guarda.',
   },
 
+  // ── NearbyNeeds (#57) ─────────────────────────────────────────────────────
+  nearby_needs: {
+    button_find: 'Ver necesidades cerca de mí',
+    button_clear: 'Volver a la lista',
+    loading: 'Buscando necesidades cercanas…',
+    geo_error: 'No pudimos obtener tu ubicación. Comprueba los permisos del navegador.',
+    geo_error_dismiss: 'Cerrar',
+    showing_nearby: '{n} necesidades cercanas',
+    privacy_note: 'Tu ubicación solo se usa en tu navegador para ordenar por cercanía; no se guarda.',
+  },
+
   // ── VerificationBadge ─────────────────────────────────────────────────────
   verification_badge: {
     official: 'Oficial',

--- a/apps/web/src/lib/group-by-country.test.ts
+++ b/apps/web/src/lib/group-by-country.test.ts
@@ -101,6 +101,30 @@ test('partitions a mixed list while preserving per-group order', () => {
   );
 });
 
+test('keeps the backend "sin contacto last" ordering stable within a group (#58)', () => {
+  // The API returns points WITH contact first, then the contactless ones last.
+  // groupByCountry must not reorder, so within the Venezuela group the
+  // contactless points stay at the end.
+  const withContact = { ...makeResource('a', 'Venezuela'), contact: '+58 1' };
+  const withContact2 = { ...makeResource('b', 'Venezuela'), contact: '+58 2' };
+  const noContact = makeResource('c', 'Venezuela'); // contact: null
+  const noContact2 = makeResource('d', 'Venezuela'); // contact: null
+
+  const { venezuela } = groupByCountry([
+    withContact,
+    withContact2,
+    noContact,
+    noContact2,
+  ]);
+
+  assert.deepEqual(
+    venezuela.map((r) => r.id),
+    ['a', 'b', 'c', 'd'],
+  );
+  assert.equal(venezuela.at(-1)?.contact, null);
+  assert.equal(venezuela.at(-2)?.contact, null);
+});
+
 test('isVenezuela accepts the full name and ISO code, rejects everything else', () => {
   assert.equal(isVenezuela('Venezuela'), true);
   assert.equal(isVenezuela('venezuela'), true);

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -655,6 +655,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/emergencies/{emergencyId}/public/needs/nearby": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List validated needs near a GPS point, ordered by distance (public, #57) */
+        get: operations["NeedsController_listNearby"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/emergencies/{emergencyId}/needs/queue": {
         parameters: {
             query?: never;
@@ -2224,6 +2241,79 @@ export interface components {
              * @description Linked resource / final recipient id (#60), or null if standalone.
              */
             resourceId?: string | null;
+        };
+        NearbyNeedViewDto: {
+            /**
+             * Format: uuid
+             * @example 3fa85f64-5717-4562-b3fc-2c963f66afa6
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @example 11111111-1111-4111-8111-111111111111
+             */
+            emergencyId: string;
+            /** @example Alimentos para 50 familias */
+            title: string;
+            /** @example Descripción detallada */
+            description?: string | null;
+            location: components["schemas"]["NeedLocationResponseDto"];
+            /**
+             * @description When "approximate", the coordinates in location are jittered for privacy. Coordinators always receive exact coordinates regardless of this value.
+             * @example approximate
+             * @enum {string}
+             */
+            locationSensitivity: "public" | "approximate";
+            /**
+             * @example high
+             * @enum {string}
+             */
+            priority: "low" | "medium" | "high" | "urgent";
+            /** Format: uuid */
+            requesterOrganizationId?: string | null;
+            /** Format: uuid */
+            managingOrganizationId?: string | null;
+            items: components["schemas"]["NeedItemResponseDto"][];
+            /**
+             * @example pending
+             * @enum {string}
+             */
+            status: "pending" | "validated" | "rejected" | "fulfilled";
+            /** @example 2024-01-01T00:00:00.000Z */
+            createdAt: string;
+            /**
+             * @description Timestamp when the need expires (48 h after validation). Null for legacy needs.
+             * @example 2024-01-03T00:00:00.000Z
+             */
+            expiresAt?: string | null;
+            /**
+             * @description Timestamp when the need was last verified by a coordinator.
+             * @example 2024-01-01T12:00:00.000Z
+             */
+            lastVerifiedAt?: string | null;
+            /**
+             * @description Required volunteer skill (personnel needs only)
+             * @enum {string|null}
+             */
+            requiredSkill?: "driving" | "medical" | "logistics" | "cooking" | "languages" | "admin" | "general" | null;
+            /**
+             * @description Number of personnel needed
+             * @example 3
+             */
+            requestedCount?: number | null;
+            /**
+             * Format: uuid
+             * @description Linked resource / final recipient id (#60), or null if standalone.
+             */
+            resourceId?: string | null;
+            /**
+             * @description Distance in meters from the queried location to the (public) need location.
+             * @example 1850
+             */
+            distanceMeters: number;
+        };
+        NearbyNeedsResponseDto: {
+            items: components["schemas"]["NearbyNeedViewDto"][];
         };
         AssignNeedManagerDto: {
             /**
@@ -4383,6 +4473,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NeedViewDto"][];
+                };
+            };
+        };
+    };
+    NeedsController_listNearby: {
+        parameters: {
+            query: {
+                /** @description Latitude between -90 and 90 */
+                lat: number;
+                /** @description Longitude between -180 and 180 */
+                lng: number;
+                /** @description Search radius in meters (max 100000) */
+                radius: number;
+                /** @description Max results (default 50, max 100) */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Emergency UUID */
+                emergencyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Validated needs within radius ordered by distance */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NearbyNeedsResponseDto"];
                 };
             };
         };


### PR DESCRIPTION
Cierra #57 y #58 — ambos salen del mismo feedback de campo ("ver necesidades de los puntos cercanos" y "mover los puntos 'Sin Contacto' al final de la lista").

## #57 — Necesidades cerca de mí

**Backend**
- Nuevo endpoint público `GET /emergencies/:id/public/needs/nearby?lat&lng&radius&limit`: devuelve las necesidades validadas (no expiradas) ordenadas por proximidad, cada una con `distanceMeters`.
- Reutiliza el índice geoespacial (`ll_to_earth` / `earth_box` / `earth_distance`, migración `0019`), igual que el equivalente de puntos (`findNearbyVisible`).
- Puerto `findNearbyValidated` (Drizzle + in-memory), caso de uso `GetNearbyNeeds`, y helper compartido `haversineMeters` en el shared kernel.
- **Privacidad**: la distancia expuesta se recalcula desde las coordenadas **públicas** (aproximadas cuando `locationSensitivity = approximate`), de modo que no se filtra la ubicación exacta de un solicitante sensible aunque se conozca el punto de consulta.

**Web**
- `NeedsList` (nuevo organismo) reutiliza `NearbyButton` (geolocalización efímera, no se persiste) y `DistanceBadge` en la lista pública de necesidades.
- `NearbyButton` ahora delega la petición al padre vía `onLocate`, así sirve tanto para puntos como para necesidades.
- i18n ES/EN (`nearby_needs`).

## #58 — "Sin Contacto" al final
- `findVisiblePaged` ordena de forma determinista **server-side**: los puntos sin datos de contacto se hunden al final → `ORDER BY (contact IS NULL), name, id` (estable entre páginas).
- `groupByCountry` ya preservaba el orden recibido; se añade un test que lo fija.

## Decisiones
- "Sin contacto" = `contact IS NULL` (coincide con lo que la ficha ya etiqueta como "Sin contacto oficial").
- Las necesidades usan su propia ubicación (la tabla `needs` no referencia un punto logístico); "los respectivos puntos" del feedback = la ubicación de la propia necesidad.

## Tests
- API: unit (`GetNearbyNeeds`, in-memory) + integración (`findNearbyValidated`; orden de `findVisiblePaged`).
- Web: test de `groupByCountry` para el orden estable.

## Gate local
`build` (api) · `eslint` · `prettier --check` · `build` api-client + web · `lint` web · tests web en verde. Los tests jest de API contra Postgres corren en CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuYpxshGYSRgc9L29VeSVV)_