### PR TITLE
feat(logistics): TransportCapacity — oferta de capacidad de transporte (backend #105)

### DIFF
--- a/apps/api/drizzle/0028_transport_capacity.sql
+++ b/apps/api/drizzle/0028_transport_capacity.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "transport_capacities" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"emergency_id" uuid NOT NULL,
+	"provider_type" text NOT NULL,
+	"provider_id" uuid NOT NULL,
+	"mode" text NOT NULL,
+	"weight_kg" double precision,
+	"volume_m3" double precision,
+	"coverage" jsonb NOT NULL,
+	"window_from" timestamp with time zone,
+	"window_to" timestamp with time zone,
+	"constraints" text[] NOT NULL,
+	"status" text NOT NULL,
+	"notes" text,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "transport_capacities_emergency_id_idx" ON "transport_capacities" ("emergency_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "transport_capacities_status_idx" ON "transport_capacities" ("status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "transport_capacities_mode_idx" ON "transport_capacities" ("mode");

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1946,6 +1946,24 @@
               "format": "uuid",
               "type": "string"
             }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Page size for pagination (1-100). Omit to return all.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "Number of items to skip (pagination). Defaults to 0.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2037,6 +2055,89 @@
           }
         },
         "summary": "List validated needs near a GPS point, ordered by distance (public, #57)",
+        "tags": [
+          "needs"
+        ]
+      }
+    },
+    "/emergencies/{emergencyId}/public/needs/in-bounds": {
+      "get": {
+        "operationId": "NeedsController_needsInBounds",
+        "parameters": [
+          {
+            "name": "emergencyId",
+            "required": true,
+            "in": "path",
+            "description": "Emergency UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "minLat",
+            "required": true,
+            "in": "query",
+            "description": "South latitude bound (-90 to 90)",
+            "schema": {
+              "example": 10.3,
+              "type": "number"
+            }
+          },
+          {
+            "name": "minLng",
+            "required": true,
+            "in": "query",
+            "description": "West longitude bound (-180 to 180)",
+            "schema": {
+              "example": -67.2,
+              "type": "number"
+            }
+          },
+          {
+            "name": "maxLat",
+            "required": true,
+            "in": "query",
+            "description": "North latitude bound (-90 to 90)",
+            "schema": {
+              "example": 10.7,
+              "type": "number"
+            }
+          },
+          {
+            "name": "maxLng",
+            "required": true,
+            "in": "query",
+            "description": "East longitude bound (-180 to 180)",
+            "schema": {
+              "example": -66.6,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Max results (default 500, max 1000)",
+            "schema": {
+              "example": 500,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Validated needs within the bounding box",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InBoundsNeedsDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "List validated needs within a geographic bounding box (public)",
         "tags": [
           "needs"
         ]
@@ -3257,6 +3358,193 @@
         "summary": "Cancel an offer (owner or coordinator)",
         "tags": [
           "offers"
+        ]
+      }
+    },
+    "/logistics/capacities": {
+      "post": {
+        "operationId": "LogisticsController_publish",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublishCapacityDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Capacity published",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublishCapacityResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing capacity:publish permission"
+          },
+          "409": {
+            "description": "Emergency is not accepting intake (paused/closed)"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Publish a transport-capacity offer (authenticated, citizen-grade)",
+        "tags": [
+          "logistics"
+        ]
+      }
+    },
+    "/logistics/capacities/{id}/withdraw": {
+      "post": {
+        "operationId": "LogisticsController_withdraw",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Capacity UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Capacity withdrawn"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Only the provider or a coordinator can withdraw"
+          },
+          "404": {
+            "description": "Capacity not found"
+          },
+          "409": {
+            "description": "Capacity cannot be withdrawn in its current status"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Withdraw a transport-capacity offer (provider or coordinator)",
+        "tags": [
+          "logistics"
+        ]
+      }
+    },
+    "/emergencies/{emergencyId}/logistics/capacities": {
+      "get": {
+        "operationId": "LogisticsController_list",
+        "parameters": [
+          {
+            "name": "emergencyId",
+            "required": true,
+            "in": "path",
+            "description": "Emergency UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "mode",
+            "required": false,
+            "in": "query",
+            "description": "Filter by mode",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "road",
+                "sea",
+                "air"
+              ]
+            }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "description": "Filter by status",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "available",
+                "reserved",
+                "withdrawn"
+              ]
+            }
+          },
+          {
+            "name": "availableFrom",
+            "required": false,
+            "in": "query",
+            "description": "Keep capacities available at/after this instant (ISO-8601)",
+            "schema": {
+              "example": "2026-07-05T00:00:00.000Z",
+              "type": "string"
+            }
+          },
+          {
+            "name": "availableTo",
+            "required": false,
+            "in": "query",
+            "description": "Keep capacities available at/before this instant (ISO-8601)",
+            "schema": {
+              "example": "2026-07-10T00:00:00.000Z",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Capacities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CapacityViewDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing capacity:read permission"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List transport capacities for an emergency (coordinator/verifier)",
+        "tags": [
+          "logistics"
         ]
       }
     },
@@ -6681,6 +6969,20 @@
           "items"
         ]
       },
+      "InBoundsNeedsDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NeedViewDto"
+            }
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
       "AssignNeedManagerDto": {
         "type": "object",
         "properties": {
@@ -6862,6 +7164,7 @@
               "company",
               "public_admin",
               "association",
+              "transport_operator",
               "other"
             ],
             "example": "ngo"
@@ -6908,6 +7211,7 @@
               "company",
               "public_admin",
               "association",
+              "transport_operator",
               "other"
             ]
           },
