### PR TITLE
feat(auth): volver a la página de origen tras login con Google/Facebook

### DIFF
--- a/apps/api/src/contexts/identity/infrastructure/http/oauth-next.spec.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/oauth-next.spec.ts
@@ -1,0 +1,34 @@
+import { sanitizeNextPath, OAUTH_NEXT_COOKIE } from './oauth-next';
+
+describe('sanitizeNextPath', () => {
+  it('accepts internal absolute paths (with query strings)', () => {
+    expect(sanitizeNextPath('/grupos')).toBe('/grupos');
+    expect(sanitizeNextPath('/e/slug/reportar?x=1&y=2')).toBe(
+      '/e/slug/reportar?x=1&y=2',
+    );
+    expect(sanitizeNextPath('/')).toBe('/');
+  });
+
+  it('rejects absolute URLs', () => {
+    expect(sanitizeNextPath('https://evil.com')).toBeUndefined();
+    expect(sanitizeNextPath('http://evil.com/path')).toBeUndefined();
+  });
+
+  it('rejects protocol-relative and backslash tricks', () => {
+    expect(sanitizeNextPath('//evil.com')).toBeUndefined();
+    expect(sanitizeNextPath('/\\evil.com')).toBeUndefined();
+    expect(sanitizeNextPath('/\\/evil.com')).toBeUndefined();
+  });
+
+  it('rejects non-rooted paths and non-strings', () => {
+    expect(sanitizeNextPath('grupos')).toBeUndefined();
+    expect(sanitizeNextPath('')).toBeUndefined();
+    expect(sanitizeNextPath(undefined)).toBeUndefined();
+    expect(sanitizeNextPath(null)).toBeUndefined();
+    expect(sanitizeNextPath(42)).toBeUndefined();
+  });
+
+  it('exposes a stable cookie name', () => {
+    expect(OAUTH_NEXT_COOKIE).toBe('rh_oauth_next');
+  });
+});

--- a/apps/api/src/contexts/identity/infrastructure/http/oauth-next.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/oauth-next.ts
@@ -1,0 +1,28 @@
+/**
+ * Helpers for carrying the post-login "return path" (`next`) across the OAuth
+ * round-trip.
+ *
+ * A protected page sends the browser to `/login?next=/grupos`; if the user then
+ * chooses Google/Facebook, the flow bounces API → provider → API before landing
+ * back on the web app. The path can't ride on the OAuth `state` (reserved for
+ * CSRF) nor on a cookie shared with the web app (API and web live on different
+ * domains), so we stash it in a short-lived httpOnly cookie on the API side when
+ * the flow starts and read it back in the callback to build the final redirect.
+ */
+
+/** Cookie that carries the sanitized return path between initiate and callback. */
+export const OAUTH_NEXT_COOKIE = 'rh_oauth_next';
+
+/**
+ * Returns `value` only when it is a safe internal relative path; otherwise
+ * `undefined`. Guards against open-redirect attacks: absolute URLs
+ * (`https://evil.com`), protocol-relative (`//evil.com`) and backslash tricks
+ * (`/\evil.com`, which browsers fold into `//evil.com`).
+ */
+export function sanitizeNextPath(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  if (!value.startsWith('/')) return undefined;
+  if (value.startsWith('//')) return undefined;
+  if (value.includes('\\')) return undefined;
+  return value;
+}

--- a/apps/api/src/contexts/identity/infrastructure/http/oauth-state.guard.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/oauth-state.guard.ts
@@ -7,6 +7,7 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { randomUUID } from 'node:crypto';
 import type { Request, Response } from 'express';
+import { OAUTH_NEXT_COOKIE, sanitizeNextPath } from './oauth-next';
 
 /** Name of the cookie that carries the CSRF state token. */
 const STATE_COOKIE = 'rh_oauth_state';
