### PR TITLE
feat(web): coordinación por secciones — pestañas, hub y buscador/filtros (#117)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1000,18 +1000,66 @@
               "format": "uuid",
               "type": "string"
             }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number (1-based)",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Items per page (max 100)",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          },
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Filter the queue by resource type",
+            "schema": {
+              "example": "collection_point",
+              "type": "string",
+              "enum": [
+                "collection_point",
+                "delivery_point",
+                "collection_and_delivery",
+                "warehouse",
+                "transport",
+                "supplier",
+                "venue"
+              ]
+            }
+          },
+          {
+            "name": "q",
+            "required": false,
+            "in": "query",
+            "description": "Full-text search string matched against name, address, and city (case-insensitive, max 100 chars)",
+            "schema": {
+              "example": "cruz roja",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "List of resources in queue",
+            "description": "Paged list of resources pending verification",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ResourceViewDto"
-                  }
+                  "$ref": "#/components/schemas/PagedResourcesDto"
                 }
               }
             }
@@ -1031,7 +1079,7 @@
             "bearer": []
           }
         ],
-        "summary": "Get the coordination queue for an emergency (coordinator only)",
+        "summary": "Get the verification queue for an emergency (paginated + searchable)",
         "tags": [
           "resources"
         ]
@@ -1946,6 +1994,24 @@
               "format": "uuid",
               "type": "string"
             }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Page size for pagination (1-100). Omit to return all.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "Number of items to skip (pagination). Defaults to 0.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2037,6 +2103,89 @@
           }
         },
         "summary": "List validated needs near a GPS point, ordered by distance (public, #57)",
