### PR TITLE
feat: scope DAG logístico — tipos hub/corredor para autoridad transversal (#108)

### DIFF
--- a/apps/api/src/contexts/identity/domain/authorization/local-access-control.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/local-access-control.spec.ts
@@ -31,8 +31,8 @@ describe('LocalAccessControl', () => {
       ...valid,
       id: 'g2',
       scope: {
-        type: 'hub',
-        id: 'valencia',
+        type: 'customs_zone',
+        id: 'la-guaira',
       } as unknown as (typeof valid)['scope'],
     };
     const ctx: AuthorizationContext = {
@@ -184,6 +184,38 @@ describe('LocalAccessControl', () => {
     expect(perms.has('resource:verify')).toBe(true);
     // …and from the hub (group_manager) parent
     expect(perms.has('task:create')).toBe(true);
+  });
+
+  it('a hub_manager sees cargo transiting its hub across emergencies (§16.3 DAG)', async () => {
+    // Ana manages the Valencia hub and holds NO grant in any emergency.
+    const ctx = ctxWith(
+      Grant.create({
+        id: 'g1',
+        principalId: PRINCIPAL,
+        roleId: 'hub_manager',
+        scope: ScopeRef.hub('valencia'),
+      }),
+    );
+    // A shipment bound for the "dana" emergency that transits the Valencia hub:
+    // two DAG parents (hub + emergency).
+    const shipment = {
+      scopeChain: chain(
+        ScopeRef.entity('shipment', 's1'),
+        ScopeRef.hub('valencia'),
+        ScopeRef.emergency('dana'),
+        ScopeRef.platform(),
+      ),
+    };
+    // Authority enters via the hub parent, not the emergency.
+    await expect(ac.can(ctx, 'shipment:read', shipment)).resolves.toBe(true);
+    await expect(ac.can(ctx, 'shipment:track', shipment)).resolves.toBe(true);
+    // …but she is nothing in the emergency itself (no hub in that chain).
+    const emergencyOnly = {
+      scopeChain: chain(ScopeRef.emergency('dana'), ScopeRef.platform()),
+    };
+    await expect(ac.can(ctx, 'shipment:read', emergencyOnly)).resolves.toBe(
+      false,
+    );
   });
 
   it('effectivePermissions returns the union for a scope chain', async () => {

--- a/apps/api/src/contexts/identity/domain/authorization/scope-ref.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/scope-ref.spec.ts
@@ -30,6 +30,14 @@ describe('ScopeRef', () => {
         ),
       ).toBe(false);
     });
+    it('same-id hubs are equal; a hub and a corridor with the same id are not', () => {
+      expect(ScopeRef.hub('valencia').equals(ScopeRef.hub('valencia'))).toBe(
+        true,
+      );
+      expect(
+        ScopeRef.hub('valencia').equals(ScopeRef.corridor('valencia')),
+      ).toBe(false);
+    });
   });
 
   describe('coversAnyOf()', () => {
@@ -47,6 +55,16 @@ describe('ScopeRef', () => {
       const chain = [ScopeRef.emergency('e2'), ScopeRef.platform()];
       expect(ScopeRef.emergency('e1').coversAnyOf(chain)).toBe(false);
     });
+    it('a hub scope covers a multi-parent chain that transits it (cross-emergency)', () => {
+      const chain = [
+        ScopeRef.entity('shipment', 's1'),
+        ScopeRef.hub('valencia'),
+        ScopeRef.emergency('dana'),
+        ScopeRef.platform(),
+      ];
+      expect(ScopeRef.hub('valencia').coversAnyOf(chain)).toBe(true);
+      expect(ScopeRef.hub('barcelona').coversAnyOf(chain)).toBe(false);
+    });
   });
 
   describe('fromProps() / toPlain()', () => {
@@ -56,12 +74,24 @@ describe('ScopeRef', () => {
         true,
       );
     });
+    it('round-trips hub and corridor scopes', () => {
+      const hub = ScopeRef.hub('valencia').toPlain();
+      expect(ScopeRef.fromProps(hub).equals(ScopeRef.hub('valencia'))).toBe(
+        true,
+      );
+      const corridor = ScopeRef.corridor('caracas-valencia').toPlain();
+      expect(
+        ScopeRef.fromProps(corridor).equals(
+          ScopeRef.corridor('caracas-valencia'),
+        ),
+      ).toBe(true);
+    });
     it('throws on an empty id', () => {
       expect(() => ScopeRef.emergency('')).toThrow();
     });
     it('rejects an unknown scope type (fail-closed, never platform)', () => {
       // Grant snapshots arrive from JWTs and are not type-checked at runtime.
-      const forged = { type: 'hub', id: 'x' } as unknown as Parameters<
+      const forged = { type: 'customs_zone', id: 'x' } as unknown as Parameters<
         typeof ScopeRef.fromProps
       >[0];
       expect(() => ScopeRef.fromProps(forged)).toThrow(/unknown scope type/);

--- a/apps/api/src/contexts/identity/domain/authorization/scope-ref.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/scope-ref.ts
@@ -11,7 +11,9 @@ export type ScopeRefProps =
   | { type: 'organization'; id: string }
   | { type: 'emergency'; id: string }
   | { type: 'group'; id: string }
-  | { type: 'entity'; entityType: string; id: string };
+  | { type: 'entity'; entityType: string; id: string }
+  | { type: 'hub'; id: string }
+  | { type: 'corridor'; id: string };
 
 export type ScopeType = ScopeRefProps['type'];
 
@@ -49,6 +51,16 @@ export class ScopeRef {
     });
   }
 
+  /** Logistics hub (e.g. a port/airport) — a cross-emergency scope (§16). */
+  static hub(id: string): ScopeRef {
+    return new ScopeRef({ type: 'hub', id: requireId(id) });
+  }
+
+  /** Logistics corridor between nodes — a cross-emergency scope (§16). */
+  static corridor(id: string): ScopeRef {
+    return new ScopeRef({ type: 'corridor', id: requireId(id) });
+  }
+
   static fromProps(props: ScopeRefProps): ScopeRef {
     switch (props.type) {
       case 'platform':
@@ -61,6 +73,10 @@ export class ScopeRef {
         return ScopeRef.group(props.id);
       case 'entity':
         return ScopeRef.entity(props.entityType, props.id);
+      case 'hub':
+        return ScopeRef.hub(props.id);
+      case 'corridor':
+        return ScopeRef.corridor(props.id);
       default: {
         // Unknown scope type. The compiler proves this is unreachable for valid
         // input, but grant snapshots arrive from JWTs and are not re-validated
@@ -94,10 +110,14 @@ export class ScopeRef {
     if (
       (a.type === 'organization' ||
         a.type === 'emergency' ||
-        a.type === 'group') &&
+        a.type === 'group' ||
+        a.type === 'hub' ||
+        a.type === 'corridor') &&
       (b.type === 'organization' ||
         b.type === 'emergency' ||
-        b.type === 'group')
+        b.type === 'group' ||
+        b.type === 'hub' ||
+        b.type === 'corridor')
     ) {
       return a.id === b.id;
     }
@@ -121,9 +141,10 @@ export class ScopeRef {
 
 /**
  * The ancestor chain of a scope (the scope itself → platform). Simplified for
- * the current model, where emergencies and organizations sit directly under
- * platform; group/org nesting resolution is a later addition (docs/features/13
- * §16, §18.3-b). Platform is always the root.
+ * the current model, where emergencies, organizations and logistics
+ * hubs/corridors sit directly under platform (hubs/corridors are
+ * cross-emergency, docs/features/13 §16); group/org nesting resolution is a
+ * later addition (§18.3-b). Platform is always the root.
  */
 export function ancestorChain(scope: ScopeRefProps): ScopeRefProps[] {
   if (scope.type === 'platform') return [{ type: 'platform' }];

--- a/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-grant.repository.ts
+++ b/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-grant.repository.ts
@@ -39,6 +39,8 @@ function rowToScope(row: Row): ScopeRefProps {
     case 'organization':
     case 'emergency':
     case 'group':
+    case 'hub':
+    case 'corridor':
       if (row.scopeId === null) {
         throw new Error(
           `grant ${row.id}: scope_id is required for scope ${row.scopeType}`,


### PR DESCRIPTION
Closes #108. Parte del EPIC #103 (logística de transporte).

## Qué hace

Capa de **autorización transversal**: habilita que actores logísticos que **cruzan emergencias** (navieras, aerolíneas, hubs) tengan autoridad sobre la carga que transita su hub/corredor, **sin tocar el algoritmo `can()`** — solo se amplía el conjunto abierto de tipos de scope (§3.2/§16.3 de `docs/features/13-roles-permisos-y-autenticacion.md`).

### Dominio (`ScopeRef`)
- Nuevos tipos de scope **`hub`** y **`corridor`** en la unión abierta `ScopeRefProps`, con constructores `ScopeRef.hub(id)` / `ScopeRef.corridor(id)`, casos en `fromProps` (mantiene el `never` exhaustivo) y `equals`.
- Son **transversales**: cuelgan directamente de `platform` (cruzan emergencias).
- La **resolución DAG** ya existente (cierre transitivo de ancestros sobre `scopeChain`) los aprovecha **sin cambios**: un `hub_manager` con grant en `hub:valencia` ve un `Shipment` cuya cadena incluye `hub:valencia` **y** `emergency:dana`, **sin ser nada en esa emergencia** (ejemplo trabajado §16.3).

### Persistencia
- `drizzle-grant.repository`: `rowToScope` mapea `hub`/`corridor` al cargar (`scopeToColumns` ya los cubría por su rama `default`). Round-trip completo.

## Tests (TDD, sin DB)
- `scope-ref.spec`: `equals`, `coversAnyOf` (cadena multi-padre que transita el hub) y round-trip `fromProps` de hub/corredor.
- `local-access-control.spec`: el caso **§16.3** en el PDP (hub_manager ve carga transversal; nada en la emergencia).
- Los dos tests de **"tipo de scope desconocido"** pasan de usar `hub` (ahora conocido) a `customs_zone` (aún no implementado), conservando su intención fail-closed.

## Gate
- ✅ build api (nest/tsc — el `switch` exhaustivo de `fromProps` obliga a cubrir los tipos nuevos) · eslint · prettier
- ✅ **Tests de dominio ejecutados localmente** (config jest sin `globalSetup`): **155/155** en `identity`+`groups`, incluidos los nuevos. El suite completo con int-specs lo corre CI (no hay Postgres en el sandbox).

## Decisión (§15.10, confirmar PM)
Implementa el tipo `hub` de primera clase. La nota previa "modelar hub como `entity` mientras sirva una sola emergencia" queda **superada** para hubs transversales; un hub mono-emergencia puede seguir como `entity`/`group` si se prefiere (coexisten).

## Fuera de alcance (follow-up)
Exponer `hub`/`corridor` en el **DTO HTTP de grants** (`SCOPE_TYPES` en `grants-dto.ts`) implica `gen:api` (arranca AppModule con Postgres+Redis); se hará donde haya infra. El criterio de aceptación de #108 es a nivel PDP/dominio y queda cubierto.