@@ -33,21 +34,36 @@ function parseCookieHeader(
 }
 
 /**
- * Reads the OAuth CSRF state cookie from the request.
- * Prefers `req.cookies` (cookie-parser) but falls back to manual header parsing
- * since this project does NOT register cookie-parser middleware.
+ * Best-effort percent-decode. Express' `res.cookie` URL-encodes values, so the
+ * manual header parser must decode them back. Malformed sequences (rare) fall
+ * through to the raw value instead of throwing.
  */
-function readStateCookie(req: Request): string | undefined {
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Reads a cookie from the request by name.
+ * Prefers `req.cookies` (cookie-parser, already decoded) but falls back to
+ * manual header parsing — this project does NOT register cookie-parser
+ * middleware — decoding the raw value to undo Express' `res.cookie` encoding.
+ */
+export function readCookie(req: Request, name: string): string | undefined {
   // Express types `req.cookies` as `any` (cookie-parser may or may not be
   // registered). We go through `unknown` to satisfy `no-unsafe-*` lint rules.
   const cookieJar: unknown = (req as Request & { cookies?: unknown }).cookies;
   if (cookieJar !== null && typeof cookieJar === 'object') {
-    const raw: unknown = (cookieJar as Record<string, unknown>)[STATE_COOKIE];
+    const raw: unknown = (cookieJar as Record<string, unknown>)[name];
     if (typeof raw === 'string') {
       return raw;
     }
   }
-  return parseCookieHeader(req.headers.cookie, STATE_COOKIE);
+  const fromHeader = parseCookieHeader(req.headers.cookie, name);
+  return fromHeader === undefined ? undefined : safeDecode(fromHeader);
 }
 
 /**
@@ -63,16 +79,29 @@ export function OAuthInitiateGuard(
 ): new () => CanActivate {
   class MixinOAuthInitiateGuard extends AuthGuard(provider) {
     override getAuthenticateOptions(context: ExecutionContext): object {
+      const req = context.switchToHttp().getRequest<Request>();
       const res = context.switchToHttp().getResponse<Response>();
       const state = randomUUID();
 
-      res.cookie(STATE_COOKIE, state, {
+      const cookieOptions = {
         httpOnly: true,
-        sameSite: 'lax',
+        sameSite: 'lax' as const,
         path: '/auth',
         maxAge: STATE_MAX_AGE_MS,
         secure: process.env.COOKIE_SECURE === 'true',
-      });
+      };
+
+      res.cookie(STATE_COOKIE, state, cookieOptions);
+
+      // Stash the post-login return path so the callback can send the user back
+      // to the page that triggered the login. Cleared when absent or unsafe so a
+      // previous attempt's target can never leak into this one.
+      const next = sanitizeNextPath(req.query['next']);
+      if (next === undefined) {
+        res.clearCookie(OAUTH_NEXT_COOKIE, { path: '/auth' });
+      } else {
+        res.cookie(OAUTH_NEXT_COOKIE, next, cookieOptions);
+      }
 
       return { state };
     }
@@ -107,7 +136,7 @@ export function OAuthCallbackGuard(
       const stateFromQuery: string | undefined =
         typeof queryState === 'string' ? queryState : undefined;
 
-      const stateFromCookie = readStateCookie(req);
+      const stateFromCookie = readCookie(req, STATE_COOKIE);
 
       if (
         !stateFromQuery ||

--- a/apps/api/src/contexts/identity/infrastructure/http/oauth.controller.spec.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/oauth.controller.spec.ts
@@ -1,0 +1,96 @@
+import type { Request, Response } from 'express';
+import { OAuthController } from './oauth.controller';
+import { OAUTH_NEXT_COOKIE } from './oauth-next';
+
+const FRONTEND = 'https://web.test';
+
+function resMock() {
+  const calls = { redirect: [] as string[], cleared: [] as string[] };
+  const res = {
+    redirect: (url: string): void => {
+      calls.redirect.push(url);
+    },
+    clearCookie: (name: string): void => {
+      calls.cleared.push(name);
+    },
+  } as unknown as Response;
+  return { res, calls };
+}
+
+function reqMock(opts: {
+  accessToken?: string;
+  cookieHeader?: string;
+}): Request {
+  return {
+    user: opts.accessToken ? { accessToken: opts.accessToken } : undefined,
+    headers: { cookie: opts.cookieHeader },
+    query: {},
+  } as unknown as Request;
+}
+
+describe('OAuthController', () => {
+  let savedFrontend: string | undefined;
+
+  beforeAll(() => {
+    savedFrontend = process.env.FRONTEND_URL;
+    process.env.FRONTEND_URL = FRONTEND;
+  });
+
+  afterAll(() => {
+    if (savedFrontend === undefined) delete process.env.FRONTEND_URL;
+    else process.env.FRONTEND_URL = savedFrontend;
+  });
+
+  it('redirects to /auth/complete with just the token when there is no next cookie', () => {
+    const { res, calls } = resMock();
+    new OAuthController().googleCallback(
+      reqMock({ accessToken: 'jwt123' }),
+      res,
+    );
+
+    expect(calls.redirect).toEqual([`${FRONTEND}/auth/complete#token=jwt123`]);
+    expect(calls.cleared).toContain(OAUTH_NEXT_COOKIE);
+  });
+
+  it('appends the sanitized return path from the next cookie', () => {
+    const { res, calls } = resMock();
+    new OAuthController().googleCallback(
+      reqMock({
+        accessToken: 'jwt123',
+        // Express URL-encodes cookie values; the controller must decode + re-encode.
+        cookieHeader: `${OAUTH_NEXT_COOKIE}=%2Fgrupos`,
+      }),
+      res,
+    );
+
+    expect(calls.redirect).toEqual([
+      `${FRONTEND}/auth/complete#token=jwt123&next=%2Fgrupos`,
+    ]);
+  });
+
+  it('drops an open-redirect next and lands on the app root', () => {
+    const { res, calls } = resMock();
+    new OAuthController().facebookCallback(
+      reqMock({
+        accessToken: 'jwt123',
+        cookieHeader: `${OAUTH_NEXT_COOKIE}=https%3A%2F%2Fevil.com`,
+      }),
+      res,
+    );
+
+    expect(calls.redirect).toEqual([`${FRONTEND}/auth/complete#token=jwt123`]);
+  });
+
+  it('redirects to /login on a missing token, preserving next for the retry', () => {
+    const { res, calls } = resMock();
+    new OAuthController().googleCallback(
+      reqMock({ cookieHeader: `${OAUTH_NEXT_COOKIE}=%2Fgrupos` }),
+      res,
+    );
+
+    expect(calls.redirect).toEqual([
+      `${FRONTEND}/login?error=oauth_failed&next=%2Fgrupos`,
+    ]);
+    expect(calls.cleared).toContain(OAUTH_NEXT_COOKIE);
+  });
+});

--- a/apps/api/src/contexts/identity/infrastructure/http/oauth.controller.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/oauth.controller.ts
@@ -1,7 +1,12 @@
 import { Controller, Get, Req, Res, UseGuards, Logger } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
-import { OAuthInitiateGuard, OAuthCallbackGuard } from './oauth-state.guard';
+import {
+  OAuthInitiateGuard,
+  OAuthCallbackGuard,
+  readCookie,
+} from './oauth-state.guard';
+import { OAUTH_NEXT_COOKIE, sanitizeNextPath } from './oauth-next';
 
 /**
  * OAuth 2.0 redirect-based endpoints for Google and Facebook login.
@@ -41,13 +46,7 @@ export class OAuthController {
   @Get('google/callback')
   @UseGuards(OAuthCallbackGuard('google'))
   googleCallback(@Req() req: Request, @Res() res: Response): void {
-    const user = req.user as { accessToken: string } | undefined;
-    if (!user?.accessToken) {
-      this.logger.error('Google callback: no accessToken on request.user');
-      res.redirect(`${this.frontendUrl}/login?error=oauth_failed`);
-      return;
-    }
-    res.redirect(`${this.frontendUrl}/auth/complete#token=${user.accessToken}`);
+    this.finishOAuth(req, res, 'Google');
   }
 
   // ─── Facebook ─────────────────────────────────────────────────────────────
@@ -61,12 +60,30 @@ export class OAuthController {
   @Get('facebook/callback')
   @UseGuards(OAuthCallbackGuard('facebook'))
   facebookCallback(@Req() req: Request, @Res() res: Response): void {
+    this.finishOAuth(req, res, 'Facebook');
+  }
+
+  // ─── Shared ───────────────────────────────────────────────────────────────
+
+  /**
+   * Completes any OAuth callback: consumes the stashed `next` cookie and sends
+   * the browser back to the frontend — to `/auth/complete` with the token on
+   * success, or to `/login` on failure — preserving the return path so the user
+   * lands on the page that started the login.
+   */
+  private finishOAuth(req: Request, res: Response, provider: string): void {
+    const next = sanitizeNextPath(readCookie(req, OAUTH_NEXT_COOKIE));
+    res.clearCookie(OAUTH_NEXT_COOKIE, { path: '/auth' });
+    const nextParam = next ? `&next=${encodeURIComponent(next)}` : '';
+
     const user = req.user as { accessToken: string } | undefined;
     if (!user?.accessToken) {
-      this.logger.error('Facebook callback: no accessToken on request.user');
-      res.redirect(`${this.frontendUrl}/login?error=oauth_failed`);
+      this.logger.error(`${provider} callback: no accessToken on request.user`);
+      res.redirect(`${this.frontendUrl}/login?error=oauth_failed${nextParam}`);
       return;
     }
-    res.redirect(`${this.frontendUrl}/auth/complete#token=${user.accessToken}`);
+    res.redirect(
+      `${this.frontendUrl}/auth/complete#token=${user.accessToken}${nextParam}`,
+    );
   }
 }