+        "tags": [
+          "needs"
+        ]
+      }
+    },
+    "/emergencies/{emergencyId}/public/needs/in-bounds": {
+      "get": {
+        "operationId": "NeedsController_needsInBounds",
+        "parameters": [
+          {
+            "name": "emergencyId",
+            "required": true,
+            "in": "path",
+            "description": "Emergency UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "minLat",
+            "required": true,
+            "in": "query",
+            "description": "South latitude bound (-90 to 90)",
+            "schema": {
+              "example": 10.3,
+              "type": "number"
+            }
+          },
+          {
+            "name": "minLng",
+            "required": true,
+            "in": "query",
+            "description": "West longitude bound (-180 to 180)",
+            "schema": {
+              "example": -67.2,
+              "type": "number"
+            }
+          },
+          {
+            "name": "maxLat",
+            "required": true,
+            "in": "query",
+            "description": "North latitude bound (-90 to 90)",
+            "schema": {
+              "example": 10.7,
+              "type": "number"
+            }
+          },
+          {
+            "name": "maxLng",
+            "required": true,
+            "in": "query",
+            "description": "East longitude bound (-180 to 180)",
+            "schema": {
+              "example": -66.6,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Max results (default 500, max 1000)",
+            "schema": {
+              "example": 500,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Validated needs within the bounding box",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InBoundsNeedsDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "List validated needs within a geographic bounding box (public)",
         "tags": [
           "needs"
         ]
@@ -6681,6 +6830,20 @@
           "items"
         ]
       },
+      "InBoundsNeedsDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NeedViewDto"
+            }
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
       "AssignNeedManagerDto": {
         "type": "object",
         "properties": {
@@ -6862,6 +7025,7 @@
               "company",
               "public_admin",
               "association",
+              "transport_operator",
               "other"
             ],
             "example": "ngo"
@@ -6908,6 +7072,7 @@
               "company",
               "public_admin",
               "association",
+              "transport_operator",
               "other"
             ]
           },

--- a/apps/api/src/contexts/resources/application/get-coordination-queue.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-coordination-queue.spec.ts
@@ -16,15 +16,14 @@ const activeReader: ResourceEmergencyStatusReader = {
   getStatus: () => Promise.resolve('active'),
 };
 
+function makeRegister(repo: InMemoryResourceRepository): RegisterResource {
+  return new RegisterResource(repo, new FakeEventBus(), activeReader);
+}
+
 describe('GetCoordinationQueue', () => {
-  it('returns pending resources of the emergency as views', async () => {
+  it('returns pending resources of the emergency as a paged result', async () => {
     const repo = new InMemoryResourceRepository();
-    const register = new RegisterResource(
-      repo,
-      new FakeEventBus(),
-      activeReader,
-    );
-    await register.execute({
+    await makeRegister(repo).execute({
       emergencyId: EM,
       type: ResourceType.CollectionPoint,
       stage: ResourceStage.Origin,
@@ -33,17 +32,106 @@ describe('GetCoordinationQueue', () => {
       ownerUserId: 'user-coord-test',
     });
 
-    const views = await new GetCoordinationQueue(repo).execute({
+    const result = await new GetCoordinationQueue(repo).execute({
       emergencyId: EM,
     });
 
-    expect(views).toEqual([
-      expect.objectContaining({
-        name: 'Punto 1',
+    expect(result).toEqual({
+      items: [
+        expect.objectContaining({
+          name: 'Punto 1',
+          stage: ResourceStage.Origin,
+          verificationLevel: 'unverified',
+          publicStatus: 'hidden',
+        }),
+      ],
+      total: 1,
+      page: 1,
+      limit: 50,
+    });
+  });
+
+  it('paginates the queue and reports the full total', async () => {
+    const repo = new InMemoryResourceRepository();
+    const register = makeRegister(repo);
+    for (let i = 0; i < 5; i++) {
+      await register.execute({
+        emergencyId: EM,
+        type: ResourceType.CollectionPoint,
         stage: ResourceStage.Origin,
-        verificationLevel: 'unverified',
-        publicStatus: 'hidden',
-      }),
-    ]);
+        name: `Punto ${i}`,
+        location: baseLocation,
+        ownerUserId: `user-${i}`,
+      });
+    }
+
+    const page2 = await new GetCoordinationQueue(repo).execute({
+      emergencyId: EM,
+      page: 2,
+      limit: 2,
+    });
+
+    expect(page2.total).toBe(5);
+    expect(page2.page).toBe(2);
+    expect(page2.limit).toBe(2);
+    expect(page2.items).toHaveLength(2);
+  });
+
+  it('filters by free-text search over name/address/city', async () => {
+    const repo = new InMemoryResourceRepository();
+    const register = makeRegister(repo);
+    await register.execute({
+      emergencyId: EM,
+      type: ResourceType.CollectionPoint,
+      stage: ResourceStage.Origin,
+      name: 'Cruz Roja Valencia',
+      location: baseLocation,
+      ownerUserId: 'user-a',
+    });
+    await register.execute({
+      emergencyId: EM,
+      type: ResourceType.CollectionPoint,
+      stage: ResourceStage.Origin,
+      name: 'Cáritas Madrid',
+      location: baseLocation,
+      ownerUserId: 'user-b',
+    });
+
+    const result = await new GetCoordinationQueue(repo).execute({
+      emergencyId: EM,
+      q: 'cruz',
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.items[0]?.name).toBe('Cruz Roja Valencia');
+  });
+
+  it('filters by resource type', async () => {
+    const repo = new InMemoryResourceRepository();
+    const register = makeRegister(repo);
+    await register.execute({
+      emergencyId: EM,
+      type: ResourceType.CollectionPoint,
+      stage: ResourceStage.Origin,
+      name: 'Acopio',
+      location: baseLocation,
+      ownerUserId: 'user-a',
+    });
+    await register.execute({
+      emergencyId: EM,
+      type: ResourceType.Warehouse,
+      stage: ResourceStage.Intermediate,
+      name: 'Almacén central',
+      location: baseLocation,
+      ownerUserId: 'user-b',
+    });
+
+    const result = await new GetCoordinationQueue(repo).execute({
+      emergencyId: EM,
+      type: ResourceType.Warehouse,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.items[0]?.name).toBe('Almacén central');
   });
 });

--- a/apps/api/src/contexts/resources/application/get-coordination-queue.ts
+++ b/apps/api/src/contexts/resources/application/get-coordination-queue.ts
@@ -1,14 +1,42 @@
 import { ResourceRepository } from '../domain/ports/resource.repository';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
-import { ResourceView, toResourceView } from './resource-view';
+import { toResourceView } from './resource-view';
+import { PagedResourcesResult } from './get-public-resources';
 
+/**
+ * Coordination queue: the resources still pending verification for an
+ * emergency, paginated and searchable. An emergency seeded from an external
+ * import can hold hundreds of unverified points, so the queue must page and
+ * filter (type + free text) instead of returning everything at once.
+ */
 export class GetCoordinationQueue {
   constructor(private readonly repo: ResourceRepository) {}
 
-  async execute(q: { emergencyId: string }): Promise<ResourceView[]> {
-    const pending = await this.repo.findPendingByEmergency(
+  async execute(q: {
+    emergencyId: string;
+    page?: number;
+    limit?: number;
+    type?: string;
+    q?: string;
+  }): Promise<PagedResourcesResult> {
+    const page = q.page ?? 1;
+    const limit = Math.min(q.limit ?? 50, 100);
+
+    const { items, total } = await this.repo.findPendingByEmergencyPaged(
       EmergencyId.fromString(q.emergencyId),
+      {
+        page,
+        limit,
+        ...(q.type !== undefined && { type: q.type }),
+        ...(q.q !== undefined && q.q !== '' && { q: q.q }),
+      },
     );
-    return pending.map(toResourceView);
+
+    return {
+      items: items.map(toResourceView),
+      total,
+      page,
+      limit,
+    };
   }
 }

--- a/apps/api/src/contexts/resources/application/get-resource-facets.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-resource-facets.spec.ts
@@ -10,6 +10,7 @@ function makeRepo(
     save: jest.fn(),
     findById: jest.fn(),
     findPendingByEmergency: jest.fn(),
+    findPendingByEmergencyPaged: jest.fn(),
     findActiveByEmergency: jest.fn(),
     countByEmergencyGroupedByPublicStatus: jest.fn(),
     findByOwnerAndEmergency: jest.fn(),

--- a/apps/api/src/contexts/resources/domain/ports/resource.repository.ts
+++ b/apps/api/src/contexts/resources/domain/ports/resource.repository.ts
@@ -9,6 +9,21 @@ export interface ResourceRepository {
   save(resource: Resource): Promise<void>;
   findById(id: ResourceId): Promise<Resource | null>;
   findPendingByEmergency(emergencyId: EmergencyId): Promise<Resource[]>;
+  /**
+   * Paginated list of resources pending verification (unverified), optionally
+   * filtered by type and a free-text search over name/address/city. Resolves
+   * the coordination "bulk" problem when an emergency has hundreds of imported,
+   * still-unverified points.
+   */
+  findPendingByEmergencyPaged(
+    emergencyId: EmergencyId,
+    q: {
+      page: number;
+      limit: number;
+      type?: string;
+      q?: string;
+    },
+  ): Promise<{ items: Resource[]; total: number }>;
   findActiveByEmergency(emergencyId: EmergencyId): Promise<Resource[]>;
   /** Returns a count map for all PublicStatus values for the given emergency. */
   countByEmergencyGroupedByPublicStatus(

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
@@ -111,6 +111,64 @@ describe('DrizzleResourceRepository (integration)', () => {
     expect(result.map((x) => x.name)).toEqual(['P']);
   });
 
+  it('findPendingByEmergencyPaged filters by type and free text, and paginates', async () => {
+    const acopio = Resource.register({
+      id: ResourceId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      type: ResourceType.CollectionPoint,
+      stage: ResourceStage.Origin,
+      name: 'Cruz Roja Centro',
+      location: baseLocation,
+      ownerUserId: OWNER_ID,
+    });
+    const almacen = Resource.register({
+      id: ResourceId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      type: ResourceType.Warehouse,
+      stage: ResourceStage.Intermediate,
+      name: 'Almacén Cáritas',
+      location: baseLocation,
+      ownerUserId: OWNER_ID,
+    });
+    const verified = Resource.register({
+      id: ResourceId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      type: ResourceType.CollectionPoint,
+      stage: ResourceStage.Origin,
+      name: 'Cruz Roja Verificada',
+      location: baseLocation,
+      ownerUserId: OWNER_ID,
+    });
+    verified.verify(VerificationLevel.Verified, 'c1');
+    await repo.save(acopio);
+    await repo.save(almacen);
+    await repo.save(verified);
+
+    // Type filter narrows to warehouses (and never returns verified rows).
+    const byType = await repo.findPendingByEmergencyPaged(
+      EmergencyId.fromString(EM),
+      { page: 1, limit: 50, type: ResourceType.Warehouse },
+    );
+    expect(byType.total).toBe(1);
+    expect(byType.items.map((x) => x.name)).toEqual(['Almacén Cáritas']);
+
+    // Free-text search matches the still-pending "Cruz Roja Centro" only.
+    const byText = await repo.findPendingByEmergencyPaged(
+      EmergencyId.fromString(EM),
+      { page: 1, limit: 50, q: 'cruz roja' },
+    );
+    expect(byText.total).toBe(1);
+    expect(byText.items.map((x) => x.name)).toEqual(['Cruz Roja Centro']);
+
+    // Pagination reports the full pending total but returns one item per page.
+    const page1 = await repo.findPendingByEmergencyPaged(
+      EmergencyId.fromString(EM),
+      { page: 1, limit: 1 },
+    );
+    expect(page1.total).toBe(2);
+    expect(page1.items).toHaveLength(1);
+  });
+
   it('findActiveByEmergency returns only published resources and excludes them from pending', async () => {
     const active = Resource.register({
       id: ResourceId.create(),

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
@@ -261,6 +261,59 @@ export class DrizzleResourceRepository implements ResourceRepository {
     return rows.map((r) => Resource.fromSnapshot(rowToSnapshot(r)));
   }
 
+  async findPendingByEmergencyPaged(
+    emergencyId: EmergencyId,
+    q: {
+      page: number;
+      limit: number;
+      type?: string;
+      q?: string;
+    },
+  ): Promise<{ items: Resource[]; total: number }> {
+    const offset = (q.page - 1) * q.limit;
+
+    const conditions = [
+      eq(resourcesTable.emergencyId, emergencyId.value),
+      eq(resourcesTable.verificationLevel, VerificationLevel.Unverified),
+    ];
+
+    if (q.type) {
+      conditions.push(eq(resourcesTable.type, q.type));
+    }
+    if (q.q) {
+      // Escape SQL LIKE metacharacters so the user string is matched literally
+      // (mirrors findVisiblePaged). Search spans name, address and city.
+      const escaped = q.q.replace(/[%_\\]/g, (c) => `\\${c}`);
+      conditions.push(
+        sql`(${resourcesTable.name} ILIKE ${'%' + escaped + '%'} OR ${resourcesTable.address} ILIKE ${'%' + escaped + '%'} OR ${resourcesTable.city} ILIKE ${'%' + escaped + '%'})`,
+      );
+    }
+
+    const whereClause = and(...conditions);
+
+    const [rows, countRows] = await Promise.all([
+      this.db
+        .select()
+        .from(resourcesTable)
+        .where(whereClause)
+        // Same deterministic order as the public list (#58): points without
+        // contact data sink to the bottom, then by name, then id (stable paging).
+        .orderBy(
+          asc(sql`(${resourcesTable.contact} IS NULL)`),
+          asc(resourcesTable.name),
+          asc(resourcesTable.id),
+        )
+        .limit(q.limit)
+        .offset(offset),
+      this.db.select({ cnt: count() }).from(resourcesTable).where(whereClause),
+    ]);
+
+    return {
+      items: rows.map((r) => Resource.fromSnapshot(rowToSnapshot(r))),
+      total: Number(countRows[0]?.cnt ?? 0),
+    };
+  }
+
   async findActiveByEmergency(emergencyId: EmergencyId): Promise<Resource[]> {
     const rows = await this.db
       .select()

--- a/apps/api/src/contexts/resources/infrastructure/http/coordination.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/coordination.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Param,
   ParseUUIDPipe,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -16,8 +17,8 @@ import {
   ApiForbiddenResponse,
 } from '@nestjs/swagger';
 import { GetCoordinationQueue } from '../../application/get-coordination-queue';
-import { ResourceView } from '../../application/resource-view';
-import { ResourceViewDto } from './response.dto';
+import { PagedResourcesDto } from './response.dto';
+import { CoordinationQueueQueryDto } from './dto';
 import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
 import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
 import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
@@ -32,7 +33,8 @@ export class CoordinationController {
   @RequirePermission('resource:read')
   @ApiBearerAuth()
   @ApiOperation({
-    summary: 'Get the coordination queue for an emergency (coordinator only)',
+    summary:
+      'Get the verification queue for an emergency (paginated + searchable)',
   })
   @ApiParam({
     name: 'emergencyId',
@@ -40,8 +42,8 @@ export class CoordinationController {
     format: 'uuid',
   })
   @ApiOkResponse({
-    description: 'List of resources in queue',
-    type: [ResourceViewDto],
+    description: 'Paged list of resources pending verification',
+    type: PagedResourcesDto,
   })
   @ApiNotFoundResponse({ description: 'Emergency not found' })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
@@ -50,7 +52,14 @@ export class CoordinationController {
   })
   async list(
     @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
-  ): Promise<ResourceView[]> {
-    return this.queue.execute({ emergencyId });
+    @Query() query: CoordinationQueueQueryDto,
+  ): Promise<PagedResourcesDto> {
+    return this.queue.execute({
+      emergencyId,
+      page: query.page ?? 1,
+      limit: query.limit ?? 50,
+      ...(query.type !== undefined && { type: query.type }),
+      ...(query.q !== undefined && query.q !== '' && { q: query.q }),
+    });
   }
 }

--- a/apps/api/src/contexts/resources/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/dto.ts
@@ -255,6 +255,53 @@ export class InBoundsQueryDto {
   limit?: number;
 }
 
+export class CoordinationQueueQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-based)',
+    example: 1,
+    default: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({
+    description: 'Items per page (max 100)',
+    example: 50,
+    default: 50,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    enum: ResourceType,
+    description: 'Filter the queue by resource type',
+    example: ResourceType.CollectionPoint,
+  })
+  @IsOptional()
+  @IsEnum(ResourceType)
+  type?: ResourceType;
+
+  @ApiPropertyOptional({
+    description:
+      'Full-text search string matched against name, address, and city (case-insensitive, max 100 chars)',
+    example: 'cruz roja',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
+  q?: string;
+}
+
 export class PublicResourcesQueryDto {
   @ApiPropertyOptional({
     description: 'Page number (1-based)',

--- a/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
@@ -54,6 +54,49 @@ export class InMemoryResourceRepository implements ResourceRepository {
     return Promise.resolve(result);
   }
 
+  findPendingByEmergencyPaged(
+    emergencyId: EmergencyId,
+    q: {
+      page: number;
+      limit: number;
+      type?: string;
+      q?: string;
+    },
+  ): Promise<{ items: Resource[]; total: number }> {
+    let all = [...this.store.values()].filter(
+      (s) =>
+        s.emergencyId === emergencyId.value &&
+        s.verificationLevel === VerificationLevel.Unverified,
+    );
+    if (q.type) {
+      all = all.filter((s) => s.type === q.type);
+    }
+    if (q.q) {
+      const term = q.q.toLowerCase();
+      all = all.filter(
+        (s) =>
+          s.name.toLowerCase().includes(term) ||
+          s.location.address.toLowerCase().includes(term) ||
+          (s.city != null && s.city.toLowerCase().includes(term)),
+      );
+    }
+    // Deterministic order mirrors the Drizzle repo: no-contact points sink,
+    // then by name, then id.
+    all.sort((a, b) => {
+      const aNoContact = a.contact == null ? 1 : 0;
+      const bNoContact = b.contact == null ? 1 : 0;
+      if (aNoContact !== bNoContact) return aNoContact - bNoContact;
+      if (a.name !== b.name) return a.name < b.name ? -1 : 1;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+    const total = all.length;
+    const offset = (q.page - 1) * q.limit;
+    const items = all
+      .slice(offset, offset + q.limit)
+      .map((s) => Resource.fromSnapshot(s));
+    return Promise.resolve({ items, total });
+  }
+
   findActiveByEmergency(emergencyId: EmergencyId): Promise<Resource[]> {
     const result = [...this.store.values()]
       .filter(

--- a/apps/api/test/resource-flow.e2e-spec.ts
+++ b/apps/api/test/resource-flow.e2e-spec.ts
@@ -139,7 +139,9 @@ describe('Resource flow (e2e)', () => {
       .get(`/emergencies/${EM}/coordination/queue`)
       .set('Authorization', `Bearer ${coordToken}`)
       .expect(200);
-    expect(queue.body).toEqual([
+    const queueBody = queue.body as PagedResourcesBody;
+    expect(queueBody.total).toBe(1);
+    expect(queueBody.items).toEqual([
       expect.objectContaining({
         id,
         stage: 'intermediate',
@@ -165,7 +167,9 @@ describe('Resource flow (e2e)', () => {
       .get(`/emergencies/${EM}/coordination/queue`)
       .set('Authorization', `Bearer ${coordToken}`)
       .expect(200);
-    expect(afterPublish.body).toEqual([]); // no longer pending
+    const afterBody = afterPublish.body as PagedResourcesBody;
+    expect(afterBody.total).toBe(0);
+    expect(afterBody.items).toEqual([]); // no longer pending
 
     const publicResources = await request(server)
       .get(`/emergencies/${EM}/public/resources`)

--- a/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
@@ -1,12 +1,46 @@
 import type { ReactNode } from 'react';
+import { notFound, redirect } from 'next/navigation';
+import { getToken, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { getEmergencyBySlug } from '@/lib/emergencies';
+import { getMe, getRoles } from '@/lib/navigation-data';
+import {
+  resolveEmergencyAccess,
+  type EmergencyAccess,
+} from '@/lib/emergency-permissions';
+import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
 import { DashboardLayout } from '@/lib/dashboard-layout';
 import { EmergencyContextBanner } from '@/components/molecules/emergency-context-banner';
+import { CoordinationTabs } from '@/components/organisms/coordination-tabs';
+import { Badge } from '@/components/atoms/badge';
+import type { Messages } from '@/i18n/messages/es';
+
+/** Friendly per-role label, falling back to the catalog description. */
+function roleLabel(
+  roleId: string,
+  tc: Messages['coord'],
+  roleDesc: Map<string, string>,
+): string {
+  switch (roleId) {
+    case 'emergency_coordinator':
+      return tc.role_emergency_coordinator;
+    case 'emergency_verifier':
+      return tc.role_emergency_verifier;
+    case 'platform_admin':
+      return tc.role_platform_admin;
+    case 'platform_operator':
+      return tc.role_platform_operator;
+    default:
+      return roleDesc.get(roleId) ?? roleId;
+  }
+}
 
 /**
- * Wraps the coordination subtree in the dashboard shell and pins an emergency
- * context banner above it (which emergency you're operating + a way back out).
+ * Coordination shell: dashboard chrome + emergency context banner, plus the
+ * panel container, integrated header (title · emergency name · role badges) and
+ * the permission-aware sub-nav ({@link CoordinationTabs}). Every coordination
+ * page renders only its own sections inside this frame — the header and tabs no
+ * longer live in each page.
  */
 export default async function CoordinacionLayout({
   children,
@@ -16,17 +50,76 @@ export default async function CoordinacionLayout({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const { t } = await getT();
-  const emergency = await getEmergencyBySlug(slug);
 
-  const banner = emergency ? (
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/coordinacion`);
+  }
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) {
+    notFound();
+  }
+
+  const [me, roles] = await Promise.all([getMe(), getRoles()]);
+  if (me == null) {
+    await clearToken();
+    redirect(`/login?next=/e/${slug}/coordinacion`);
+  }
+
+  const access: EmergencyAccess = resolveEmergencyAccess(
+    emergency.id,
+    (me.grants ?? []) as MeGrant[],
+    roles as RoleCatalogEntry[],
+  );
+
+  const { t } = await getT();
+  const tc = t.coord;
+  const roleDesc = new Map(roles.map((r) => [r.id, r.description ?? r.id]));
+
+  const banner = (
     <EmergencyContextBanner
       name={emergency.name}
       slug={slug}
       contextLabel={t.nav.emergency_context}
       exitLabel={t.nav.exit_emergency}
     />
-  ) : undefined;
+  );
 
-  return <DashboardLayout emergencyContext={banner}>{children}</DashboardLayout>;
+  return (
+    <DashboardLayout emergencyContext={banner}>
+      <main className="flex-1 bg-surface">
+        <div className="mx-auto flex w-full max-w-md flex-col gap-8 px-5 pb-12 pt-6 lg:max-w-5xl lg:px-8">
+          <header className="flex flex-col gap-2">
+            <h1 className="font-display text-xl font-bold text-navy lg:text-2xl">
+              {tc.dashboard_title}
+            </h1>
+            <p className="text-sm text-muted">{emergency.name}</p>
+            {access.roleIds.length > 0 && (
+              <div className="mt-1 flex flex-wrap items-center gap-2">
+                <span className="text-sm text-muted">{tc.your_role_heading}</span>
+                {access.roleIds.map((rid) => (
+                  <Badge key={rid} variant="role-owner">
+                    {roleLabel(rid, tc, roleDesc)}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </header>
+
+          <CoordinationTabs
+            slug={slug}
+            access={{
+              canVerifyResources: access.canVerifyResources,
+              canValidateNeeds: access.canValidateNeeds,
+              canMatchOffers: access.canMatchOffers,
+              canCoordinate: access.canCoordinate,
+            }}
+          />
+
+          {children}
+        </div>
+      </main>
+    </DashboardLayout>
+  );
 }

--- a/apps/web/src/app/e/[slug]/coordinacion/ofertas/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/ofertas/page.tsx
@@ -1,0 +1,153 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { getMe, getRoles } from '@/lib/navigation-data';
+import {
+  resolveEmergencyAccess,
+  type EmergencyAccess,
+} from '@/lib/emergency-permissions';
+import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
+import type { components } from '@reliefhub/api-client';
+import { OffersQueue } from '@/components/organisms/coordination-queues';
+import { OffersFilter } from '@/components/molecules/offers-filter';
+import { getT } from '@/i18n/server';
+
+export const dynamic = 'force-dynamic';
+
+type OfferCategory = components['schemas']['OfferViewDto']['category'];
+type OfferStatus = components['schemas']['OfferViewDto']['status'];
+
+const VALID_CATEGORIES: OfferCategory[] = [
+  'hygiene', 'water', 'food', 'medical', 'shelter', 'tools', 'other',
+  'medicines', 'medical_equipment', 'medical_supplies', 'medical_personnel',
+];
+const VALID_STATUSES: OfferStatus[] = ['open', 'matched', 'fulfilled', 'cancelled'];
+
+type Props = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const { t } = await getT();
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) return { title: t.coord.meta_not_found };
+  return {
+    title: t.coord.offers_section_meta_title.replace('{name}', emergency.name),
+    description: t.coord.offers_section_meta_description.replace('{name}', emergency.name),
+  };
+}
+
+export default async function CoordinacionOfertasPage({
+  params,
+  searchParams,
+}: Props) {
+  const { slug } = await params;
+  const resolvedSearchParams = await searchParams;
+
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/coordinacion/ofertas`);
+  }
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) {
+    notFound();
+  }
+
+  const emergencyId = emergency.id;
+  const headers = authHeaders(token);
+
+  const [me, roles] = await Promise.all([getMe(), getRoles()]);
+  if (me == null) {
+    await clearToken();
+    redirect(`/login?next=/e/${slug}/coordinacion/ofertas`);
+  }
+
+  const access: EmergencyAccess = resolveEmergencyAccess(
+    emergencyId,
+    (me.grants ?? []) as MeGrant[],
+    roles as RoleCatalogEntry[],
+  );
+
+  // Permission gate: a principal without offer:match is bounced to the hub.
+  if (!access.canMatchOffers) {
+    redirect(`/e/${slug}/coordinacion`);
+  }
+
+  // --- Parse filter params ----------------------------------------------
+  const rawCategory =
+    typeof resolvedSearchParams.category === 'string' ? resolvedSearchParams.category : undefined;
+  const rawStatus =
+    typeof resolvedSearchParams.status === 'string' ? resolvedSearchParams.status : undefined;
+  const category = VALID_CATEGORIES.includes(rawCategory as OfferCategory)
+    ? (rawCategory as OfferCategory)
+    : undefined;
+  const status = VALID_STATUSES.includes(rawStatus as OfferStatus)
+    ? (rawStatus as OfferStatus)
+    : undefined;
+
+  const { t } = await getT();
+  const tc = t.coord;
+
+  const onUnauthorized = async (statusCode: number): Promise<void> => {
+    if (statusCode === 401) {
+      await clearToken();
+      redirect(`/login?next=/e/${slug}/coordinacion/ofertas`);
+    }
+  };
+
+  // --- Fetch the offers queue + validated needs (match targets) ---------
+  const [offersQueue, validatedNeeds] = await Promise.all([
+    api
+      .GET('/emergencies/{emergencyId}/offers/queue', {
+        params: { path: { emergencyId } },
+        headers,
+      })
+      .then(async (r) => {
+        await onUnauthorized(r.response.status);
+        if (r.response.status === 403) redirect(`/e/${slug}/coordinacion`);
+        return r.data ?? [];
+      }),
+    api
+      .GET('/emergencies/{emergencyId}/public/needs', {
+        params: { path: { emergencyId } },
+      })
+      .then((r) => r.data ?? []),
+  ]);
+
+  // Category/status filters are applied here (the queue endpoint has no
+  // filters): the offers queue is small relative to the resources queue.
+  const visibleOffers = offersQueue.filter(
+    (o) =>
+      (category === undefined || o.category === category) &&
+      (status === undefined || o.status === status),
+  );
+
+  const isFiltered = category !== undefined || status !== undefined;
+
+  return (
+    <section aria-labelledby="offers-heading" className="flex flex-col gap-5">
+      <h2 id="offers-heading" className="text-xl font-bold text-ink">
+        {tc.offers_heading}
+      </h2>
+
+      <OffersFilter />
+
+      <OffersQueue
+        offers={visibleOffers}
+        validatedNeeds={validatedNeeds}
+        slug={slug}
+        canMatch={access.canMatchOffers}
+        listLabel={tc.offers_list_label}
+        emptyTitle={isFiltered ? tc.offers_no_match_title : tc.offers_empty_title}
+        emptyDescription={
+          isFiltered ? tc.offers_no_match_description : tc.offers_empty_description
+        }
+      />
+    </section>
+  );
+}

--- a/apps/web/src/app/e/[slug]/coordinacion/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import { getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
@@ -10,21 +9,16 @@ import {
   type EmergencyAccess,
 } from '@/lib/emergency-permissions';
 import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
-import { NeedsQueue, ResourcesQueue, OffersQueue } from '@/components/organisms/coordination-queues';
-import { ExpiredNeedCard } from '@/components/organisms/expired-need-card';
 import { EmergencyControls } from '@/components/organisms/emergency-controls';
-import { NeedsFilter } from '@/components/molecules/needs-filter';
+import { CoordinationSectionLink } from '@/components/molecules/coordination-section-link';
 import { EmptyState } from '@/components/molecules/empty-state';
-import { Badge } from '@/components/atoms/badge';
 import { getT } from '@/i18n/server';
-import type { Messages } from '@/i18n/messages/es';
 
 // Always fetch live data — never serve a stale cached page.
 export const dynamic = 'force-dynamic';
 
 type Props = {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -38,37 +32,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-/** Friendly per-role label, falling back to the catalog description. */
-function roleLabel(
-  roleId: string,
-  tc: Messages['coord'],
-  roleDesc: Map<string, string>,
-): string {
-  switch (roleId) {
-    case 'emergency_coordinator':
-      return tc.role_emergency_coordinator;
-    case 'emergency_verifier':
-      return tc.role_emergency_verifier;
-    case 'platform_admin':
-      return tc.role_platform_admin;
-    case 'platform_operator':
-      return tc.role_platform_operator;
-    default:
-      return roleDesc.get(roleId) ?? roleId;
-  }
-}
-
-export default async function CoordinacionPage({ params, searchParams }: Props) {
+export default async function CoordinacionPage({ params }: Props) {
   const { slug } = await params;
-  const resolvedSearchParams = await searchParams;
 
-  // --- Auth guard -------------------------------------------------------
+  // --- Auth + emergency (frame is rendered by the layout) ---------------
   const token = await getToken();
   if (token === null) {
     redirect(`/login?next=/e/${slug}/coordinacion`);
   }
 
-  // --- Emergency resolution ---------------------------------------------
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {
     notFound();
@@ -77,7 +49,6 @@ export default async function CoordinacionPage({ params, searchParams }: Props) 
   const emergencyId = emergency.id;
   const headers = authHeaders(token);
 
-  // --- Effective permissions for THIS emergency -------------------------
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
@@ -92,26 +63,7 @@ export default async function CoordinacionPage({ params, searchParams }: Props) 
 
   const { t } = await getT();
   const tc = t.coord;
-  const roleDesc = new Map(roles.map((r) => [r.id, r.description ?? r.id]));
 
-  // --- Parse and validate need filter params ----------------------------
-  const rawCategory = typeof resolvedSearchParams.category === 'string' ? resolvedSearchParams.category : undefined;
-  const rawPriority = typeof resolvedSearchParams.priority === 'string' ? resolvedSearchParams.priority : undefined;
-
-  const VALID_CATEGORIES = [
-    'hygiene', 'water', 'food', 'medical', 'shelter', 'tools', 'other',
-    'medicines', 'medical_equipment', 'medical_supplies', 'medical_personnel',
-  ] as const;
-  const VALID_PRIORITIES = ['low', 'medium', 'high', 'urgent'] as const;
-
-  type NeedCategory = typeof VALID_CATEGORIES[number];
-  type Priority = typeof VALID_PRIORITIES[number];
-
-  const category = VALID_CATEGORIES.includes(rawCategory as NeedCategory) ? rawCategory as NeedCategory : undefined;
-  const priority = VALID_PRIORITIES.includes(rawPriority as Priority) ? rawPriority as Priority : undefined;
-
-  // On a mid-flight 401 from any authed call, drop the token and re-login.
-  // `redirect()` throws a NEXT_REDIRECT that propagates out of Promise.all.
   const onUnauthorized = async (status: number): Promise<void> => {
     if (status === 401) {
       await clearToken();
@@ -119,87 +71,104 @@ export default async function CoordinacionPage({ params, searchParams }: Props) 
     }
   };
 
-  // --- Conditionally fetch only the queues the user can act on ----------
-  const [resourceQueue, needsQueue, offersQueue, validatedNeeds, expiredNeeds] =
-    await Promise.all([
-      access.canVerifyResources
-        ? api
-            .GET('/emergencies/{emergencyId}/coordination/queue', {
-              params: { path: { emergencyId } },
-              headers,
-            })
-            .then(async (r) => {
-              await onUnauthorized(r.response.status);
-              return r.data ?? [];
-            })
-        : Promise.resolve([]),
-      access.canValidateNeeds
-        ? api
-            .GET('/emergencies/{emergencyId}/needs/queue', {
-              params: {
-                path: { emergencyId },
-                query: {
-                  ...(category !== undefined && { category }),
-                  ...(priority !== undefined && { priority }),
-                },
-              },
-              headers,
-            })
-            .then(async (r) => {
-              await onUnauthorized(r.response.status);
-              return r.data ?? [];
-            })
-        : Promise.resolve([]),
-      access.canMatchOffers
-        ? api
-            .GET('/emergencies/{emergencyId}/offers/queue', {
-              params: { path: { emergencyId } },
-              headers,
-            })
-            .then(async (r) => {
-              await onUnauthorized(r.response.status);
-              return r.data ?? [];
-            })
-        : Promise.resolve([]),
-      access.canMatchOffers
-        ? api
-            .GET('/emergencies/{emergencyId}/public/needs', {
-              params: { path: { emergencyId } },
-            })
-            .then((r) => r.data ?? [])
-        : Promise.resolve([]),
-      access.canCoordinate
-        ? api
-            .GET('/emergencies/{emergencyId}/needs/expired', {
-              params: { path: { emergencyId } },
-              headers,
-            })
-            .then(async (r) => {
-              await onUnauthorized(r.response.status);
-              return r.data ?? [];
-            })
-        : Promise.resolve([]),
-    ]);
+  // --- Pending counters for each actionable section ---------------------
+  // Resources: ask for one row only — we just need the `total`.
+  const [resourcesPending, needsPending, offersPending] = await Promise.all([
+    access.canVerifyResources
+      ? api
+          .GET('/emergencies/{emergencyId}/coordination/queue', {
+            params: { path: { emergencyId }, query: { page: 1, limit: 1 } },
+            headers,
+          })
+          .then(async (r) => {
+            await onUnauthorized(r.response.status);
+            return r.data?.total ?? 0;
+          })
+      : Promise.resolve(null),
+    access.canValidateNeeds
+      ? api
+          .GET('/emergencies/{emergencyId}/needs/queue', {
+            params: { path: { emergencyId }, query: {} },
+            headers,
+          })
+          .then(async (r) => {
+            await onUnauthorized(r.response.status);
+            return r.data?.length ?? 0;
+          })
+      : Promise.resolve(null),
+    access.canMatchOffers
+      ? api
+          .GET('/emergencies/{emergencyId}/offers/queue', {
+            params: { path: { emergencyId } },
+            headers,
+          })
+          .then(async (r) => {
+            await onUnauthorized(r.response.status);
+            return r.data?.length ?? 0;
+          })
+      : Promise.resolve(null),
+  ]);
+
+  const base = `/e/${slug}/coordinacion`;
 
   return (
-    <main className="flex-1 bg-surface">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-8 px-5 pb-12 pt-6 lg:max-w-5xl lg:px-8">
+    <>
+      {!access.canActOnAnyQueue && !access.canCoordinate && (
+        <EmptyState
+          title={tc.no_actionable_queues_title}
+          description={tc.no_actionable_queues_description}
+        />
+      )}
 
-        <header className="flex flex-col gap-2">
-          <h1 className="font-display text-xl font-bold text-navy lg:text-2xl">{tc.dashboard_title}</h1>
-          <p className="text-sm text-muted">{emergency.name}</p>
-          {access.roleIds.length > 0 && (
-            <div className="mt-1 flex flex-wrap items-center gap-2">
-              <span className="text-sm text-muted">{tc.your_role_heading}</span>
-              {access.roleIds.map((rid) => (
-                <Badge key={rid} variant="role-owner">{roleLabel(rid, tc, roleDesc)}</Badge>
-              ))}
-            </div>
+      {(access.canActOnAnyQueue || access.canCoordinate) && (
+        <section aria-label={tc.hub_sections_label} className="flex flex-col gap-4">
+          {resourcesPending !== null && (
+            <CoordinationSectionLink
+              href={`${base}/recursos`}
+              label={tc.hub_resources_label}
+              description={tc.hub_resources_description}
+              count={resourcesPending}
+              countAria={tc.hub_count_aria}
+            />
           )}
-        </header>
+          {needsPending !== null && (
+            <CoordinationSectionLink
+              href={`${base}/peticiones`}
+              label={tc.hub_needs_label}
+              description={tc.hub_needs_description}
+              count={needsPending}
+              countAria={tc.hub_count_aria}
+            />
+          )}
+          {offersPending !== null && (
+            <CoordinationSectionLink
+              href={`${base}/ofertas`}
+              label={tc.hub_offers_label}
+              description={tc.hub_offers_description}
+              count={offersPending}
+              countAria={tc.hub_count_aria}
+            />
+          )}
+          {access.canCoordinate && (
+            <>
+              <CoordinationSectionLink
+                href={`${base}/voluntarios`}
+                label={tc.hub_volunteers_label}
+                description={tc.hub_volunteers_description}
+              />
+              <CoordinationSectionLink
+                href={`${base}/reportes`}
+                label={tc.hub_reports_label}
+                description={tc.hub_reports_description}
+              />
+            </>
+          )}
+        </section>
+      )}
 
-        {/* ── CONTROLES (solo coordinación) ───────────────────────────── */}
-        {access.canCoordinate && (
+      {access.canCoordinate && (
+        <>
+          <hr className="border-line" />
           <EmergencyControls
             emergencyId={emergency.id}
             slug={slug}
@@ -210,126 +179,8 @@ export default async function CoordinacionPage({ params, searchParams }: Props) 
                 : null
             }
           />
-        )}
-
-        {/* ── ENLACES DE COORDINACIÓN (solo coordinación) ─────────────── */}
-        {access.canCoordinate && (
-          <>
-            <Link
-              href={`/e/${slug}/coordinacion/voluntarios`}
-              className="flex items-center justify-between gap-3 rounded-lg border-2 border-navy bg-white px-5 py-4 font-semibold text-ink transition-colors hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
-            >
-              <span>{tc.link_volunteers}</span>
-              <span aria-hidden="true" className="text-lg">→</span>
-            </Link>
-
-            <Link
-              href={`/e/${slug}/coordinacion/reportes`}
-              className="flex items-center justify-between gap-3 rounded-lg border-2 border-navy bg-white px-5 py-4 font-semibold text-ink transition-colors hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
-            >
-              <span>{tc.link_reports}</span>
-              <span aria-hidden="true" className="text-lg">→</span>
-            </Link>
-          </>
-        )}
-
-        {/* ── SIN COLAS ACCIONABLES ───────────────────────────────────── */}
-        {!access.canActOnAnyQueue && !access.canCoordinate && (
-          <EmptyState
-            title={tc.no_actionable_queues_title}
-            description={tc.no_actionable_queues_description}
-          />
-        )}
-
-        {/* ── RECURSOS PENDIENTES (resource:verify) ───────────────────── */}
-        {access.canVerifyResources && (
-          <>
-            <hr className="border-line" />
-            <section aria-labelledby="resources-heading" className="flex flex-col gap-4">
-              <h2 id="resources-heading" className="text-xl font-bold text-ink">
-                {tc.resources_heading}
-              </h2>
-              <ResourcesQueue
-                resources={resourceQueue}
-                slug={slug}
-                canVerify={access.canVerifyResources}
-                listLabel={tc.resources_list_label}
-                emptyTitle={tc.resources_empty_title}
-                emptyDescription={tc.resources_empty_description}
-              />
-            </section>
-          </>
-        )}
-
-        {/* ── PETICIONES PENDIENTES (need:validate) ───────────────────── */}
-        {access.canValidateNeeds && (
-          <>
-            <hr className="border-line" />
-            <section aria-labelledby="needs-heading" className="flex flex-col gap-4">
-              <h2 id="needs-heading" className="text-xl font-bold text-ink">
-                {tc.needs_heading}
-              </h2>
-              <NeedsFilter />
-              <NeedsQueue
-                needs={needsQueue}
-                slug={slug}
-                canValidate={access.canValidateNeeds}
-                listLabel={tc.needs_list_label}
-                emptyTitle={tc.needs_empty_title}
-                emptyDescription={tc.needs_empty_description}
-              />
-            </section>
-          </>
-        )}
-
-        {/* ── OFERTAS DE MATERIAL (offer:match) ───────────────────────── */}
-        {access.canMatchOffers && (
-          <>
-            <hr className="border-line" />
-            <section aria-labelledby="offers-heading" className="flex flex-col gap-4">
-              <h2 id="offers-heading" className="text-xl font-bold text-ink">
-                {tc.offers_heading}
-              </h2>
-              <OffersQueue
-                offers={offersQueue}
-                validatedNeeds={validatedNeeds}
-                slug={slug}
-                canMatch={access.canMatchOffers}
-                listLabel={tc.offers_list_label}
-                emptyTitle={tc.offers_empty_title}
-                emptyDescription={tc.offers_empty_description}
-              />
-            </section>
-          </>
-        )}
-
-        {/* ── PETICIONES CADUCADAS (solo coordinación / renovar) ──────── */}
-        {access.canCoordinate && (
-          <>
-            <hr className="border-line" />
-            <section aria-labelledby="expired-heading" className="flex flex-col gap-4">
-              <h2 id="expired-heading" className="text-xl font-bold text-ink">
-                {tc.expired_heading}
-              </h2>
-              {expiredNeeds.length === 0 ? (
-                <EmptyState
-                  title={tc.expired_empty_title}
-                  description={tc.expired_empty_description}
-                />
-              ) : (
-                <ul className="flex flex-col gap-4" aria-label={tc.expired_list_label}>
-                  {expiredNeeds.map((need) => (
-                    <li key={need.id}>
-                      <ExpiredNeedCard need={need} slug={slug} />
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </section>
-          </>
-        )}
-
-      </div>
-    </main>
+        </>
+      )}
+    </>
   );
 }

--- a/apps/web/src/app/e/[slug]/coordinacion/peticiones/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/peticiones/page.tsx
@@ -1,0 +1,203 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { getMe, getRoles } from '@/lib/navigation-data';
+import {
+  resolveEmergencyAccess,
+  type EmergencyAccess,
+} from '@/lib/emergency-permissions';
+import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
+import { NeedsQueue } from '@/components/organisms/coordination-queues';
+import { ExpiredNeedCard } from '@/components/organisms/expired-need-card';
+import { NeedsFilter } from '@/components/molecules/needs-filter';
+import { SearchBox } from '@/components/molecules/search-box';
+import { EmptyState } from '@/components/molecules/empty-state';
+import { getT } from '@/i18n/server';
+
+export const dynamic = 'force-dynamic';
+
+const VALID_CATEGORIES = [
+  'hygiene', 'water', 'food', 'medical', 'shelter', 'tools', 'other',
+  'medicines', 'medical_equipment', 'medical_supplies', 'medical_personnel',
+] as const;
+const VALID_PRIORITIES = ['low', 'medium', 'high', 'urgent'] as const;
+type NeedCategory = (typeof VALID_CATEGORIES)[number];
+type Priority = (typeof VALID_PRIORITIES)[number];
+
+type Props = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const { t } = await getT();
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) return { title: t.coord.meta_not_found };
+  return {
+    title: t.coord.needs_section_meta_title.replace('{name}', emergency.name),
+    description: t.coord.needs_section_meta_description.replace('{name}', emergency.name),
+  };
+}
+
+export default async function CoordinacionPeticionesPage({
+  params,
+  searchParams,
+}: Props) {
+  const { slug } = await params;
+  const resolvedSearchParams = await searchParams;
+
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/coordinacion/peticiones`);
+  }
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) {
+    notFound();
+  }
+
+  const emergencyId = emergency.id;
+  const headers = authHeaders(token);
+
+  const [me, roles] = await Promise.all([getMe(), getRoles()]);
+  if (me == null) {
+    await clearToken();
+    redirect(`/login?next=/e/${slug}/coordinacion/peticiones`);
+  }
+
+  const access: EmergencyAccess = resolveEmergencyAccess(
+    emergencyId,
+    (me.grants ?? []) as MeGrant[],
+    roles as RoleCatalogEntry[],
+  );
+
+  // Permission gate: a principal without need:validate is bounced to the hub.
+  if (!access.canValidateNeeds) {
+    redirect(`/e/${slug}/coordinacion`);
+  }
+
+  // --- Parse filter / search params -------------------------------------
+  const rawCategory =
+    typeof resolvedSearchParams.category === 'string' ? resolvedSearchParams.category : undefined;
+  const rawPriority =
+    typeof resolvedSearchParams.priority === 'string' ? resolvedSearchParams.priority : undefined;
+  const category = VALID_CATEGORIES.includes(rawCategory as NeedCategory)
+    ? (rawCategory as NeedCategory)
+    : undefined;
+  const priority = VALID_PRIORITIES.includes(rawPriority as Priority)
+    ? (rawPriority as Priority)
+    : undefined;
+  const q = (
+    typeof resolvedSearchParams.q === 'string' ? resolvedSearchParams.q.trim() : ''
+  )
+    .slice(0, 100)
+    .toLowerCase();
+
+  const { t } = await getT();
+  const tc = t.coord;
+
+  const onUnauthorized = async (status: number): Promise<void> => {
+    if (status === 401) {
+      await clearToken();
+      redirect(`/login?next=/e/${slug}/coordinacion/peticiones`);
+    }
+  };
+
+  // --- Fetch the validation queue + (coordinator) the expired list ------
+  const [needsQueue, expiredNeeds] = await Promise.all([
+    api
+      .GET('/emergencies/{emergencyId}/needs/queue', {
+        params: {
+          path: { emergencyId },
+          query: {
+            ...(category !== undefined && { category }),
+            ...(priority !== undefined && { priority }),
+          },
+        },
+        headers,
+      })
+      .then(async (r) => {
+        await onUnauthorized(r.response.status);
+        if (r.response.status === 403) redirect(`/e/${slug}/coordinacion`);
+        return r.data ?? [];
+      }),
+    access.canCoordinate
+      ? api
+          .GET('/emergencies/{emergencyId}/needs/expired', {
+            params: { path: { emergencyId } },
+            headers,
+          })
+          .then(async (r) => {
+            await onUnauthorized(r.response.status);
+            return r.data ?? [];
+          })
+      : Promise.resolve([]),
+  ]);
+
+  // Free-text search is applied here (the queue endpoint has no `q`): match on
+  // the need title or any requested item name.
+  const visibleNeeds =
+    q === ''
+      ? needsQueue
+      : needsQueue.filter(
+          (n) =>
+            n.title.toLowerCase().includes(q) ||
+            n.items.some((it) => it.name.toLowerCase().includes(q)),
+        );
+
+  const isFiltered = q !== '' || category !== undefined || priority !== undefined;
+
+  return (
+    <>
+      <section aria-labelledby="needs-heading" className="flex flex-col gap-5">
+        <h2 id="needs-heading" className="text-xl font-bold text-ink">
+          {tc.needs_heading}
+        </h2>
+
+        <div className="flex flex-col gap-3">
+          <SearchBox />
+          <NeedsFilter />
+        </div>
+
+        <NeedsQueue
+          needs={visibleNeeds}
+          slug={slug}
+          canValidate={access.canValidateNeeds}
+          listLabel={tc.needs_list_label}
+          emptyTitle={isFiltered ? tc.needs_no_match_title : tc.needs_empty_title}
+          emptyDescription={
+            isFiltered ? tc.needs_no_match_description : tc.needs_empty_description
+          }
+        />
+      </section>
+
+      {access.canCoordinate && (
+        <>
+          <hr className="border-line" />
+          <section aria-labelledby="expired-heading" className="flex flex-col gap-4">
+            <h2 id="expired-heading" className="text-xl font-bold text-ink">
+              {tc.expired_heading}
+            </h2>
+            {expiredNeeds.length === 0 ? (
+              <EmptyState
+                title={tc.expired_empty_title}
+                description={tc.expired_empty_description}
+              />
+            ) : (
+              <ul className="flex flex-col gap-4" aria-label={tc.expired_list_label}>
+                {expiredNeeds.map((need) => (
+                  <li key={need.id}>
+                    <ExpiredNeedCard need={need} slug={slug} />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/app/e/[slug]/coordinacion/recursos/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/recursos/page.tsx
@@ -1,0 +1,177 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { getMe, getRoles } from '@/lib/navigation-data';
+import {
+  resolveEmergencyAccess,
+  type EmergencyAccess,
+} from '@/lib/emergency-permissions';
+import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
+import { ResourcesQueue } from '@/components/organisms/coordination-queues';
+import { SearchBox } from '@/components/molecules/search-box';
+import { ResourceTypeFilter } from '@/components/molecules/resource-type-filter';
+import { Pagination } from '@/components/molecules/pagination';
+import { getT } from '@/i18n/server';
+
+export const dynamic = 'force-dynamic';
+
+const PAGE_SIZE = 20;
+
+const VALID_TYPES = [
+  'collection_point',
+  'delivery_point',
+  'collection_and_delivery',
+  'warehouse',
+  'transport',
+  'supplier',
+  'venue',
+] as const;
+type ResourceType = (typeof VALID_TYPES)[number];
+
+type Props = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const { t } = await getT();
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) return { title: t.coord.meta_not_found };
+  return {
+    title: t.coord.resources_section_meta_title.replace('{name}', emergency.name),
+    description: t.coord.resources_section_meta_description.replace(
+      '{name}',
+      emergency.name,
+    ),
+  };
+}
+
+export default async function CoordinacionRecursosPage({
+  params,
+  searchParams,
+}: Props) {
+  const { slug } = await params;
+  const resolvedSearchParams = await searchParams;
+
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/coordinacion/recursos`);
+  }
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) {
+    notFound();
+  }
+
+  const emergencyId = emergency.id;
+  const headers = authHeaders(token);
+
+  const [me, roles] = await Promise.all([getMe(), getRoles()]);
+  if (me == null) {
+    await clearToken();
+    redirect(`/login?next=/e/${slug}/coordinacion/recursos`);
+  }
+
+  const access: EmergencyAccess = resolveEmergencyAccess(
+    emergencyId,
+    (me.grants ?? []) as MeGrant[],
+    roles as RoleCatalogEntry[],
+  );
+
+  // Permission gate: a principal without resource:verify is bounced to the hub.
+  if (!access.canVerifyResources) {
+    redirect(`/e/${slug}/coordinacion`);
+  }
+
+  // --- Parse search / filter / page params ------------------------------
+  const rawQ =
+    typeof resolvedSearchParams.q === 'string' ? resolvedSearchParams.q.trim() : '';
+  const q = rawQ.slice(0, 100);
+
+  const rawType =
+    typeof resolvedSearchParams.type === 'string' ? resolvedSearchParams.type : undefined;
+  const type = VALID_TYPES.includes(rawType as ResourceType)
+    ? (rawType as ResourceType)
+    : undefined;
+
+  const rawPage =
+    typeof resolvedSearchParams.page === 'string'
+      ? Number.parseInt(resolvedSearchParams.page, 10)
+      : 1;
+  const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
+
+  const { t } = await getT();
+  const tc = t.coord;
+
+  // --- Fetch the paged verification queue -------------------------------
+  const result = await api.GET('/emergencies/{emergencyId}/coordination/queue', {
+    params: {
+      path: { emergencyId },
+      query: {
+        page,
+        limit: PAGE_SIZE,
+        ...(type !== undefined && { type }),
+        ...(q !== '' && { q }),
+      },
+    },
+    headers,
+  });
+
+  if (result.response.status === 401) {
+    await clearToken();
+    redirect(`/login?next=/e/${slug}/coordinacion/recursos`);
+  }
+  if (result.response.status === 403) {
+    redirect(`/e/${slug}/coordinacion`);
+  }
+
+  const resources = result.data?.items ?? [];
+  const total = result.data?.total ?? 0;
+  const isFiltered = q !== '' || type !== undefined;
+
+  const preserve: Record<string, string> = {
+    ...(q !== '' && { q }),
+    ...(type !== undefined && { type }),
+  };
+
+  return (
+    <section aria-labelledby="resources-heading" className="flex flex-col gap-5">
+      <h2 id="resources-heading" className="text-xl font-bold text-ink">
+        {tc.resources_heading}
+      </h2>
+
+      <div className="flex flex-col gap-3">
+        <SearchBox />
+        <ResourceTypeFilter />
+      </div>
+
+      <ResourcesQueue
+        resources={resources}
+        slug={slug}
+        canVerify={access.canVerifyResources}
+        listLabel={tc.resources_list_label}
+        emptyTitle={isFiltered ? tc.resources_no_match_title : tc.resources_empty_title}
+        emptyDescription={
+          isFiltered
+            ? tc.resources_no_match_description
+            : tc.resources_empty_description
+        }
+      />
+
+      <Pagination
+        page={page}
+        limit={PAGE_SIZE}
+        total={total}
+        preserve={preserve}
+        labels={{
+          prev: tc.pagination_prev,
+          next: tc.pagination_next,
+          summary: tc.pagination_summary,
+        }}
+      />
+    </section>
+  );
+}

--- a/apps/web/src/app/e/[slug]/coordinacion/reportes/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/reportes/page.tsx
@@ -132,110 +132,101 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
   };
 
   return (
-    <main className="flex-1 bg-surface">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-8 px-5 pb-12 pt-6 lg:max-w-5xl lg:px-8">
+    <>
+      {/* ── FILTROS ─────────────────────────────────────────────────── */}
+      <section aria-labelledby="filters-heading" className="flex flex-col gap-3">
+        <h2 id="filters-heading" className="text-sm font-semibold text-ink uppercase tracking-wide">
+          {tc.reports_filter_heading}
+        </h2>
 
-        <header className="flex flex-col gap-2">
-          <h1 className="font-display text-xl font-bold text-navy lg:text-2xl">{tc.reports_title}</h1>
-          <p className="text-sm text-muted">{emergency.name}</p>
-        </header>
-
-        {/* ── FILTROS ─────────────────────────────────────────────────── */}
-        <section aria-labelledby="filters-heading" className="flex flex-col gap-3">
-          <h2 id="filters-heading" className="text-sm font-semibold text-ink uppercase tracking-wide">
-            {tc.reports_filter_heading}
-          </h2>
-
-          <div className="flex flex-wrap gap-2">
-            {/* Status filter */}
-            <div className="flex gap-1">
+        <div className="flex flex-wrap gap-2">
+          {/* Status filter */}
+          <div className="flex gap-1">
+            <Link
+              href={baseUrl}
+              className={[
+                'rounded-lg border-2 px-3 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-1',
+                statusFilter === undefined
+                  ? 'border-navy bg-navy text-white'
+                  : 'border-line text-muted hover:border-navy hover:text-ink',
+              ].join(' ')}
+            >
+              {tc.reports_filter_all}
+            </Link>
+            {VALID_STATUSES.map((s) => (
               <Link
-                href={baseUrl}
+                key={s}
+                href={`${baseUrl}?status=${s}${priorityFilter !== undefined ? `&priority=${priorityFilter}` : ''}`}
                 className={[
                   'rounded-lg border-2 px-3 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-1',
-                  statusFilter === undefined
+                  statusFilter === s
                     ? 'border-navy bg-navy text-white'
                     : 'border-line text-muted hover:border-navy hover:text-ink',
                 ].join(' ')}
               >
-                {tc.reports_filter_all}
+                {STATUS_LABELS[s]}
               </Link>
-              {VALID_STATUSES.map((s) => (
-                <Link
-                  key={s}
-                  href={`${baseUrl}?status=${s}${priorityFilter !== undefined ? `&priority=${priorityFilter}` : ''}`}
-                  className={[
-                    'rounded-lg border-2 px-3 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-1',
-                    statusFilter === s
-                      ? 'border-navy bg-navy text-white'
-                      : 'border-line text-muted hover:border-navy hover:text-ink',
-                  ].join(' ')}
-                >
-                  {STATUS_LABELS[s]}
-                </Link>
-              ))}
-            </div>
-
-            {/* Priority filter */}
-            <div className="flex gap-1">
-              {VALID_PRIORITIES.map((p) => (
-                <Link
-                  key={p}
-                  href={`${baseUrl}?${statusFilter !== undefined ? `status=${statusFilter}&` : ''}priority=${p}`}
-                  className={[
-                    'rounded-lg border-2 px-3 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-1',
-                    priorityFilter === p
-                      ? 'border-navy bg-navy text-white'
-                      : 'border-line text-muted hover:border-navy hover:text-ink',
-                  ].join(' ')}
-                >
-                  {PRIORITY_LABELS[p]}
-                </Link>
-              ))}
-            </div>
+            ))}
           </div>
 
-          {/* Clear filters */}
-          {(statusFilter !== undefined || priorityFilter !== undefined) && (
-            <Link
-              href={baseUrl}
-              className="text-xs text-muted-soft underline underline-offset-2 hover:text-ink-soft focus:outline-none focus:ring-1 focus:ring-navy rounded w-fit"
-            >
-              {tc.reports_filter_clear}
-            </Link>
+          {/* Priority filter */}
+          <div className="flex gap-1">
+            {VALID_PRIORITIES.map((p) => (
+              <Link
+                key={p}
+                href={`${baseUrl}?${statusFilter !== undefined ? `status=${statusFilter}&` : ''}priority=${p}`}
+                className={[
+                  'rounded-lg border-2 px-3 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-1',
+                  priorityFilter === p
+                    ? 'border-navy bg-navy text-white'
+                    : 'border-line text-muted hover:border-navy hover:text-ink',
+                ].join(' ')}
+              >
+                {PRIORITY_LABELS[p]}
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        {/* Clear filters */}
+        {(statusFilter !== undefined || priorityFilter !== undefined) && (
+          <Link
+            href={baseUrl}
+            className="text-xs text-muted-soft underline underline-offset-2 hover:text-ink-soft focus:outline-none focus:ring-1 focus:ring-navy rounded w-fit"
+          >
+            {tc.reports_filter_clear}
+          </Link>
+        )}
+      </section>
+
+      <hr className="border-line" />
+
+      {/* ── LISTA DE PARTES ─────────────────────────────────────────── */}
+      <section aria-labelledby="reports-heading" className="flex flex-col gap-4">
+        <h2 id="reports-heading" className="text-xl font-bold text-ink">
+          {tc.reports_received_heading}
+          {reports.length > 0 && (
+            <span className="ml-2 text-sm font-normal text-muted">
+              ({reports.length})
+            </span>
           )}
-        </section>
+        </h2>
 
-        <hr className="border-line" />
-
-        {/* ── LISTA DE PARTES ─────────────────────────────────────────── */}
-        <section aria-labelledby="reports-heading" className="flex flex-col gap-4">
-          <h2 id="reports-heading" className="text-xl font-bold text-ink">
-            {tc.reports_received_heading}
-            {reports.length > 0 && (
-              <span className="ml-2 text-sm font-normal text-muted">
-                ({reports.length})
-              </span>
-            )}
-          </h2>
-
-          {reports.length === 0 ? (
-            <EmptyState
-              title={tc.reports_empty_title}
-              description={tc.reports_empty_description}
-            />
-          ) : (
-            <ul className="flex flex-col gap-4" aria-label={tc.reports_list_label}>
-              {reports.map((report) => (
-                <li key={report.id}>
-                  <ReportCard report={report} slug={slug} />
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-
-      </div>
-    </main>
+        {reports.length === 0 ? (
+          <EmptyState
+            title={tc.reports_empty_title}
+            description={tc.reports_empty_description}
+          />
+        ) : (
+          <ul className="flex flex-col gap-4" aria-label={tc.reports_list_label}>
+            {reports.map((report) => (
+              <li key={report.id}>
+                <ReportCard report={report} slug={slug} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </>
   );
 }

--- a/apps/web/src/app/e/[slug]/coordinacion/voluntarios/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/voluntarios/page.tsx
@@ -115,77 +115,62 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
   const tc = t.coord;
 
   return (
-    <main className="flex-1 bg-surface">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-8 px-5 pb-12 pt-6 lg:max-w-5xl lg:px-8">
+    <>
+      {/* ── ROSTER DE VOLUNTARIOS ────────────────────────────────── */}
+      <section aria-labelledby="roster-heading" className="flex flex-col gap-4">
+        <h2 id="roster-heading" className="text-xl font-bold text-ink">
+          {tc.roster_heading}
+        </h2>
 
-        <header className="flex flex-col gap-2">
-          <h1 className="font-display text-xl font-bold text-navy lg:text-2xl">{tc.volunteers_title}</h1>
-          <p className="text-sm text-muted">{emergency.name}</p>
-        </header>
+        <VolunteerRosterFilter />
 
-        {/* ── ROSTER DE VOLUNTARIOS ────────────────────────────────── */}
-        <section aria-labelledby="roster-heading" className="flex flex-col gap-4">
-          <h2
-            id="roster-heading"
-            className="text-xl font-bold text-ink"
-          >
-            {tc.roster_heading}
-          </h2>
+        {volunteers.length === 0 ? (
+          <EmptyState
+            title={tc.roster_empty_title}
+            description={tc.roster_empty_description}
+          />
+        ) : (
+          <ul className="flex flex-col gap-3" aria-label={tc.roster_list_label}>
+            {volunteers.map((volunteer) => (
+              <li key={volunteer.id}>
+                <VolunteerCard volunteer={volunteer} slug={slug} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
 
-          <VolunteerRosterFilter />
+      <hr className="border-line" />
 
-          {volunteers.length === 0 ? (
-            <EmptyState
-              title={tc.roster_empty_title}
-              description={tc.roster_empty_description}
-            />
-          ) : (
-            <ul className="flex flex-col gap-3" aria-label={tc.roster_list_label}>
-              {volunteers.map((volunteer) => (
-                <li key={volunteer.id}>
-                  <VolunteerCard volunteer={volunteer} slug={slug} />
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
+      {/* ── TAREAS ───────────────────────────────────────────────── */}
+      <section aria-labelledby="tasks-heading" className="flex flex-col gap-6">
+        <h2 id="tasks-heading" className="text-xl font-bold text-ink">
+          {tc.tasks_heading}
+        </h2>
 
-        <hr className="border-line" />
+        {/* Create task form */}
+        <CreateTaskForm emergencyId={emergencyId} slug={slug} />
 
-        {/* ── TAREAS ───────────────────────────────────────────────── */}
-        <section aria-labelledby="tasks-heading" className="flex flex-col gap-6">
-          <h2
-            id="tasks-heading"
-            className="text-xl font-bold text-ink"
-          >
-            {tc.tasks_heading}
-          </h2>
-
-          {/* Create task form */}
-          <CreateTaskForm emergencyId={emergencyId} slug={slug} />
-
-          {/* Task list */}
-          {tasks.length === 0 ? (
-            <EmptyState
-              title={tc.tasks_empty_title}
-              description={tc.tasks_empty_description}
-            />
-          ) : (
-            <ul className="flex flex-col gap-4" aria-label={tc.tasks_list_label}>
-              {tasks.map((task) => (
-                <li key={task.id}>
-                  <TaskCard
-                    task={task}
-                    availableVolunteers={availableVolunteers}
-                    slug={slug}
-                  />
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-
-      </div>
-    </main>
+        {/* Task list */}
+        {tasks.length === 0 ? (
+          <EmptyState
+            title={tc.tasks_empty_title}
+            description={tc.tasks_empty_description}
+          />
+        ) : (
+          <ul className="flex flex-col gap-4" aria-label={tc.tasks_list_label}>
+            {tasks.map((task) => (
+              <li key={task.id}>
+                <TaskCard
+                  task={task}
+                  availableVolunteers={availableVolunteers}
+                  slug={slug}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </>
   );
 }

--- a/apps/web/src/components/molecules/coordination-section-link.tsx
+++ b/apps/web/src/components/molecules/coordination-section-link.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+
+/**
+ * Hub entry for one coordination section: a full-width tap target with the
+ * section name, an optional pending-count pill and a trailing arrow. Used by the
+ * coordination landing to route into each section (Recursos, Peticiones…).
+ */
+interface CoordinationSectionLinkProps {
+  href: string;
+  label: string;
+  description?: string;
+  /** Pending count shown as a pill; omit for sections without a counter. */
+  count?: number;
+  /** Accessible suffix for the count, e.g. "pendientes". */
+  countAria?: string;
+}
+
+export function CoordinationSectionLink({
+  href,
+  label,
+  description,
+  count,
+  countAria,
+}: CoordinationSectionLinkProps) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center justify-between gap-3 rounded-lg border-2 border-navy bg-white px-5 py-4 transition-colors hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+    >
+      <span className="flex flex-col gap-0.5">
+        <span className="font-semibold text-ink">{label}</span>
+        {description != null && description !== '' && (
+          <span className="text-sm text-muted">{description}</span>
+        )}
+      </span>
+      <span className="flex shrink-0 items-center gap-3">
+        {count !== undefined && (
+          <span className="rounded-full bg-navy/10 px-2.5 py-0.5 text-sm font-bold tabular-nums text-navy">
+            {count}
+            {countAria != null && <span className="sr-only"> {countAria}</span>}
+          </span>
+        )}
+        <span aria-hidden="true" className="text-lg text-navy">
+          →
+        </span>
+      </span>
+    </Link>
+  );
+}

--- a/apps/web/src/components/molecules/offers-filter.tsx
+++ b/apps/web/src/components/molecules/offers-filter.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+/**
+ * Category + status filter for the coordination Offers queue. Drives the
+ * `category` and `status` search params; the page applies them to the fetched
+ * offers. Mirrors {@link NeedsFilter}'s URL-sync approach.
+ */
+import type { ChangeEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Select } from '@/components/atoms/select';
+import { FilterField } from '@/components/molecules/filter-field';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+const CATEGORY_VALUES = [
+  'food',
+  'water',
+  'hygiene',
+  'medical',
+  'shelter',
+  'tools',
+  'other',
+  'medicines',
+  'medical_equipment',
+  'medical_supplies',
+  'medical_personnel',
+] as const;
+
+const STATUS_VALUES = ['open', 'matched', 'fulfilled', 'cancelled'] as const;
+
+export function OffersFilter() {
+  const tc = getMessages(useLocale()).coord;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentCategory = searchParams.get('category') ?? '';
+  const currentStatus = searchParams.get('status') ?? '';
+
+  const CATEGORY_LABELS: Record<(typeof CATEGORY_VALUES)[number], string> = {
+    food: tc.category_food,
+    water: tc.category_water,
+    hygiene: tc.category_hygiene,
+    medical: tc.category_medical,
+    shelter: tc.category_shelter,
+    tools: tc.category_tools,
+    other: tc.category_other,
+    medicines: tc.category_medicines,
+    medical_equipment: tc.category_medical_equipment,
+    medical_supplies: tc.category_medical_supplies,
+    medical_personnel: tc.category_medical_personnel,
+  };
+
+  const STATUS_LABELS: Record<(typeof STATUS_VALUES)[number], string> = {
+    open: tc.offer_status_open,
+    matched: tc.offer_status_matched,
+    fulfilled: tc.offer_status_fulfilled,
+    cancelled: tc.offer_status_cancelled,
+  };
+
+  function updateParam(key: string, value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === '') params.delete(key);
+    else params.set(key, value);
+    const qs = params.toString();
+    router.replace(qs === '' ? '?' : `?${qs}`, { scroll: false });
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-3"
+      role="group"
+      aria-label={tc.offers_filter_group_label}
+    >
+      <FilterField label={tc.offers_filter_category_label}>
+        <Select
+          value={currentCategory}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+            updateParam('category', e.target.value)
+          }
+          aria-label={tc.offers_filter_category_aria}
+        >
+          <option value="">{tc.offers_filter_category_all}</option>
+          {CATEGORY_VALUES.map((value) => (
+            <option key={value} value={value}>
+              {CATEGORY_LABELS[value]}
+            </option>
+          ))}
+        </Select>
+      </FilterField>
+
+      <FilterField label={tc.offers_filter_status_label}>
+        <Select
+          value={currentStatus}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+            updateParam('status', e.target.value)
+          }
+          aria-label={tc.offers_filter_status_aria}
+        >
+          <option value="">{tc.offers_filter_status_all}</option>
+          {STATUS_VALUES.map((value) => (
+            <option key={value} value={value}>
+              {STATUS_LABELS[value]}
+            </option>
+          ))}
+        </Select>
+      </FilterField>
+    </div>
+  );
+}

--- a/apps/web/src/components/molecules/pagination.tsx
+++ b/apps/web/src/components/molecules/pagination.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link';
+
+/**
+ * Server-rendered pager. Prev/next links preserve the current filter params
+ * (e.g. `q`, `type`) and only set `page` when it is > 1, keeping page-1 URLs
+ * clean. Renders a summary line ("Página X de Y · N resultados") and hides the
+ * prev/next controls when there is a single page.
+ */
+interface PaginationProps {
+  page: number;
+  limit: number;
+  total: number;
+  /** Other query params to keep on every page link (filters/search). */
+  preserve?: Record<string, string>;
+  labels: {
+    prev: string;
+    next: string;
+    /** Template: "Página {page} de {pages} · {total} resultados". */
+    summary: string;
+  };
+}
+
+export function Pagination({
+  page,
+  limit,
+  total,
+  preserve = {},
+  labels,
+}: PaginationProps) {
+  const pages = Math.max(1, Math.ceil(total / limit));
+
+  function href(target: number): string {
+    const params = new URLSearchParams(preserve);
+    if (target > 1) params.set('page', String(target));
+    const qs = params.toString();
+    return qs === '' ? '?' : `?${qs}`;
+  }
+
+  const summary = labels.summary
+    .replace('{page}', String(page))
+    .replace('{pages}', String(pages))
+    .replace('{total}', String(total));
+
+  const linkBase =
+    'rounded-lg border-2 px-4 py-2 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-1';
+  const enabled = 'border-navy text-ink hover:bg-surface';
+  const disabled = 'pointer-events-none border-line text-muted-soft';
+
+  return (
+    <nav
+      className="flex flex-col items-center gap-3 pt-2"
+      aria-label={labels.summary.replace(/\s*·.*/, '')}
+    >
+      <p className="text-sm text-muted">{summary}</p>
+      {pages > 1 && (
+        <div className="flex items-center gap-3">
+          {page > 1 ? (
+            <Link href={href(page - 1)} className={`${linkBase} ${enabled}`} rel="prev">
+              ← {labels.prev}
+            </Link>
+          ) : (
+            <span className={`${linkBase} ${disabled}`} aria-disabled="true">
+              ← {labels.prev}
+            </span>
+          )}
+          {page < pages ? (
+            <Link href={href(page + 1)} className={`${linkBase} ${enabled}`} rel="next">
+              {labels.next} →
+            </Link>
+          ) : (
+            <span className={`${linkBase} ${disabled}`} aria-disabled="true">
+              {labels.next} →
+            </span>
+          )}
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/apps/web/src/components/molecules/resource-type-filter.tsx
+++ b/apps/web/src/components/molecules/resource-type-filter.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * Single-select filter for the resource verification queue: narrows the queue
+ * by resource type via the `type` search param. Pairs with {@link SearchBox}
+ * and pagination on the coordination Recursos page. Resets `page` on change.
+ */
+import type { ChangeEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Select } from '@/components/atoms/select';
+import { FilterField } from '@/components/molecules/filter-field';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+const TYPE_VALUES = [
+  'collection_point',
+  'delivery_point',
+  'collection_and_delivery',
+  'warehouse',
+  'transport',
+  'supplier',
+  'venue',
+] as const;
+
+export function ResourceTypeFilter() {
+  const tc = getMessages(useLocale()).coord;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = searchParams.get('type') ?? '';
+
+  const TYPE_LABELS: Record<(typeof TYPE_VALUES)[number], string> = {
+    collection_point: tc.resource_type_collection_point,
+    delivery_point: tc.resource_type_delivery_point,
+    collection_and_delivery: tc.resource_type_collection_and_delivery,
+    warehouse: tc.resource_type_warehouse,
+    transport: tc.resource_type_transport,
+    supplier: tc.resource_type_supplier,
+    venue: tc.resource_type_venue,
+  };
+
+  function onChange(e: ChangeEvent<HTMLSelectElement>) {
+    const value = e.target.value;
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === '') params.delete('type');
+    else params.set('type', value);
+    params.delete('page');
+    const qs = params.toString();
+    router.replace(qs === '' ? '?' : `?${qs}`, { scroll: false });
+  }
+
+  return (
+    <FilterField label={tc.resource_type_filter_label}>
+      <Select
+        value={current}
+        onChange={onChange}
+        aria-label={tc.resource_type_filter_aria}
+      >
+        <option value="">{tc.resource_type_filter_all}</option>
+        {TYPE_VALUES.map((value) => (
+          <option key={value} value={value}>
+            {TYPE_LABELS[value]}
+          </option>
+        ))}
+      </Select>
+    </FilterField>
+  );
+}

--- a/apps/web/src/components/molecules/search-box.tsx
+++ b/apps/web/src/components/molecules/search-box.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * URL-synced search box. Writes the trimmed query into a search param (default
+ * `q`) with a short debounce so typing doesn't fire a navigation per keystroke,
+ * and resets `page` to 1 whenever the query changes. Reads its labels from the
+ * active locale so it stays framework-i18n-consistent without prop drilling.
+ */
+import { useState, useEffect, useRef, type ChangeEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Input } from '@/components/atoms/input';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+interface SearchBoxProps {
+  /** Search param to drive. Defaults to `q`. */
+  paramKey?: string;
+}
+
+const SEARCH_ICON = (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="11" cy="11" r="7" />
+    <path d="m21 21-4.3-4.3" />
+  </svg>
+);
+
+export function SearchBox({ paramKey = 'q' }: SearchBoxProps) {
+  const tc = getMessages(useLocale()).coord;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = searchParams.get(paramKey) ?? '';
+
+  const [value, setValue] = useState(current);
+  // Track the last URL value we reconciled against so we can detect *external*
+  // changes (back/forward, a Clear elsewhere) and reflect them into the input —
+  // adjusting state during render, the React-recommended alternative to an
+  // effect (https://react.dev/learn/you-might-not-need-an-effect).
+  const [syncedValue, setSyncedValue] = useState(current);
+  if (current !== syncedValue) {
+    setSyncedValue(current);
+    setValue(current);
+  }
+
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Drop any pending debounce when unmounting.
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  function commit(next: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next === '') params.delete(paramKey);
+    else params.set(paramKey, next);
+    params.delete('page'); // a new query starts from the first page
+    const qs = params.toString();
+    router.replace(qs === '' ? '?' : `?${qs}`, { scroll: false });
+  }
+
+  function onChange(e: ChangeEvent<HTMLInputElement>) {
+    const next = e.target.value;
+    setValue(next);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => commit(next.trim()), 300);
+  }
+
+  function clear() {
+    setValue('');
+    if (timer.current) clearTimeout(timer.current);
+    commit('');
+  }
+
+  return (
+    <div className="relative w-full">
+      <Input
+        type="search"
+        value={value}
+        onChange={onChange}
+        placeholder={tc.search_placeholder}
+        aria-label={tc.search_aria}
+        icon={SEARCH_ICON}
+        className={value !== '' ? 'pr-10' : ''}
+      />
+      {value !== '' && (
+        <button
+          type="button"
+          onClick={clear}
+          aria-label={tc.search_clear}
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-soft transition-colors hover:text-ink focus:outline-none focus:ring-2 focus:ring-navy"
+        >
+          <span aria-hidden="true" className="text-lg leading-none">
+            ×
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/organisms/coordination-tabs.tsx
+++ b/apps/web/src/components/organisms/coordination-tabs.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+/**
+ * Sub-navigation for the coordination area. Renders one tab per section the
+ * principal can act on (permission-gated by the flags the server resolves with
+ * {@link resolveEmergencyAccess}). Mobile-first: a horizontally scrollable row
+ * of pills that collapses to inline tabs on wider screens. The active tab is
+ * derived from the current path and exposed via `aria-current="page"`.
+ */
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+export interface CoordinationTabsAccess {
+  canVerifyResources: boolean;
+  canValidateNeeds: boolean;
+  canMatchOffers: boolean;
+  canCoordinate: boolean;
+}
+
+interface CoordinationTabsProps {
+  slug: string;
+  access: CoordinationTabsAccess;
+}
+
+export function CoordinationTabs({ slug, access }: CoordinationTabsProps) {
+  const tc = getMessages(useLocale()).coord;
+  const pathname = usePathname();
+  const base = `/e/${slug}/coordinacion`;
+
+  const tabs: Array<{ href: string; label: string; exact: boolean }> = [
+    { href: base, label: tc.tab_overview, exact: true },
+  ];
+  if (access.canVerifyResources) {
+    tabs.push({ href: `${base}/recursos`, label: tc.tab_resources, exact: false });
+  }
+  if (access.canValidateNeeds) {
+    tabs.push({ href: `${base}/peticiones`, label: tc.tab_needs, exact: false });
+  }
+  if (access.canMatchOffers) {
+    tabs.push({ href: `${base}/ofertas`, label: tc.tab_offers, exact: false });
+  }
+  if (access.canCoordinate) {
+    tabs.push({ href: `${base}/voluntarios`, label: tc.tab_volunteers, exact: false });
+    tabs.push({ href: `${base}/reportes`, label: tc.tab_reports, exact: false });
+  }
+
+  // A lone "overview" tab means the user has no actionable section — the hub
+  // already conveys that, so the sub-nav adds nothing.
+  if (tabs.length <= 1) return null;
+
+  function isActive(href: string, exact: boolean): boolean {
+    if (exact) return pathname === href;
+    return pathname === href || pathname.startsWith(`${href}/`);
+  }
+
+  return (
+    <nav aria-label={tc.tabs_aria} className="-mx-5 lg:mx-0">
+      <ul className="flex gap-2 overflow-x-auto px-5 pb-1 lg:flex-wrap lg:px-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {tabs.map((tab) => {
+          const active = isActive(tab.href, tab.exact);
+          return (
+            <li key={tab.href} className="shrink-0">
+              <Link
+                href={tab.href}
+                aria-current={active ? 'page' : undefined}
+                className={[
+                  'inline-flex items-center rounded-full border-2 px-4 py-2 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-1',
+                  active
+                    ? 'border-navy bg-navy text-white'
+                    : 'border-line text-muted hover:border-navy hover:text-ink',
+                ].join(' ')}
+              >
+                {tab.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -1542,6 +1542,63 @@ export const en = {
       'Your role does not include validation, verification or matching permissions here.',
     queue_view_detail: 'View detail',
 
+    // ── Sub-navigation / hub / search (#117) ──────────────────────────
+    tab_overview: 'Overview',
+    tab_resources: 'Resources',
+    tab_needs: 'Requests',
+    tab_offers: 'Offers',
+    tab_volunteers: 'Volunteers',
+    tab_reports: 'Reports',
+    tabs_aria: 'Coordination sections',
+
+    hub_sections_label: 'Coordination sections',
+    hub_count_aria: 'pending',
+    hub_resources_label: 'Resources to verify',
+    hub_resources_description: 'Review and publish pending points.',
+    hub_needs_label: 'Requests to validate',
+    hub_needs_description: 'Validate incoming citizen requests.',
+    hub_offers_label: 'Material offers',
+    hub_offers_description: 'Match donor offers with validated needs.',
+    hub_volunteers_label: 'Volunteers & tasks',
+    hub_volunteers_description: 'Coordinate the roster and assign tasks.',
+    hub_reports_label: 'Field reports',
+    hub_reports_description: 'Review reports sent from the field.',
+
+    search_placeholder: 'Search…',
+    search_aria: 'Search',
+    search_clear: 'Clear search',
+
+    pagination_prev: 'Previous',
+    pagination_next: 'Next',
+    pagination_summary: 'Page {page} of {pages} · {total} results',
+
+    resource_type_filter_label: 'Type',
+    resource_type_filter_aria: 'Filter by resource type',
+    resource_type_filter_all: 'All types',
+
+    offers_filter_group_label: 'Offer filters',
+    offers_filter_category_label: 'Category',
+    offers_filter_category_aria: 'Filter by category',
+    offers_filter_category_all: 'All categories',
+    offers_filter_status_label: 'Status',
+    offers_filter_status_aria: 'Filter by status',
+    offers_filter_status_all: 'All statuses',
+
+    resources_section_meta_title: 'Resources — {name} coordination · ResponseGrid',
+    resources_section_meta_description: 'Resource verification queue for {name}.',
+    resources_no_match_title: 'No resources for this search.',
+    resources_no_match_description: 'Try different terms or change the type filter.',
+
+    needs_section_meta_title: 'Requests — {name} coordination · ResponseGrid',
+    needs_section_meta_description: 'Request validation queue for {name}.',
+    needs_no_match_title: 'No requests for this search.',
+    needs_no_match_description: 'Try different terms or adjust the filters.',
+
+    offers_section_meta_title: 'Offers — {name} coordination · ResponseGrid',
+    offers_section_meta_description: 'Material offers queue for {name}.',
+    offers_no_match_title: 'No offers for these filters.',
+    offers_no_match_description: 'Adjust the category or status to see more offers.',
+
     controls_heading: 'Emergency controls',
     controls_intake_heading: 'Intake status',
     controls_intake_paused: 'Intake paused.',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -1571,6 +1571,65 @@ export const es = {
       'Tu rol no incluye permisos de validación, verificación o asignación aquí.',
     queue_view_detail: 'Ver detalle',
 
+    // ── Sub-navegación / hub / buscador (#117) ────────────────────────
+    tab_overview: 'Resumen',
+    tab_resources: 'Recursos',
+    tab_needs: 'Peticiones',
+    tab_offers: 'Ofertas',
+    tab_volunteers: 'Voluntarios',
+    tab_reports: 'Reportes',
+    tabs_aria: 'Secciones de coordinación',
+
+    hub_sections_label: 'Secciones de coordinación',
+    hub_count_aria: 'pendientes',
+    hub_resources_label: 'Recursos por verificar',
+    hub_resources_description: 'Revisa y publica los puntos pendientes.',
+    hub_needs_label: 'Peticiones por validar',
+    hub_needs_description: 'Valida las peticiones ciudadanas entrantes.',
+    hub_offers_label: 'Ofertas de material',
+    hub_offers_description: 'Casa ofertas de donantes con necesidades validadas.',
+    hub_volunteers_label: 'Voluntarios y tareas',
+    hub_volunteers_description: 'Coordina el roster y asigna tareas.',
+    hub_reports_label: 'Reportes de campo',
+    hub_reports_description: 'Revisa los partes enviados desde el terreno.',
+
+    search_placeholder: 'Buscar…',
+    search_aria: 'Buscar',
+    search_clear: 'Limpiar búsqueda',
+
+    pagination_prev: 'Anterior',
+    pagination_next: 'Siguiente',
+    pagination_summary: 'Página {page} de {pages} · {total} resultados',
+
+    resource_type_filter_label: 'Tipo',
+    resource_type_filter_aria: 'Filtrar por tipo de recurso',
+    resource_type_filter_all: 'Todos los tipos',
+
+    offers_filter_group_label: 'Filtros de ofertas',
+    offers_filter_category_label: 'Categoría',
+    offers_filter_category_aria: 'Filtrar por categoría',
+    offers_filter_category_all: 'Todas las categorías',
+    offers_filter_status_label: 'Estado',
+    offers_filter_status_aria: 'Filtrar por estado',
+    offers_filter_status_all: 'Todos los estados',
+
+    resources_section_meta_title: 'Recursos — Coordinación de {name} · ResponseGrid',
+    resources_section_meta_description: 'Cola de verificación de recursos de {name}.',
+    resources_no_match_title: 'Sin recursos para esta búsqueda.',
+    resources_no_match_description:
+      'Prueba con otros términos o cambia el filtro de tipo.',
+
+    needs_section_meta_title: 'Peticiones — Coordinación de {name} · ResponseGrid',
+    needs_section_meta_description: 'Cola de validación de peticiones de {name}.',
+    needs_no_match_title: 'Sin peticiones para esta búsqueda.',
+    needs_no_match_description: 'Prueba con otros términos o ajusta los filtros.',
+
+    offers_section_meta_title: 'Ofertas — Coordinación de {name} · ResponseGrid',
+    offers_section_meta_description: 'Cola de ofertas de material de {name}.',
+    offers_no_match_title: 'Sin ofertas para estos filtros.',
+    offers_no_match_description:
+      'Ajusta la categoría o el estado para ver más ofertas.',
+
     controls_heading: 'Controles de la emergencia',
     controls_intake_heading: 'Estado de la recogida',
     controls_intake_paused: 'Recogida pausada.',

--- a/apps/web/src/lib/emergencies.ts
+++ b/apps/web/src/lib/emergencies.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 
@@ -7,17 +8,21 @@ export type EmergencyViewDto = components['schemas']['EmergencyViewDto'];
  * Fetch a single emergency by its URL slug.
  * Returns null when the slug does not exist (404) or on network error.
  * Must only be called from Server Components or Server Actions.
+ *
+ * Wrapped in React `cache()` so a section layout, its pages and
+ * `generateMetadata` share a single round-trip per request (the coordination
+ * layout and each sub-page both resolve the emergency by slug).
  */
-export async function getEmergencyBySlug(
-  slug: string,
-): Promise<EmergencyViewDto | null> {
-  const { data, error } = await api.GET('/emergencies/by-slug/{slug}', {
-    params: { path: { slug } },
-  });
+export const getEmergencyBySlug = cache(
+  async (slug: string): Promise<EmergencyViewDto | null> => {
+    const { data, error } = await api.GET('/emergencies/by-slug/{slug}', {
+      params: { path: { slug } },
+    });
 
-  if (error !== undefined || data === undefined) {
-    return null;
-  }
+    if (error !== undefined || data === undefined) {
+      return null;
+    }
 
-  return data;
-}
+    return data;
+  },
+);

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -371,7 +371,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get the coordination queue for an emergency (coordinator only) */
+        /** Get the verification queue for an emergency (paginated + searchable) */
         get: operations["CoordinationController_list"];
         put?: never;
         post?: never;
@@ -1961,9 +1961,6 @@ export interface components {
         InBoundsResourcesDto: {
             items: components["schemas"]["ResourceViewDto"][];
         };
-        InBoundsNeedsDto: {
-            items: components["schemas"]["NeedViewDto"][];
-        };
         ResourceFacetsDto: {
             /**
              * @example {
@@ -2387,6 +2384,9 @@ export interface components {
         };
         NearbyNeedsResponseDto: {
             items: components["schemas"]["NearbyNeedViewDto"][];
+        };
+        InBoundsNeedsDto: {
+            items: components["schemas"]["NeedViewDto"][];
         };
         AssignNeedManagerDto: {
             /**
@@ -3830,7 +3830,16 @@ export interface operations {
     };
     CoordinationController_list: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Page number (1-based) */
+                page?: number;
+                /** @description Items per page (max 100) */
+                limit?: number;
+                /** @description Filter the queue by resource type */
+                type?: "collection_point" | "delivery_point" | "collection_and_delivery" | "warehouse" | "transport" | "supplier" | "venue";
+                /** @description Full-text search string matched against name, address, and city (case-insensitive, max 100 chars) */
+                q?: string;
+            };
             header?: never;
             path: {
                 /** @description Emergency UUID */
@@ -3840,13 +3849,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description List of resources in queue */
+            /** @description Paged list of resources pending verification */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ResourceViewDto"][];
+                    "application/json": components["schemas"]["PagedResourcesDto"];
                 };
             };
             /** @description Missing or invalid token */
@@ -3968,40 +3977,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InBoundsResourcesDto"];
-                };
-            };
-        };
-    };
-    NeedsController_needsInBounds: {
-        parameters: {
-            query: {
-                /** @description South latitude bound (-90 to 90) */
-                minLat: number;
-                /** @description West longitude bound (-180 to 180) */
-                minLng: number;
-                /** @description North latitude bound (-90 to 90) */
-                maxLat: number;
-                /** @description East longitude bound (-180 to 180) */
-                maxLng: number;
-                /** @description Max results (default 500, max 1000) */
-                limit?: number;
-            };
-            header?: never;
-            path: {
-                /** @description Emergency UUID */
-                emergencyId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Validated needs within the bounding box */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InBoundsNeedsDto"];
                 };
             };
         };
@@ -4643,6 +4618,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NearbyNeedsResponseDto"];
+                };
+            };
+        };
+    };
+    NeedsController_needsInBounds: {
+        parameters: {
+            query: {
+                /** @description South latitude bound (-90 to 90) */
+                minLat: number;
+                /** @description West longitude bound (-180 to 180) */
+                minLng: number;
+                /** @description North latitude bound (-90 to 90) */
+                maxLat: number;
+                /** @description East longitude bound (-180 to 180) */
+                maxLng: number;
+                /** @description Max results (default 500, max 1000) */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Emergency UUID */
+                emergencyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Validated needs within the bounding box */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InBoundsNeedsDto"];
                 };
             };
         };


### PR DESCRIPTION
## Objetivo

Cierra #117. La página de coordinación (`/e/[slug]/coordinacion`) mostraba **todas las colas apiladas en una sola vista** (574 recursos = inmanejable). Esta PR **separa cada sección en su sub-página**, con sub-navegación por pestañas, un hub de entrada con contadores, y **buscador/filtros/paginación por sección**. Construye sobre #110.

## Web

- **Layout de coordinación** (`coordinacion/layout.tsx`): cabecera integrada (h1 «Panel de coordinación» · nombre de la emergencia · badges de rol) + `CoordinationTabs` + contenedor del panel. La cabecera deja de vivir en cada página y pasa al layout; todas las páginas renderizan solo sus secciones.
- **Hub** (`/coordinacion`): contadores de pendientes por sección (recursos por verificar · peticiones por validar · ofertas) + accesos a voluntarios/reportes + controles de la emergencia (coordinador). Estado vacío si no hay colas accionables.
- **Sub-páginas nuevas**, todas permission-aware (acceso directo sin permiso → redirige al hub):
  - `/recursos` — **buscador (`q`) + filtro por tipo + paginación** → resuelve el bulk de 574. Cola + drawer + «Verificar y publicar».
  - `/peticiones` — `NeedsFilter` (categoría/prioridad) + buscador; sección de **caducadas solo para coordinador**.
  - `/ofertas` — filtro categoría/estado. Cola + drawer.
  - `/voluntarios` y `/reportes` — entran en la sub-nav y dejan de pintar su propia cabecera.
- **Sub-navegación = pestañas** dentro del área de coordinación (scrollables en móvil), gateadas por permiso (p. ej. un verificador → solo Recursos + Peticiones).
- Componentes nuevos (Atomic Design): `SearchBox`, `Pagination`, `ResourceTypeFilter`, `OffersFilter`, `CoordinationSectionLink` (molecules) y `CoordinationTabs` (organism). Copys ES/EN en `i18n/messages/{es,en}.ts`.
- `getEmergencyBySlug` envuelto en `cache()` para que layout, páginas y `generateMetadata` compartan una sola petición por request.

## API

- **Cola de coordinación de recursos** (`GET /emergencies/{id}/coordination/queue`): ahora soporta **`q`** (búsqueda case-insensitive sobre name/address/city, escapando metacaracteres LIKE), **`type`** y **paginación** (`page`/`limit`). Devuelve `PagedResourcesDto` (`items` · `total` · `page` · `limit`) en lugar de un array plano.
- Puerto + adaptadores: `findPendingByEmergencyPaged` (Drizzle + in-memory), con el mismo orden determinista que la lista pública.
- `pnpm gen:api` → `openapi.json` + `packages/api-client/src/schema.ts` regenerados.

## Gate (local)

- `pnpm --filter api build` ✓ · `eslint --max-warnings=0` ✓ · `prettier --check` ✓ · `pnpm --filter api test` ✓ (852 tests, 128 suites)
- `pnpm --filter @reliefhub/api-client build` ✓ · `pnpm --filter web build` ✓ · `pnpm --filter web lint` ✓

## Notas

- Se actualizaron las aserciones de `resource-flow.e2e-spec.ts` al nuevo shape paginado de la cola.
- Cobertura de tests nueva: unitaria (`get-coordination-queue.spec.ts`: paginación, `q`, `type`) e integración Drizzle (filtro por tipo, búsqueda, paginación).

Closes #117