### PR TITLE
feat(emergencies): prioridades sanitarias recomendadas

### DIFF
--- a/apps/api/drizzle/0027_recommended_lists.sql
+++ b/apps/api/drizzle/0027_recommended_lists.sql
@@ -1,0 +1,3 @@
+-- Listas de recomendación y "qué sí llevar" para templates y emergencias.
+ALTER TABLE templates ADD COLUMN recommended_list text[] NOT NULL DEFAULT '{}';
+ALTER TABLE emergencies ADD COLUMN recommended_list text[] NOT NULL DEFAULT '{}';

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5861,12 +5861,25 @@
             "type": "string",
             "example": "No se aceptan mascotas en el centro de acopio.",
             "nullable": true
+          },
+          "recommendedList": {
+            "example": [
+              "agua",
+              "dieta líquida",
+              "ítems EV"
+            ],
+            "description": "Items and priorities people SHOULD bring",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
           "name",
           "description",
-          "dontBringList"
+          "dontBringList",
+          "recommendedList"
         ]
       },
       "CreateTemplateResponseDto": {
@@ -5914,6 +5927,16 @@
           "createdAt": {
             "type": "string",
             "example": "2026-06-27T10:00:00.000Z"
+          },
+          "recommendedList": {
+            "example": [
+              "agua",
+              "dieta líquida"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -5922,7 +5945,8 @@
           "description",
           "dontBringList",
           "defaultAnnouncement",
-          "createdAt"
+          "createdAt",
+          "recommendedList"
         ]
       },
       "CreateEmergencyDto": {
@@ -6016,6 +6040,18 @@
           "updatedAt": {
             "type": "string",
             "example": "2026-06-25T10:00:00.000Z"
+          },
+          "recommendedList": {
+            "example": [
+              "agua",
+              "dieta líquida",
+              "ítems EV"
+            ],
+            "description": "Items and priorities people SHOULD bring to the emergency",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -6026,7 +6062,8 @@
           "status",
           "announcement",
           "dontBringList",
-          "updatedAt"
+          "updatedAt",
+          "recommendedList"
         ]
       },
       "CreateEmergencyFromTemplateDto": {

--- a/apps/api/scripts/seed-templates.ts
+++ b/apps/api/scripts/seed-templates.ts
@@ -24,6 +24,14 @@ const DONT_BRING_LIST = [
   'Personas sin formación sanitaria mínima en zonas de atención',
 ];
 
+const RECOMMENDED_LIST = [
+  'Agua potable y alimento de fácil consumo',
+  'Documento de identidad y tarjeta sanitaria',
+  'Medicamentos personales con receta o prospecto',
+  'Ropa de recambio y cargadores portátiles',
+  'Mascarillas, guantes y gel hidroalcohólico',
+];
+
 const DEFAULT_ANNOUNCEMENT =
   'Activado protocolo de emergencia sanitaria. Coordinamos necesidades de ' +
   'medicamentos, equipos e insumos médicos. Solo personal sanitario ' +
@@ -46,6 +54,7 @@ async function seed(): Promise<void> {
           'Plantilla para emergencias del vertical sanitario: hospitales, ' +
           'refugios médicos y situaciones que requieren taxonomía médica.',
         dontBringList: DONT_BRING_LIST,
+        recommendedList: RECOMMENDED_LIST,
         defaultAnnouncement: DEFAULT_ANNOUNCEMENT,
         createdAt: new Date(),
       })
@@ -54,9 +63,10 @@ async function seed(): Promise<void> {
         set: {
           name: 'Emergencia sanitaria',
           description:
-            'Plantilla para emergencias del vertical sanitario: hospitales, ' +
-            'refugios médicos y situaciones que requieren taxonomía médica.',
+          'Plantilla para emergencias del vertical sanitario: hospitales, ' +
+          'refugios médicos y situaciones que requieren taxonomía médica.',
           dontBringList: DONT_BRING_LIST,
+          recommendedList: RECOMMENDED_LIST,
           defaultAnnouncement: DEFAULT_ANNOUNCEMENT,
         },
       });

