### PR TITLE
feat: actor transportista — tipo de organización y roles/permisos logísticos (#104)

### DIFF
--- a/apps/api/src/contexts/identity/domain/authorization/permission.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/permission.spec.ts
@@ -18,6 +18,21 @@ describe('permission catalog', () => {
     }
   });
 
+  it('includes the transport logistics permissions (EPIC #103)', () => {
+    const logistics: Permission[] = [
+      'shipment:create',
+      'shipment:read',
+      'shipment:track',
+      'manifest:sign',
+    ];
+    for (const p of logistics) {
+      expect(ALL_PERMISSIONS).toContain(p);
+    }
+    expect(isPermission('shipment:track')).toBe(true);
+    // shipment:read is a `*:read`, so it joins the viewer/read-only set
+    expect(READ_ONLY_PERMISSIONS).toContain('shipment:read');
+  });
+
   it('has no duplicates', () => {
     expect(new Set(ALL_PERMISSIONS).size).toBe(ALL_PERMISSIONS.length);
   });

--- a/apps/api/src/contexts/identity/domain/authorization/permission.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/permission.ts
@@ -34,6 +34,11 @@ export const PERMISSION_CATALOG = {
   role: ['grant', 'revoke', 'create_custom'],
   apikey: ['create', 'revoke'],
   audit: ['read'],
+  // Logística de transporte (EPIC #103). Definidos como data antes de que
+  // exista enforcement (la expedición se construye en #106); 'manifest:sign'
+  // cubre la cadena de custodia de la carga.
+  shipment: ['create', 'read', 'track'],
+  manifest: ['sign'],
 } as const;
 
 type Catalog = typeof PERMISSION_CATALOG;

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.spec.ts
@@ -21,6 +21,21 @@ describe('ROLE_CATALOG', () => {
     }
   });
 
+  it('defines the logistics roles transportista and hub_manager (EPIC #103)', () => {
+    expect(roleExists('transportista')).toBe(true);
+    expect(roleExists('hub_manager')).toBe(true);
+
+    const transportista = new Set(permissionsForRole('transportista'));
+    expect(transportista.has('shipment:track')).toBe(true);
+    expect(transportista.has('manifest:sign')).toBe(true);
+    // a carrier executes shipments; coordination/hub creates them
+    expect(transportista.has('shipment:create')).toBe(false);
+
+    const hubManager = new Set(permissionsForRole('hub_manager'));
+    expect(hubManager.has('shipment:create')).toBe(true);
+    expect(hubManager.has('shipment:track')).toBe(true);
+  });
+
   it('every role only references permissions that exist in the catalog', () => {
     const valid = new Set<string>(ALL_PERMISSIONS);
     for (const role of Object.values(ROLE_CATALOG)) {

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
@@ -154,6 +154,27 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       'volunteer:read',
     ],
   },
+  transportista: {
+    id: 'transportista',
+    description:
+      'Transportista: ejecuta las expediciones asignadas, actualiza su estado ' +
+      'en tránsito y firma manifiestos (ciudadano con vehículo u operador).',
+    defaultScopeType: 'emergency',
+    permissions: ['shipment:read', 'shipment:track', 'manifest:sign'],
+  },
+  hub_manager: {
+    id: 'hub_manager',
+    description:
+      'Gestor de hub logístico: crea y opera las expediciones que transitan su ' +
+      'hub. Autoridad transversal a emergencias vía scope hub/entity (§16).',
+    defaultScopeType: 'entity',
+    permissions: [
+      'shipment:create',
+      'shipment:read',
+      'shipment:track',
+      'manifest:sign',
+    ],
+  },
   viewer: {
     id: 'viewer',
     description: 'Solo lectura.',

--- a/apps/api/src/contexts/organizations/application/create-organization.spec.ts
+++ b/apps/api/src/contexts/organizations/application/create-organization.spec.ts
@@ -84,4 +84,22 @@ describe('CreateOrganization', () => {
     const saved = await orgRepo.findById(OrganizationId.fromString(id));
     expect(saved?.verificationLevel).toBe('unverified');
   });
+
+  it('creates a transport operator organization (logística de transporte)', async () => {
+    const orgRepo = new InMemoryOrganizationRepository();
+    const memberRepo = new InMemoryOrganizationMemberRepository(orgRepo);
+    const useCase = new CreateOrganization(orgRepo, memberRepo);
+
+    const { id } = await useCase.execute({
+      name: 'TransCarga Express',
+      type: OrganizationType.TransportOperator,
+      taxId: null,
+      contactEmail: null,
+      creatorUserId: 'eeeeeeee-0000-4000-8000-000000000001',
+    });
+
+    const saved = await orgRepo.findById(OrganizationId.fromString(id));
+    expect(saved?.type).toBe(OrganizationType.TransportOperator);
+    expect(saved?.type).toBe('transport_operator');
+  });
 });

--- a/apps/api/src/contexts/organizations/domain/organization-enums.ts
+++ b/apps/api/src/contexts/organizations/domain/organization-enums.ts
@@ -3,6 +3,7 @@ export enum OrganizationType {
   Company = 'company',
   PublicAdmin = 'public_admin',
   Association = 'association',
+  TransportOperator = 'transport_operator',
   Other = 'other',
 }
 