--- a/apps/web/src/app/auth/complete/actions.ts
+++ b/apps/web/src/app/auth/complete/actions.ts
@@ -2,15 +2,20 @@
 
 import { redirect } from 'next/navigation';
 import { setToken } from '@/lib/auth';
+import { safeNextPath } from '@/lib/safe-next';
 
 /**
  * Receives the JWT token that arrived in the URL fragment after OAuth callback,
- * stores it as an httpOnly cookie, then redirects to the app root.
+ * stores it as an httpOnly cookie, then redirects to `next` — the page that
+ * originally sent the user to login — falling back to the app root.
  */
-export async function completeOAuthAction(token: string): Promise<never> {
+export async function completeOAuthAction(
+  token: string,
+  next?: string,
+): Promise<never> {
   if (!token || typeof token !== 'string' || token.trim() === '') {
     redirect('/login?error=oauth_failed');
   }
   await setToken(token.trim());
-  redirect('/');
+  redirect(safeNextPath(next) ?? '/');
 }

--- a/apps/web/src/app/auth/complete/page.tsx
+++ b/apps/web/src/app/auth/complete/page.tsx
@@ -9,11 +9,13 @@ import { completeOAuthAction } from './actions';
 /**
  * Landing page after OAuth redirect.
  *
- * The backend sends the browser here with the JWT in the URL fragment:
- *   /auth/complete#token=<jwt>
+ * The backend sends the browser here with the JWT in the URL fragment, plus an
+ * optional return path:
+ *   /auth/complete#token=<jwt>&next=<path>
  *
- * Fragments are never sent to the server, so we read it client-side and
- * pass it to a Server Action that stores it in an httpOnly cookie.
+ * Fragments are never sent to the server, so we read them client-side and
+ * pass them to a Server Action that stores the token in an httpOnly cookie and
+ * redirects to `next` (the page that originally triggered the login).
  */
 export default function AuthCompletePage() {
   const t = getMessages(useLocale()).auth_complete;
@@ -23,17 +25,18 @@ export default function AuthCompletePage() {
     if (done.current) return;
     done.current = true;
 
-    const hash = window.location.hash; // e.g. "#token=eyJ..."
+    const hash = window.location.hash; // e.g. "#token=eyJ...&next=%2Fgrupos"
     const params = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
     const token = params.get('token');
+    const next = params.get('next');
 
     if (!token) {
       window.location.replace('/login?error=oauth_failed');
       return;
     }
 
-    // Call the Server Action — it will set the cookie and redirect to /
-    void completeOAuthAction(token);
+    // Call the Server Action — it sets the cookie and redirects to `next` (or /).
+    void completeOAuthAction(token, next ?? undefined);
   }, []);
 
   return (

--- a/apps/web/src/app/login/actions.ts
+++ b/apps/web/src/app/login/actions.ts
@@ -3,6 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import { setToken } from '@/lib/auth';
+import { safeNextPath } from '@/lib/safe-next';
 import { getT } from '@/i18n/server';
 
 export type LoginResult =
@@ -27,11 +28,6 @@ export async function loginAction(
   }
 
   await setToken(data.accessToken);
-  // Sanitize the redirect target: only allow internal relative paths to prevent
-  // open redirect attacks (e.g. ?next=https://evil.com or ?next=//evil.com).
-  const safe =
-    typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')
-      ? next
-      : '/panel';
-  redirect(safe);
+  // Only allow internal relative paths (prevents open-redirect attacks).
+  redirect(safeNextPath(next) ?? '/panel');
 }

--- a/apps/web/src/app/signup/actions.ts
+++ b/apps/web/src/app/signup/actions.ts
@@ -3,6 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import { setToken } from '@/lib/auth';
+import { safeNextPath } from '@/lib/safe-next';
 import { getT } from '@/i18n/server';
 
 export type SignupResult =
@@ -47,11 +48,6 @@ export async function signupAction(
   }
 
   await setToken(data.accessToken);
-  // Sanitize the redirect target: only allow internal relative paths to prevent
-  // open redirect attacks (e.g. ?next=https://evil.com or ?next=//evil.com).
-  const safe =
-    typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')
-      ? next
-      : '/';
-  redirect(safe);
+  // Only allow internal relative paths (prevents open-redirect attacks).
+  redirect(safeNextPath(next) ?? '/');
 }

