### PR TITLE
fix + docs: API pública (404 by-slug, solo verified/official, categorías y x-api-key) (#93, #94, #95, #96)

### DIFF
--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -24,6 +24,11 @@ async function generate(): Promise<void> {
     .setTitle('ResponseGrid API')
     .setDescription('API for humanitarian emergency resource coordination')
     .setVersion('0.1')
+    // Bearer JWT (user accounts) — matches @ApiBearerAuth() on write endpoints.
+    .addBearerAuth()
+    // Service-account API keys — matches @ApiSecurity('api-key'); sent as the
+    // `X-API-Key: rh_live_…` header (issue #96).
+    .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, 'api-key')
     .addTag('resources')
     .addTag('emergencies')
     .build();

--- a/apps/api/src/contexts/emergencies/application/get-emergency-by-slug.spec.ts
+++ b/apps/api/src/contexts/emergencies/application/get-emergency-by-slug.spec.ts
@@ -34,12 +34,16 @@ describe('GetEmergencyBySlug', () => {
     expect(view).toBeNull();
   });
 
-  it('throws when slug format is invalid', async () => {
+  it('returns null when slug format is non-canonical (→ 404, not 500)', async () => {
     const repo = new InMemoryEmergencyRepository();
     const useCase = new GetEmergencyBySlug(repo);
 
-    await expect(useCase.execute({ slug: 'INVALID SLUG!' })).rejects.toThrow(
-      'Invalid slug',
-    );
+    // Uppercase, underscores and spaces are not canonical slugs; none can match
+    // a stored (canonical) slug, so the lookup resolves to "not found" (#93).
+    await expect(useCase.execute({ slug: 'Terremoto' })).resolves.toBeNull();
+    await expect(useCase.execute({ slug: 'abc_def' })).resolves.toBeNull();
+    await expect(
+      useCase.execute({ slug: 'INVALID SLUG!' }),
+    ).resolves.toBeNull();
   });
 });

--- a/apps/api/src/contexts/emergencies/application/get-emergency-by-slug.ts
+++ b/apps/api/src/contexts/emergencies/application/get-emergency-by-slug.ts
@@ -1,12 +1,22 @@
 import { EmergencyRepository } from '../domain/ports/emergency.repository';
 import { Slug } from '../domain/slug';
+import { InvalidSlugError } from '../domain/invalid-slug.error';
 import { EmergencyView, toEmergencyView } from './emergency-view';
 
 export class GetEmergencyBySlug {
   constructor(private readonly repo: EmergencyRepository) {}
 
   async execute(q: { slug: string }): Promise<EmergencyView | null> {
-    const slug = Slug.fromString(q.slug);
+    // A non-canonical slug (uppercase, underscores, spaces…) can never match a
+    // stored slug, which is always canonical. Treat it as "not found" so the
+    // public lookup returns 404 instead of bubbling a 500 (issue #93).
+    let slug: Slug;
+    try {
+      slug = Slug.fromString(q.slug);
+    } catch (e) {
+      if (e instanceof InvalidSlugError) return null;
+      throw e;
+    }
     const emergency = await this.repo.findBySlug(slug);
     return emergency ? toEmergencyView(emergency) : null;
   }

--- a/apps/api/src/contexts/emergencies/domain/invalid-slug.error.ts
+++ b/apps/api/src/contexts/emergencies/domain/invalid-slug.error.ts
@@ -1,0 +1,12 @@
+/**
+ * Raised by {@link Slug.fromString} when the input is not a canonical slug
+ * (lowercase letters, digits and single hyphens). It is a typed domain error so
+ * the HTTP layer can map it deliberately (a public by-slug lookup treats it as
+ * "not found" → 404) instead of letting a plain `Error` surface as a 500.
+ */
+export class InvalidSlugError extends Error {
+  constructor(public readonly slug: string) {
+    super(`Invalid slug: "${slug}"`);
+    this.name = 'InvalidSlugError';
+  }
+}

--- a/apps/api/src/contexts/emergencies/domain/slug.ts
+++ b/apps/api/src/contexts/emergencies/domain/slug.ts
@@ -1,10 +1,12 @@
+import { InvalidSlugError } from './invalid-slug.error';
+
 export class Slug {
   private static readonly RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
   private constructor(public readonly value: string) {}
 
   static fromString(s: string): Slug {
-    if (!Slug.RE.test(s)) throw new Error(`Invalid slug: "${s}"`);
+    if (!Slug.RE.test(s)) throw new InvalidSlugError(s);
     return new Slug(s);
   }
 

--- a/apps/api/src/contexts/resources/application/get-public-resource.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-public-resource.spec.ts
@@ -86,4 +86,19 @@ describe('GetPublicResource', () => {
     const view = await useCase.execute({ emergencyId: EM, resourceId: ID });
     expect(view).toBeNull();
   });
+
+  it('returns null when the resource is active but unverified — #94', async () => {
+    // An ingested point can be Active yet Unverified; the public API must not
+    // expose it as if it were validated.
+    const unverified = Resource.fromSnapshot(
+      snapshot({
+        id: ID,
+        publicStatus: PublicStatus.Active,
+        verificationLevel: VerificationLevel.Unverified,
+      }),
+    );
+    const useCase = new GetPublicResource(repoWith(unverified));
+    const view = await useCase.execute({ emergencyId: EM, resourceId: ID });
+    expect(view).toBeNull();
+  });
 });

--- a/apps/api/src/contexts/resources/application/get-public-resource.ts
+++ b/apps/api/src/contexts/resources/application/get-public-resource.ts
@@ -1,6 +1,6 @@
 import { ResourceRepository } from '../domain/ports/resource.repository';
 import { ResourceId } from '../domain/resource-id';
-import { PublicStatus } from '../domain/resource-enums';
+import { PublicStatus, VerificationLevel } from '../domain/resource-enums';
 import { ResourceView, toResourceView } from './resource-view';
 
 const VISIBLE = [
@@ -9,11 +9,17 @@ const VISIBLE = [
   PublicStatus.Paused,
 ];
 
+const PUBLICLY_VISIBLE_VERIFICATION = [
+  VerificationLevel.Verified,
+  VerificationLevel.Official,
+];
+
 /**
  * Fetch a single published resource by id, scoped to an emergency.
  * Returns null when the resource does not exist, belongs to another emergency,
- * or is not publicly visible (Hidden/Closed). Powers the public resource
- * detail page (#59 — "necesidades de este destinatario").
+ * is not publicly visible (Hidden/Closed), or is still `unverified` — the
+ * public API only exposes verified/official points (#94). Powers the public
+ * resource detail page (#59 — "necesidades de este destinatario").
  */
 export class GetPublicResource {
   constructor(private readonly repo: ResourceRepository) {}
@@ -28,6 +34,8 @@ export class GetPublicResource {
     if (resource === null) return null;
     if (resource.emergencyId.value !== q.emergencyId) return null;
     if (!VISIBLE.includes(resource.publicStatus)) return null;
+    if (!PUBLICLY_VISIBLE_VERIFICATION.includes(resource.verificationLevel))
+      return null;
     return toResourceView(resource);
   }
 }

--- a/apps/api/src/contexts/resources/application/get-public-resources.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-public-resources.spec.ts
@@ -4,10 +4,12 @@ import { VerifyResource } from './verify-resource';
 import { PublishResource } from './publish-resource';
 import { InMemoryResourceRepository } from '../infrastructure/in-memory-resource.repository';
 import { FakeEventBus } from '../infrastructure/fake-event-bus';
+import { Resource } from '../domain/resource';
 import {
   ResourceType,
   ResourceStage,
   PublicStatus,
+  VerificationLevel,
 } from '../domain/resource-enums';
 import { ResourceEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
 
@@ -74,6 +76,44 @@ describe('GetPublicResources', () => {
       location: baseLocation,
       ownerUserId: 'user-unverified-test',
     });
+
+    const result = await new GetPublicResources(repo).execute({
+      emergencyId: EM,
+    });
+
+    expect(result.items).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it('excludes active-but-unverified (ingested) points — #94', async () => {
+    const repo = new InMemoryResourceRepository();
+
+    // Active yet Unverified, as written by the external ingest path.
+    await repo.save(
+      Resource.fromSnapshot({
+        id: '44444444-4444-4444-8444-444444444444',
+        emergencyId: EM,
+        type: ResourceType.CollectionPoint,
+        stage: ResourceStage.Destination,
+        name: 'Ingested Unverified',
+        description: null,
+        location: baseLocation,
+        ownerUserId: 'ingest',
+        ownerOrganizationId: null,
+        verificationLevel: VerificationLevel.Unverified,
+        publicStatus: PublicStatus.Active,
+        createdAt: new Date('2026-06-01T00:00:00Z'),
+        contact: null,
+        schedule: null,
+        manager: null,
+        accepts: [],
+        country: null,
+        city: null,
+        provenance: null,
+        isFinalRecipient: false,
+        recipientType: null,
+      }),
+    );
 
     const result = await new GetPublicResources(repo).execute({
       emergencyId: EM,

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
@@ -521,6 +521,47 @@ describe('DrizzleResourceRepository (integration)', () => {
       expect(total).toBe(5);
     });
 
+    it('excludes active-but-unverified (ingested) points — #94', async () => {
+      const verified = Resource.fromSnapshot({
+        ...Resource.register({
+          id: ResourceId.create(),
+          emergencyId: EmergencyId.fromString(EM),
+          type: ResourceType.CollectionPoint,
+          stage: ResourceStage.Origin,
+          name: 'Verified',
+          location: baseLocation,
+          ownerUserId: OWNER_ID,
+        }).toSnapshot(),
+        verificationLevel: VerificationLevel.Verified,
+        publicStatus: PublicStatus.Active,
+        createdAt: new Date(),
+      });
+      // Active yet Unverified, exactly as the external ingest writes it.
+      const unverified = Resource.fromSnapshot({
+        ...Resource.register({
+          id: ResourceId.create(),
+          emergencyId: EmergencyId.fromString(EM),
+          type: ResourceType.CollectionPoint,
+          stage: ResourceStage.Origin,
+          name: 'Ingested Unverified',
+          location: baseLocation,
+          ownerUserId: OWNER_ID,
+        }).toSnapshot(),
+        verificationLevel: VerificationLevel.Unverified,
+        publicStatus: PublicStatus.Active,
+        createdAt: new Date(),
+      });
+      await repo.save(verified);
+      await repo.save(unverified);
+
+      const { items, total } = await repo.findVisiblePaged(
+        EmergencyId.fromString(EM),
+        { page: 1, limit: 10 },
+      );
+      expect(total).toBe(1);
+      expect(items.map((r) => r.name)).toEqual(['Verified']);
+    });
+
     it('filters by category (accepts @> ARRAY[category])', async () => {
       const withWater = Resource.fromSnapshot({
         ...Resource.register({
@@ -789,6 +830,53 @@ describe('DrizzleResourceRepository (integration)', () => {
       expect(byCategory['water']).not.toBe(3); // R3 excluded
       expect(byCountry['VE']).toBe(1); // R1
       expect(byCountry['CO']).toBe(1); // R2
+    });
+
+    it('does not count active-but-unverified (ingested) points — #94', async () => {
+      const verified = Resource.fromSnapshot({
+        ...Resource.register({
+          id: ResourceId.create(),
+          emergencyId: EmergencyId.fromString(EM),
+          type: ResourceType.CollectionPoint,
+          stage: ResourceStage.Origin,
+          name: 'Verified',
+          location: baseLocation,
+          ownerUserId: OWNER_ID,
+          accepts: ['water'],
+          country: 'VE',
+        }).toSnapshot(),
+        verificationLevel: VerificationLevel.Verified,
+        publicStatus: PublicStatus.Active,
+        createdAt: new Date(),
+      });
+      const unverified = Resource.fromSnapshot({
+        ...Resource.register({
+          id: ResourceId.create(),
+          emergencyId: EmergencyId.fromString(EM),
+          type: ResourceType.CollectionPoint,
+          stage: ResourceStage.Origin,
+          name: 'Ingested Unverified',
+          location: baseLocation,
+          ownerUserId: OWNER_ID,
+          accepts: ['clothing'],
+          country: 'CO',
+        }).toSnapshot(),
+        verificationLevel: VerificationLevel.Unverified,
+        publicStatus: PublicStatus.Active,
+        createdAt: new Date(),
+      });
+      await repo.save(verified);
+      await repo.save(unverified);
+
+      const { byCategory, byCountry, total } = await repo.facets(
+        EmergencyId.fromString(EM),
+      );
+
+      expect(total).toBe(1);
+      expect(byCategory['water']).toBe(1);
+      expect(byCategory['clothing']).toBeUndefined();
+      expect(byCountry['VE']).toBe(1);
+      expect(byCountry['CO']).toBeUndefined();
     });
   });
 

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
@@ -14,6 +14,24 @@ import {
 
 type Row = typeof resourcesTable.$inferSelect;
 
+/** Operational statuses a resource must be in to appear in any public read. */
+const PUBLICLY_VISIBLE_STATUSES = [
+  PublicStatus.Active,
+  PublicStatus.Saturated,
+  PublicStatus.Paused,
+];
+
+/**
+ * Trust levels the public API is allowed to expose. The public read API is the
+ * product's "source of truth", so it must never surface `unverified` points —
+ * only `verified`/`official` ones (issue #94). Applied to every public read
+ * path (paged list, facets, nearby, in-bounds and single-resource lookup).
+ */
+const PUBLICLY_VISIBLE_VERIFICATION = [
+  VerificationLevel.Verified,
+  VerificationLevel.Official,
+];
+
 /**
  * Raw snake_case row returned by db.execute() (no Drizzle camelCase mapping).
  * NOTE: the `pg` driver returns timestamptz columns as strings and
@@ -316,16 +334,12 @@ export class DrizzleResourceRepository implements ResourceRepository {
       q?: string;
     },
   ): Promise<{ items: Resource[]; total: number }> {
-    const VISIBLE = [
-      PublicStatus.Active,
-      PublicStatus.Saturated,
-      PublicStatus.Paused,
-    ];
     const offset = (q.page - 1) * q.limit;
 
     const conditions = [
       eq(resourcesTable.emergencyId, emergencyId.value),
-      inArray(resourcesTable.publicStatus, VISIBLE),
+      inArray(resourcesTable.publicStatus, PUBLICLY_VISIBLE_STATUSES),
+      inArray(resourcesTable.verificationLevel, PUBLICLY_VISIBLE_VERIFICATION),
     ];
 
     if (q.category) {
@@ -369,18 +383,18 @@ export class DrizzleResourceRepository implements ResourceRepository {
     byCountry: Record<string, number>;
     total: number;
   }> {
-    const VISIBLE = [
-      PublicStatus.Active,
-      PublicStatus.Saturated,
-      PublicStatus.Paused,
-    ];
     const visibleWhere = and(
       eq(resourcesTable.emergencyId, emergencyId.value),
-      inArray(resourcesTable.publicStatus, VISIBLE),
+      inArray(resourcesTable.publicStatus, PUBLICLY_VISIBLE_STATUSES),
+      inArray(resourcesTable.verificationLevel, PUBLICLY_VISIBLE_VERIFICATION),
     );
 
     const visibleArr = sql.join(
-      VISIBLE.map((v) => sql`${v}`),
+      PUBLICLY_VISIBLE_STATUSES.map((v) => sql`${v}`),
+      sql`, `,
+    );
+    const verifiedArr = sql.join(
+      PUBLICLY_VISIBLE_VERIFICATION.map((v) => sql`${v}`),
       sql`, `,
     );
     const [totalRows, categoryRows, countryRows] = await Promise.all([
@@ -390,6 +404,7 @@ export class DrizzleResourceRepository implements ResourceRepository {
         FROM resources
         WHERE emergency_id = ${emergencyId.value}
           AND public_status = ANY(ARRAY[${visibleArr}])
+          AND verification_level = ANY(ARRAY[${verifiedArr}])
         GROUP BY cat
       `),
       this.db.execute<{ country: string; cnt: string }>(sql`
@@ -397,6 +412,7 @@ export class DrizzleResourceRepository implements ResourceRepository {
         FROM resources
         WHERE emergency_id = ${emergencyId.value}
           AND public_status = ANY(ARRAY[${visibleArr}])
+          AND verification_level = ANY(ARRAY[${verifiedArr}])
           AND country IS NOT NULL
         GROUP BY country
       `),
@@ -423,13 +439,12 @@ export class DrizzleResourceRepository implements ResourceRepository {
     emergencyId: EmergencyId,
     q: { lat: number; lng: number; radiusMeters: number; limit: number },
   ): Promise<Array<{ resource: Resource; distanceMeters: number }>> {
-    const VISIBLE = [
-      PublicStatus.Active,
-      PublicStatus.Saturated,
-      PublicStatus.Paused,
-    ];
     const visibleArr = sql.join(
-      VISIBLE.map((v) => sql`${v}`),
+      PUBLICLY_VISIBLE_STATUSES.map((v) => sql`${v}`),
+      sql`, `,
+    );
+    const verifiedArr = sql.join(
+      PUBLICLY_VISIBLE_VERIFICATION.map((v) => sql`${v}`),
       sql`, `,
     );
 
@@ -440,6 +455,7 @@ export class DrizzleResourceRepository implements ResourceRepository {
       FROM resources
       WHERE emergency_id = ${emergencyId.value}
         AND public_status = ANY(ARRAY[${visibleArr}])
+        AND verification_level = ANY(ARRAY[${verifiedArr}])
         AND earth_box(ll_to_earth(${q.lat}, ${q.lng}), ${q.radiusMeters}) @> ll_to_earth(latitude, longitude)
         AND earth_distance(ll_to_earth(${q.lat}, ${q.lng}), ll_to_earth(latitude, longitude)) <= ${q.radiusMeters}
       ORDER BY dist ASC
@@ -462,18 +478,17 @@ export class DrizzleResourceRepository implements ResourceRepository {
       limit: number;
     },
   ): Promise<Resource[]> {
-    const VISIBLE = [
-      PublicStatus.Active,
-      PublicStatus.Saturated,
-      PublicStatus.Paused,
-    ];
     const rows = await this.db
       .select()
       .from(resourcesTable)
       .where(
         and(
           eq(resourcesTable.emergencyId, emergencyId.value),
-          inArray(resourcesTable.publicStatus, VISIBLE),
+          inArray(resourcesTable.publicStatus, PUBLICLY_VISIBLE_STATUSES),
+          inArray(
+            resourcesTable.verificationLevel,
+            PUBLICLY_VISIBLE_VERIFICATION,
+          ),
           between(resourcesTable.latitude, q.minLat, q.maxLat),
           between(resourcesTable.longitude, q.minLng, q.maxLng),
         ),

--- a/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.spec.ts
@@ -29,6 +29,41 @@ const make = (emergencyId: string, name: string) =>
     ownerUserId: 'user-test-inmem',
   });
 
+/**
+ * Mimics an ingested point (e.g. acopiove.org import): Active + Unverified.
+ * Built via fromSnapshot because the domain `publish()` guard forbids
+ * publishing an unverified resource — yet ingest writes this state directly,
+ * which is exactly how unverified points leaked into the public API (#94).
+ */
+const makeActiveUnverified = (
+  emergencyId: string,
+  name: string,
+  opts: { accepts?: string[]; country?: string | null } = {},
+) =>
+  Resource.fromSnapshot({
+    id: ResourceId.create().value,
+    emergencyId,
+    type: ResourceType.CollectionPoint,
+    stage: ResourceStage.Origin,
+    name,
+    description: null,
+    location: baseLocation.toPlain(),
+    ownerUserId: 'ingest',
+    ownerOrganizationId: null,
+    verificationLevel: VerificationLevel.Unverified,
+    publicStatus: PublicStatus.Active,
+    createdAt: new Date('2026-06-01T00:00:00Z'),
+    contact: null,
+    schedule: null,
+    manager: null,
+    accepts: opts.accepts ?? [],
+    country: opts.country ?? null,
+    city: null,
+    provenance: null,
+    isFinalRecipient: false,
+    recipientType: null,
+  });
+
 describe('InMemoryResourceRepository', () => {
   it('saves and finds by id', async () => {
     const repo = new InMemoryResourceRepository();
@@ -144,6 +179,19 @@ describe('InMemoryResourceRepository', () => {
       expect(total).toBe(1);
       expect(items[0].name).toBe('VE Resource');
     });
+
+    it('excludes active-but-unverified (ingested) points — #94', async () => {
+      const repo = new InMemoryResourceRepository();
+      await repo.save(makeVisible(EM_A, 'Verified'));
+      await repo.save(makeActiveUnverified(EM_A, 'Unverified'));
+
+      const { items, total } = await repo.findVisiblePaged(
+        EmergencyId.fromString(EM_A),
+        { page: 1, limit: 10 },
+      );
+      expect(total).toBe(1);
+      expect(items.map((r) => r.name)).toEqual(['Verified']);
+    });
   });
 
   describe('facets', () => {
@@ -183,6 +231,39 @@ describe('InMemoryResourceRepository', () => {
       expect(byCategory['food']).toBe(1);
       expect(byCountry['VE']).toBe(1);
       expect(byCountry['CO']).toBe(1);
+    });
+
+    it('does not count active-but-unverified (ingested) points — #94', async () => {
+      const repo = new InMemoryResourceRepository();
+      const verified = Resource.register({
+        id: ResourceId.create(),
+        emergencyId: EmergencyId.fromString(EM_A),
+        type: ResourceType.CollectionPoint,
+        stage: ResourceStage.Origin,
+        name: 'Verified',
+        location: baseLocation,
+        ownerUserId: 'u1',
+        accepts: ['water'],
+        country: 'VE',
+      });
+      verified.verify(VerificationLevel.Verified, 'c1');
+      verified.publish();
+      await repo.save(verified);
+      // Unverified but Active (ingested) — must be invisible to facets.
+      await repo.save(
+        makeActiveUnverified(EM_A, 'Unverified', {
+          accepts: ['clothing'],
+          country: 'CO',
+        }),
+      );
+
+      const { byCategory, byCountry, total } = await repo.facets(
+        EmergencyId.fromString(EM_A),
+      );
+      expect(total).toBe(1);
+      expect(byCategory).toEqual({ water: 1 });
+      expect(byCategory['clothing']).toBeUndefined();
+      expect(byCountry).toEqual({ VE: 1 });
     });
   });
 });

--- a/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
@@ -21,6 +21,15 @@ function haversineMeters(
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
+/**
+ * Trust levels the public read API may expose — never `unverified` (issue #94).
+ * Mirrors `PUBLICLY_VISIBLE_VERIFICATION` in the Drizzle repository.
+ */
+const PUBLICLY_VISIBLE_VERIFICATION = new Set<VerificationLevel>([
+  VerificationLevel.Verified,
+  VerificationLevel.Official,
+]);
+
 export class InMemoryResourceRepository implements ResourceRepository {
   private store = new Map<string, ReturnType<Resource['toSnapshot']>>();
 
@@ -133,7 +142,10 @@ export class InMemoryResourceRepository implements ResourceRepository {
       PublicStatus.Paused,
     ]);
     let all = [...this.store.values()].filter(
-      (s) => s.emergencyId === emergencyId.value && visible.has(s.publicStatus),
+      (s) =>
+        s.emergencyId === emergencyId.value &&
+        visible.has(s.publicStatus) &&
+        PUBLICLY_VISIBLE_VERIFICATION.has(s.verificationLevel),
     );
     if (q.category) {
       all = all.filter((s) => s.accepts.includes(q.category!));
@@ -170,7 +182,9 @@ export class InMemoryResourceRepository implements ResourceRepository {
     const withDist = [...this.store.values()]
       .filter(
         (s) =>
-          s.emergencyId === emergencyId.value && visible.has(s.publicStatus),
+          s.emergencyId === emergencyId.value &&
+          visible.has(s.publicStatus) &&
+          PUBLICLY_VISIBLE_VERIFICATION.has(s.verificationLevel),
       )
       .map((s) => {
         const dist = haversineMeters(
@@ -213,6 +227,7 @@ export class InMemoryResourceRepository implements ResourceRepository {
         (s) =>
           s.emergencyId === emergencyId.value &&
           visible.has(s.publicStatus) &&
+          PUBLICLY_VISIBLE_VERIFICATION.has(s.verificationLevel) &&
           s.location.latitude >= q.minLat &&
           s.location.latitude <= q.maxLat &&
           s.location.longitude >= q.minLng &&
@@ -234,7 +249,10 @@ export class InMemoryResourceRepository implements ResourceRepository {
       PublicStatus.Paused,
     ]);
     const all = [...this.store.values()].filter(
-      (s) => s.emergencyId === emergencyId.value && visible.has(s.publicStatus),
+      (s) =>
+        s.emergencyId === emergencyId.value &&
+        visible.has(s.publicStatus) &&
+        PUBLICLY_VISIBLE_VERIFICATION.has(s.verificationLevel),
     );
     const byCategory: Record<string, number> = {};
     const byCountry: Record<string, number> = {};

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -72,6 +72,11 @@ async function bootstrap(): Promise<void> {
     .setTitle('ResponseGrid API')
     .setDescription('API for humanitarian emergency resource coordination')
     .setVersion('0.1')
+    // Bearer JWT (user accounts) — matches @ApiBearerAuth() on write endpoints.
+    .addBearerAuth()
+    // Service-account API keys — matches @ApiSecurity('api-key'); sent as the
+    // `X-API-Key: rh_live_…` header (issue #96).
+    .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, 'api-key')
     .addTag('resources')
     .build();
   const document = SwaggerModule.createDocument(app, config);

--- a/apps/api/test/emergency-lifecycle.e2e-spec.ts
+++ b/apps/api/test/emergency-lifecycle.e2e-spec.ts
@@ -228,6 +228,20 @@ describe('Emergency lifecycle (e2e)', () => {
     expect(typeof body.updatedAt).toBe('string');
   });
 
+  it('by-slug with a non-canonical slug → 404 (not 500) — #93', async () => {
+    // Uppercase, underscores and spaces are not canonical slugs. Before #93
+    // these surfaced a plain Error → 500; now they resolve as "not found".
+    for (const slug of ['Terremoto', 'abc_def', 'lifecycle E2E']) {
+      await request(server)
+        .get(`/emergencies/by-slug/${encodeURIComponent(slug)}`)
+        .expect(404);
+    }
+  });
+
+  it('by-slug with a canonical but unknown slug → 404', async () => {
+    await request(server).get('/emergencies/by-slug/zzz-no-existe').expect(404);
+  });
+
   // ── 5. Resume: intake resumes ───────────────────────────────────────────────
 
   it('coordinator resumes the emergency → 204', async () => {

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -438,7 +438,9 @@ for (const p of items) {
                 <div className="grid gap-3 sm:grid-cols-2">
                   <Card title={d.auth_read_t}>{d.auth_read_b}</Card>
                   <Card title={d.auth_write_t}>{d.auth_write_b}</Card>
+                  <Card title={d.auth_sa_t}>{d.auth_sa_b}</Card>
                 </div>
+                <Callout tone="warn">{d.auth_note}</Callout>
               </Section>
 
               {/* Quickstart */}
@@ -565,8 +567,9 @@ for (const p of items) {
                     'hygiene',
                     'water',
                     'food',
-                    'medical',
+                    'clothing',
                     'shelter',
+                    'medical',
                     'tools',
                     'other',
                     'medicines',

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -790,13 +790,19 @@ export const en = {
 
     // Authentication
     auth_heading: 'Authentication',
-    auth_intro: 'There are two planes. Tell them apart before integrating.',
+    auth_intro:
+      'There are three schemes. Work out which one each endpoint accepts before integrating.',
     auth_read_t: 'Reads — no token',
     auth_read_b:
       'The read endpoints (emergencies, public points, public needs) need no credentials. If all you want is to display data, you do not need to authenticate.',
     auth_write_t: 'Writes — Bearer token',
     auth_write_b:
-      'To create needs, offers or points you need an account. Register or log in and you get an accessToken (JWT) that you send in the Authorization: Bearer <token> header.',
+      'To create needs, offers or points you need a user account. Register or log in and you get an accessToken (JWT) that you send in the Authorization: Bearer <token> header.',
+    auth_sa_t: 'Service accounts — x-api-key header',
+    auth_sa_b:
+      'For machine-to-machine integrations there are service accounts. An admin creates the account and issues a key (rh_live_…) that travels in the x-api-key header (not as Bearer). With it, the caller can introspect its own identity and permissions: GET /service-accounts/me.',
+    auth_note:
+      'An x-api-key authenticates the service-account principal, but it does not replace the Bearer token on the documented write endpoints (needs, offers and points): those expect a user-account JWT and return 401 for an API key. A service account can only act within its grants (none by default), so without explicit permissions its key does not enable writes.',
 
     // Quickstart
     qs_heading: 'Quickstart: a map of points',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -818,13 +818,18 @@ export const es = {
     // Autenticación
     auth_heading: 'Autenticación',
     auth_intro:
-      'Hay dos planos. Distínguelos antes de integrar.',
+      'Hay tres esquemas. Identifica cuál acepta cada endpoint antes de integrar.',
     auth_read_t: 'Lectura — sin token',
     auth_read_b:
       'Los endpoints de consulta (emergencias, puntos públicos, necesidades públicas) no requieren credenciales. Si solo quieres mostrar datos, no necesitas autenticarte.',
     auth_write_t: 'Escritura — token Bearer',
     auth_write_b:
-      'Para crear necesidades, ofertas o puntos necesitas una cuenta. Regístrate o haz login y recibirás un accessToken (JWT) que envías en la cabecera Authorization: Bearer <token>.',
+      'Para crear necesidades, ofertas o puntos necesitas una cuenta de usuario. Regístrate o haz login y recibirás un accessToken (JWT) que envías en la cabecera Authorization: Bearer <token>.',
+    auth_sa_t: 'Cuentas de servicio — cabecera x-api-key',
+    auth_sa_b:
+      'Para integraciones máquina-a-máquina existen las cuentas de servicio. Un administrador crea la cuenta y emite una clave (rh_live_…) que viaja en la cabecera x-api-key (no como Bearer). Con ella el llamante puede introspeccionar su identidad y permisos: GET /service-accounts/me.',
+    auth_note:
+      'Una clave x-api-key autentica al principal de la cuenta de servicio, pero no sustituye al Bearer en los endpoints de escritura documentados (necesidades, ofertas y puntos): estos esperan un JWT de cuenta de usuario y responden 401 ante una API key. Una cuenta de servicio solo puede actuar dentro de sus grants (por defecto, ninguno), así que sin permisos explícitos su clave no habilita escritura.',
 
     // Inicio rápido
     qs_heading: 'Inicio rápido: un mapa de puntos',


### PR DESCRIPTION
Resuelve cuatro incidencias de la API pública / `/docs`.

Closes #93
Closes #94
Closes #95
Closes #96

## #93 — `by-slug` devuelve 500 con slugs no canónicos → ahora 404
`Slug.fromString` lanzaba un `Error` plano al validar el formato; al no ser una `HttpException`, Nest lo traducía a **500** (mayúsculas, `_`, espacios…).
- Nuevo `InvalidSlugError` tipado lanzado desde `Slug.fromString`.
- `GetEmergencyBySlug` lo trata como "no encontrado" (un slug no canónico nunca puede coincidir con uno almacenado, que siempre es canónico) → el controlador responde **404**.
- El flujo de creación no cambia: el DTO ya valida el formato con `@Matches` antes de llegar al dominio.

## #94 — `/public/resources` (y `facets`, nearby, in-bounds, detalle) exponían puntos `unverified`
La lectura pública filtraba por `publicStatus` pero **no** por `verificationLevel`. Los puntos ingestados (acopiove) se escriben `Active` + `Unverified` vía `fromSnapshot`, saltándose el guard de dominio `publish()` (que exige verificación), por lo que aparecían como validados.
- Se añade el filtro `verificationLevel IN ('verified','official')` a **todas** las rutas de lectura pública: listado paginado, `facets`, `nearby`, `in-bounds` y detalle por id (no solo a las dos citadas en la issue, para no dejar fugas hermanas).
- Centralizado en constantes compartidas (`PUBLICLY_VISIBLE_STATUSES` / `PUBLICLY_VISIBLE_VERIFICATION`) en el repo Drizzle e in-memory.

## #95 — `facets` exponía `clothing` fuera del enum documentado
`clothing` **ya es una categoría oficial** (seed `0020_taxonomy_seed.sql`, `seed-taxonomy.ts` y `categories.ts`) con alias de ingest (`ropa`, `abrigos`). Solo faltaba en el enum documentado de `/docs` → se añade a la lista de categorías. Sin cambios de dominio/datos.

## #96 — Documentar `x-api-key` / service accounts y alinear `/docs`
- **Web `/docs`**: nueva tarjeta en *Autenticación* para el esquema `x-api-key` (cuentas de servicio) además del Bearer JWT, indicando qué esquema acepta cada endpoint, y un aviso de que una API key `rh_live_` **no** habilita los endpoints de escritura (responden 401, piden Bearer JWT) salvo grants explícitos. Copias añadidas a `es`/`en` (paridad forzada por `satisfies Messages`).
- **Swagger**: se registran los *security schemes* `bearer` (`addBearerAuth`) y `api-key` (`addApiKey`, header `X-API-Key`) en el `DocumentBuilder` de `main.ts` **y** `generate-openapi.ts`, y se añaden a `apps/api/openapi.json` (`components.securitySchemes`), resolviendo las referencias `security` por-operación que estaban colgantes. Estaban referenciados por `@ApiBearerAuth()`/`@ApiSecurity('api-key')` pero sin definir.

## Pruebas
Gate ejecutado localmente (verde), también tras el merge de `main`:
- `pnpm --filter api build` (nest build / tsc, estricto) ✅
- `eslint` + `prettier --check` (api) ✅
- `@reliefhub/api-client build` + `pnpm --filter web build` + `web lint` ✅
- Specs unitarios sin BD (slug, public-resources, public-resource, facets, in-memory repo) ✅

Tests de regresión añadidos: spec del use-case + e2e de `by-slug` (#93); in-memory repo, int-spec de Drizzle y use-cases de recursos públicos (#94).

> Nota: este entorno no tiene Postgres/Docker, así que los tests con BD (`pnpm --filter api test`: int-spec + e2e) los validará CI. `schema.ts` no cambia (openapi-typescript ignora `securitySchemes`), así que no hay drift del cliente tipado.

> Mergeado `origin/main` (feat #57/#58 de necesidades cercanas + orden "sin contacto") y resueltos los conflictos: en el int-spec del repo de recursos conviven mi test de #94 y su test de #58; en el repo Drizzle/in-memory, mi filtro de `verificationLevel` y su `ORDER BY`; e i18n con ambas tandas de claves.