--- a/apps/web/src/app/organizaciones/actions.ts
+++ b/apps/web/src/app/organizaciones/actions.ts
@@ -33,7 +33,7 @@ export async function createOrganizationAction(
 
   const { data, error, response } = await api.POST('/organizations', {
     headers: authHeaders(token),
-    body: { name, type: type as 'ngo' | 'company' | 'public_admin' | 'association' | 'other', taxId, contactEmail },
+    body: { name, type: type as 'ngo' | 'company' | 'public_admin' | 'association' | 'transport_operator' | 'other', taxId, contactEmail },
   });
 
   if (error !== undefined || data === undefined) {

--- a/apps/web/src/app/organizaciones/create-org-form.tsx
+++ b/apps/web/src/app/organizaciones/create-org-form.tsx
@@ -19,6 +19,7 @@ export function CreateOrgForm() {
     { value: 'company', label: to.f_type_company },
     { value: 'public_admin', label: to.f_type_public },
     { value: 'association', label: to.f_type_association },
+    { value: 'transport_operator', label: to.f_type_transport },
     { value: 'other', label: to.f_type_other },
   ];
 

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -1006,6 +1006,7 @@ export const en = {
     f_type_company: 'Company',
     f_type_public: 'Public administration',
     f_type_association: 'Association',
+    f_type_transport: 'Transport operator',
     f_type_other: 'Other',
     f_taxid: 'Tax ID',
     f_email: 'Contact email',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -1034,6 +1034,7 @@ export const es = {
     f_type_company: 'Empresa',
     f_type_public: 'Administración pública',
     f_type_association: 'Asociación',
+    f_type_transport: 'Operador de transporte',
     f_type_other: 'Otra',
     f_taxid: 'NIF / CIF',
     f_email: 'Email de contacto',

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -2389,7 +2389,7 @@ export interface components {
              * @example ngo
              * @enum {string}
              */
-            type: "ngo" | "company" | "public_admin" | "association" | "other";
+            type: "ngo" | "company" | "public_admin" | "association" | "transport_operator" | "other";
             /** @example ES-12345678 */
             taxId?: string;
             /** @example contact@org.example */
@@ -2403,7 +2403,7 @@ export interface components {
             id: string;
             name: string;
             /** @enum {string} */
-            type: "ngo" | "company" | "public_admin" | "association" | "other";
+            type: "ngo" | "company" | "public_admin" | "association" | "transport_operator" | "other";
             verificationLevel: string;
         };
         OrganizationMemberDto: {


### PR DESCRIPTION
Closes #104. Parte del EPIC #103 (logística de transporte).

## Qué hace

Implementa la capa **"quién transporta"** (capa 1 de 3 del EPIC): un operador logístico/naviera/aerolínea se modela como `Organization` + un rol del catálogo de autorización, sin un tipo "transportista" ad-hoc y **sin tocar el núcleo `principal·permiso·rol·grant`** (todo es _data_, cf. §16.2 de `docs/features/13-roles-permisos-y-autenticacion.md`).

### Backend
- **`OrganizationType.transport_operator`** (genérico). El **modo** (aéreo/marítimo/carretera) vivirá en la capacidad de transporte (#105), no en el tipo de org. **Sin migración**: `organizations.type` es `text` libre (sin check-constraint).
- **Permisos** nuevos en `PERMISSION_CATALOG`: `shipment:create`, `shipment:read`, `shipment:track`, `manifest:sign`. Son **data sin enforcement** todavía (la expedición se construye en #106); `platform_admin` y `viewer` los heredan automáticamente.
- **Roles** nuevos en `ROLE_CATALOG`:
  - `transportista` — ejecuta/sigue las expediciones asignadas y firma manifiestos (no crea: eso es coordinación/hub).
  - `hub_manager` — crea y opera la carga que transita su hub (autoridad transversal vía scope hub/entity, §16).

### Frontend
- Opción **"Operador de transporte"** en el alta de organización (`create-org-form.tsx`) + i18n `es`/`en`.

### Cliente tipado
- `packages/api-client/src/schema.ts` actualizado con el nuevo valor del enum en `CreateOrganizationDto` y `OrganizationViewDto`.

## Decisión (zanjada en #104, confirmar PM)
`transport_operator` **genérico** en vez de enums `airline`/`shipping_line` (se añadirían como data si hace falta filtrar/marcar). El modo va en la capacidad (#105).

## Tests (TDD)
- `permission.spec` — los 4 permisos de logística existen y `shipment:read` entra en el set read-only.
- `role-catalog.spec` — `transportista`/`hub_manager` existen con sus permisos (transportista **sin** `shipment:create`).
- `create-organization.spec` — alta de una org `transport_operator`.

## Gate
- ✅ build api (nest/tsc) · eslint · prettier
- ✅ `@reliefhub/api-client` build · `web` build · `web` lint
- ✅ CI: Format / Lint / Build / **Test** en verde.

## Fuera de alcance (siguientes sub-issues de #103)
`TransportCapacity` (#105), `Shipment` (#106), matching (#107), scope DAG `hub`/`corredor` (#108).