--- a/apps/web/src/components/molecules/social-login-buttons.tsx
+++ b/apps/web/src/components/molecules/social-login-buttons.tsx
@@ -2,12 +2,21 @@
 
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
+import { safeNextPath } from '@/lib/safe-next';
 
 const API_URL =
   process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000';
 
-export function SocialLoginButtons() {
+interface SocialLoginButtonsProps {
+  /** Path to return to after login; forwarded to the API so OAuth lands back there. */
+  next?: string;
+}
+
+export function SocialLoginButtons({ next }: SocialLoginButtonsProps) {
   const t = getMessages(useLocale()).ui;
+  // Carry the return path through the OAuth round-trip; drop unsafe values.
+  const safe = safeNextPath(next);
+  const nextQuery = safe ? `?next=${encodeURIComponent(safe)}` : '';
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center gap-3">
@@ -18,7 +27,7 @@ export function SocialLoginButtons() {
 
       {/* Google */}
       <a
-        href={`${API_URL}/auth/google`}
+        href={`${API_URL}/auth/google${nextQuery}`}
         className="flex items-center justify-center gap-3 w-full rounded-lg border border-line bg-white px-4 py-2.5 text-sm font-medium text-ink-soft hover:bg-surface transition-colors"
       >
         <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
@@ -44,7 +53,7 @@ export function SocialLoginButtons() {
 
       {/* Facebook */}
       <a
-        href={`${API_URL}/auth/facebook`}
+        href={`${API_URL}/auth/facebook${nextQuery}`}
         className="flex items-center justify-center gap-3 w-full rounded-lg border border-line bg-white px-4 py-2.5 text-sm font-medium text-ink-soft hover:bg-surface transition-colors"
       >
         <svg className="w-5 h-5 text-[#1877F2]" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/apps/web/src/components/organisms/login-form.tsx
+++ b/apps/web/src/components/organisms/login-form.tsx
@@ -62,7 +62,7 @@ export function LoginForm({ next, t }: LoginFormProps) {
         </Button>
       </form>
 
-      <SocialLoginButtons />
+      <SocialLoginButtons next={next} />
 
       <p className="text-center text-sm text-muted">
         {t.no_account}{' '}

--- a/apps/web/src/components/organisms/signup-form.tsx
+++ b/apps/web/src/components/organisms/signup-form.tsx
@@ -79,7 +79,7 @@ export function SignupForm({ next, t }: SignupFormProps) {
         </Button>
       </form>
 
-      <SocialLoginButtons />
+      <SocialLoginButtons next={next} />
 
       <p className="text-center text-sm text-muted">
         {t.already_account}{' '}

--- a/apps/web/src/lib/safe-next.ts
+++ b/apps/web/src/lib/safe-next.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns `value` only when it is a safe internal relative path; otherwise
+ * `null`. Centralizes the post-login redirect sanitization so every entry point
+ * (email/password login, signup, OAuth completion, social buttons) rejects
+ * open-redirect targets the same way: absolute URLs (`https://evil.com`),
+ * protocol-relative (`//evil.com`) and backslash tricks (`/\evil.com`, which
+ * browsers fold into `//evil.com`).
+ */
+export function safeNextPath(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  if (!value.startsWith('/')) return null;
+  if (value.startsWith('//')) return null;
+  if (value.includes('\\')) return null;
+  return value;
+}


### PR DESCRIPTION
## Contexto

El login con email/contraseña ya respeta el parámetro `next` (vuelve a la página que envió al usuario al login), pero **el login social no**: tras autenticarse con Google o Facebook el usuario aterrizaba siempre en `/`, perdiendo el destino. Esta PR hace que el `next` viaje por todo el flujo OAuth.

## Por qué se perdía

El `next` se descartaba en tres puntos:
- `SocialLoginButtons` enlazaba a `${API}/auth/google` sin arrastrar el destino.
- La API no transportaba el `next` (el `state` de OAuth es solo CSRF) y el callback redirigía con la URL de `/auth/complete` hardcodeada.
- `completeOAuthAction` redirigía con `redirect('/')` fijo.

## Cambios

**Web**
- `SocialLoginButtons` recibe `next` y lo propaga como `?next=` a `/auth/google` y `/auth/facebook` (login y signup ya disponían del valor).
- `/auth/complete` lee `next` del fragmento (`#token=…&next=…`) y `completeOAuthAction(token, next)` redirige a ese destino (fallback `/`).
- Nuevo helper `safeNextPath` que centraliza el saneo anti-open-redirect; se reutiliza en login y signup eliminando la duplicación inline.

**API**
- Al iniciar el flujo, el guard guarda el `next` saneado en una cookie httpOnly `rh_oauth_next` (no puede ir en el `state`, reservado para CSRF, ni en una cookie compartida: API y web están en dominios distintos).
- El callback consume esa cookie y añade el `next` al redirect final, tanto en éxito (`/auth/complete`) como en fallo (`/login`, para reintentar sin perder el destino). Lógica común para Google y Facebook.
- Nuevo helper `sanitizeNextPath` + `OAUTH_NEXT_COOKIE`. Lectura de cookies generalizada en `readCookie` con decodificación (Express codifica los valores de cookie).

## Seguridad

Solo se aceptan rutas internas relativas. Se rechazan URLs absolutas (`https://evil.com`), protocolo-relativas (`//evil.com`) y trucos con backslash (`/\evil.com`), evitando open-redirect.

## Tests

- `oauth-next.spec.ts`: saneo de rutas (acepta rutas internas con query, rechaza absolutas/`//`/`\`/no-string).
- `oauth.controller.spec.ts`: el callback añade el `next` saneado, ignora open-redirect, y preserva `next` en el fallo.
- Gate local completo en verde: build + eslint + prettier + 857 tests de la API, y build + lint de web.

## Notas

No afecta al esquema OpenAPI (los endpoints OAuth son `@ApiExcludeController`), por lo que no se regenera `api-client`.