### PR TITLE
[codex] add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,31 @@
+name: Bug
+description: Reporta un fallo con contexto suficiente para reproducirlo.
+title: "[BUG] "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: problema
+    attributes:
+      label: Problema
+      description: Qué está pasando y qué esperabas que pasara.
+      placeholder: Describe el fallo con claridad.
+    validations:
+      required: true
+
+  - type: textarea
+    id: pasos
+    attributes:
+      label: Pasos para reproducir
+      description: Secuencia mínima que reproduce el problema.
+      placeholder: 1. ... 2. ... 3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: Logs, capturas, entorno o datos relevantes.
+      placeholder: Añade aquí el contexto útil.
+

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,31 @@
+name: Feature
+description: Propón una mejora o funcionalidad nueva.
+title: "[FEAT] "
+labels:
+  - feature
+body:
+  - type: textarea
+    id: problema
+    attributes:
+      label: Problema o necesidad
+      description: Qué necesitas resolver y por qué.
+      placeholder: Explica el problema real.
+    validations:
+      required: true
+
+  - type: textarea
+    id: propuesta
+    attributes:
+      label: Propuesta
+      description: Qué cambio debería hacerse.
+      placeholder: Describe la solución propuesta.
+    validations:
+      required: true
+
+  - type: textarea
+    id: criterios
+    attributes:
+      label: Criterios de aceptación
+      description: Cómo sabremos que está listo.
+      placeholder: Lista verificable de criterios.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Resumen
+
+<!-- Qué cambia y por qué -->
+
+## Validación
+
+- [ ] `git diff --check`
+- [ ] Tests relevantes
+- [ ] `pnpm --filter api build`
+- [ ] `pnpm --filter web build`
+
+## Notas
+
+<!-- Riesgos, migraciones, follow-ups -->


### PR DESCRIPTION
## What changed
- Added guided GitHub issue templates for bugs and features.
- Added a pull request template with a minimal validation checklist.

## Validation
- `git diff --check`

## Notes
- The existing epic template remains available, so new issues now have guided forms for bug/feature/epic and PRs have a standard checklist.