@@ -7373,6 +7677,351 @@
         },
         "required": [
           "needId"
+        ]
+      },
+      "PublishCapacityProviderDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "volunteer",
+              "organization"
+            ],
+            "example": "volunteer"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Volunteer or organization id (polymorphic, no FK)"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ]
+      },
+      "CapacityAmountDto": {
+        "type": "object",
+        "properties": {
+          "weightKg": {
+            "type": "number",
+            "example": 1500,
+            "description": "Carrying weight in kilograms (positive)",
+            "nullable": true
+          },
+          "volumeM3": {
+            "type": "number",
+            "example": 12,
+            "description": "Carrying volume in cubic metres (positive)",
+            "nullable": true
+          }
+        }
+      },
+      "CoverageDto": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "corridor",
+              "area"
+            ],
+            "example": "corridor"
+          },
+          "originResourceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Corridor: origin collection point (resource) id"
+          },
+          "destinationResourceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Corridor: destination collection point (resource) id"
+          },
+          "originLat": {
+            "type": "number",
+            "example": 10.4806,
+            "description": "Corridor: origin lat"
+          },
+          "originLng": {
+            "type": "number",
+            "example": -66.9036,
+            "description": "Corridor: origin lng"
+          },
+          "destinationLat": {
+            "type": "number",
+            "example": 10.6,
+            "description": "Corridor: destination lat"
+          },
+          "destinationLng": {
+            "type": "number",
+            "example": -67,
+            "description": "Corridor: destination lng"
+          },
+          "area": {
+            "type": "string",
+            "example": "Estado Vargas",
+            "description": "Area: free-text served area (required when kind=area)"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "CapacityWindowDto": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string",
+            "example": "2026-07-01T00:00:00.000Z",
+            "description": "Availability start (ISO-8601)"
+          },
+          "to": {
+            "type": "string",
+            "example": "2026-07-31T00:00:00.000Z",
+            "description": "Availability end (ISO-8601)"
+          }
+        }
+      },
+      "PublishCapacityDto": {
+        "type": "object",
+        "properties": {
+          "emergencyId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Emergency this capacity serves"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/PublishCapacityProviderDto"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "road",
+              "sea",
+              "air"
+            ],
+            "example": "road"
+          },
+          "capacity": {
+            "description": "At least one of weightKg / volumeM3 is required",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CapacityAmountDto"
+              }
+            ]
+          },
+          "coverage": {
+            "$ref": "#/components/schemas/CoverageDto"
+          },
+          "window": {
+            "$ref": "#/components/schemas/CapacityWindowDto"
+          },
+          "constraints": {
+            "example": [
+              "refrigerated",
+              "hazmat"
+            ],
+            "description": "Free-form constraints",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "notes": {
+            "type": "string",
+            "example": "Salida diaria a las 08:00",
+            "description": "Additional notes"
+          }
+        },
+        "required": [
+          "emergencyId",
+          "provider",
+          "mode",
+          "capacity",
+          "coverage"
+        ]
+      },
+      "PublishCapacityResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "CapacityAmountResponseDto": {
+        "type": "object",
+        "properties": {
+          "weightKg": {
+            "type": "number",
+            "example": 1500,
+            "nullable": true
+          },
+          "volumeM3": {
+            "type": "number",
+            "example": 12,
+            "nullable": true
+          }
+        }
+      },
+      "CoverageResponseDto": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "corridor",
+              "area"
+            ],
+            "example": "corridor"
+          },
+          "originResourceId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "destinationResourceId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "originLat": {
+            "type": "number",
+            "example": 10.4806,
+            "nullable": true
+          },
+          "originLng": {
+            "type": "number",
+            "example": -66.9036,
+            "nullable": true
+          },
+          "destinationLat": {
+            "type": "number",
+            "example": 10.6,
+            "nullable": true
+          },
+          "destinationLng": {
+            "type": "number",
+            "example": -67,
+            "nullable": true
+          },
+          "area": {
+            "type": "string",
+            "example": "Estado Vargas"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "CapacityWindowResponseDto": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string",
+            "example": "2026-07-01T00:00:00.000Z",
+            "nullable": true
+          },
+          "to": {
+            "type": "string",
+            "example": "2026-07-31T00:00:00.000Z",
+            "nullable": true
+          }
+        }
+      },
+      "CapacityViewDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "emergencyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "providerType": {
+            "type": "string",
+            "enum": [
+              "volunteer",
+              "organization"
+            ],
+            "example": "volunteer"
+          },
+          "providerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "road",
+              "sea",
+              "air"
+            ],
+            "example": "road"
+          },
+          "capacity": {
+            "$ref": "#/components/schemas/CapacityAmountResponseDto"
+          },
+          "coverage": {
+            "$ref": "#/components/schemas/CoverageResponseDto"
+          },
+          "window": {
+            "$ref": "#/components/schemas/CapacityWindowResponseDto"
+          },
+          "constraints": {
+            "example": [
+              "refrigerated"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "available",
+              "reserved",
+              "withdrawn"
+            ],
+            "example": "available"
+          },
+          "notes": {
+            "type": "string",
+            "example": "Salida diaria a las 08:00",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "example": "2026-07-01T00:00:00.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "example": "2026-07-01T00:00:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "emergencyId",
+          "providerType",
+          "providerId",
+          "mode",
+          "capacity",
+          "coverage",
+          "window",
+          "constraints",
+          "status",
+          "createdAt",
+          "updatedAt"
         ]
       },
       "RegisterVolunteerDto": {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { AccreditationModule } from './contexts/accreditation/infrastructure/acc
 import { GeocodingModule } from './contexts/geocoding/infrastructure/geocoding.module';
 import { MetricsModule } from './contexts/metrics/infrastructure/metrics.module';
 import { OffersModule } from './contexts/offers/infrastructure/offers.module';
+import { LogisticsModule } from './contexts/logistics/infrastructure/logistics.module';
 import { VolunteersModule } from './contexts/volunteers/infrastructure/volunteers.module';
 import { FilesModule } from './contexts/files/infrastructure/files.module';
 import { ReportsModule } from './contexts/reports/infrastructure/reports.module';
@@ -48,6 +49,7 @@ const isTestEnv = process.env.NODE_ENV === 'test';
     GeocodingModule,
     MetricsModule,
     OffersModule,
+    LogisticsModule,
     VolunteersModule,
     FilesModule,
     ReportsModule,

--- a/apps/api/src/contexts/identity/domain/authorization/permission.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/permission.spec.ts
@@ -33,6 +33,14 @@ describe('permission catalog', () => {
     expect(READ_ONLY_PERMISSIONS).toContain('shipment:read');
   });
 
+  it('includes the transport-capacity permissions (#105)', () => {
+    expect(ALL_PERMISSIONS).toContain('capacity:publish');
+    expect(ALL_PERMISSIONS).toContain('capacity:read');
+    expect(isPermission('capacity:publish')).toBe(true);
+    // capacity:read is a `*:read`, so it joins the viewer/read-only set
+    expect(READ_ONLY_PERMISSIONS).toContain('capacity:read');
+  });
+
   it('has no duplicates', () => {
     expect(new Set(ALL_PERMISSIONS).size).toBe(ALL_PERMISSIONS.length);
   });

--- a/apps/api/src/contexts/identity/domain/authorization/permission.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/permission.ts
@@ -39,6 +39,9 @@ export const PERMISSION_CATALOG = {
   // cubre la cadena de custodia de la carga.
   shipment: ['create', 'read', 'track'],
   manifest: ['sign'],
+  // Capacidad de transporte (#105): ofertar mover carga A->B. 'publish' es de
+  // grado ciudadano (como 'offer:create'); 'read' lo consume la coordinación.
+  capacity: ['publish', 'read'],
 } as const;
 
 type Catalog = typeof PERMISSION_CATALOG;

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.spec.ts
@@ -36,6 +36,16 @@ describe('ROLE_CATALOG', () => {
     expect(hubManager.has('shipment:track')).toBe(true);
   });
 
+  it('wires the transport-capacity permissions (#105)', () => {
+    // citizen publishes (grado ciudadano, como offer:create)
+    expect(permissionsForRole('citizen')).toContain('capacity:publish');
+    // coordination and verification read capacities (como offer:read)
+    expect(permissionsForRole('emergency_coordinator')).toContain(
+      'capacity:read',
+    );
+    expect(permissionsForRole('emergency_verifier')).toContain('capacity:read');
+  });
+
   it('every role only references permissions that exist in the catalog', () => {
     const valid = new Set<string>(ALL_PERMISSIONS);
     for (const role of Object.values(ROLE_CATALOG)) {

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
@@ -90,6 +90,7 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       'need:prioritize',
       'offer:read',
       'offer:match',
+      'capacity:read',
       'campaign:read',
       'campaign:verify',
       'campaign:block',
@@ -120,6 +121,7 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       'campaign:read',
       'campaign:verify',
       'offer:read',
+      'capacity:read',
     ],
   },
   group_manager: {
@@ -189,6 +191,7 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
     permissions: [
       'offer:create',
       'offer:read',
+      'capacity:publish',
       'resource:register',
       'resource:read',
       'need:read',

--- a/apps/api/src/contexts/logistics/application/capacity-not-found.error.ts
+++ b/apps/api/src/contexts/logistics/application/capacity-not-found.error.ts
@@ -1,0 +1,6 @@
+export class CapacityNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Transport capacity not found: ${id}`);
+    this.name = 'CapacityNotFoundError';
+  }
+}

--- a/apps/api/src/contexts/logistics/application/capacity-view.ts
+++ b/apps/api/src/contexts/logistics/application/capacity-view.ts
@@ -1,0 +1,39 @@
+import { TransportCapacity } from '../domain/transport-capacity';
+import { CapacityProps } from '../domain/capacity';
+import { CoverageProps } from '../domain/coverage';
+import { CapacityWindowProps } from '../domain/capacity-window';
+
+export interface CapacityView {
+  id: string;
+  emergencyId: string;
+  providerType: string;
+  providerId: string;
+  mode: string;
+  capacity: CapacityProps;
+  coverage: CoverageProps;
+  window: CapacityWindowProps;
+  constraints: string[];
+  status: string;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function toCapacityView(c: TransportCapacity): CapacityView {
+  const s = c.toSnapshot();
+  return {
+    id: s.id,
+    emergencyId: s.emergencyId,
+    providerType: s.providerType,
+    providerId: s.providerId,
+    mode: s.mode,
+    capacity: s.capacity,
+    coverage: s.coverage,
+    window: s.window,
+    constraints: s.constraints,
+    status: s.status,
+    notes: s.notes,
+    createdAt: s.createdAt.toISOString(),
+    updatedAt: s.updatedAt.toISOString(),
+  };
+}

--- a/apps/api/src/contexts/logistics/application/list-capacities.spec.ts
+++ b/apps/api/src/contexts/logistics/application/list-capacities.spec.ts
@@ -1,0 +1,117 @@
+import { ListCapacities } from './list-capacities';
+import { InMemoryTransportCapacityRepository } from '../infrastructure/in-memory-transport-capacity.repository';
+import { TransportCapacity } from '../domain/transport-capacity';
+import { TransportCapacityId } from '../domain/transport-capacity-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+  TransportProviderType,
+} from '../domain/transport-capacity-enums';
+import { Capacity } from '../domain/capacity';
+import { Coverage } from '../domain/coverage';
+import { CapacityWindow } from '../domain/capacity-window';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const OTHER_EM = '22222222-2222-4222-8222-222222222222';
+const PROVIDER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function makeCapacity(opts: {
+  emergencyId?: string;
+  mode?: TransportMode;
+  window?: CapacityWindow;
+  withdrawn?: boolean;
+}): TransportCapacity {
+  const cap = TransportCapacity.publish({
+    id: TransportCapacityId.create(),
+    emergencyId: EmergencyId.fromString(opts.emergencyId ?? EM),
+    provider: { type: TransportProviderType.Organization, id: PROVIDER_ID },
+    mode: opts.mode ?? TransportMode.Road,
+    capacity: Capacity.create({ weightKg: 1000, volumeM3: null }),
+    coverage: Coverage.area('Caracas'),
+    window: opts.window ?? CapacityWindow.empty(),
+    constraints: [],
+    notes: null,
+  });
+  if (opts.withdrawn) cap.withdraw();
+  return cap;
+}
+
+describe('ListCapacities', () => {
+  it('returns only capacities of the requested emergency', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    await repo.save(makeCapacity({ emergencyId: EM }));
+    await repo.save(makeCapacity({ emergencyId: OTHER_EM }));
+    const useCase = new ListCapacities(repo);
+
+    const result = await useCase.execute({ emergencyId: EM });
+    expect(result).toHaveLength(1);
+    expect(result[0].emergencyId).toBe(EM);
+  });
+
+  it('filters by mode', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    await repo.save(makeCapacity({ mode: TransportMode.Road }));
+    await repo.save(makeCapacity({ mode: TransportMode.Air }));
+    const useCase = new ListCapacities(repo);
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      mode: TransportMode.Air,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].mode).toBe(TransportMode.Air);
+  });
+
+  it('filters by status', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    await repo.save(makeCapacity({}));
+    await repo.save(makeCapacity({ withdrawn: true }));
+    const useCase = new ListCapacities(repo);
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      status: TransportCapacityStatus.Available,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe(TransportCapacityStatus.Available);
+  });
+
+  it('filters by window overlap', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    // July window
+    await repo.save(
+      makeCapacity({
+        window: CapacityWindow.create({
+          from: '2026-07-01T00:00:00Z',
+          to: '2026-07-31T00:00:00Z',
+        }),
+      }),
+    );
+    // August window
+    await repo.save(
+      makeCapacity({
+        window: CapacityWindow.create({
+          from: '2026-08-01T00:00:00Z',
+          to: '2026-08-31T00:00:00Z',
+        }),
+      }),
+    );
+    const useCase = new ListCapacities(repo);
+
+    const result = await useCase.execute({
+      emergencyId: EM,
+      availableFrom: '2026-07-05T00:00:00Z',
+      availableTo: '2026-07-10T00:00:00Z',
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].window.from).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('returns an empty list when nothing matches', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    const useCase = new ListCapacities(repo);
+    const result = await useCase.execute({ emergencyId: EM });
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/contexts/logistics/application/list-capacities.ts
+++ b/apps/api/src/contexts/logistics/application/list-capacities.ts
@@ -1,0 +1,36 @@
+import {
+  ListCapacitiesFilter,
+  TransportCapacityRepository,
+} from '../domain/ports/transport-capacity.repository';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+} from '../domain/transport-capacity-enums';
+import { CapacityView, toCapacityView } from './capacity-view';
+
+export interface ListCapacitiesQuery {
+  emergencyId: string;
+  mode?: TransportMode;
+  status?: TransportCapacityStatus;
+  availableFrom?: string;
+  availableTo?: string;
+}
+
+export class ListCapacities {
+  constructor(private readonly repo: TransportCapacityRepository) {}
+
+  async execute(q: ListCapacitiesQuery): Promise<CapacityView[]> {
+    const filter: ListCapacitiesFilter = {};
+    if (q.mode !== undefined) filter.mode = q.mode;
+    if (q.status !== undefined) filter.status = q.status;
+    if (q.availableFrom !== undefined) filter.availableFrom = q.availableFrom;
+    if (q.availableTo !== undefined) filter.availableTo = q.availableTo;
+
+    const capacities = await this.repo.findByEmergency(
+      EmergencyId.fromString(q.emergencyId),
+      filter,
+    );
+    return capacities.map(toCapacityView);
+  }
+}

--- a/apps/api/src/contexts/logistics/application/publish-capacity.spec.ts
+++ b/apps/api/src/contexts/logistics/application/publish-capacity.spec.ts
@@ -1,0 +1,85 @@
+import { PublishCapacity } from './publish-capacity';
+import { InMemoryTransportCapacityRepository } from '../infrastructure/in-memory-transport-capacity.repository';
+import { LogisticsEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+  TransportProviderType,
+} from '../domain/transport-capacity-enums';
+import { TransportCapacityId } from '../domain/transport-capacity-id';
+import { EmergencyNotAcceptingIntakeError } from '../../emergencies/domain/emergency-not-accepting-intake.error';
+import { CapacityMustHaveWeightOrVolumeError } from '../domain/transport-capacity-errors';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const PROVIDER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+class FakeStatusReader implements LogisticsEmergencyStatusReader {
+  constructor(private status: string | null) {}
+  getStatus(): Promise<string | null> {
+    return Promise.resolve(this.status);
+  }
+}
+
+function baseCmd() {
+  return {
+    emergencyId: EM,
+    provider: {
+      type: TransportProviderType.Volunteer,
+      id: PROVIDER_ID,
+    },
+    mode: TransportMode.Road,
+    capacity: { weightKg: 1500, volumeM3: null },
+    coverage: {
+      kind: 'area' as const,
+      area: 'Caracas',
+    },
+    window: { from: null, to: null },
+    constraints: ['refrigerated'],
+    notes: null,
+  };
+}
+
+describe('PublishCapacity', () => {
+  it('publishes a capacity when the emergency is active', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    const useCase = new PublishCapacity(repo, new FakeStatusReader('active'));
+
+    const { id } = await useCase.execute(baseCmd());
+
+    const saved = await repo.findById(TransportCapacityId.fromString(id));
+    expect(saved).not.toBeNull();
+    expect(saved!.status).toBe(TransportCapacityStatus.Available);
+    expect(saved!.capacity.weightKg).toBe(1500);
+    expect(saved!.coverage.kind).toBe('area');
+  });
+
+  it('rejects publishing to a paused emergency', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    const useCase = new PublishCapacity(repo, new FakeStatusReader('paused'));
+
+    await expect(useCase.execute(baseCmd())).rejects.toThrow(
+      EmergencyNotAcceptingIntakeError,
+    );
+  });
+
+  it('rejects publishing to a non-existent emergency', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    const useCase = new PublishCapacity(repo, new FakeStatusReader(null));
+
+    await expect(useCase.execute(baseCmd())).rejects.toThrow(
+      EmergencyNotAcceptingIntakeError,
+    );
+  });
+
+  it('propagates the domain invariant when capacity is empty', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    const useCase = new PublishCapacity(repo, new FakeStatusReader('active'));
+
+    await expect(
+      useCase.execute({
+        ...baseCmd(),
+        capacity: { weightKg: null, volumeM3: null },
+      }),
+    ).rejects.toThrow(CapacityMustHaveWeightOrVolumeError);
+  });
+});

--- a/apps/api/src/contexts/logistics/application/publish-capacity.ts
+++ b/apps/api/src/contexts/logistics/application/publish-capacity.ts
@@ -1,0 +1,58 @@
+import { TransportCapacityRepository } from '../domain/ports/transport-capacity.repository';
+import { LogisticsEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+import { TransportCapacity } from '../domain/transport-capacity';
+import { TransportCapacityId } from '../domain/transport-capacity-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  TransportMode,
+  TransportProviderType,
+} from '../domain/transport-capacity-enums';
+import { Capacity } from '../domain/capacity';
+import { Coverage, CoverageProps } from '../domain/coverage';
+import { CapacityWindow } from '../domain/capacity-window';
+import { EmergencyNotAcceptingIntakeError } from '../../emergencies/domain/emergency-not-accepting-intake.error';
+
+const ACTIVE_STATUS = 'active';
+
+export interface PublishCapacityCommand {
+  emergencyId: string;
+  provider: { type: TransportProviderType; id: string };
+  mode: TransportMode;
+  capacity: { weightKg: number | null; volumeM3: number | null };
+  coverage: CoverageProps;
+  window: { from: string | null; to: string | null };
+  constraints: string[];
+  notes: string | null;
+}
+
+export class PublishCapacity {
+  constructor(
+    private readonly repo: TransportCapacityRepository,
+    private readonly emergencyStatusReader: LogisticsEmergencyStatusReader,
+  ) {}
+
+  async execute(cmd: PublishCapacityCommand): Promise<{ id: string }> {
+    const status = await this.emergencyStatusReader.getStatus(cmd.emergencyId);
+    if (status !== ACTIVE_STATUS) {
+      throw new EmergencyNotAcceptingIntakeError(
+        cmd.emergencyId,
+        status ?? 'not-found',
+      );
+    }
+
+    const capacity = TransportCapacity.publish({
+      id: TransportCapacityId.create(),
+      emergencyId: EmergencyId.fromString(cmd.emergencyId),
+      provider: cmd.provider,
+      mode: cmd.mode,
+      capacity: Capacity.create(cmd.capacity),
+      coverage: Coverage.fromPlain(cmd.coverage),
+      window: CapacityWindow.create(cmd.window),
+      constraints: cmd.constraints,
+      notes: cmd.notes,
+    });
+
+    await this.repo.save(capacity);
+    return { id: capacity.id.value };
+  }
+}

--- a/apps/api/src/contexts/logistics/application/withdraw-capacity.spec.ts
+++ b/apps/api/src/contexts/logistics/application/withdraw-capacity.spec.ts
@@ -1,0 +1,97 @@
+import {
+  WithdrawCapacity,
+  CapacityWithdrawUnauthorizedError,
+} from './withdraw-capacity';
+import { CapacityNotFoundError } from './capacity-not-found.error';
+import { InMemoryTransportCapacityRepository } from '../infrastructure/in-memory-transport-capacity.repository';
+import { TransportCapacity } from '../domain/transport-capacity';
+import { TransportCapacityId } from '../domain/transport-capacity-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+  TransportProviderType,
+} from '../domain/transport-capacity-enums';
+import { Capacity } from '../domain/capacity';
+import { Coverage } from '../domain/coverage';
+import { CapacityWindow } from '../domain/capacity-window';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const OWNER = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OTHER = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+function makeCapacity(): TransportCapacity {
+  return TransportCapacity.publish({
+    id: TransportCapacityId.create(),
+    emergencyId: EmergencyId.fromString(EM),
+    provider: { type: TransportProviderType.Volunteer, id: OWNER },
+    mode: TransportMode.Road,
+    capacity: Capacity.create({ weightKg: 1000, volumeM3: null }),
+    coverage: Coverage.area('Caracas'),
+    window: CapacityWindow.empty(),
+    constraints: [],
+    notes: null,
+  });
+}
+
+describe('WithdrawCapacity', () => {
+  it('lets the owner withdraw their own capacity', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    const cap = makeCapacity();
+    await repo.save(cap);
+    const useCase = new WithdrawCapacity(repo);
+
+    await useCase.execute({
+      capacityId: cap.id.value,
+      requesterUserId: OWNER,
+      isCoordinator: false,
+    });
+
+    const saved = await repo.findById(cap.id);
+    expect(saved!.status).toBe(TransportCapacityStatus.Withdrawn);
+  });
+
+  it('lets a coordinator withdraw any capacity', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    const cap = makeCapacity();
+    await repo.save(cap);
+    const useCase = new WithdrawCapacity(repo);
+
+    await useCase.execute({
+      capacityId: cap.id.value,
+      requesterUserId: OTHER,
+      isCoordinator: true,
+    });
+
+    const saved = await repo.findById(cap.id);
+    expect(saved!.status).toBe(TransportCapacityStatus.Withdrawn);
+  });
+
+  it('rejects a non-owner non-coordinator', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    const cap = makeCapacity();
+    await repo.save(cap);
+    const useCase = new WithdrawCapacity(repo);
+
+    await expect(
+      useCase.execute({
+        capacityId: cap.id.value,
+        requesterUserId: OTHER,
+        isCoordinator: false,
+      }),
+    ).rejects.toThrow(CapacityWithdrawUnauthorizedError);
+  });
+
+  it('throws CapacityNotFoundError for an unknown id', async () => {
+    const repo = new InMemoryTransportCapacityRepository();
+    const useCase = new WithdrawCapacity(repo);
+
+    await expect(
+      useCase.execute({
+        capacityId: '99999999-9999-4999-8999-999999999999',
+        requesterUserId: OWNER,
+        isCoordinator: true,
+      }),
+    ).rejects.toThrow(CapacityNotFoundError);
+  });
+});

--- a/apps/api/src/contexts/logistics/application/withdraw-capacity.ts
+++ b/apps/api/src/contexts/logistics/application/withdraw-capacity.ts
@@ -1,0 +1,39 @@
+import { TransportCapacityRepository } from '../domain/ports/transport-capacity.repository';
+import { TransportCapacityId } from '../domain/transport-capacity-id';
+import { CapacityNotFoundError } from './capacity-not-found.error';
+
+export class CapacityWithdrawUnauthorizedError extends Error {
+  constructor() {
+    super(
+      'Only the capacity provider or a coordinator can withdraw a capacity',
+    );
+    this.name = 'CapacityWithdrawUnauthorizedError';
+  }
+}
+
+export interface WithdrawCapacityCommand {
+  capacityId: string;
+  /** The authenticated user id (the volunteer provider, when self-service). */
+  requesterUserId: string;
+  /** True when the requester is an admin or coordinator of the emergency. */
+  isCoordinator: boolean;
+}
+
+export class WithdrawCapacity {
+  constructor(private readonly repo: TransportCapacityRepository) {}
+
+  async execute(cmd: WithdrawCapacityCommand): Promise<void> {
+    const capacity = await this.repo.findById(
+      TransportCapacityId.fromString(cmd.capacityId),
+    );
+    if (!capacity) throw new CapacityNotFoundError(cmd.capacityId);
+
+    const isOwner = capacity.provider.id === cmd.requesterUserId;
+    if (!cmd.isCoordinator && !isOwner) {
+      throw new CapacityWithdrawUnauthorizedError();
+    }
+
+    capacity.withdraw();
+    await this.repo.save(capacity);
+  }
+}

--- a/apps/api/src/contexts/logistics/domain/capacity-window.ts
+++ b/apps/api/src/contexts/logistics/domain/capacity-window.ts
@@ -1,0 +1,60 @@
+import { InvalidCapacityWindowError } from './transport-capacity-errors';
+
+export interface CapacityWindowProps {
+  /** Availability start (ISO-8601) or null for "no lower bound". */
+  from: string | null;
+  /** Availability end (ISO-8601) or null for "no upper bound". */
+  to: string | null;
+}
+
+function parseIso(value: string, field: string): Date {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new InvalidCapacityWindowError(
+      `Capacity window ${field} must be a valid ISO date, got '${value}'`,
+    );
+  }
+  return date;
+}
+
+/**
+ * Time window during which the capacity is on offer. Both ends are optional; an
+ * empty window (no bounds) means "open-ended availability". When both are
+ * present, `from` must not be after `to`.
+ */
+export class CapacityWindow {
+  readonly from: string | null;
+  readonly to: string | null;
+
+  private constructor(props: CapacityWindowProps) {
+    this.from = props.from;
+    this.to = props.to;
+  }
+
+  static create(props: CapacityWindowProps): CapacityWindow {
+    const from = props.from ?? null;
+    const to = props.to ?? null;
+
+    const fromDate = from !== null ? parseIso(from, 'from') : null;
+    const toDate = to !== null ? parseIso(to, 'to') : null;
+
+    if (fromDate !== null && toDate !== null && fromDate > toDate) {
+      throw new InvalidCapacityWindowError(
+        `Capacity window 'from' (${from}) must not be after 'to' (${to})`,
+      );
+    }
+
+    return new CapacityWindow({
+      from: fromDate !== null ? fromDate.toISOString() : null,
+      to: toDate !== null ? toDate.toISOString() : null,
+    });
+  }
+
+  static empty(): CapacityWindow {
+    return new CapacityWindow({ from: null, to: null });
+  }
+
+  toPlain(): CapacityWindowProps {
+    return { from: this.from, to: this.to };
+  }
+}

--- a/apps/api/src/contexts/logistics/domain/capacity.ts
+++ b/apps/api/src/contexts/logistics/domain/capacity.ts
@@ -1,0 +1,46 @@
+import {
+  CapacityMustHaveWeightOrVolumeError,
+  InvalidCapacityAmountError,
+} from './transport-capacity-errors';
+
+export interface CapacityProps {
+  weightKg: number | null;
+  volumeM3: number | null;
+}
+
+/**
+ * Transport capacity expressed as weight and/or volume. Invariant: at least one
+ * of the two must be present and positive (a vehicle that can carry neither is
+ * not a capacity offer). Either dimension may be omitted when the provider only
+ * knows one of them.
+ */
+export class Capacity {
+  readonly weightKg: number | null;
+  readonly volumeM3: number | null;
+
+  private constructor(props: CapacityProps) {
+    this.weightKg = props.weightKg;
+    this.volumeM3 = props.volumeM3;
+  }
+
+  static create(props: CapacityProps): Capacity {
+    const weightKg = props.weightKg ?? null;
+    const volumeM3 = props.volumeM3 ?? null;
+
+    if (weightKg === null && volumeM3 === null) {
+      throw new CapacityMustHaveWeightOrVolumeError();
+    }
+    if (weightKg !== null && weightKg <= 0) {
+      throw new InvalidCapacityAmountError('weightKg', weightKg);
+    }
+    if (volumeM3 !== null && volumeM3 <= 0) {
+      throw new InvalidCapacityAmountError('volumeM3', volumeM3);
+    }
+
+    return new Capacity({ weightKg, volumeM3 });
+  }
+
+  toPlain(): CapacityProps {
+    return { weightKg: this.weightKg, volumeM3: this.volumeM3 };
+  }
+}

--- a/apps/api/src/contexts/logistics/domain/coverage.ts
+++ b/apps/api/src/contexts/logistics/domain/coverage.ts
@@ -1,0 +1,130 @@
+import { InvalidCoverageError } from './transport-capacity-errors';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * A corridor: a directed A→B route the provider can serve. Endpoints are
+ * pragmatic and all optional — either a known collection point (resource id) or
+ * raw coordinates, on each end. A corridor with no endpoint at all is
+ * meaningless, so at least one hint is required.
+ */
+export interface CorridorCoverageProps {
+  kind: 'corridor';
+  originResourceId: string | null;
+  destinationResourceId: string | null;
+  originLat: number | null;
+  originLng: number | null;
+  destinationLat: number | null;
+  destinationLng: number | null;
+}
+
+/** An area the provider can serve (free-text, e.g. "Estado Vargas"). */
+export interface AreaCoverageProps {
+  kind: 'area';
+  area: string;
+}
+
+export type CoverageProps = CorridorCoverageProps | AreaCoverageProps;
+
+function assertOptionalUuid(value: string | null, field: string): void {
+  if (value !== null && !UUID_RE.test(value)) {
+    throw new InvalidCoverageError(`Coverage ${field} must be a UUID: ${value}`);
+  }
+}
+
+function assertOptionalLat(value: number | null, field: string): void {
+  if (value !== null && (value < -90 || value > 90)) {
+    throw new InvalidCoverageError(
+      `Coverage ${field} must be between -90 and 90, got ${value}`,
+    );
+  }
+}
+
+function assertOptionalLng(value: number | null, field: string): void {
+  if (value !== null && (value < -180 || value > 180)) {
+    throw new InvalidCoverageError(
+      `Coverage ${field} must be between -180 and 180, got ${value}`,
+    );
+  }
+}
+
+/**
+ * Discriminated value object describing where a transport capacity can operate:
+ * either a directed corridor (A→B) or a named area. Kept deliberately pragmatic
+ * — endpoints are optional hints (resource id and/or coordinates), not a strict
+ * routing graph.
+ */
+export class Coverage {
+  private constructor(private readonly props: CoverageProps) {}
+
+  static corridor(
+    props: Omit<CorridorCoverageProps, 'kind'>,
+  ): Coverage {
+    const originResourceId = props.originResourceId ?? null;
+    const destinationResourceId = props.destinationResourceId ?? null;
+    const originLat = props.originLat ?? null;
+    const originLng = props.originLng ?? null;
+    const destinationLat = props.destinationLat ?? null;
+    const destinationLng = props.destinationLng ?? null;
+
+    const hasOrigin =
+      originResourceId !== null || (originLat !== null && originLng !== null);
+    const hasDestination =
+      destinationResourceId !== null ||
+      (destinationLat !== null && destinationLng !== null);
+    if (!hasOrigin && !hasDestination) {
+      throw new InvalidCoverageError(
+        'Corridor coverage requires at least an origin or a destination hint',
+      );
+    }
+
+    assertOptionalUuid(originResourceId, 'originResourceId');
+    assertOptionalUuid(destinationResourceId, 'destinationResourceId');
+    assertOptionalLat(originLat, 'originLat');
+    assertOptionalLng(originLng, 'originLng');
+    assertOptionalLat(destinationLat, 'destinationLat');
+    assertOptionalLng(destinationLng, 'destinationLng');
+
+    return new Coverage({
+      kind: 'corridor',
+      originResourceId,
+      destinationResourceId,
+      originLat,
+      originLng,
+      destinationLat,
+      destinationLng,
+    });
+  }
+
+  static area(area: string): Coverage {
+    if (!area || area.trim().length === 0) {
+      throw new InvalidCoverageError('Area coverage must not be empty');
+    }
+    return new Coverage({ kind: 'area', area: area.trim() });
+  }
+
+  static fromPlain(props: CoverageProps): Coverage {
+    if (props.kind === 'area') {
+      return Coverage.area(props.area);
+    }
+    return Coverage.corridor({
+      originResourceId: props.originResourceId,
+      destinationResourceId: props.destinationResourceId,
+      originLat: props.originLat,
+      originLng: props.originLng,
+      destinationLat: props.destinationLat,
+      destinationLng: props.destinationLng,
+    });
+  }
+
+  get kind(): 'corridor' | 'area' {
+    return this.props.kind;
+  }
+
+  toPlain(): CoverageProps {
+    return this.props.kind === 'area'
+      ? { kind: 'area', area: this.props.area }
+      : { ...this.props };
+  }
+}

--- a/apps/api/src/contexts/logistics/domain/coverage.ts
+++ b/apps/api/src/contexts/logistics/domain/coverage.ts
@@ -29,7 +29,9 @@ export type CoverageProps = CorridorCoverageProps | AreaCoverageProps;
 
 function assertOptionalUuid(value: string | null, field: string): void {
   if (value !== null && !UUID_RE.test(value)) {
-    throw new InvalidCoverageError(`Coverage ${field} must be a UUID: ${value}`);
+    throw new InvalidCoverageError(
+      `Coverage ${field} must be a UUID: ${value}`,
+    );
   }
 }
 
@@ -58,9 +60,7 @@ function assertOptionalLng(value: number | null, field: string): void {
 export class Coverage {
   private constructor(private readonly props: CoverageProps) {}
 
-  static corridor(
-    props: Omit<CorridorCoverageProps, 'kind'>,
-  ): Coverage {
+  static corridor(props: Omit<CorridorCoverageProps, 'kind'>): Coverage {
     const originResourceId = props.originResourceId ?? null;
     const destinationResourceId = props.destinationResourceId ?? null;
     const originLat = props.originLat ?? null;

--- a/apps/api/src/contexts/logistics/domain/ports/capacity-emergency-lookup.ts
+++ b/apps/api/src/contexts/logistics/domain/ports/capacity-emergency-lookup.ts
@@ -1,0 +1,11 @@
+export const CAPACITY_EMERGENCY_LOOKUP = Symbol('CapacityEmergencyLookup');
+
+/**
+ * Resolves the owning emergency of a transport capacity, so the controller can
+ * decide whether the requester is a coordinator of that emergency (mirrors how
+ * offers resolve an offer's emergency for the cancel authorization check).
+ */
+export interface CapacityEmergencyLookup {
+  /** The capacity's emergency id, or null when the capacity does not exist. */
+  findEmergencyId(capacityId: string): Promise<string | null>;
+}

--- a/apps/api/src/contexts/logistics/domain/ports/emergency-status-reader.ts
+++ b/apps/api/src/contexts/logistics/domain/ports/emergency-status-reader.ts
@@ -1,0 +1,14 @@
+/**
+ * Port — logistics context.
+ *
+ * Re-declares the same interface as other contexts' emergency status reader so
+ * this context stays independent. The Drizzle adapter is shared in infrastructure.
+ */
+export const LOGISTICS_EMERGENCY_STATUS_READER = Symbol(
+  'LogisticsEmergencyStatusReader',
+);
+
+export interface LogisticsEmergencyStatusReader {
+  /** Returns the current status string, or null when the emergency does not exist. */
+  getStatus(emergencyId: string): Promise<string | null>;
+}

--- a/apps/api/src/contexts/logistics/domain/ports/transport-capacity.repository.ts
+++ b/apps/api/src/contexts/logistics/domain/ports/transport-capacity.repository.ts
@@ -1,0 +1,34 @@
+import { TransportCapacity } from '../transport-capacity';
+import { TransportCapacityId } from '../transport-capacity-id';
+import { EmergencyId } from '../../../../shared/domain/emergency-id';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+} from '../transport-capacity-enums';
+
+export const TRANSPORT_CAPACITY_REPOSITORY = Symbol(
+  'TransportCapacityRepository',
+);
+
+/**
+ * Filter for listing capacities within an emergency. All fields are optional
+ * and AND-combined. The window filter selects capacities whose availability
+ * window overlaps the requested instants (open-ended bounds always overlap).
+ */
+export interface ListCapacitiesFilter {
+  mode?: TransportMode;
+  status?: TransportCapacityStatus;
+  /** Keep only capacities still available at/after this instant (ISO). */
+  availableFrom?: string;
+  /** Keep only capacities available at/before this instant (ISO). */
+  availableTo?: string;
+}
+
+export interface TransportCapacityRepository {
+  save(capacity: TransportCapacity): Promise<void>;
+  findById(id: TransportCapacityId): Promise<TransportCapacity | null>;
+  findByEmergency(
+    emergencyId: EmergencyId,
+    filter: ListCapacitiesFilter,
+  ): Promise<TransportCapacity[]>;
+}

--- a/apps/api/src/contexts/logistics/domain/transport-capacity-enums.ts
+++ b/apps/api/src/contexts/logistics/domain/transport-capacity-enums.ts
@@ -1,0 +1,41 @@
+/**
+ * Transport mode of a capacity offer. Ground vehicles (moto, coche, camioneta,
+ * camión) all map to `road`; maritime to `sea`; aerial to `air`. Kept coarse on
+ * purpose — the matching cares about the medium, not the exact vehicle.
+ */
+export enum TransportMode {
+  Road = 'road',
+  Sea = 'sea',
+  Air = 'air',
+}
+
+/**
+ * Lifecycle of a capacity offer. `available` when published, `reserved` once a
+ * coordinator earmarks it for a shipment (kept for the future expedición flow,
+ * EPIC #103), `withdrawn` when the provider retires it.
+ */
+export enum TransportCapacityStatus {
+  Available = 'available',
+  Reserved = 'reserved',
+  Withdrawn = 'withdrawn',
+}
+
+/**
+ * Who is offering the capacity. Polymorphic by design (mirrors how grants model
+ * their principal): a capacity can come from a volunteer with a vehicle or from
+ * a transport organization, with no FK to either table.
+ */
+export enum TransportProviderType {
+  Volunteer = 'volunteer',
+  Organization = 'organization',
+}
+
+export function isTransportMode(value: string): value is TransportMode {
+  return (Object.values(TransportMode) as string[]).includes(value);
+}
+
+export function isTransportProviderType(
+  value: string,
+): value is TransportProviderType {
+  return (Object.values(TransportProviderType) as string[]).includes(value);
+}

--- a/apps/api/src/contexts/logistics/domain/transport-capacity-errors.ts
+++ b/apps/api/src/contexts/logistics/domain/transport-capacity-errors.ts
@@ -1,0 +1,41 @@
+export class CapacityMustHaveWeightOrVolumeError extends Error {
+  constructor() {
+    super('Transport capacity must declare at least weightKg or volumeM3');
+    this.name = 'CapacityMustHaveWeightOrVolumeError';
+  }
+}
+
+export class InvalidCapacityAmountError extends Error {
+  constructor(field: string, value: number) {
+    super(`Capacity ${field} must be greater than 0, got ${value}`);
+    this.name = 'InvalidCapacityAmountError';
+  }
+}
+
+export class InvalidCoverageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidCoverageError';
+  }
+}
+
+export class InvalidCapacityWindowError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidCapacityWindowError';
+  }
+}
+
+export class CapacityNotAvailableError extends Error {
+  constructor() {
+    super('Transport capacity must be in available status to be withdrawn');
+    this.name = 'CapacityNotAvailableError';
+  }
+}
+
+export class CapacityAlreadyWithdrawnError extends Error {
+  constructor() {
+    super('Transport capacity is already withdrawn');
+    this.name = 'CapacityAlreadyWithdrawnError';
+  }
+}

--- a/apps/api/src/contexts/logistics/domain/transport-capacity-id.ts
+++ b/apps/api/src/contexts/logistics/domain/transport-capacity-id.ts
@@ -1,0 +1,21 @@
+import { randomUUID } from 'node:crypto';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export class TransportCapacityId {
+  private constructor(public readonly value: string) {}
+
+  static create(): TransportCapacityId {
+    return new TransportCapacityId(randomUUID());
+  }
+
+  static fromString(s: string): TransportCapacityId {
+    if (!UUID_RE.test(s)) throw new Error(`Invalid TransportCapacityId: ${s}`);
+    return new TransportCapacityId(s);
+  }
+
+  equals(o: TransportCapacityId): boolean {
+    return this.value === o.value;
+  }
+}

--- a/apps/api/src/contexts/logistics/domain/transport-capacity.spec.ts
+++ b/apps/api/src/contexts/logistics/domain/transport-capacity.spec.ts
@@ -37,7 +37,8 @@ function makeCapacity(
     emergencyId: EmergencyId.fromString(EM),
     provider: { type: TransportProviderType.Volunteer, id: PROVIDER_ID },
     mode: overrides?.mode ?? TransportMode.Road,
-    capacity: overrides?.capacity ?? Capacity.create({ weightKg: 1000, volumeM3: 8 }),
+    capacity:
+      overrides?.capacity ?? Capacity.create({ weightKg: 1000, volumeM3: 8 }),
     coverage:
       overrides?.coverage ??
       Coverage.corridor({
@@ -68,9 +69,9 @@ describe('Capacity value object', () => {
   });
 
   it('throws when neither weight nor volume is present', () => {
-    expect(() =>
-      Capacity.create({ weightKg: null, volumeM3: null }),
-    ).toThrow(CapacityMustHaveWeightOrVolumeError);
+    expect(() => Capacity.create({ weightKg: null, volumeM3: null })).toThrow(
+      CapacityMustHaveWeightOrVolumeError,
+    );
   });
 
   it('throws when weight is not positive', () => {

--- a/apps/api/src/contexts/logistics/domain/transport-capacity.spec.ts
+++ b/apps/api/src/contexts/logistics/domain/transport-capacity.spec.ts
@@ -1,0 +1,269 @@
+import { TransportCapacity } from './transport-capacity';
+import { TransportCapacityId } from './transport-capacity-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+  TransportProviderType,
+} from './transport-capacity-enums';
+import { Capacity } from './capacity';
+import { Coverage } from './coverage';
+import { CapacityWindow } from './capacity-window';
+import {
+  CapacityAlreadyWithdrawnError,
+  CapacityMustHaveWeightOrVolumeError,
+  InvalidCapacityAmountError,
+  InvalidCapacityWindowError,
+  InvalidCoverageError,
+} from './transport-capacity-errors';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const PROVIDER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORIGIN_RES = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const DEST_RES = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+function makeCapacity(
+  overrides?: Partial<{
+    mode: TransportMode;
+    capacity: Capacity;
+    coverage: Coverage;
+    window: CapacityWindow;
+    constraints: string[];
+    notes: string | null;
+  }>,
+): TransportCapacity {
+  return TransportCapacity.publish({
+    id: TransportCapacityId.create(),
+    emergencyId: EmergencyId.fromString(EM),
+    provider: { type: TransportProviderType.Volunteer, id: PROVIDER_ID },
+    mode: overrides?.mode ?? TransportMode.Road,
+    capacity: overrides?.capacity ?? Capacity.create({ weightKg: 1000, volumeM3: 8 }),
+    coverage:
+      overrides?.coverage ??
+      Coverage.corridor({
+        originResourceId: ORIGIN_RES,
+        destinationResourceId: DEST_RES,
+        originLat: null,
+        originLng: null,
+        destinationLat: null,
+        destinationLng: null,
+      }),
+    window: overrides?.window ?? CapacityWindow.empty(),
+    constraints: overrides?.constraints ?? ['refrigerated'],
+    notes: overrides?.notes ?? null,
+  });
+}
+
+describe('Capacity value object', () => {
+  it('accepts weight only', () => {
+    const c = Capacity.create({ weightKg: 500, volumeM3: null });
+    expect(c.weightKg).toBe(500);
+    expect(c.volumeM3).toBeNull();
+  });
+
+  it('accepts volume only', () => {
+    const c = Capacity.create({ weightKg: null, volumeM3: 12 });
+    expect(c.weightKg).toBeNull();
+    expect(c.volumeM3).toBe(12);
+  });
+
+  it('throws when neither weight nor volume is present', () => {
+    expect(() =>
+      Capacity.create({ weightKg: null, volumeM3: null }),
+    ).toThrow(CapacityMustHaveWeightOrVolumeError);
+  });
+
+  it('throws when weight is not positive', () => {
+    expect(() => Capacity.create({ weightKg: 0, volumeM3: null })).toThrow(
+      InvalidCapacityAmountError,
+    );
+  });
+
+  it('throws when volume is negative', () => {
+    expect(() => Capacity.create({ weightKg: null, volumeM3: -3 })).toThrow(
+      InvalidCapacityAmountError,
+    );
+  });
+});
+
+describe('Coverage value object', () => {
+  it('builds a corridor from resource ids', () => {
+    const cov = Coverage.corridor({
+      originResourceId: ORIGIN_RES,
+      destinationResourceId: DEST_RES,
+      originLat: null,
+      originLng: null,
+      destinationLat: null,
+      destinationLng: null,
+    });
+    expect(cov.kind).toBe('corridor');
+    const plain = cov.toPlain();
+    expect(plain.kind).toBe('corridor');
+  });
+
+  it('builds a corridor from coordinates', () => {
+    const cov = Coverage.corridor({
+      originResourceId: null,
+      destinationResourceId: null,
+      originLat: 10.5,
+      originLng: -66.9,
+      destinationLat: 11.0,
+      destinationLng: -67.0,
+    });
+    expect(cov.kind).toBe('corridor');
+  });
+
+  it('throws when corridor has neither origin nor destination', () => {
+    expect(() =>
+      Coverage.corridor({
+        originResourceId: null,
+        destinationResourceId: null,
+        originLat: null,
+        originLng: null,
+        destinationLat: null,
+        destinationLng: null,
+      }),
+    ).toThrow(InvalidCoverageError);
+  });
+
+  it('throws when a corridor coordinate is out of range', () => {
+    expect(() =>
+      Coverage.corridor({
+        originResourceId: null,
+        destinationResourceId: null,
+        originLat: 200,
+        originLng: -66.9,
+        destinationLat: null,
+        destinationLng: null,
+      }),
+    ).toThrow(InvalidCoverageError);
+  });
+
+  it('builds an area coverage', () => {
+    const cov = Coverage.area('Estado Vargas');
+    expect(cov.kind).toBe('area');
+    expect(cov.toPlain()).toEqual({ kind: 'area', area: 'Estado Vargas' });
+  });
+
+  it('throws on empty area', () => {
+    expect(() => Coverage.area('  ')).toThrow(InvalidCoverageError);
+  });
+
+  it('round-trips through fromPlain', () => {
+    const cov = Coverage.fromPlain({ kind: 'area', area: 'Caracas' });
+    expect(cov.kind).toBe('area');
+  });
+});
+
+describe('CapacityWindow value object', () => {
+  it('accepts an empty window', () => {
+    const w = CapacityWindow.empty();
+    expect(w.from).toBeNull();
+    expect(w.to).toBeNull();
+  });
+
+  it('normalizes to ISO', () => {
+    const w = CapacityWindow.create({
+      from: '2026-07-01T00:00:00Z',
+      to: '2026-07-10T00:00:00Z',
+    });
+    expect(w.from).toBe('2026-07-01T00:00:00.000Z');
+    expect(w.to).toBe('2026-07-10T00:00:00.000Z');
+  });
+
+  it('throws when from is after to', () => {
+    expect(() =>
+      CapacityWindow.create({
+        from: '2026-07-10T00:00:00Z',
+        to: '2026-07-01T00:00:00Z',
+      }),
+    ).toThrow(InvalidCapacityWindowError);
+  });
+
+  it('throws on an invalid date', () => {
+    expect(() =>
+      CapacityWindow.create({ from: 'not-a-date', to: null }),
+    ).toThrow(InvalidCapacityWindowError);
+  });
+});
+
+describe('TransportCapacity aggregate', () => {
+  it('publishes with available status', () => {
+    const cap = makeCapacity();
+    expect(cap.status).toBe(TransportCapacityStatus.Available);
+  });
+
+  it('publish() sets all fields', () => {
+    const cap = makeCapacity({ notes: 'Salida diaria 08:00' });
+    expect(cap.provider.type).toBe(TransportProviderType.Volunteer);
+    expect(cap.provider.id).toBe(PROVIDER_ID);
+    expect(cap.mode).toBe(TransportMode.Road);
+    expect(cap.capacity.weightKg).toBe(1000);
+    expect(cap.capacity.volumeM3).toBe(8);
+    expect(cap.coverage.kind).toBe('corridor');
+    expect(cap.constraints).toEqual(['refrigerated']);
+    expect(cap.notes).toBe('Salida diaria 08:00');
+  });
+
+  it('publish() normalizes constraints (trim, lowercase, dedupe)', () => {
+    const cap = makeCapacity({
+      constraints: ['Refrigerated', ' HAZMAT ', 'refrigerated', ''],
+    });
+    expect(cap.constraints).toEqual(['refrigerated', 'hazmat']);
+  });
+
+  it('withdraw() transitions available → withdrawn', () => {
+    const cap = makeCapacity();
+    cap.withdraw();
+    expect(cap.status).toBe(TransportCapacityStatus.Withdrawn);
+  });
+
+  it('withdraw() throws CapacityAlreadyWithdrawnError when already withdrawn', () => {
+    const cap = makeCapacity();
+    cap.withdraw();
+    expect(() => cap.withdraw()).toThrow(CapacityAlreadyWithdrawnError);
+  });
+
+  it('withdraw() bumps updatedAt', () => {
+    const cap = makeCapacity();
+    const before = cap.updatedAt.getTime();
+    cap.withdraw();
+    expect(cap.updatedAt.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('toSnapshot/fromSnapshot round-trip preserves all fields (corridor)', () => {
+    const cap = makeCapacity({
+      window: CapacityWindow.create({
+        from: '2026-07-01T00:00:00Z',
+        to: null,
+      }),
+      constraints: ['hazmat'],
+    });
+    const snap = cap.toSnapshot();
+    const restored = TransportCapacity.fromSnapshot(snap);
+
+    expect(restored.id.value).toBe(cap.id.value);
+    expect(restored.emergencyId.value).toBe(EM);
+    expect(restored.provider.id).toBe(PROVIDER_ID);
+    expect(restored.mode).toBe(TransportMode.Road);
+    expect(restored.capacity.weightKg).toBe(1000);
+    expect(restored.coverage.kind).toBe('corridor');
+    expect(restored.window.from).toBe('2026-07-01T00:00:00.000Z');
+    expect(restored.window.to).toBeNull();
+    expect(restored.constraints).toEqual(['hazmat']);
+    expect(restored.status).toBe(TransportCapacityStatus.Available);
+  });
+
+  it('toSnapshot/fromSnapshot round-trip preserves area coverage and withdrawn status', () => {
+    const cap = makeCapacity({
+      coverage: Coverage.area('Caracas'),
+      capacity: Capacity.create({ weightKg: null, volumeM3: 20 }),
+    });
+    cap.withdraw();
+    const restored = TransportCapacity.fromSnapshot(cap.toSnapshot());
+    expect(restored.coverage.kind).toBe('area');
+    expect(restored.capacity.weightKg).toBeNull();
+    expect(restored.capacity.volumeM3).toBe(20);
+    expect(restored.status).toBe(TransportCapacityStatus.Withdrawn);
+  });
+});

--- a/apps/api/src/contexts/logistics/domain/transport-capacity.ts
+++ b/apps/api/src/contexts/logistics/domain/transport-capacity.ts
@@ -1,0 +1,153 @@
+import { TransportCapacityId } from './transport-capacity-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+  TransportProviderType,
+} from './transport-capacity-enums';
+import { Capacity, CapacityProps } from './capacity';
+import { Coverage, CoverageProps } from './coverage';
+import { CapacityWindow, CapacityWindowProps } from './capacity-window';
+import {
+  CapacityAlreadyWithdrawnError,
+  CapacityNotAvailableError,
+} from './transport-capacity-errors';
+
+/**
+ * Polymorphic reference to whoever offers the capacity. No FK to volunteers or
+ * organizations — like grants' principal, the type discriminates the table.
+ */
+export interface TransportProvider {
+  type: TransportProviderType;
+  id: string;
+}
+
+export interface PublishTransportCapacityProps {
+  id: TransportCapacityId;
+  emergencyId: EmergencyId;
+  provider: TransportProvider;
+  mode: TransportMode;
+  capacity: Capacity;
+  coverage: Coverage;
+  window: CapacityWindow;
+  constraints: string[];
+  notes: string | null;
+}
+
+export interface TransportCapacitySnapshot {
+  id: string;
+  emergencyId: string;
+  providerType: TransportProviderType;
+  providerId: string;
+  mode: TransportMode;
+  capacity: CapacityProps;
+  coverage: CoverageProps;
+  window: CapacityWindowProps;
+  constraints: string[];
+  status: TransportCapacityStatus;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Aggregate root for a transport-capacity offer: a vehicle/airline/ship offering
+ * to MOVE cargo A→B during an emergency. The logistics analogue of
+ * {@link DonationOffer} (which offers material, not movement). See #105.
+ */
+export class TransportCapacity {
+  private constructor(
+    public readonly id: TransportCapacityId,
+    public readonly emergencyId: EmergencyId,
+    public readonly provider: TransportProvider,
+    public readonly mode: TransportMode,
+    public readonly capacity: Capacity,
+    public readonly coverage: Coverage,
+    public readonly window: CapacityWindow,
+    public readonly constraints: string[],
+    private _status: TransportCapacityStatus,
+    public readonly notes: string | null,
+    public readonly createdAt: Date,
+    private _updatedAt: Date,
+  ) {}
+
+  static publish(props: PublishTransportCapacityProps): TransportCapacity {
+    const now = new Date();
+    return new TransportCapacity(
+      props.id,
+      props.emergencyId,
+      props.provider,
+      props.mode,
+      props.capacity,
+      props.coverage,
+      props.window,
+      TransportCapacity.normalizeConstraints(props.constraints),
+      TransportCapacityStatus.Available,
+      props.notes,
+      now,
+      now,
+    );
+  }
+
+  static fromSnapshot(s: TransportCapacitySnapshot): TransportCapacity {
+    return new TransportCapacity(
+      TransportCapacityId.fromString(s.id),
+      EmergencyId.fromString(s.emergencyId),
+      { type: s.providerType, id: s.providerId },
+      s.mode,
+      Capacity.create(s.capacity),
+      Coverage.fromPlain(s.coverage),
+      CapacityWindow.create(s.window),
+      [...s.constraints],
+      s.status,
+      s.notes,
+      s.createdAt,
+      s.updatedAt,
+    );
+  }
+
+  private static normalizeConstraints(constraints: string[]): string[] {
+    const cleaned = constraints
+      .map((c) => c.trim().toLowerCase())
+      .filter((c) => c.length > 0);
+    return [...new Set(cleaned)];
+  }
+
+  get status(): TransportCapacityStatus {
+    return this._status;
+  }
+
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+
+  /** Retires the offer. Must be available (a withdrawn offer can't re-withdraw). */
+  withdraw(): void {
+    if (this._status === TransportCapacityStatus.Withdrawn) {
+      throw new CapacityAlreadyWithdrawnError();
+    }
+    if (this._status !== TransportCapacityStatus.Available) {
+      throw new CapacityNotAvailableError();
+    }
+    this._status = TransportCapacityStatus.Withdrawn;
+    this._updatedAt = new Date();
+  }
+
+  toSnapshot(): TransportCapacitySnapshot {
+    return {
+      id: this.id.value,
+      emergencyId: this.emergencyId.value,
+      providerType: this.provider.type,
+      providerId: this.provider.id,
+      mode: this.mode,
+      capacity: this.capacity.toPlain(),
+      coverage: this.coverage.toPlain(),
+      window: this.window.toPlain(),
+      constraints: [...this.constraints],
+      status: this._status,
+      notes: this.notes,
+      createdAt: this.createdAt,
+      updatedAt: this._updatedAt,
+    };
+  }
+}

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-capacity-emergency-lookup.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-capacity-emergency-lookup.ts
@@ -1,0 +1,22 @@
+import { eq } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import { CapacityEmergencyLookup } from '../../domain/ports/capacity-emergency-lookup';
+import { transportCapacitiesTable } from './schema';
+
+/**
+ * Drizzle adapter resolving a capacity's owning emergency for the withdraw
+ * authorization check. Reads only the logistics table, so there is no
+ * cross-context coupling.
+ */
+export class DrizzleCapacityEmergencyLookup implements CapacityEmergencyLookup {
+  constructor(private readonly db: Db) {}
+
+  async findEmergencyId(capacityId: string): Promise<string | null> {
+    const rows = await this.db
+      .select({ emergencyId: transportCapacitiesTable.emergencyId })
+      .from(transportCapacitiesTable)
+      .where(eq(transportCapacitiesTable.id, capacityId))
+      .limit(1);
+    return rows[0]?.emergencyId ?? null;
+  }
+}

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-transport-capacity.repository.int-spec.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-transport-capacity.repository.int-spec.ts
@@ -1,0 +1,186 @@
+import { createDb, Db } from '../../../../shared/db';
+import { transportCapacitiesTable } from './schema';
+import { DrizzleTransportCapacityRepository } from './drizzle-transport-capacity.repository';
+import { TransportCapacity } from '../../domain/transport-capacity';
+import { TransportCapacityId } from '../../domain/transport-capacity-id';
+import { EmergencyId } from '../../../../shared/domain/emergency-id';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+  TransportProviderType,
+} from '../../domain/transport-capacity-enums';
+import { Capacity } from '../../domain/capacity';
+import { Coverage } from '../../domain/coverage';
+import { CapacityWindow } from '../../domain/capacity-window';
+import type { Pool } from 'pg';
+
+const URL =
+  process.env.DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub';
+const EM = '44444444-4444-4444-8444-444444444444';
+const PROVIDER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORIGIN_RES = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const DEST_RES = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+function makeCapacity(opts?: {
+  mode?: TransportMode;
+  coverage?: Coverage;
+  capacity?: Capacity;
+  window?: CapacityWindow;
+  constraints?: string[];
+}): TransportCapacity {
+  return TransportCapacity.publish({
+    id: TransportCapacityId.create(),
+    emergencyId: EmergencyId.fromString(EM),
+    provider: { type: TransportProviderType.Organization, id: PROVIDER_ID },
+    mode: opts?.mode ?? TransportMode.Road,
+    capacity:
+      opts?.capacity ?? Capacity.create({ weightKg: 1200, volumeM3: 10 }),
+    coverage:
+      opts?.coverage ??
+      Coverage.corridor({
+        originResourceId: ORIGIN_RES,
+        destinationResourceId: DEST_RES,
+        originLat: null,
+        originLng: null,
+        destinationLat: null,
+        destinationLng: null,
+      }),
+    window: opts?.window ?? CapacityWindow.empty(),
+    constraints: opts?.constraints ?? ['refrigerated'],
+    notes: null,
+  });
+}
+
+describe('DrizzleTransportCapacityRepository (integration)', () => {
+  let db: Db;
+  let pool: Pool;
+  let repo: DrizzleTransportCapacityRepository;
+
+  beforeAll(() => {
+    ({ db, pool } = createDb(URL));
+    repo = new DrizzleTransportCapacityRepository(db);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await db.delete(transportCapacitiesTable);
+  });
+
+  it('round-trips a corridor capacity through Postgres', async () => {
+    const cap = makeCapacity({
+      window: CapacityWindow.create({ from: '2026-07-01T00:00:00Z', to: null }),
+    });
+    await repo.save(cap);
+    const found = await repo.findById(cap.id);
+
+    expect(found).not.toBeNull();
+    expect(found!.id.value).toBe(cap.id.value);
+    expect(found!.status).toBe(TransportCapacityStatus.Available);
+    expect(found!.provider.type).toBe(TransportProviderType.Organization);
+    expect(found!.provider.id).toBe(PROVIDER_ID);
+    expect(found!.mode).toBe(TransportMode.Road);
+    expect(found!.capacity.weightKg).toBe(1200);
+    expect(found!.capacity.volumeM3).toBe(10);
+    expect(found!.coverage.kind).toBe('corridor');
+    expect(found!.window.from).toBe('2026-07-01T00:00:00.000Z');
+    expect(found!.window.to).toBeNull();
+    expect(found!.constraints).toEqual(['refrigerated']);
+    // createdAt/updatedAt come back as real Dates (typed query builder).
+    expect(found!.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('round-trips an area capacity with weight-only and no constraints', async () => {
+    const cap = makeCapacity({
+      coverage: Coverage.area('Estado Vargas'),
+      capacity: Capacity.create({ weightKg: 800, volumeM3: null }),
+      constraints: [],
+    });
+    await repo.save(cap);
+    const found = await repo.findById(cap.id);
+
+    expect(found!.coverage.kind).toBe('area');
+    const plain = found!.coverage.toPlain();
+    expect(plain.kind === 'area' && plain.area).toBe('Estado Vargas');
+    expect(found!.capacity.weightKg).toBe(800);
+    expect(found!.capacity.volumeM3).toBeNull();
+    expect(found!.constraints).toEqual([]);
+  });
+
+  it('save() updates status on upsert (withdraw)', async () => {
+    const cap = makeCapacity();
+    await repo.save(cap);
+
+    cap.withdraw();
+    await repo.save(cap);
+
+    const found = await repo.findById(cap.id);
+    expect(found!.status).toBe(TransportCapacityStatus.Withdrawn);
+  });
+
+  it('findByEmergency filters by mode', async () => {
+    await repo.save(makeCapacity({ mode: TransportMode.Road }));
+    await repo.save(
+      makeCapacity({ mode: TransportMode.Air, coverage: Coverage.area('Hub') }),
+    );
+
+    const result = await repo.findByEmergency(EmergencyId.fromString(EM), {
+      mode: TransportMode.Air,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].mode).toBe(TransportMode.Air);
+  });
+
+  it('findByEmergency filters by status', async () => {
+    await repo.save(makeCapacity());
+    const withdrawn = makeCapacity({ coverage: Coverage.area('X') });
+    withdrawn.withdraw();
+    await repo.save(withdrawn);
+
+    const result = await repo.findByEmergency(EmergencyId.fromString(EM), {
+      status: TransportCapacityStatus.Available,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe(TransportCapacityStatus.Available);
+  });
+
+  it('findByEmergency filters by window overlap', async () => {
+    await repo.save(
+      makeCapacity({
+        window: CapacityWindow.create({
+          from: '2026-07-01T00:00:00Z',
+          to: '2026-07-31T00:00:00Z',
+        }),
+      }),
+    );
+    await repo.save(
+      makeCapacity({
+        coverage: Coverage.area('Aug'),
+        window: CapacityWindow.create({
+          from: '2026-08-01T00:00:00Z',
+          to: '2026-08-31T00:00:00Z',
+        }),
+      }),
+    );
+
+    const result = await repo.findByEmergency(EmergencyId.fromString(EM), {
+      availableFrom: '2026-07-05T00:00:00Z',
+      availableTo: '2026-07-10T00:00:00Z',
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].window.from).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('findByEmergency includes open-ended windows in any range', async () => {
+    await repo.save(makeCapacity({ window: CapacityWindow.empty() }));
+
+    const result = await repo.findByEmergency(EmergencyId.fromString(EM), {
+      availableFrom: '2030-01-01T00:00:00Z',
+      availableTo: '2030-12-31T00:00:00Z',
+    });
+    expect(result).toHaveLength(1);
+  });
+});

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-transport-capacity.repository.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-transport-capacity.repository.ts
@@ -1,0 +1,140 @@
+import { and, eq, gte, isNull, lte, or, type SQL } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import { transportCapacitiesTable } from './schema';
+import {
+  ListCapacitiesFilter,
+  TransportCapacityRepository,
+} from '../../domain/ports/transport-capacity.repository';
+import {
+  TransportCapacity,
+  TransportCapacitySnapshot,
+} from '../../domain/transport-capacity';
+import { TransportCapacityId } from '../../domain/transport-capacity-id';
+import { EmergencyId } from '../../../../shared/domain/emergency-id';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+  TransportProviderType,
+} from '../../domain/transport-capacity-enums';
+import { CoverageProps } from '../../domain/coverage';
+
+type CapacityRow = typeof transportCapacitiesTable.$inferSelect;
+
+function rowToSnapshot(row: CapacityRow): TransportCapacitySnapshot {
+  return {
+    id: row.id,
+    emergencyId: row.emergencyId,
+    providerType: row.providerType as TransportProviderType,
+    providerId: row.providerId,
+    mode: row.mode as TransportMode,
+    capacity: {
+      weightKg: row.weightKg ?? null,
+      volumeM3: row.volumeM3 ?? null,
+    },
+    coverage: row.coverage as CoverageProps,
+    window: {
+      from: row.windowFrom ? row.windowFrom.toISOString() : null,
+      to: row.windowTo ? row.windowTo.toISOString() : null,
+    },
+    constraints: row.constraints ?? [],
+    status: row.status as TransportCapacityStatus,
+    notes: row.notes ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class DrizzleTransportCapacityRepository
+  implements TransportCapacityRepository
+{
+  constructor(private readonly db: Db) {}
+
+  async save(capacity: TransportCapacity): Promise<void> {
+    const s = capacity.toSnapshot();
+    await this.db
+      .insert(transportCapacitiesTable)
+      .values({
+        id: s.id,
+        emergencyId: s.emergencyId,
+        providerType: s.providerType,
+        providerId: s.providerId,
+        mode: s.mode,
+        weightKg: s.capacity.weightKg,
+        volumeM3: s.capacity.volumeM3,
+        coverage: s.coverage,
+        windowFrom: s.window.from ? new Date(s.window.from) : null,
+        windowTo: s.window.to ? new Date(s.window.to) : null,
+        constraints: s.constraints,
+        status: s.status,
+        notes: s.notes,
+        createdAt: s.createdAt,
+        updatedAt: s.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: transportCapacitiesTable.id,
+        set: {
+          status: s.status,
+          updatedAt: s.updatedAt,
+        },
+      });
+  }
+
+  async findById(
+    id: TransportCapacityId,
+  ): Promise<TransportCapacity | null> {
+    const rows = await this.db
+      .select()
+      .from(transportCapacitiesTable)
+      .where(eq(transportCapacitiesTable.id, id.value))
+      .limit(1);
+    if (!rows[0]) return null;
+    return TransportCapacity.fromSnapshot(rowToSnapshot(rows[0]));
+  }
+
+  async findByEmergency(
+    emergencyId: EmergencyId,
+    filter: ListCapacitiesFilter,
+  ): Promise<TransportCapacity[]> {
+    const conditions: SQL[] = [
+      eq(transportCapacitiesTable.emergencyId, emergencyId.value),
+    ];
+
+    if (filter.mode !== undefined) {
+      conditions.push(eq(transportCapacitiesTable.mode, filter.mode));
+    }
+    if (filter.status !== undefined) {
+      conditions.push(eq(transportCapacitiesTable.status, filter.status));
+    }
+    // Window overlap: a capacity matches when it doesn't end before the
+    // requested start and doesn't start after the requested end. Null bounds
+    // are open-ended and always overlap on that side.
+    if (filter.availableFrom !== undefined) {
+      const from = new Date(filter.availableFrom);
+      conditions.push(
+        or(
+          isNull(transportCapacitiesTable.windowTo),
+          gte(transportCapacitiesTable.windowTo, from),
+        ) as SQL,
+      );
+    }
+    if (filter.availableTo !== undefined) {
+      const to = new Date(filter.availableTo);
+      conditions.push(
+        or(
+          isNull(transportCapacitiesTable.windowFrom),
+          lte(transportCapacitiesTable.windowFrom, to),
+        ) as SQL,
+      );
+    }
+
+    const rows = await this.db
+      .select()
+      .from(transportCapacitiesTable)
+      .where(and(...conditions))
+      .orderBy(transportCapacitiesTable.createdAt);
+
+    return rows
+      .map((r) => TransportCapacity.fromSnapshot(rowToSnapshot(r)))
+      .reverse();
+  }
+}

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-transport-capacity.repository.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-transport-capacity.repository.ts
@@ -16,7 +16,6 @@ import {
   TransportMode,
   TransportProviderType,
 } from '../../domain/transport-capacity-enums';
-import { CoverageProps } from '../../domain/coverage';
 
 type CapacityRow = typeof transportCapacitiesTable.$inferSelect;
 
@@ -31,7 +30,7 @@ function rowToSnapshot(row: CapacityRow): TransportCapacitySnapshot {
       weightKg: row.weightKg ?? null,
       volumeM3: row.volumeM3 ?? null,
     },
-    coverage: row.coverage as CoverageProps,
+    coverage: row.coverage,
     window: {
       from: row.windowFrom ? row.windowFrom.toISOString() : null,
       to: row.windowTo ? row.windowTo.toISOString() : null,
@@ -44,9 +43,7 @@ function rowToSnapshot(row: CapacityRow): TransportCapacitySnapshot {
   };
 }
 
-export class DrizzleTransportCapacityRepository
-  implements TransportCapacityRepository
-{
+export class DrizzleTransportCapacityRepository implements TransportCapacityRepository {
   constructor(private readonly db: Db) {}
 
   async save(capacity: TransportCapacity): Promise<void> {
@@ -79,9 +76,7 @@ export class DrizzleTransportCapacityRepository
       });
   }
 
-  async findById(
-    id: TransportCapacityId,
-  ): Promise<TransportCapacity | null> {
+  async findById(id: TransportCapacityId): Promise<TransportCapacity | null> {
     const rows = await this.db
       .select()
       .from(transportCapacitiesTable)

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/schema.ts
@@ -1,0 +1,32 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  doublePrecision,
+  jsonb,
+} from 'drizzle-orm/pg-core';
+import { CoverageProps } from '../../domain/coverage';
+
+export const transportCapacitiesTable = pgTable('transport_capacities', {
+  id: uuid('id').primaryKey(),
+  emergencyId: uuid('emergency_id').notNull(),
+  // Polymorphic provider (no FK, like grants' principal): 'volunteer' | 'organization'.
+  providerType: text('provider_type').notNull(),
+  providerId: uuid('provider_id').notNull(),
+  mode: text('mode').notNull(),
+  // Capacity: at least one of the two is non-null (enforced in the domain).
+  weightKg: doublePrecision('weight_kg'),
+  volumeM3: doublePrecision('volume_m3'),
+  // Coverage: discriminated value object (corridor | area) stored as JSONB.
+  coverage: jsonb('coverage').$type<CoverageProps>().notNull(),
+  // Availability window (both ends optional).
+  windowFrom: timestamp('window_from', { withTimezone: true }),
+  windowTo: timestamp('window_to', { withTimezone: true }),
+  // Free-form constraints (e.g. refrigerated, hazmat).
+  constraints: text('constraints').array().notNull(),
+  status: text('status').notNull(),
+  notes: text('notes'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});

--- a/apps/api/src/contexts/logistics/infrastructure/http/domain-exception.filter.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/domain-exception.filter.ts
@@ -1,0 +1,61 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { CapacityNotFoundError } from '../../application/capacity-not-found.error';
+import { CapacityWithdrawUnauthorizedError } from '../../application/withdraw-capacity';
+import {
+  CapacityAlreadyWithdrawnError,
+  CapacityMustHaveWeightOrVolumeError,
+  CapacityNotAvailableError,
+  InvalidCapacityAmountError,
+  InvalidCapacityWindowError,
+  InvalidCoverageError,
+} from '../../domain/transport-capacity-errors';
+import { EmergencyNotAcceptingIntakeError } from '../../../emergencies/domain/emergency-not-accepting-intake.error';
+
+type DomainError =
+  | CapacityNotFoundError
+  | CapacityWithdrawUnauthorizedError
+  | CapacityAlreadyWithdrawnError
+  | CapacityNotAvailableError
+  | CapacityMustHaveWeightOrVolumeError
+  | InvalidCapacityAmountError
+  | InvalidCapacityWindowError
+  | InvalidCoverageError
+  | EmergencyNotAcceptingIntakeError;
+
+@Catch(
+  CapacityNotFoundError,
+  CapacityWithdrawUnauthorizedError,
+  CapacityAlreadyWithdrawnError,
+  CapacityNotAvailableError,
+  CapacityMustHaveWeightOrVolumeError,
+  InvalidCapacityAmountError,
+  InvalidCapacityWindowError,
+  InvalidCoverageError,
+  EmergencyNotAcceptingIntakeError,
+)
+export class LogisticsDomainExceptionFilter implements ExceptionFilter {
+  catch(exception: DomainError, host: ArgumentsHost): void {
+    const response = host.switchToHttp().getResponse<Response>();
+    const statusCode =
+      exception instanceof CapacityNotFoundError
+        ? HttpStatus.NOT_FOUND
+        : exception instanceof CapacityWithdrawUnauthorizedError
+          ? HttpStatus.FORBIDDEN
+          : exception instanceof EmergencyNotAcceptingIntakeError
+            ? HttpStatus.CONFLICT
+            : exception instanceof CapacityAlreadyWithdrawnError
+              ? HttpStatus.CONFLICT
+              : exception instanceof CapacityNotAvailableError
+                ? HttpStatus.CONFLICT
+                : HttpStatus.UNPROCESSABLE_ENTITY;
+    response
+      .status(statusCode)
+      .json({ statusCode, message: exception.message });
+  }
+}

--- a/apps/api/src/contexts/logistics/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/dto.ts
@@ -1,0 +1,232 @@
+import {
+  IsArray,
+  IsEnum,
+  IsIn,
+  IsISO8601,
+  IsLatitude,
+  IsLongitude,
+  IsNotEmpty,
+  IsOptional,
+  IsPositive,
+  IsString,
+  IsUUID,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+  TransportProviderType,
+} from '../../domain/transport-capacity-enums';
+
+export class CapacityAmountDto {
+  @ApiPropertyOptional({
+    example: 1500,
+    description: 'Carrying weight in kilograms (positive)',
+    nullable: true,
+    type: Number,
+  })
+  @IsOptional()
+  @IsPositive()
+  weightKg?: number;
+
+  @ApiPropertyOptional({
+    example: 12,
+    description: 'Carrying volume in cubic metres (positive)',
+    nullable: true,
+    type: Number,
+  })
+  @IsOptional()
+  @IsPositive()
+  volumeM3?: number;
+}
+
+/**
+ * Coverage of the offer: a discriminated object. `kind: 'corridor'` describes a
+ * directed A->B route (endpoints optional: resource id and/or coordinates);
+ * `kind: 'area'` is a free-text served area.
+ */
+export class CoverageDto {
+  @ApiProperty({ enum: ['corridor', 'area'], example: 'corridor' })
+  @IsIn(['corridor', 'area'])
+  kind!: 'corridor' | 'area';
+
+  @ApiPropertyOptional({
+    format: 'uuid',
+    description: 'Corridor: origin collection point (resource) id',
+  })
+  @ValidateIf((o: CoverageDto) => o.kind === 'corridor')
+  @IsOptional()
+  @IsUUID()
+  originResourceId?: string;
+
+  @ApiPropertyOptional({
+    format: 'uuid',
+    description: 'Corridor: destination collection point (resource) id',
+  })
+  @ValidateIf((o: CoverageDto) => o.kind === 'corridor')
+  @IsOptional()
+  @IsUUID()
+  destinationResourceId?: string;
+
+  @ApiPropertyOptional({ example: 10.4806, description: 'Corridor: origin lat' })
+  @ValidateIf((o: CoverageDto) => o.kind === 'corridor')
+  @IsOptional()
+  @IsLatitude()
+  originLat?: number;
+
+  @ApiPropertyOptional({
+    example: -66.9036,
+    description: 'Corridor: origin lng',
+  })
+  @ValidateIf((o: CoverageDto) => o.kind === 'corridor')
+  @IsOptional()
+  @IsLongitude()
+  originLng?: number;
+
+  @ApiPropertyOptional({
+    example: 10.6,
+    description: 'Corridor: destination lat',
+  })
+  @ValidateIf((o: CoverageDto) => o.kind === 'corridor')
+  @IsOptional()
+  @IsLatitude()
+  destinationLat?: number;
+
+  @ApiPropertyOptional({
+    example: -67.0,
+    description: 'Corridor: destination lng',
+  })
+  @ValidateIf((o: CoverageDto) => o.kind === 'corridor')
+  @IsOptional()
+  @IsLongitude()
+  destinationLng?: number;
+
+  @ApiPropertyOptional({
+    example: 'Estado Vargas',
+    description: 'Area: free-text served area (required when kind=area)',
+  })
+  @ValidateIf((o: CoverageDto) => o.kind === 'area')
+  @IsString()
+  @IsNotEmpty()
+  area?: string;
+}
+
+export class CapacityWindowDto {
+  @ApiPropertyOptional({
+    example: '2026-07-01T00:00:00.000Z',
+    description: 'Availability start (ISO-8601)',
+  })
+  @IsOptional()
+  @IsISO8601()
+  from?: string;
+
+  @ApiPropertyOptional({
+    example: '2026-07-31T00:00:00.000Z',
+    description: 'Availability end (ISO-8601)',
+  })
+  @IsOptional()
+  @IsISO8601()
+  to?: string;
+}
+
+export class PublishCapacityProviderDto {
+  @ApiProperty({
+    enum: TransportProviderType,
+    example: TransportProviderType.Volunteer,
+  })
+  @IsEnum(TransportProviderType)
+  type!: TransportProviderType;
+
+  @ApiProperty({
+    format: 'uuid',
+    description: 'Volunteer or organization id (polymorphic, no FK)',
+  })
+  @IsUUID()
+  id!: string;
+}
+
+export class PublishCapacityDto {
+  @ApiProperty({ format: 'uuid', description: 'Emergency this capacity serves' })
+  @IsUUID()
+  emergencyId!: string;
+
+  @ApiProperty({ type: PublishCapacityProviderDto })
+  @ValidateNested()
+  @Type(() => PublishCapacityProviderDto)
+  provider!: PublishCapacityProviderDto;
+
+  @ApiProperty({ enum: TransportMode, example: TransportMode.Road })
+  @IsEnum(TransportMode)
+  mode!: TransportMode;
+
+  @ApiProperty({
+    type: CapacityAmountDto,
+    description: 'At least one of weightKg / volumeM3 is required',
+  })
+  @ValidateNested()
+  @Type(() => CapacityAmountDto)
+  capacity!: CapacityAmountDto;
+
+  @ApiProperty({ type: CoverageDto })
+  @ValidateNested()
+  @Type(() => CoverageDto)
+  coverage!: CoverageDto;
+
+  @ApiPropertyOptional({ type: CapacityWindowDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CapacityWindowDto)
+  window?: CapacityWindowDto;
+
+  @ApiPropertyOptional({
+    type: [String],
+    example: ['refrigerated', 'hazmat'],
+    description: 'Free-form constraints',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  constraints?: string[];
+
+  @ApiPropertyOptional({
+    example: 'Salida diaria a las 08:00',
+    description: 'Additional notes',
+  })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}
+
+export class ListCapacitiesQueryDto {
+  @ApiPropertyOptional({ enum: TransportMode, description: 'Filter by mode' })
+  @IsOptional()
+  @IsEnum(TransportMode)
+  mode?: TransportMode;
+
+  @ApiPropertyOptional({
+    enum: TransportCapacityStatus,
+    description: 'Filter by status',
+  })
+  @IsOptional()
+  @IsEnum(TransportCapacityStatus)
+  status?: TransportCapacityStatus;
+
+  @ApiPropertyOptional({
+    example: '2026-07-05T00:00:00.000Z',
+    description: 'Keep capacities available at/after this instant (ISO-8601)',
+  })
+  @IsOptional()
+  @IsISO8601()
+  availableFrom?: string;
+
+  @ApiPropertyOptional({
+    example: '2026-07-10T00:00:00.000Z',
+    description: 'Keep capacities available at/before this instant (ISO-8601)',
+  })
+  @IsOptional()
+  @IsISO8601()
+  availableTo?: string;
+}

--- a/apps/api/src/contexts/logistics/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/dto.ts
@@ -71,7 +71,10 @@ export class CoverageDto {
   @IsUUID()
   destinationResourceId?: string;
 
-  @ApiPropertyOptional({ example: 10.4806, description: 'Corridor: origin lat' })
+  @ApiPropertyOptional({
+    example: 10.4806,
+    description: 'Corridor: origin lat',
+  })
   @ValidateIf((o: CoverageDto) => o.kind === 'corridor')
   @IsOptional()
   @IsLatitude()
@@ -149,7 +152,10 @@ export class PublishCapacityProviderDto {
 }
 
 export class PublishCapacityDto {
-  @ApiProperty({ format: 'uuid', description: 'Emergency this capacity serves' })
+  @ApiProperty({
+    format: 'uuid',
+    description: 'Emergency this capacity serves',
+  })
   @IsUUID()
   emergencyId!: string;
 

--- a/apps/api/src/contexts/logistics/infrastructure/http/logistics.controller.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/logistics.controller.ts
@@ -1,0 +1,198 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Inject,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiConflictResponse,
+} from '@nestjs/swagger';
+import { PublishCapacity } from '../../application/publish-capacity';
+import { WithdrawCapacity } from '../../application/withdraw-capacity';
+import { ListCapacities } from '../../application/list-capacities';
+import { CapacityView } from '../../application/capacity-view';
+import {
+  PublishCapacityDto,
+  CoverageDto,
+  ListCapacitiesQueryDto,
+} from './dto';
+import { PublishCapacityResponseDto, CapacityViewDto } from './response.dto';
+import { CoverageProps } from '../../domain/coverage';
+import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
+import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
+import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
+import {
+  CAPACITY_EMERGENCY_LOOKUP,
+  type CapacityEmergencyLookup,
+} from '../../domain/ports/capacity-emergency-lookup';
+import {
+  MEMBERSHIP_REPOSITORY,
+  type MembershipRepository,
+} from '../../../identity/domain/ports/membership.repository';
+import { UserId } from '../../../identity/domain/user-id';
+import { Role } from '../../../identity/domain/role';
+
+interface AuthenticatedRequest extends Express.Request {
+  user: { id: string; email: string; isAdmin: boolean };
+}
+
+/** Maps the flat coverage DTO (optionals → undefined) to domain props (null). */
+function toCoverageProps(dto: CoverageDto): CoverageProps {
+  if (dto.kind === 'area') {
+    return { kind: 'area', area: dto.area ?? '' };
+  }
+  return {
+    kind: 'corridor',
+    originResourceId: dto.originResourceId ?? null,
+    destinationResourceId: dto.destinationResourceId ?? null,
+    originLat: dto.originLat ?? null,
+    originLng: dto.originLng ?? null,
+    destinationLat: dto.destinationLat ?? null,
+    destinationLng: dto.destinationLng ?? null,
+  };
+}
+
+@ApiTags('logistics')
+@Controller()
+export class LogisticsController {
+  constructor(
+    private readonly publishCapacity: PublishCapacity,
+    private readonly withdrawCapacity: WithdrawCapacity,
+    private readonly listCapacities: ListCapacities,
+    @Inject(CAPACITY_EMERGENCY_LOOKUP)
+    private readonly capacityEmergencyLookup: CapacityEmergencyLookup,
+    @Inject(MEMBERSHIP_REPOSITORY)
+    private readonly membershipRepo: MembershipRepository,
+  ) {}
+
+  @Post('logistics/capacities')
+  @HttpCode(201)
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('capacity:publish')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Publish a transport-capacity offer (authenticated, citizen-grade)',
+  })
+  @ApiCreatedResponse({
+    description: 'Capacity published',
+    type: PublishCapacityResponseDto,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid request body' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing capacity:publish permission' })
+  @ApiConflictResponse({
+    description: 'Emergency is not accepting intake (paused/closed)',
+  })
+  async publish(
+    @Body() dto: PublishCapacityDto,
+  ): Promise<PublishCapacityResponseDto> {
+    return this.publishCapacity.execute({
+      emergencyId: dto.emergencyId,
+      provider: { type: dto.provider.type, id: dto.provider.id },
+      mode: dto.mode,
+      capacity: {
+        weightKg: dto.capacity.weightKg ?? null,
+        volumeM3: dto.capacity.volumeM3 ?? null,
+      },
+      coverage: toCoverageProps(dto.coverage),
+      window: {
+        from: dto.window?.from ?? null,
+        to: dto.window?.to ?? null,
+      },
+      constraints: dto.constraints ?? [],
+      notes: dto.notes ?? null,
+    });
+  }
+
+  @Post('logistics/capacities/:id/withdraw')
+  @HttpCode(204)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Withdraw a transport-capacity offer (provider or coordinator)',
+  })
+  @ApiParam({ name: 'id', description: 'Capacity UUID', format: 'uuid' })
+  @ApiNoContentResponse({ description: 'Capacity withdrawn' })
+  @ApiNotFoundResponse({ description: 'Capacity not found' })
+  @ApiConflictResponse({
+    description: 'Capacity cannot be withdrawn in its current status',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({
+    description: 'Only the provider or a coordinator can withdraw',
+  })
+  async withdraw(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<void> {
+    let isCoordinator = req.user.isAdmin;
+
+    if (!isCoordinator) {
+      const emergencyId =
+        await this.capacityEmergencyLookup.findEmergencyId(id);
+      if (emergencyId !== null) {
+        isCoordinator = await this.membershipRepo.hasRole(
+          UserId.fromString(req.user.id),
+          emergencyId,
+          Role.Coordinator,
+        );
+      }
+    }
+
+    await this.withdrawCapacity.execute({
+      capacityId: id,
+      requesterUserId: req.user.id,
+      isCoordinator,
+    });
+  }
+
+  @Get('emergencies/:emergencyId/logistics/capacities')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('capacity:read')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'List transport capacities for an emergency (coordinator/verifier)',
+  })
+  @ApiParam({
+    name: 'emergencyId',
+    description: 'Emergency UUID',
+    format: 'uuid',
+  })
+  @ApiOkResponse({ description: 'Capacities', type: [CapacityViewDto] })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing capacity:read permission' })
+  async list(
+    @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
+    @Query() query: ListCapacitiesQueryDto,
+  ): Promise<CapacityView[]> {
+    return this.listCapacities.execute({
+      emergencyId,
+      ...(query.mode !== undefined ? { mode: query.mode } : {}),
+      ...(query.status !== undefined ? { status: query.status } : {}),
+      ...(query.availableFrom !== undefined
+        ? { availableFrom: query.availableFrom }
+        : {}),
+      ...(query.availableTo !== undefined
+        ? { availableTo: query.availableTo }
+        : {}),
+    });
+  }
+}

--- a/apps/api/src/contexts/logistics/infrastructure/http/logistics.controller.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/logistics.controller.ts
@@ -29,11 +29,7 @@ import { PublishCapacity } from '../../application/publish-capacity';
 import { WithdrawCapacity } from '../../application/withdraw-capacity';
 import { ListCapacities } from '../../application/list-capacities';
 import { CapacityView } from '../../application/capacity-view';
-import {
-  PublishCapacityDto,
-  CoverageDto,
-  ListCapacitiesQueryDto,
-} from './dto';
+import { PublishCapacityDto, CoverageDto, ListCapacitiesQueryDto } from './dto';
 import { PublishCapacityResponseDto, CapacityViewDto } from './response.dto';
 import { CoverageProps } from '../../domain/coverage';
 import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
@@ -89,7 +85,8 @@ export class LogisticsController {
   @RequirePermission('capacity:publish')
   @ApiBearerAuth()
   @ApiOperation({
-    summary: 'Publish a transport-capacity offer (authenticated, citizen-grade)',
+    summary:
+      'Publish a transport-capacity offer (authenticated, citizen-grade)',
   })
   @ApiCreatedResponse({
     description: 'Capacity published',
@@ -169,7 +166,8 @@ export class LogisticsController {
   @RequirePermission('capacity:read')
   @ApiBearerAuth()
   @ApiOperation({
-    summary: 'List transport capacities for an emergency (coordinator/verifier)',
+    summary:
+      'List transport capacities for an emergency (coordinator/verifier)',
   })
   @ApiParam({
     name: 'emergencyId',

--- a/apps/api/src/contexts/logistics/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/response.dto.ts
@@ -1,0 +1,115 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  TransportCapacityStatus,
+  TransportMode,
+  TransportProviderType,
+} from '../../domain/transport-capacity-enums';
+
+export class PublishCapacityResponseDto {
+  @ApiProperty({
+    format: 'uuid',
+    example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+  })
+  id!: string;
+}
+
+export class CapacityAmountResponseDto {
+  @ApiPropertyOptional({ example: 1500, nullable: true, type: Number })
+  weightKg!: number | null;
+
+  @ApiPropertyOptional({ example: 12, nullable: true, type: Number })
+  volumeM3!: number | null;
+}
+
+export class CoverageResponseDto {
+  @ApiProperty({ enum: ['corridor', 'area'], example: 'corridor' })
+  kind!: 'corridor' | 'area';
+
+  @ApiPropertyOptional({ format: 'uuid', nullable: true, type: String })
+  originResourceId?: string | null;
+
+  @ApiPropertyOptional({ format: 'uuid', nullable: true, type: String })
+  destinationResourceId?: string | null;
+
+  @ApiPropertyOptional({ example: 10.4806, nullable: true, type: Number })
+  originLat?: number | null;
+
+  @ApiPropertyOptional({ example: -66.9036, nullable: true, type: Number })
+  originLng?: number | null;
+
+  @ApiPropertyOptional({ example: 10.6, nullable: true, type: Number })
+  destinationLat?: number | null;
+
+  @ApiPropertyOptional({ example: -67.0, nullable: true, type: Number })
+  destinationLng?: number | null;
+
+  @ApiPropertyOptional({ example: 'Estado Vargas', type: String })
+  area?: string;
+}
+
+export class CapacityWindowResponseDto {
+  @ApiPropertyOptional({
+    example: '2026-07-01T00:00:00.000Z',
+    nullable: true,
+    type: String,
+  })
+  from!: string | null;
+
+  @ApiPropertyOptional({
+    example: '2026-07-31T00:00:00.000Z',
+    nullable: true,
+    type: String,
+  })
+  to!: string | null;
+}
+
+export class CapacityViewDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  emergencyId!: string;
+
+  @ApiProperty({
+    enum: TransportProviderType,
+    example: TransportProviderType.Volunteer,
+  })
+  providerType!: TransportProviderType;
+
+  @ApiProperty({ format: 'uuid' })
+  providerId!: string;
+
+  @ApiProperty({ enum: TransportMode, example: TransportMode.Road })
+  mode!: TransportMode;
+
+  @ApiProperty({ type: CapacityAmountResponseDto })
+  capacity!: CapacityAmountResponseDto;
+
+  @ApiProperty({ type: CoverageResponseDto })
+  coverage!: CoverageResponseDto;
+
+  @ApiProperty({ type: CapacityWindowResponseDto })
+  window!: CapacityWindowResponseDto;
+
+  @ApiProperty({ type: [String], example: ['refrigerated'] })
+  constraints!: string[];
+
+  @ApiProperty({
+    enum: TransportCapacityStatus,
+    example: TransportCapacityStatus.Available,
+  })
+  status!: TransportCapacityStatus;
+
+  @ApiPropertyOptional({
+    example: 'Salida diaria a las 08:00',
+    nullable: true,
+    type: String,
+  })
+  notes!: string | null;
+
+  @ApiProperty({ example: '2026-07-01T00:00:00.000Z' })
+  createdAt!: string;
+
+  @ApiProperty({ example: '2026-07-01T00:00:00.000Z' })
+  updatedAt!: string;
+}

--- a/apps/api/src/contexts/logistics/infrastructure/in-memory-transport-capacity.repository.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/in-memory-transport-capacity.repository.ts
@@ -27,9 +27,7 @@ function windowOverlaps(
   return true;
 }
 
-export class InMemoryTransportCapacityRepository
-  implements TransportCapacityRepository
-{
+export class InMemoryTransportCapacityRepository implements TransportCapacityRepository {
   private store = new Map<string, TransportCapacitySnapshot>();
 
   save(capacity: TransportCapacity): Promise<void> {
@@ -39,9 +37,7 @@ export class InMemoryTransportCapacityRepository
 
   findById(id: TransportCapacityId): Promise<TransportCapacity | null> {
     const snap = this.store.get(id.value);
-    return Promise.resolve(
-      snap ? TransportCapacity.fromSnapshot(snap) : null,
-    );
+    return Promise.resolve(snap ? TransportCapacity.fromSnapshot(snap) : null);
   }
 
   findByEmergency(

--- a/apps/api/src/contexts/logistics/infrastructure/in-memory-transport-capacity.repository.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/in-memory-transport-capacity.repository.ts
@@ -1,0 +1,60 @@
+import {
+  ListCapacitiesFilter,
+  TransportCapacityRepository,
+} from '../domain/ports/transport-capacity.repository';
+import {
+  TransportCapacity,
+  TransportCapacitySnapshot,
+} from '../domain/transport-capacity';
+import { TransportCapacityId } from '../domain/transport-capacity-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+
+/**
+ * A capacity's window overlaps the requested [from, to] interval when it does
+ * not end before `from` and does not start after `to`. Null bounds are
+ * open-ended and always overlap on that side.
+ */
+function windowOverlaps(
+  snap: TransportCapacitySnapshot,
+  filter: ListCapacitiesFilter,
+): boolean {
+  if (filter.availableFrom !== undefined && snap.window.to !== null) {
+    if (snap.window.to < filter.availableFrom) return false;
+  }
+  if (filter.availableTo !== undefined && snap.window.from !== null) {
+    if (snap.window.from > filter.availableTo) return false;
+  }
+  return true;
+}
+
+export class InMemoryTransportCapacityRepository
+  implements TransportCapacityRepository
+{
+  private store = new Map<string, TransportCapacitySnapshot>();
+
+  save(capacity: TransportCapacity): Promise<void> {
+    this.store.set(capacity.id.value, capacity.toSnapshot());
+    return Promise.resolve();
+  }
+
+  findById(id: TransportCapacityId): Promise<TransportCapacity | null> {
+    const snap = this.store.get(id.value);
+    return Promise.resolve(
+      snap ? TransportCapacity.fromSnapshot(snap) : null,
+    );
+  }
+
+  findByEmergency(
+    emergencyId: EmergencyId,
+    filter: ListCapacitiesFilter,
+  ): Promise<TransportCapacity[]> {
+    const result = [...this.store.values()]
+      .filter((s) => s.emergencyId === emergencyId.value)
+      .filter((s) => filter.mode === undefined || s.mode === filter.mode)
+      .filter((s) => filter.status === undefined || s.status === filter.status)
+      .filter((s) => windowOverlaps(s, filter))
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .map((s) => TransportCapacity.fromSnapshot(s));
+    return Promise.resolve(result);
+  }
+}

--- a/apps/api/src/contexts/logistics/infrastructure/logistics.module.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/logistics.module.ts
@@ -1,0 +1,82 @@
+import { Module } from '@nestjs/common';
+import { DB, DatabaseModule } from '../../../shared/database.module';
+import { Db } from '../../../shared/db';
+import { LogisticsController } from './http/logistics.controller';
+import { PublishCapacity } from '../application/publish-capacity';
+import { WithdrawCapacity } from '../application/withdraw-capacity';
+import { ListCapacities } from '../application/list-capacities';
+import {
+  TRANSPORT_CAPACITY_REPOSITORY,
+  TransportCapacityRepository,
+} from '../domain/ports/transport-capacity.repository';
+import {
+  LOGISTICS_EMERGENCY_STATUS_READER,
+  LogisticsEmergencyStatusReader,
+} from '../domain/ports/emergency-status-reader';
+import {
+  CAPACITY_EMERGENCY_LOOKUP,
+  CapacityEmergencyLookup,
+} from '../domain/ports/capacity-emergency-lookup';
+import { DrizzleTransportCapacityRepository } from './drizzle/drizzle-transport-capacity.repository';
+import { DrizzleCapacityEmergencyLookup } from './drizzle/drizzle-capacity-emergency-lookup';
+import { DrizzleEmergencyStatusReader } from '../../../shared/drizzle-emergency-status-reader';
+import { IdentityModule } from '../../identity/infrastructure/identity.module';
+// MEMBERSHIP_REPOSITORY is exported by IdentityModule and consumed by
+// LogisticsController via @Inject — no factory needed here.
+
+const transportCapacityRepositoryProvider = {
+  provide: TRANSPORT_CAPACITY_REPOSITORY,
+  inject: [DB],
+  useFactory: (db: Db): TransportCapacityRepository =>
+    new DrizzleTransportCapacityRepository(db),
+};
+
+const emergencyStatusReaderProvider = {
+  provide: LOGISTICS_EMERGENCY_STATUS_READER,
+  inject: [DB],
+  useFactory: (db: Db): LogisticsEmergencyStatusReader =>
+    new DrizzleEmergencyStatusReader(db),
+};
+
+const capacityEmergencyLookupProvider = {
+  provide: CAPACITY_EMERGENCY_LOOKUP,
+  inject: [DB],
+  useFactory: (db: Db): CapacityEmergencyLookup =>
+    new DrizzleCapacityEmergencyLookup(db),
+};
+
+const publishCapacityProvider = {
+  provide: PublishCapacity,
+  inject: [TRANSPORT_CAPACITY_REPOSITORY, LOGISTICS_EMERGENCY_STATUS_READER],
+  useFactory: (
+    repo: TransportCapacityRepository,
+    statusReader: LogisticsEmergencyStatusReader,
+  ) => new PublishCapacity(repo, statusReader),
+};
+
+const withdrawCapacityProvider = {
+  provide: WithdrawCapacity,
+  inject: [TRANSPORT_CAPACITY_REPOSITORY],
+  useFactory: (repo: TransportCapacityRepository) =>
+    new WithdrawCapacity(repo),
+};
+
+const listCapacitiesProvider = {
+  provide: ListCapacities,
+  inject: [TRANSPORT_CAPACITY_REPOSITORY],
+  useFactory: (repo: TransportCapacityRepository) => new ListCapacities(repo),
+};
+
+@Module({
+  imports: [DatabaseModule, IdentityModule],
+  controllers: [LogisticsController],
+  providers: [
+    transportCapacityRepositoryProvider,
+    emergencyStatusReaderProvider,
+    capacityEmergencyLookupProvider,
+    publishCapacityProvider,
+    withdrawCapacityProvider,
+    listCapacitiesProvider,
+  ],
+})
+export class LogisticsModule {}

--- a/apps/api/src/contexts/logistics/infrastructure/logistics.module.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/logistics.module.ts
@@ -57,8 +57,7 @@ const publishCapacityProvider = {
 const withdrawCapacityProvider = {
   provide: WithdrawCapacity,
   inject: [TRANSPORT_CAPACITY_REPOSITORY],
-  useFactory: (repo: TransportCapacityRepository) =>
-    new WithdrawCapacity(repo),
+  useFactory: (repo: TransportCapacityRepository) => new WithdrawCapacity(repo),
 };
 
 const listCapacitiesProvider = {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -7,6 +7,7 @@ import { AppModule } from './app.module';
 import { DomainExceptionFilter } from './contexts/resources/infrastructure/http/domain-exception.filter';
 import { NeedsDomainExceptionFilter } from './contexts/needs/infrastructure/http/domain-exception.filter';
 import { ReportExceptionFilter } from './contexts/reports/infrastructure/http/report-exception.filter';
+import { LogisticsDomainExceptionFilter } from './contexts/logistics/infrastructure/http/domain-exception.filter';
 
 /**
  * Validates that JWT_SECRET is strong enough in production.
@@ -65,6 +66,7 @@ async function bootstrap(): Promise<void> {
     new DomainExceptionFilter(),
     new NeedsDomainExceptionFilter(),
     new ReportExceptionFilter(),
+    new LogisticsDomainExceptionFilter(),
   );
   app.enableShutdownHooks();
 

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -1103,6 +1103,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/logistics/capacities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Publish a transport-capacity offer (authenticated, citizen-grade) */
+        post: operations["LogisticsController_publish"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/logistics/capacities/{id}/withdraw": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Withdraw a transport-capacity offer (provider or coordinator) */
+        post: operations["LogisticsController_withdraw"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/emergencies/{emergencyId}/logistics/capacities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List transport capacities for an emergency (coordinator/verifier) */
+        get: operations["LogisticsController_list"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/emergencies/{emergencyId}/volunteers": {
         parameters: {
             query?: never;
@@ -1961,9 +2012,6 @@ export interface components {
         InBoundsResourcesDto: {
             items: components["schemas"]["ResourceViewDto"][];
         };
-        InBoundsNeedsDto: {
-            items: components["schemas"]["NeedViewDto"][];
-        };
         ResourceFacetsDto: {
             /**
              * @example {
@@ -2388,6 +2436,9 @@ export interface components {
         NearbyNeedsResponseDto: {
             items: components["schemas"]["NearbyNeedViewDto"][];
         };
+        InBoundsNeedsDto: {
+            items: components["schemas"]["NeedViewDto"][];
+        };
         AssignNeedManagerDto: {
             /**
              * Format: uuid
@@ -2688,6 +2739,192 @@ export interface components {
              * @description The need to match this offer against
              */
             needId: string;
+        };
+        PublishCapacityProviderDto: {
+            /**
+             * @example volunteer
+             * @enum {string}
+             */
+            type: "volunteer" | "organization";
+            /**
+             * Format: uuid
+             * @description Volunteer or organization id (polymorphic, no FK)
+             */
+            id: string;
+        };
+        CapacityAmountDto: {
+            /**
+             * @description Carrying weight in kilograms (positive)
+             * @example 1500
+             */
+            weightKg?: number | null;
+            /**
+             * @description Carrying volume in cubic metres (positive)
+             * @example 12
+             */
+            volumeM3?: number | null;
+        };
+        CoverageDto: {
+            /**
+             * @example corridor
+             * @enum {string}
+             */
+            kind: "corridor" | "area";
+            /**
+             * Format: uuid
+             * @description Corridor: origin collection point (resource) id
+             */
+            originResourceId?: string;
+            /**
+             * Format: uuid
+             * @description Corridor: destination collection point (resource) id
+             */
+            destinationResourceId?: string;
+            /**
+             * @description Corridor: origin lat
+             * @example 10.4806
+             */
+            originLat?: number;
+            /**
+             * @description Corridor: origin lng
+             * @example -66.9036
+             */
+            originLng?: number;
+            /**
+             * @description Corridor: destination lat
+             * @example 10.6
+             */
+            destinationLat?: number;
+            /**
+             * @description Corridor: destination lng
+             * @example -67
+             */
+            destinationLng?: number;
+            /**
+             * @description Area: free-text served area (required when kind=area)
+             * @example Estado Vargas
+             */
+            area?: string;
+        };
+        CapacityWindowDto: {
+            /**
+             * @description Availability start (ISO-8601)
+             * @example 2026-07-01T00:00:00.000Z
+             */
+            from?: string;
+            /**
+             * @description Availability end (ISO-8601)
+             * @example 2026-07-31T00:00:00.000Z
+             */
+            to?: string;
+        };
+        PublishCapacityDto: {
+            /**
+             * Format: uuid
+             * @description Emergency this capacity serves
+             */
+            emergencyId: string;
+            provider: components["schemas"]["PublishCapacityProviderDto"];
+            /**
+             * @example road
+             * @enum {string}
+             */
+            mode: "road" | "sea" | "air";
+            /** @description At least one of weightKg / volumeM3 is required */
+            capacity: components["schemas"]["CapacityAmountDto"];
+            coverage: components["schemas"]["CoverageDto"];
+            window?: components["schemas"]["CapacityWindowDto"];
+            /**
+             * @description Free-form constraints
+             * @example [
+             *       "refrigerated",
+             *       "hazmat"
+             *     ]
+             */
+            constraints?: string[];
+            /**
+             * @description Additional notes
+             * @example Salida diaria a las 08:00
+             */
+            notes?: string;
+        };
+        PublishCapacityResponseDto: {
+            /**
+             * Format: uuid
+             * @example 3fa85f64-5717-4562-b3fc-2c963f66afa6
+             */
+            id: string;
+        };
+        CapacityAmountResponseDto: {
+            /** @example 1500 */
+            weightKg?: number | null;
+            /** @example 12 */
+            volumeM3?: number | null;
+        };
+        CoverageResponseDto: {
+            /**
+             * @example corridor
+             * @enum {string}
+             */
+            kind: "corridor" | "area";
+            /** Format: uuid */
+            originResourceId?: string | null;
+            /** Format: uuid */
+            destinationResourceId?: string | null;
+            /** @example 10.4806 */
+            originLat?: number | null;
+            /** @example -66.9036 */
+            originLng?: number | null;
+            /** @example 10.6 */
+            destinationLat?: number | null;
+            /** @example -67 */
+            destinationLng?: number | null;
+            /** @example Estado Vargas */
+            area?: string;
+        };
+        CapacityWindowResponseDto: {
+            /** @example 2026-07-01T00:00:00.000Z */
+            from?: string | null;
+            /** @example 2026-07-31T00:00:00.000Z */
+            to?: string | null;
+        };
+        CapacityViewDto: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            emergencyId: string;
+            /**
+             * @example volunteer
+             * @enum {string}
+             */
+            providerType: "volunteer" | "organization";
+            /** Format: uuid */
+            providerId: string;
+            /**
+             * @example road
+             * @enum {string}
+             */
+            mode: "road" | "sea" | "air";
+            capacity: components["schemas"]["CapacityAmountResponseDto"];
+            coverage: components["schemas"]["CoverageResponseDto"];
+            window: components["schemas"]["CapacityWindowResponseDto"];
+            /**
+             * @example [
+             *       "refrigerated"
+             *     ]
+             */
+            constraints: string[];
+            /**
+             * @example available
+             * @enum {string}
+             */
+            status: "available" | "reserved" | "withdrawn";
+            /** @example Salida diaria a las 08:00 */
+            notes?: string | null;
+            /** @example 2026-07-01T00:00:00.000Z */
+            createdAt: string;
+            /** @example 2026-07-01T00:00:00.000Z */
+            updatedAt: string;
         };
         RegisterVolunteerDto: {
             /** @example Ana García */
@@ -3972,40 +4209,6 @@ export interface operations {
             };
         };
     };
-    NeedsController_needsInBounds: {
-        parameters: {
-            query: {
-                /** @description South latitude bound (-90 to 90) */
-                minLat: number;
-                /** @description West longitude bound (-180 to 180) */
-                minLng: number;
-                /** @description North latitude bound (-90 to 90) */
-                maxLat: number;
-                /** @description East longitude bound (-180 to 180) */
-                maxLng: number;
-                /** @description Max results (default 500, max 1000) */
-                limit?: number;
-            };
-            header?: never;
-            path: {
-                /** @description Emergency UUID */
-                emergencyId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Validated needs within the bounding box */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InBoundsNeedsDto"];
-                };
-            };
-        };
-    };
     PublicController_facets: {
         parameters: {
             query?: never;
@@ -4643,6 +4846,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NearbyNeedsResponseDto"];
+                };
+            };
+        };
+    };
+    NeedsController_needsInBounds: {
+        parameters: {
+            query: {
+                /** @description South latitude bound (-90 to 90) */
+                minLat: number;
+                /** @description West longitude bound (-180 to 180) */
+                minLng: number;
+                /** @description North latitude bound (-90 to 90) */
+                maxLat: number;
+                /** @description East longitude bound (-180 to 180) */
+                maxLng: number;
+                /** @description Max results (default 500, max 1000) */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Emergency UUID */
+                emergencyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Validated needs within the bounding box */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InBoundsNeedsDto"];
                 };
             };
         };
@@ -5687,6 +5924,153 @@ export interface operations {
             };
             /** @description Offer cannot be cancelled in its current status */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    LogisticsController_publish: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PublishCapacityDto"];
+            };
+        };
+        responses: {
+            /** @description Capacity published */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublishCapacityResponseDto"];
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing capacity:publish permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Emergency is not accepting intake (paused/closed) */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    LogisticsController_withdraw: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Capacity UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Capacity withdrawn */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Only the provider or a coordinator can withdraw */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Capacity not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Capacity cannot be withdrawn in its current status */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    LogisticsController_list: {
+        parameters: {
+            query?: {
+                /** @description Filter by mode */
+                mode?: "road" | "sea" | "air";
+                /** @description Filter by status */
+                status?: "available" | "reserved" | "withdrawn";
+                /** @description Keep capacities available at/after this instant (ISO-8601) */
+                availableFrom?: string;
+                /** @description Keep capacities available at/before this instant (ISO-8601) */
+                availableTo?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Emergency UUID */
+                emergencyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Capacities */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CapacityViewDto"][];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing capacity:read permission */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Backend de #105. Nuevo contexto hexagonal **logistics** con el agregado **TransportCapacity** (oferta de capacidad de transporte: provider volunteer/organization, mode road/sea/air, capacity peso/volumen, coverage corredor o area, window, constraints, status available/reserved/withdrawn) — analogo a DonationOffer pero servicio en vez de material.

Endpoints: POST /logistics/capacities (publish; permiso capacity:publish, citizen-grade), POST /logistics/capacities/{id}/withdraw (provider o coordinador/admin), GET /emergencies/{id}/logistics/capacities (list filtrable por mode/status/ventana; permiso capacity:read). Migracion 0028_transport_capacity (tabla + indices). Permisos capacity:publish/read en el role-catalog. gen:api regenerado (schema.ts + openapi.json). Respeta el kill-switch de intake. TDD: dominio (24) + casos de uso (13) + integracion DB (7). Gate verde: api build/lint/prettier + 894/894 tests + api-client build.

Parte de #105 (el formulario frontend 'Ofrezco transporte' va en PR aparte). Desbloquea #106 y #107.