### PR TITLE
chore(deploy): bootstrap puntual de grants (admin@ + validator@)

### DIFF
--- a/.github/workflows/bootstrap-grant.yml
+++ b/.github/workflows/bootstrap-grant.yml
@@ -1,0 +1,57 @@
+name: Bootstrap grants (one-time)
+
+# One-time, manually-dispatched job that applies deploy/bootstrap-grant.sql to the
+# production database via the same OIDC -> SSM channel the deploy uses. Needed to
+# bootstrap the first admin grant when no admin credential / direct DB access is
+# available locally. The SQL is idempotent; safe to re-run. Remove after use.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: responsegrid-deploy
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  grant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::386707340306:role/responsegrid-gha-deploy
+          aws-region: us-east-1
+
+      - name: Apply grants via SSM
+        run: |
+          set -euo pipefail
+          CMD='cd /opt/responsegrid/deploy && PGU=$(grep "^POSTGRES_USER=" .env | cut -d= -f2-) && PGD=$(grep "^POSTGRES_DB=" .env | cut -d= -f2-) && PGP=$(grep "^POSTGRES_PASSWORD=" .env | cut -d= -f2-) && docker exec -i -e PGPASSWORD="$PGP" deploy-postgres-1 psql -U "$PGU" -d "$PGD" -v ON_ERROR_STOP=1 < bootstrap-grant.sql'
+          PARAMS=$(jq -n --arg c "$CMD" '{commands: [$c]}')
+          CID=$(aws ssm send-command \
+            --instance-ids i-0f5979080ad5da6e5 \
+            --document-name AWS-RunShellScript \
+            --comment "bootstrap-grant ${GITHUB_SHA::7}" \
+            --timeout-seconds 600 \
+            --parameters "$PARAMS" \
+            --query Command.CommandId --output text)
+          echo "SSM CommandId: $CID"
+          for i in $(seq 1 50); do
+            sleep 6
+            ST=$(aws ssm get-command-invocation --command-id "$CID" --instance-id i-0f5979080ad5da6e5 --query Status --output text 2>/dev/null || echo Pending)
+            echo "status: $ST"
+            if [ "$ST" = "Success" ]; then
+              aws ssm get-command-invocation --command-id "$CID" --instance-id i-0f5979080ad5da6e5 --query StandardOutputContent --output text
+              exit 0
+            fi
+            case "$ST" in
+              Failed|Cancelled|TimedOut)
+                echo "::error::grant $ST"
+                aws ssm get-command-invocation --command-id "$CID" --instance-id i-0f5979080ad5da6e5 --query StandardErrorContent --output text | tail -40
+                exit 1 ;;
+            esac
+          done
+          echo "::error::timed out"; exit 1

--- a/deploy/bootstrap-grant.sql
+++ b/deploy/bootstrap-grant.sql
@@ -1,0 +1,36 @@
+-- One-time bootstrap grants for the two test accounts.
+-- Idempotent (guarded by NOT EXISTS). Applied via .github/workflows/bootstrap-grant.yml
+-- (OIDC -> SSM), the same authorized channel the deploy uses. Safe to re-run.
+
+-- admin@responsegrid.app -> platform_admin (global). Also set the legacy is_admin
+-- flag for compatibility with any code path that still reads it.
+INSERT INTO grants (id, principal_id, principal_type, role_id, scope_type, scope_id, granted_at)
+SELECT gen_random_uuid(), u.id, 'user', 'platform_admin', 'platform', NULL, now()
+FROM users u
+WHERE u.email = 'admin@responsegrid.app'
+  AND NOT EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.principal_id = u.id AND g.role_id = 'platform_admin' AND g.scope_type = 'platform'
+  );
+
+UPDATE users SET is_admin = true WHERE email = 'admin@responsegrid.app';
+
+-- validator@responsegrid.app -> emergency_verifier scoped to the Venezuela emergency.
+INSERT INTO grants (id, principal_id, principal_type, role_id, scope_type, scope_id, granted_at)
+SELECT gen_random_uuid(), u.id, 'user', 'emergency_verifier', 'emergency',
+       '11111111-1111-4111-8111-111111111111', now()
+FROM users u
+WHERE u.email = 'validator@responsegrid.app'
+  AND NOT EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.principal_id = u.id AND g.role_id = 'emergency_verifier'
+      AND g.scope_type = 'emergency'
+      AND g.scope_id = '11111111-1111-4111-8111-111111111111'
+  );
+
+-- Verification (printed to the workflow log).
+SELECT u.email, u.is_admin, g.role_id, g.scope_type, g.scope_id
+FROM users u
+LEFT JOIN grants g ON g.principal_id = u.id
+WHERE u.email IN ('admin@responsegrid.app', 'validator@responsegrid.app')
+ORDER BY u.email, g.role_id;


### PR DESCRIPTION
Workflow workflow_dispatch puntual que aplica deploy/bootstrap-grant.sql a la BBDD de produccion por el mismo canal OIDC->SSM que usa el deploy. Necesario porque no hay credencial admin ni acceso directo a BBDD en local (la entrada del vault con las claves IAM se perdio). Concede: admin@responsegrid.app -> platform_admin (global, + is_admin legacy); validator@responsegrid.app -> emergency_verifier acotado a la emergencia de Venezuela. SQL idempotente (NOT EXISTS), seguro de reejecutar. Se retira tras usarlo. Autorizado explicitamente por el owner.