--- a/apps/api/src/contexts/emergencies/application/create-emergency-from-template.spec.ts
+++ b/apps/api/src/contexts/emergencies/application/create-emergency-from-template.spec.ts
@@ -12,6 +12,7 @@ const TEMPLATE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 describe('CreateEmergencyFromTemplate', () => {
   function makeTemplate(opts: {
     dontBringList?: string[];
+    recommendedList?: string[];
     defaultAnnouncement?: string | null;
   }) {
     return Template.create({
@@ -19,16 +20,18 @@ describe('CreateEmergencyFromTemplate', () => {
       name: 'Terremoto básico',
       description: 'Template de prueba',
       dontBringList: opts.dontBringList ?? [],
+      recommendedList: opts.recommendedList ?? [],
       defaultAnnouncement: opts.defaultAnnouncement ?? null,
     });
   }
 
-  it('creates an emergency copying dontBringList and announcement from template', async () => {
+  it('creates an emergency copying lists and announcement from template', async () => {
     const emergencyRepo = new InMemoryEmergencyRepository();
     const templateRepo = new InMemoryTemplateRepository();
     await templateRepo.save(
       makeTemplate({
         dontBringList: ['mascotas', 'joyas'],
+        recommendedList: ['agua', 'dieta líquida'],
         defaultAnnouncement: 'No traer mascotas',
       }),
     );
@@ -52,6 +55,7 @@ describe('CreateEmergencyFromTemplate', () => {
     );
     expect(created).not.toBeNull();
     expect(created?.dontBringList).toEqual(['mascotas', 'joyas']);
+    expect(created?.recommendedList).toEqual(['agua', 'dieta líquida']);
     expect(created?.announcement).toBe('No traer mascotas');
   });
 
@@ -59,7 +63,11 @@ describe('CreateEmergencyFromTemplate', () => {
     const emergencyRepo = new InMemoryEmergencyRepository();
     const templateRepo = new InMemoryTemplateRepository();
     await templateRepo.save(
-      makeTemplate({ dontBringList: [], defaultAnnouncement: null }),
+      makeTemplate({
+        dontBringList: [],
+        recommendedList: [],
+        defaultAnnouncement: null,
+      }),
     );
 
     const useCase = new CreateEmergencyFromTemplate(

--- a/apps/api/src/contexts/emergencies/application/create-emergency-from-template.ts
+++ b/apps/api/src/contexts/emergencies/application/create-emergency-from-template.ts
@@ -37,6 +37,7 @@ export class CreateEmergencyFromTemplate {
       slug,
       country: cmd.country,
       dontBringList: template.dontBringList,
+      recommendedList: template.recommendedList,
       announcement: template.defaultAnnouncement,
     });
 

--- a/apps/api/src/contexts/emergencies/application/emergency-view.ts
+++ b/apps/api/src/contexts/emergencies/application/emergency-view.ts
@@ -8,6 +8,7 @@ export interface EmergencyView {
   status: string;
   announcement: string | null;
   dontBringList: string[];
+  recommendedList: string[];
   updatedAt: string;
 }
 
@@ -20,6 +21,7 @@ export function toEmergencyView(e: Emergency): EmergencyView {
     status: e.status,
     announcement: e.announcement,
     dontBringList: e.dontBringList,
+    recommendedList: e.recommendedList,
     updatedAt: e.updatedAt.toISOString(),
   };
 }

--- a/apps/api/src/contexts/emergencies/application/list-active-emergencies.spec.ts
+++ b/apps/api/src/contexts/emergencies/application/list-active-emergencies.spec.ts
@@ -23,7 +23,11 @@ describe('ListActiveEmergencies', () => {
       slug: 'closed-relief',
       country: 'ES',
       status: EmergencyStatus.Closed,
+      announcement: null,
+      dontBringList: [],
+      recommendedList: [],
       createdAt: new Date(),
+      updatedAt: new Date(),
     });
     await repo.save(closed);
 

--- a/apps/api/src/contexts/emergencies/domain/emergency.spec.ts
+++ b/apps/api/src/contexts/emergencies/domain/emergency.spec.ts
@@ -26,6 +26,7 @@ describe('Emergency', () => {
   it('creates with null announcement and updatedAt equal to createdAt', () => {
     const e = makeEmergency();
     expect(e.announcement).toBeNull();
+    expect(e.recommendedList).toEqual([]);
     expect(e.updatedAt.toISOString()).toBe(e.createdAt.toISOString());
   });
 
@@ -132,6 +133,7 @@ describe('Emergency', () => {
     expect(restored.slug.equals(e.slug)).toBe(true);
     expect(restored.status).toBe(EmergencyStatus.Paused);
     expect(restored.announcement).toBe('Round-trip test');
+    expect(restored.recommendedList).toEqual([]);
     expect(restored.updatedAt.toISOString()).toBe(e.updatedAt.toISOString());
     expect(restored.country).toBe('TR');
     expect(restored.createdAt.toISOString()).toBe(e.createdAt.toISOString());

--- a/apps/api/src/contexts/emergencies/domain/emergency.ts
+++ b/apps/api/src/contexts/emergencies/domain/emergency.ts
@@ -9,6 +9,7 @@ export interface CreateEmergencyProps {
   slug: Slug;
   country: string;
   dontBringList?: string[];
+  recommendedList?: string[];
   announcement?: string | null;
 }
 
@@ -20,6 +21,7 @@ export interface EmergencySnapshot {
   status: EmergencyStatus;
   announcement: string | null;
   dontBringList: string[];
+  recommendedList: string[];
   createdAt: Date;
   updatedAt: Date;
 }
@@ -33,6 +35,7 @@ export class Emergency {
     private _status: EmergencyStatus,
     private _announcement: string | null,
     private _dontBringList: string[],
+    private _recommendedList: string[],
     public readonly createdAt: Date,
     private _updatedAt: Date,
   ) {}
@@ -47,6 +50,7 @@ export class Emergency {
       EmergencyStatus.Active,
       props.announcement ?? null,
       props.dontBringList ?? [],
+      props.recommendedList ?? [],
       now,
       now,
     );
@@ -61,6 +65,7 @@ export class Emergency {
       snap.status,
       snap.announcement,
       snap.dontBringList,
+      snap.recommendedList,
       snap.createdAt,
       snap.updatedAt,
     );
@@ -76,6 +81,10 @@ export class Emergency {
 
   get dontBringList(): string[] {
     return this._dontBringList;
+  }
+
+  get recommendedList(): string[] {
+    return this._recommendedList;
   }
 
   get updatedAt(): Date {
@@ -117,6 +126,7 @@ export class Emergency {
       status: this._status,
       announcement: this._announcement,
       dontBringList: this._dontBringList,
+      recommendedList: this._recommendedList,
       createdAt: this.createdAt,
       updatedAt: this._updatedAt,
     };

--- a/apps/api/src/contexts/emergencies/infrastructure/drizzle/drizzle-emergency.repository.int-spec.ts
+++ b/apps/api/src/contexts/emergencies/infrastructure/drizzle/drizzle-emergency.repository.int-spec.ts
@@ -36,6 +36,7 @@ describe('DrizzleEmergencyRepository (integration)', () => {
       name: 'Emergencia sísmica — Venezuela',
       slug: Slug.fromString('venezuela'),
       country: 'VE',
+      recommendedList: ['agua', 'dieta líquida'],
     });
 
     await repo.save(emergency);
@@ -47,6 +48,7 @@ describe('DrizzleEmergencyRepository (integration)', () => {
     expect(found?.slug.value).toBe('venezuela');
     expect(found?.country).toBe('VE');
     expect(found?.status).toBe(EmergencyStatus.Active);
+    expect(found?.recommendedList).toEqual(['agua', 'dieta líquida']);
   });
 
   it('findBySlug returns the correct emergency', async () => {
@@ -55,6 +57,7 @@ describe('DrizzleEmergencyRepository (integration)', () => {
       name: 'Emergencia sísmica — Venezuela',
       slug: Slug.fromString('venezuela'),
       country: 'VE',
+      recommendedList: ['agua'],
     });
 
     await repo.save(emergency);
@@ -75,6 +78,7 @@ describe('DrizzleEmergencyRepository (integration)', () => {
       name: 'Active Emergency',
       slug: Slug.fromString('active-emergency'),
       country: 'VE',
+      recommendedList: ['agua'],
     });
 
     const closed = Emergency.create({
@@ -82,6 +86,7 @@ describe('DrizzleEmergencyRepository (integration)', () => {
       name: 'Closed Emergency',
       slug: Slug.fromString('closed-emergency'),
       country: 'CO',
+      recommendedList: ['agua'],
     });
     closed.close();
 
@@ -101,6 +106,7 @@ describe('DrizzleEmergencyRepository (integration)', () => {
       slug: Slug.fromString('dont-bring-test'),
       country: 'VE',
       dontBringList: ['mascotas', 'joyas'],
+      recommendedList: ['agua', 'dieta líquida'],
     });
 
     await repo.save(emergency);
@@ -108,5 +114,6 @@ describe('DrizzleEmergencyRepository (integration)', () => {
 
     expect(found).not.toBeNull();
     expect(found?.dontBringList).toEqual(['mascotas', 'joyas']);
+    expect(found?.recommendedList).toEqual(['agua', 'dieta líquida']);
   });
 });

--- a/apps/api/src/contexts/emergencies/infrastructure/drizzle/drizzle-emergency.repository.ts
+++ b/apps/api/src/contexts/emergencies/infrastructure/drizzle/drizzle-emergency.repository.ts
@@ -18,6 +18,7 @@ function rowToSnapshot(row: Row): EmergencySnapshot {
     status: row.status as EmergencyStatus,
     announcement: row.announcement ?? null,
     dontBringList: row.dontBringList,
+    recommendedList: row.recommendedList,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -38,6 +39,7 @@ export class DrizzleEmergencyRepository implements EmergencyRepository {
         status: s.status,
         announcement: s.announcement,
         dontBringList: s.dontBringList,
+        recommendedList: s.recommendedList,
         createdAt: s.createdAt,
         updatedAt: s.updatedAt,
       })
@@ -49,6 +51,7 @@ export class DrizzleEmergencyRepository implements EmergencyRepository {
           country: s.country,
           announcement: s.announcement,
           dontBringList: s.dontBringList,
+          recommendedList: s.recommendedList,
           updatedAt: s.updatedAt,
         },
       });

--- a/apps/api/src/contexts/emergencies/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/emergencies/infrastructure/drizzle/schema.ts
@@ -8,6 +8,7 @@ export const emergenciesTable = pgTable('emergencies', {
   status: text('status').notNull(),
   announcement: text('announcement'),
   dontBringList: text('dont_bring_list').array().notNull().default([]),
+  recommendedList: text('recommended_list').array().notNull().default([]),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true })
     .notNull()

--- a/apps/api/src/contexts/emergencies/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/emergencies/infrastructure/http/dto.ts
@@ -77,6 +77,13 @@ export class EmergencyViewDto {
   })
   dontBringList!: string[];
 
+  @ApiProperty({
+    example: ['agua', 'dieta líquida', 'ítems EV'],
+    type: [String],
+    description: 'Items and priorities people SHOULD bring to the emergency',
+  })
+  recommendedList!: string[];
+
   @ApiProperty({ example: '2026-06-25T10:00:00.000Z' })
   updatedAt!: string;
 }

--- a/apps/api/src/contexts/templates/application/create-template.spec.ts
+++ b/apps/api/src/contexts/templates/application/create-template.spec.ts
@@ -10,6 +10,7 @@ describe('CreateTemplate', () => {
       name: 'Terremoto',
       description: 'Template básico para terremotos',
       dontBringList: ['mascotas', 'joyas'],
+      recommendedList: ['agua', 'dieta líquida'],
       defaultAnnouncement: 'No traer mascotas',
     });
 
@@ -20,6 +21,7 @@ describe('CreateTemplate', () => {
     expect(all).toHaveLength(1);
     expect(all[0].name).toBe('Terremoto');
     expect(all[0].dontBringList).toEqual(['mascotas', 'joyas']);
+    expect(all[0].recommendedList).toEqual(['agua', 'dieta líquida']);
     expect(all[0].defaultAnnouncement).toBe('No traer mascotas');
   });
 
@@ -31,6 +33,7 @@ describe('CreateTemplate', () => {
       name: 'Inundación',
       description: 'Template para inundaciones',
       dontBringList: [],
+      recommendedList: [],
     });
 
     expect(typeof result.id).toBe('string');

--- a/apps/api/src/contexts/templates/application/create-template.ts
+++ b/apps/api/src/contexts/templates/application/create-template.ts
@@ -6,6 +6,7 @@ export interface CreateTemplateCommand {
   name: string;
   description: string;
   dontBringList: string[];
+  recommendedList: string[];
   defaultAnnouncement?: string;
 }
 
@@ -18,6 +19,7 @@ export class CreateTemplate {
       name: cmd.name,
       description: cmd.description,
       dontBringList: cmd.dontBringList,
+      recommendedList: cmd.recommendedList,
       defaultAnnouncement: cmd.defaultAnnouncement ?? null,
     });
     await this.repo.save(template);

--- a/apps/api/src/contexts/templates/application/delete-template.spec.ts
+++ b/apps/api/src/contexts/templates/application/delete-template.spec.ts
@@ -13,6 +13,7 @@ describe('DeleteTemplate', () => {
       name: 'To Delete',
       description: 'Desc',
       dontBringList: [],
+      recommendedList: [],
     });
 
     await deleteUc.execute({ id });

--- a/apps/api/src/contexts/templates/application/template-view.ts
+++ b/apps/api/src/contexts/templates/application/template-view.ts
@@ -5,6 +5,7 @@ export interface TemplateView {
   name: string;
   description: string;
   dontBringList: string[];
+  recommendedList: string[];
   defaultAnnouncement: string | null;
   createdAt: string;
 }
@@ -15,6 +16,7 @@ export function toTemplateView(t: Template): TemplateView {
     name: t.name,
     description: t.description,
     dontBringList: t.dontBringList,
+    recommendedList: t.recommendedList,
     defaultAnnouncement: t.defaultAnnouncement,
     createdAt: t.createdAt.toISOString(),
   };

--- a/apps/api/src/contexts/templates/domain/template.spec.ts
+++ b/apps/api/src/contexts/templates/domain/template.spec.ts
@@ -10,6 +10,7 @@ describe('Template', () => {
       name: 'Terremoto básico',
       description: 'Template para terremotos de magnitud moderada',
       dontBringList: ['mascotas', 'vehículos grandes'],
+      recommendedList: ['agua', 'dieta líquida'],
       defaultAnnouncement: 'No traer mascotas al centro de acopio',
     });
 
@@ -17,6 +18,7 @@ describe('Template', () => {
     expect(t.name).toBe('Terremoto básico');
     expect(t.description).toBe('Template para terremotos de magnitud moderada');
     expect(t.dontBringList).toEqual(['mascotas', 'vehículos grandes']);
+    expect(t.recommendedList).toEqual(['agua', 'dieta líquida']);
     expect(t.defaultAnnouncement).toBe('No traer mascotas al centro de acopio');
     expect(t.createdAt).toBeInstanceOf(Date);
   });
@@ -27,6 +29,7 @@ describe('Template', () => {
       name: 'Template sin anuncio',
       description: 'Descripción',
       dontBringList: [],
+      recommendedList: [],
       defaultAnnouncement: null,
     });
 
@@ -40,6 +43,7 @@ describe('Template', () => {
       name: 'Template round-trip',
       description: 'Desc',
       dontBringList: ['item1', 'item2'],
+      recommendedList: ['itemA'],
       defaultAnnouncement: 'Anuncio',
     });
 
@@ -49,6 +53,7 @@ describe('Template', () => {
     expect(restored.name).toBe(original.name);
     expect(restored.description).toBe(original.description);
     expect(restored.dontBringList).toEqual(original.dontBringList);
+    expect(restored.recommendedList).toEqual(original.recommendedList);
     expect(restored.defaultAnnouncement).toBe(original.defaultAnnouncement);
     expect(restored.createdAt).toEqual(original.createdAt);
   });

--- a/apps/api/src/contexts/templates/domain/template.ts
+++ b/apps/api/src/contexts/templates/domain/template.ts
@@ -5,6 +5,7 @@ export interface CreateTemplateProps {
   name: string;
   description: string;
   dontBringList: string[];
+  recommendedList?: string[];
   defaultAnnouncement: string | null;
 }
 
@@ -13,6 +14,7 @@ export interface TemplateSnapshot {
   name: string;
   description: string;
   dontBringList: string[];
+  recommendedList: string[];
   defaultAnnouncement: string | null;
   createdAt: Date;
 }
@@ -23,6 +25,7 @@ export class Template {
     public readonly name: string,
     public readonly description: string,
     public readonly dontBringList: string[],
+    public readonly recommendedList: string[],
     public readonly defaultAnnouncement: string | null,
     public readonly createdAt: Date,
   ) {}
@@ -33,6 +36,7 @@ export class Template {
       props.name,
       props.description,
       props.dontBringList,
+      props.recommendedList ?? [],
       props.defaultAnnouncement,
       new Date(),
     );
@@ -44,6 +48,7 @@ export class Template {
       snap.name,
       snap.description,
       snap.dontBringList,
+      snap.recommendedList,
       snap.defaultAnnouncement,
       snap.createdAt,
     );
@@ -55,6 +60,7 @@ export class Template {
       name: this.name,
       description: this.description,
       dontBringList: this.dontBringList,
+      recommendedList: this.recommendedList,
       defaultAnnouncement: this.defaultAnnouncement,
       createdAt: this.createdAt,
     };

--- a/apps/api/src/contexts/templates/infrastructure/drizzle/drizzle-template.repository.int-spec.ts
+++ b/apps/api/src/contexts/templates/infrastructure/drizzle/drizzle-template.repository.int-spec.ts
@@ -34,6 +34,7 @@ describe('DrizzleTemplateRepository (integration)', () => {
       name: 'Terremoto básico',
       description: 'Template para terremotos',
       dontBringList: ['mascotas', 'joyas'],
+      recommendedList: ['agua', 'dieta líquida'],
       defaultAnnouncement: 'No traer mascotas',
     });
 
@@ -45,6 +46,7 @@ describe('DrizzleTemplateRepository (integration)', () => {
     expect(found?.name).toBe('Terremoto básico');
     expect(found?.description).toBe('Template para terremotos');
     expect(found?.dontBringList).toEqual(['mascotas', 'joyas']);
+    expect(found?.recommendedList).toEqual(['agua', 'dieta líquida']);
     expect(found?.defaultAnnouncement).toBe('No traer mascotas');
   });
 
@@ -55,6 +57,7 @@ describe('DrizzleTemplateRepository (integration)', () => {
         name: 'T1',
         description: 'D1',
         dontBringList: [],
+        recommendedList: [],
         defaultAnnouncement: null,
       }),
     );
@@ -64,6 +67,7 @@ describe('DrizzleTemplateRepository (integration)', () => {
         name: 'T2',
         description: 'D2',
         dontBringList: ['x'],
+        recommendedList: ['y'],
         defaultAnnouncement: null,
       }),
     );
@@ -80,6 +84,7 @@ describe('DrizzleTemplateRepository (integration)', () => {
         name: 'To Delete',
         description: 'Desc',
         dontBringList: [],
+        recommendedList: [],
         defaultAnnouncement: null,
       }),
     );

--- a/apps/api/src/contexts/templates/infrastructure/drizzle/drizzle-template.repository.ts
+++ b/apps/api/src/contexts/templates/infrastructure/drizzle/drizzle-template.repository.ts
@@ -13,6 +13,7 @@ function rowToSnapshot(row: Row): TemplateSnapshot {
     name: row.name,
     description: row.description,
     dontBringList: row.dontBringList,
+    recommendedList: row.recommendedList,
     defaultAnnouncement: row.defaultAnnouncement ?? null,
     createdAt: row.createdAt,
   };
@@ -30,6 +31,7 @@ export class DrizzleTemplateRepository implements TemplateRepository {
         name: s.name,
         description: s.description,
         dontBringList: s.dontBringList,
+        recommendedList: s.recommendedList,
         defaultAnnouncement: s.defaultAnnouncement,
         createdAt: s.createdAt,
       })
@@ -39,6 +41,7 @@ export class DrizzleTemplateRepository implements TemplateRepository {
           name: s.name,
           description: s.description,
           dontBringList: s.dontBringList,
+          recommendedList: s.recommendedList,
           defaultAnnouncement: s.defaultAnnouncement,
         },
       });

--- a/apps/api/src/contexts/templates/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/templates/infrastructure/drizzle/schema.ts
@@ -5,6 +5,7 @@ export const templatesTable = pgTable('templates', {
   name: text('name').notNull(),
   description: text('description').notNull(),
   dontBringList: text('dont_bring_list').array().notNull().default([]),
+  recommendedList: text('recommended_list').array().notNull().default([]),
   defaultAnnouncement: text('default_announcement'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
 });

--- a/apps/api/src/contexts/templates/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/templates/infrastructure/http/dto.ts
@@ -30,6 +30,15 @@ export class CreateTemplateDto {
   dontBringList!: string[];
 
   @ApiProperty({
+    example: ['agua', 'dieta líquida', 'ítems EV'],
+    type: [String],
+    description: 'Items and priorities people SHOULD bring',
+  })
+  @IsArray()
+  @IsString({ each: true })
+  recommendedList!: string[];
+
+  @ApiProperty({
     example: 'No se aceptan mascotas en el centro de acopio.',
     nullable: true,
     required: false,
@@ -56,6 +65,9 @@ export class TemplateViewDto {
 
   @ApiProperty({ example: ['mascotas', 'joyas'], type: [String] })
   dontBringList!: string[];
+
+  @ApiProperty({ example: ['agua', 'dieta líquida'], type: [String] })
+  recommendedList!: string[];
 
   @ApiProperty({
     example: 'No se aceptan mascotas.',

--- a/apps/api/src/contexts/templates/infrastructure/http/templates.controller.ts
+++ b/apps/api/src/contexts/templates/infrastructure/http/templates.controller.ts
@@ -64,6 +64,7 @@ export class TemplatesController {
       name: dto.name,
       description: dto.description,
       dontBringList: dto.dontBringList,
+      recommendedList: dto.recommendedList,
       ...(dto.defaultAnnouncement !== undefined && {
         defaultAnnouncement: dto.defaultAnnouncement,
       }),

--- a/apps/web/src/app/admin/templates/actions.ts
+++ b/apps/web/src/app/admin/templates/actions.ts
@@ -45,6 +45,7 @@ export async function createTemplateAction(
   const name = String(formData.get('name') ?? '').trim();
   const description = String(formData.get('description') ?? '').trim();
   const dontBringRaw = String(formData.get('dontBringList') ?? '');
+  const recommendedRaw = String(formData.get('recommendedList') ?? '');
   const defaultAnnouncement =
     String(formData.get('defaultAnnouncement') ?? '').trim() || null;
 
@@ -59,6 +60,10 @@ export async function createTemplateAction(
     .split('\n')
     .map((l) => l.trim())
     .filter((l) => l.length > 0);
+  const recommendedList = recommendedRaw
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
 
   if (dontBringList.length === 0) {
     return {
@@ -66,9 +71,15 @@ export async function createTemplateAction(
       message: t.templates.err_dont_bring_empty,
     };
   }
+  if (recommendedList.length === 0) {
+    return {
+      status: 'error',
+      message: t.templates.err_recommended_empty,
+    };
+  }
 
   const { error, response } = await api.POST('/templates', {
-    body: { name, description, dontBringList, defaultAnnouncement },
+    body: { name, description, dontBringList, recommendedList, defaultAnnouncement },
     headers: authHeaders(token),
   });
 

--- a/apps/web/src/app/admin/templates/create-template-form.tsx
+++ b/apps/web/src/app/admin/templates/create-template-form.tsx
@@ -68,6 +68,19 @@ export function CreateTemplateForm() {
       </FormField>
 
       <FormField
+        htmlFor="recommendedList"
+        label={t.f_recommended_label}
+      >
+        <Textarea
+          id="recommendedList"
+          name="recommendedList"
+          rows={5}
+          placeholder={t.f_recommended_ph}
+          required
+        />
+      </FormField>
+
+      <FormField
         htmlFor="defaultAnnouncement"
         label={t.f_announcement_label}
       >

--- a/apps/web/src/app/admin/templates/page.tsx
+++ b/apps/web/src/app/admin/templates/page.tsx
@@ -76,6 +76,7 @@ export default async function TemplatesPage() {
                     name={t.name}
                     description={t.description}
                     dontBringCount={t.dontBringList.length}
+                    recommendedCount={t.recommendedList.length}
                     createdAt={t.createdAt}
                     actions={<DeleteTemplateButton templateId={t.id} />}
                   />

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -140,6 +140,8 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
 
   const te = t.emergency;
   const dontList = emergency.dontBringList.length > 0 ? emergency.dontBringList : te.dont_bring_items;
+  const recommendedList =
+    emergency.recommendedList.length > 0 ? emergency.recommendedList : te.recommended_items;
   const sectionTitle = 'font-display text-base font-bold text-navy';
 
   return (
@@ -225,6 +227,27 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
                     className="flex h-[22px] w-[22px] flex-shrink-0 items-center justify-center rounded-full bg-danger-soft text-xs font-extrabold text-danger"
                   >
                     ✕
+                  </span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* Qué SÍ llevar ahora */}
+          <section aria-labelledby="bring-heading" className="flex flex-col gap-3">
+            <div>
+              <h2 id="bring-heading" className={sectionTitle}>{te.recommended_heading}</h2>
+              <p className="mt-0.5 text-[12.5px] text-muted">{te.recommended_intro}</p>
+            </div>
+            <ul className="flex flex-col gap-2.5" role="list">
+              {recommendedList.map((item) => (
+                <li key={item} className="flex items-center gap-2.5 text-sm text-ink">
+                  <span
+                    aria-hidden="true"
+                    className="flex h-[22px] w-[22px] flex-shrink-0 items-center justify-center rounded-full bg-success-soft text-xs font-extrabold text-success"
+                  >
+                    ✓
                   </span>
                   {item}
                 </li>

--- a/apps/web/src/components/molecules/template-card.tsx
+++ b/apps/web/src/components/molecules/template-card.tsx
@@ -5,6 +5,7 @@ interface TemplateCardProps {
   name: string;
   description: string;
   dontBringCount: number;
+  recommendedCount: number;
   createdAt: string;
   actions?: ReactNode;
 }
@@ -17,6 +18,7 @@ export async function TemplateCard({
   name,
   description,
   dontBringCount,
+  recommendedCount,
   createdAt,
   actions,
 }: TemplateCardProps) {
@@ -27,7 +29,11 @@ export async function TemplateCard({
         <h3 className="text-sm font-bold text-ink break-words">{name}</h3>
         <p className="text-xs text-muted break-words">{description}</p>
         <p className="text-xs text-muted-soft">
-          {t.ui.template_dont_bring_items.replace('{count}', String(dontBringCount))} · {t.ui.created}{' '}
+          {t.ui.template_dont_bring_items.replace('{count}', String(dontBringCount))}
+          {' · '}
+          {t.ui.template_recommended_items.replace('{count}', String(recommendedCount))}
+          {' · '}
+          {t.ui.created}{' '}
           <time dateTime={createdAt} suppressHydrationWarning>
             {new Date(createdAt).toLocaleDateString(locale === 'en' ? 'en-GB' : 'es-ES')}
           </time>

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -154,6 +154,16 @@ export const en = {
       'Do not go to the affected area on your own.',
     ],
 
+    // "What SHOULD bring"
+    recommended_heading: 'What to bring now',
+    recommended_intro: 'Prioritise the items that help in this stage of the emergency.',
+    recommended_items: [
+      'Clean, sealed drinking water.',
+      'Liquid diet or easy-to-digest food.',
+      'IV items, ampoules and medical material prioritised by coordination.',
+      'Basic documentation if coordination has requested it.',
+    ],
+
     actions_heading: 'How do you want to help?',
     action_offer_resource: 'Offer a resource',
     action_submit_petition: 'Submit a request',
@@ -1279,7 +1289,7 @@ export const en = {
     empty_description: 'Use the form below to create the first template.',
     new_heading: 'New template',
     create_from_heading: 'Create emergency from template',
-    inheritance_note: 'The new emergency will inherit the “what not to bring” list and the template’s default announcement.',
+    inheritance_note: 'The new emergency will inherit the “what not to bring” and “what to bring” lists, plus the template’s default announcement.',
     // Create-template form
     f_name_label: 'Template name',
     f_name_ph: 'e.g. Basic earthquake',
@@ -1287,6 +1297,8 @@ export const en = {
     f_description_ph: 'Describe when to use this template',
     f_dont_bring_label: 'What NOT to bring (one item per line)',
     f_dont_bring_ph: 'Unsorted used clothing\nUnvalidated medicines\nHomemade food',
+    f_recommended_label: 'What to bring (one item per line)',
+    f_recommended_ph: 'Drinking water\nLiquid diet\nIV items',
     f_announcement_label: 'Default announcement (optional)',
     f_announcement_ph: 'Text shown as the emergency’s initial announcement',
     f_submit: 'Create template',
@@ -1312,6 +1324,7 @@ export const en = {
     err_name_required: 'Name is required.',
     err_description_required: 'Description is required.',
     err_dont_bring_empty: 'The “what not to bring” list must have at least one item.',
+    err_recommended_empty: 'The “what to bring” list must have at least one item.',
     err_no_permission_create: 'You don’t have permission to create templates.',
     err_invalid_data: 'Invalid data. Check the fields.',
     err_create_failed: 'Couldn’t create the template. Please try again.',
@@ -1648,6 +1661,7 @@ export const en = {
     on_behalf_of: 'On whose behalf?',
     as_individual: 'As an individual',
     template_dont_bring_items: '{count} “what not to bring” items',
+    template_recommended_items: '{count} “what to bring” items',
     created: 'Created',
     search_address: 'Search address',
     address_placeholder: '123 Main St, London…',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -157,6 +157,17 @@ export const es = {
       'No acudas por tu cuenta a la zona afectada.',
     ],
 
+    // "Qué SÍ llevar"
+    recommended_heading: 'Qué SÍ llevar ahora',
+    recommended_intro:
+      'Prioriza lo que realmente ayuda en la fase actual de la emergencia.',
+    recommended_items: [
+      'Agua potable en envase limpio y cerrado.',
+      'Dieta líquida o alimentos fáciles de digerir.',
+      'Ítems EV, ampollas y material sanitario priorizado por coordinación.',
+      'Documentación básica si la coordinación la ha pedido.',
+    ],
+
     // "¿Cómo quieres colaborar?"
     actions_heading: '¿Cómo quieres colaborar?',
     action_offer_resource: 'Ofrecer un recurso',
@@ -1307,7 +1318,7 @@ export const es = {
     empty_description: 'Usa el formulario de abajo para crear la primera plantilla.',
     new_heading: 'Nueva plantilla',
     create_from_heading: 'Crear emergencia desde plantilla',
-    inheritance_note: 'La nueva emergencia heredará la lista «qué no llevar» y el comunicado por defecto de la plantilla.',
+    inheritance_note: 'La nueva emergencia heredará las listas «qué no llevar» y «qué sí llevar», además del comunicado por defecto de la plantilla.',
     // Create-template form
     f_name_label: 'Nombre de la plantilla',
     f_name_ph: 'Ej: Terremoto básico',
@@ -1315,6 +1326,8 @@ export const es = {
     f_description_ph: 'Describe cuándo usar esta plantilla',
     f_dont_bring_label: 'Qué NO llevar (una línea por ítem)',
     f_dont_bring_ph: 'Ropa usada sin clasificar\nMedicamentos sin validación\nAlimentos caseros',
+    f_recommended_label: 'Qué SÍ llevar (una línea por ítem)',
+    f_recommended_ph: 'Agua potable\nDieta líquida\nÍtems EV',
     f_announcement_label: 'Comunicado por defecto (opcional)',
     f_announcement_ph: 'Texto que aparecerá como comunicado inicial de la emergencia',
     f_submit: 'Crear plantilla',
@@ -1340,6 +1353,7 @@ export const es = {
     err_name_required: 'El nombre es obligatorio.',
     err_description_required: 'La descripción es obligatoria.',
     err_dont_bring_empty: 'La lista "qué no llevar" debe tener al menos un ítem.',
+    err_recommended_empty: 'La lista "qué sí llevar" debe tener al menos un ítem.',
     err_no_permission_create: 'No tienes permisos para crear plantillas.',
     err_invalid_data: 'Datos inválidos. Revisa los campos.',
     err_create_failed: 'Error al crear la plantilla. Inténtalo de nuevo.',
@@ -1676,6 +1690,7 @@ export const es = {
     on_behalf_of: '¿En nombre de quién?',
     as_individual: 'A título particular',
     template_dont_bring_items: '{count} ítems «qué no llevar»',
+    template_recommended_items: '{count} ítems «qué sí llevar»',
     created: 'Creada',
     search_address: 'Buscar dirección',
     address_placeholder: 'Calle Mayor 1, Madrid…',

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -1972,6 +1972,15 @@ export interface components {
             dontBringList: string[];
             /** @example No se aceptan mascotas en el centro de acopio. */
             defaultAnnouncement?: string | null;
+            /**
+             * @description Items and priorities people SHOULD bring
+             * @example [
+             *       "agua",
+             *       "dieta líquida",
+             *       "ítems EV"
+             *     ]
+             */
+            recommendedList: string[];
         };
         CreateTemplateResponseDto: {
             /** @example aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa */
@@ -1995,6 +2004,13 @@ export interface components {
             defaultAnnouncement: string | null;
             /** @example 2026-06-27T10:00:00.000Z */
             createdAt: string;
+            /**
+             * @example [
+             *       "agua",
+             *       "dieta líquida"
+             *     ]
+             */
+            recommendedList: string[];
         };
         CreateEmergencyDto: {
             /** @example Emergencia sísmica — Venezuela */
@@ -2043,6 +2059,15 @@ export interface components {
             dontBringList: string[];
             /** @example 2026-06-25T10:00:00.000Z */
             updatedAt: string;
+            /**
+             * @description Items and priorities people SHOULD bring to the emergency
+             * @example [
+             *       "agua",
+             *       "dieta líquida",
+             *       "ítems EV"
+             *     ]
+             */
+            recommendedList: string[];
         };
         CreateEmergencyFromTemplateDto: {
             /** @example aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa */


### PR DESCRIPTION
## Resumen

Añade la lista de prioridades sanitarias recomendadas en la página pública de la emergencia y actualiza la guía de qué no llevar para que el mensaje quede completo y consistente.

## Validación

- [x] Gate ejecutado en la zona tocada
- [x] Texto e i18n actualizados

## Cierre

- Closes #63
