### PR TITLE
feat(logistics): matching capacidad<->traslado (backend #107)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3938,6 +3938,56 @@
         ]
       }
     },
+    "/logistics/shipments/{id}/capacity-suggestions": {
+      "get": {
+        "operationId": "ShipmentController_capacitySuggestions",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Shipment UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Compatible capacities ranked by proximity/coverage fit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CapacityViewDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing shipment:read permission"
+          },
+          "404": {
+            "description": "Shipment not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Suggest compatible transport capacities for a shipment, ranked (coordinator)",
+        "tags": [
+          "logistics"
+        ]
+      }
+    },
     "/emergencies/{emergencyId}/volunteers": {
       "post": {
         "operationId": "VolunteersController_registerVolunteer",

--- a/apps/api/src/contexts/logistics/application/suggest-capacities-for-shipment.spec.ts
+++ b/apps/api/src/contexts/logistics/application/suggest-capacities-for-shipment.spec.ts
@@ -1,0 +1,297 @@
+import { SuggestCapacitiesForShipment } from './suggest-capacities-for-shipment';
+import { ShipmentNotFoundError } from './shipment-not-found.error';
+import { CreateShipment } from './create-shipment';
+import { InMemoryShipmentRepository } from '../infrastructure/in-memory-shipment.repository';
+import { InMemoryTransportCapacityRepository } from '../infrastructure/in-memory-transport-capacity.repository';
+import { InMemoryResourceLocationLookup } from '../infrastructure/in-memory-resource-location-lookup';
+import { LogisticsEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+import { TransportCapacity } from '../domain/transport-capacity';
+import { TransportCapacityId } from '../domain/transport-capacity-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  TransportMode,
+  TransportProviderType,
+} from '../domain/transport-capacity-enums';
+import { Capacity } from '../domain/capacity';
+import { Coverage } from '../domain/coverage';
+import { CapacityWindow } from '../domain/capacity-window';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const OTHER_EM = '22222222-2222-4222-8222-222222222222';
+const PROVIDER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORIGIN = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const DEST = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const OTHER_NODE = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+
+// Caracas-ish origin coordinates for proximity ranking
+const ORIGIN_LAT = 10.4806;
+const ORIGIN_LNG = -66.9036;
+
+class FakeStatusReader implements LogisticsEmergencyStatusReader {
+  getStatus(): Promise<string | null> {
+    return Promise.resolve('active');
+  }
+}
+
+function makeCapacity(opts: {
+  emergencyId?: string;
+  mode?: TransportMode;
+  capacity?: Capacity;
+  coverage?: Coverage;
+  window?: CapacityWindow;
+  constraints?: string[];
+  withdrawn?: boolean;
+}): TransportCapacity {
+  const cap = TransportCapacity.publish({
+    id: TransportCapacityId.create(),
+    emergencyId: EmergencyId.fromString(opts.emergencyId ?? EM),
+    provider: { type: TransportProviderType.Organization, id: PROVIDER_ID },
+    mode: opts.mode ?? TransportMode.Road,
+    capacity: opts.capacity ?? Capacity.create({ weightKg: 1000, volumeM3: 8 }),
+    coverage:
+      opts.coverage ??
+      Coverage.corridor({
+        originResourceId: ORIGIN,
+        destinationResourceId: DEST,
+        originLat: null,
+        originLng: null,
+        destinationLat: null,
+        destinationLng: null,
+      }),
+    window: opts.window ?? CapacityWindow.empty(),
+    constraints: opts.constraints ?? [],
+    notes: null,
+  });
+  if (opts.withdrawn) cap.withdraw();
+  return cap;
+}
+
+async function seedShipment(
+  shipments: InMemoryShipmentRepository,
+  opts?: { items?: { description: string; quantity?: number }[] },
+): Promise<string> {
+  const { id } = await new CreateShipment(
+    shipments,
+    new FakeStatusReader(),
+  ).execute({
+    emergencyId: EM,
+    originResourceId: ORIGIN,
+    destinationResourceId: DEST,
+    items: opts?.items ?? [{ description: 'agua', quantity: 5 }],
+    manifest: null,
+  });
+  return id;
+}
+
+function buildUseCase(
+  shipments: InMemoryShipmentRepository,
+  capacities: InMemoryTransportCapacityRepository,
+  lookup: InMemoryResourceLocationLookup,
+): SuggestCapacitiesForShipment {
+  return new SuggestCapacitiesForShipment(shipments, capacities, lookup);
+}
+
+describe('SuggestCapacitiesForShipment', () => {
+  let shipments: InMemoryShipmentRepository;
+  let capacities: InMemoryTransportCapacityRepository;
+  let lookup: InMemoryResourceLocationLookup;
+
+  beforeEach(() => {
+    shipments = new InMemoryShipmentRepository();
+    capacities = new InMemoryTransportCapacityRepository();
+    lookup = new InMemoryResourceLocationLookup();
+    lookup.set(ORIGIN, { latitude: ORIGIN_LAT, longitude: ORIGIN_LNG });
+  });
+
+  it('throws ShipmentNotFoundError for an unknown shipment', async () => {
+    const useCase = buildUseCase(shipments, capacities, lookup);
+    await expect(
+      useCase.execute({
+        shipmentId: '99999999-9999-4999-8999-999999999999',
+      }),
+    ).rejects.toThrow(ShipmentNotFoundError);
+  });
+
+  it('returns available capacities of the same emergency', async () => {
+    const shipmentId = await seedShipment(shipments);
+    await capacities.save(makeCapacity({}));
+    const useCase = buildUseCase(shipments, capacities, lookup);
+
+    const result = await useCase.execute({ shipmentId });
+    expect(result).toHaveLength(1);
+    expect(result[0].emergencyId).toBe(EM);
+  });
+
+  it('excludes capacities of a different emergency', async () => {
+    const shipmentId = await seedShipment(shipments);
+    await capacities.save(makeCapacity({}));
+    await capacities.save(makeCapacity({ emergencyId: OTHER_EM }));
+    const useCase = buildUseCase(shipments, capacities, lookup);
+
+    const result = await useCase.execute({ shipmentId });
+    expect(result).toHaveLength(1);
+    expect(result[0].emergencyId).toBe(EM);
+  });
+
+  it('excludes capacities that are not available (withdrawn)', async () => {
+    const shipmentId = await seedShipment(shipments);
+    await capacities.save(makeCapacity({}));
+    await capacities.save(makeCapacity({ withdrawn: true }));
+    const useCase = buildUseCase(shipments, capacities, lookup);
+
+    const result = await useCase.execute({ shipmentId });
+    expect(result).toHaveLength(1);
+  });
+
+  it('does NOT filter on capacity size when the shipment carries no weight/volume', async () => {
+    const shipmentId = await seedShipment(shipments);
+    // A tiny capacity that would fail a size filter if one were applied.
+    await capacities.save(
+      makeCapacity({ capacity: Capacity.create({ weightKg: 1, volumeM3: 1 }) }),
+    );
+    const useCase = buildUseCase(shipments, capacities, lookup);
+
+    const result = await useCase.execute({ shipmentId });
+    expect(result).toHaveLength(1);
+  });
+
+  it('does NOT filter on mode (the shipment specifies none today)', async () => {
+    const shipmentId = await seedShipment(shipments);
+    await capacities.save(makeCapacity({ mode: TransportMode.Road }));
+    await capacities.save(makeCapacity({ mode: TransportMode.Air }));
+    await capacities.save(makeCapacity({ mode: TransportMode.Sea }));
+    const useCase = buildUseCase(shipments, capacities, lookup);
+
+    const result = await useCase.execute({ shipmentId });
+    expect(result).toHaveLength(3);
+  });
+
+  it('ranks corridor capacities whose endpoints match the shipment nodes above area capacities', async () => {
+    const shipmentId = await seedShipment(shipments);
+    // Area capacity (weaker coverage match)
+    await capacities.save(
+      makeCapacity({ coverage: Coverage.area('Estado Vargas') }),
+    );
+    // Corridor capacity matching the exact nodes (strong match)
+    await capacities.save(
+      makeCapacity({
+        coverage: Coverage.corridor({
+          originResourceId: ORIGIN,
+          destinationResourceId: DEST,
+          originLat: null,
+          originLng: null,
+          destinationLat: null,
+          destinationLng: null,
+        }),
+      }),
+    );
+    const useCase = buildUseCase(shipments, capacities, lookup);
+
+    const result = await useCase.execute({ shipmentId });
+    expect(result).toHaveLength(2);
+    expect(result[0].coverage.kind).toBe('corridor');
+    expect(result[1].coverage.kind).toBe('area');
+  });
+
+  it('ranks corridor capacities by proximity of their origin to the shipment origin', async () => {
+    const shipmentId = await seedShipment(shipments);
+    // Far corridor (origin ~hundreds of km away), no resourceId match
+    await capacities.save(
+      makeCapacity({
+        coverage: Coverage.corridor({
+          originResourceId: null,
+          destinationResourceId: null,
+          originLat: 8.0,
+          originLng: -63.0,
+          destinationLat: 8.5,
+          destinationLng: -63.5,
+        }),
+      }),
+    );
+    // Near corridor (origin ~1km away), no resourceId match
+    await capacities.save(
+      makeCapacity({
+        coverage: Coverage.corridor({
+          originResourceId: null,
+          destinationResourceId: null,
+          originLat: 10.49,
+          originLng: -66.903,
+          destinationLat: 10.6,
+          destinationLng: -67.0,
+        }),
+      }),
+    );
+    const useCase = buildUseCase(shipments, capacities, lookup);
+
+    const result = await useCase.execute({ shipmentId });
+    expect(result).toHaveLength(2);
+    const nearOriginLat = (
+      result[0].coverage as { originLat: number }
+    ).originLat;
+    expect(nearOriginLat).toBe(10.49);
+  });
+
+  it('ranks an exact resourceId corridor match above a closer-by-coords corridor', async () => {
+    const shipmentId = await seedShipment(shipments);
+    // Corridor with coords very close to origin but NO resourceId match
+    await capacities.save(
+      makeCapacity({
+        coverage: Coverage.corridor({
+          originResourceId: OTHER_NODE,
+          destinationResourceId: null,
+          originLat: ORIGIN_LAT,
+          originLng: ORIGIN_LNG,
+          destinationLat: 10.6,
+          destinationLng: -67.0,
+        }),
+      }),
+    );
+    // Corridor matching the exact origin resourceId but with far coords
+    await capacities.save(
+      makeCapacity({
+        coverage: Coverage.corridor({
+          originResourceId: ORIGIN,
+          destinationResourceId: DEST,
+          originLat: 5.0,
+          originLng: -60.0,
+          destinationLat: 5.5,
+          destinationLng: -60.5,
+        }),
+      }),
+    );
+    const useCase = buildUseCase(shipments, capacities, lookup);
+
+    const result = await useCase.execute({ shipmentId });
+    expect(result).toHaveLength(2);
+    expect(
+      (result[0].coverage as { originResourceId: string }).originResourceId,
+    ).toBe(ORIGIN);
+  });
+
+  it('sorts capacities without resolvable coords last', async () => {
+    const shipmentId = await seedShipment(shipments);
+    // Corridor with coords near origin (resolvable)
+    await capacities.save(
+      makeCapacity({
+        coverage: Coverage.corridor({
+          originResourceId: null,
+          destinationResourceId: null,
+          originLat: 10.49,
+          originLng: -66.903,
+          destinationLat: 10.6,
+          destinationLng: -67.0,
+        }),
+      }),
+    );
+    // Area coverage: no coords, no node match -> unresolvable -> last
+    await capacities.save(
+      makeCapacity({ coverage: Coverage.area('Estado Vargas') }),
+    );
+    const useCase = buildUseCase(shipments, capacities, lookup);
+
+    const result = await useCase.execute({ shipmentId });
+    expect(result).toHaveLength(2);
+    expect(result[0].coverage.kind).toBe('corridor');
+    expect(result[1].coverage.kind).toBe('area');
+  });
+});

--- a/apps/api/src/contexts/logistics/application/suggest-capacities-for-shipment.spec.ts
+++ b/apps/api/src/contexts/logistics/application/suggest-capacities-for-shipment.spec.ts
@@ -225,9 +225,8 @@ describe('SuggestCapacitiesForShipment', () => {
 
     const result = await useCase.execute({ shipmentId });
     expect(result).toHaveLength(2);
-    const nearOriginLat = (
-      result[0].coverage as { originLat: number }
-    ).originLat;
+    const nearOriginLat = (result[0].coverage as { originLat: number })
+      .originLat;
     expect(nearOriginLat).toBe(10.49);
   });
 

--- a/apps/api/src/contexts/logistics/application/suggest-capacities-for-shipment.ts
+++ b/apps/api/src/contexts/logistics/application/suggest-capacities-for-shipment.ts
@@ -63,7 +63,9 @@ export class SuggestCapacitiesForShipment {
       origin,
     );
 
-    return ranked.map((r) => toCapacityView(TransportCapacity.fromSnapshot(r.capacity)));
+    return ranked.map((r) =>
+      toCapacityView(TransportCapacity.fromSnapshot(r.capacity)),
+    );
   }
 
   private async resolveOrigin(

--- a/apps/api/src/contexts/logistics/application/suggest-capacities-for-shipment.ts
+++ b/apps/api/src/contexts/logistics/application/suggest-capacities-for-shipment.ts
@@ -1,0 +1,78 @@
+import { ShipmentRepository } from '../domain/ports/shipment.repository';
+import { TransportCapacityRepository } from '../domain/ports/transport-capacity.repository';
+import { ResourceLocationLookup } from '../domain/ports/resource-location-lookup';
+import { ShipmentId } from '../domain/shipment-id';
+import { TransportCapacityStatus } from '../domain/transport-capacity-enums';
+import { deriveShipmentMatchCriteria } from '../domain/shipment-match-criteria';
+import {
+  capacityMatchesShipment,
+  rankCapacitiesForShipment,
+  OriginLatLng,
+} from '../domain/capacity-match';
+import { CapacityView, toCapacityView } from './capacity-view';
+import { TransportCapacity } from '../domain/transport-capacity';
+import { ShipmentNotFoundError } from './shipment-not-found.error';
+
+export interface SuggestCapacitiesForShipmentQuery {
+  shipmentId: string;
+}
+
+/**
+ * #107 — closes the logistics loop: given a Shipment that must move cargo A→B,
+ * suggest the compatible {@link TransportCapacity} offers (#105), ranked. The
+ * logistics analogue of offer↔need matching.
+ *
+ * 1. Load the shipment → derive its match criteria (mode/load/window/constraints
+ *    — all open today; see {@link deriveShipmentMatchCriteria}).
+ * 2. Load the emergency's AVAILABLE capacities and keep the compatible ones.
+ * 3. Resolve the shipment origin coordinates once and rank by proximity/coverage.
+ */
+export class SuggestCapacitiesForShipment {
+  constructor(
+    private readonly shipmentRepo: ShipmentRepository,
+    private readonly capacityRepo: TransportCapacityRepository,
+    private readonly resourceLocationLookup: ResourceLocationLookup,
+  ) {}
+
+  async execute(
+    query: SuggestCapacitiesForShipmentQuery,
+  ): Promise<CapacityView[]> {
+    const shipment = await this.shipmentRepo.findById(
+      ShipmentId.fromString(query.shipmentId),
+    );
+    if (shipment === null) {
+      throw new ShipmentNotFoundError(query.shipmentId);
+    }
+
+    const criteria = deriveShipmentMatchCriteria(shipment);
+
+    const available = await this.capacityRepo.findByEmergency(
+      shipment.emergencyId,
+      { status: TransportCapacityStatus.Available },
+    );
+
+    const compatible = available.filter((capacity: TransportCapacity) =>
+      capacityMatchesShipment(capacity.toSnapshot(), criteria),
+    );
+
+    const origin = await this.resolveOrigin(criteria.originResourceId);
+
+    const ranked = rankCapacitiesForShipment(
+      compatible.map((c) => c.toSnapshot()),
+      criteria,
+      origin,
+    );
+
+    return ranked.map((r) => toCapacityView(TransportCapacity.fromSnapshot(r.capacity)));
+  }
+
+  private async resolveOrigin(
+    originResourceId: string,
+  ): Promise<OriginLatLng | null> {
+    const latLng =
+      await this.resourceLocationLookup.findLatLng(originResourceId);
+    return latLng === null
+      ? null
+      : { latitude: latLng.latitude, longitude: latLng.longitude };
+  }
+}

--- a/apps/api/src/contexts/logistics/domain/capacity-match.spec.ts
+++ b/apps/api/src/contexts/logistics/domain/capacity-match.spec.ts
@@ -1,0 +1,210 @@
+import { capacityMatchesShipment } from './capacity-match';
+import { ShipmentMatchCriteria } from './shipment-match-criteria';
+import { TransportCapacity } from './transport-capacity';
+import { TransportCapacityId } from './transport-capacity-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  TransportMode,
+  TransportProviderType,
+} from './transport-capacity-enums';
+import { Capacity } from './capacity';
+import { Coverage } from './coverage';
+import { CapacityWindow } from './capacity-window';
+import { TransportCapacitySnapshot } from './transport-capacity';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const PROVIDER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORIGIN = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const DEST = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+function snapshot(opts: {
+  mode?: TransportMode;
+  capacity?: Capacity;
+  window?: CapacityWindow;
+  constraints?: string[];
+}): TransportCapacitySnapshot {
+  return TransportCapacity.publish({
+    id: TransportCapacityId.create(),
+    emergencyId: EmergencyId.fromString(EM),
+    provider: { type: TransportProviderType.Organization, id: PROVIDER_ID },
+    mode: opts.mode ?? TransportMode.Road,
+    capacity: opts.capacity ?? Capacity.create({ weightKg: 1000, volumeM3: 8 }),
+    coverage: Coverage.corridor({
+      originResourceId: ORIGIN,
+      destinationResourceId: DEST,
+      originLat: null,
+      originLng: null,
+      destinationLat: null,
+      destinationLng: null,
+    }),
+    window: opts.window ?? CapacityWindow.empty(),
+    constraints: opts.constraints ?? [],
+    notes: null,
+  }).toSnapshot();
+}
+
+function criteria(
+  overrides?: Partial<ShipmentMatchCriteria>,
+): ShipmentMatchCriteria {
+  return {
+    emergencyId: EM,
+    originResourceId: ORIGIN,
+    destinationResourceId: DEST,
+    requiredMode: null,
+    weightKg: null,
+    volumeM3: null,
+    window: { from: null, to: null },
+    requiredConstraints: [],
+    ...overrides,
+  };
+}
+
+describe('capacityMatchesShipment', () => {
+  it('matches an open criteria with a plain available capacity', () => {
+    expect(capacityMatchesShipment(snapshot({}), criteria())).toBe(true);
+  });
+
+  describe('mode', () => {
+    it('matches when the required mode equals the capacity mode', () => {
+      const snap = snapshot({ mode: TransportMode.Air });
+      expect(
+        capacityMatchesShipment(snap, criteria({ requiredMode: TransportMode.Air })),
+      ).toBe(true);
+    });
+
+    it('excludes when the required mode differs from the capacity mode', () => {
+      const snap = snapshot({ mode: TransportMode.Road });
+      expect(
+        capacityMatchesShipment(snap, criteria({ requiredMode: TransportMode.Air })),
+      ).toBe(false);
+    });
+
+    it('does not filter on mode when no required mode is set', () => {
+      const snap = snapshot({ mode: TransportMode.Sea });
+      expect(capacityMatchesShipment(snap, criteria())).toBe(true);
+    });
+  });
+
+  describe('capacity >= load', () => {
+    it('excludes a capacity too small for the stated weight', () => {
+      const snap = snapshot({
+        capacity: Capacity.create({ weightKg: 100, volumeM3: null }),
+      });
+      expect(capacityMatchesShipment(snap, criteria({ weightKg: 500 }))).toBe(
+        false,
+      );
+    });
+
+    it('excludes a capacity too small for the stated volume', () => {
+      const snap = snapshot({
+        capacity: Capacity.create({ weightKg: null, volumeM3: 2 }),
+      });
+      expect(capacityMatchesShipment(snap, criteria({ volumeM3: 10 }))).toBe(
+        false,
+      );
+    });
+
+    it('includes a capacity that fits the stated weight and volume', () => {
+      const snap = snapshot({
+        capacity: Capacity.create({ weightKg: 1000, volumeM3: 8 }),
+      });
+      expect(
+        capacityMatchesShipment(snap, criteria({ weightKg: 500, volumeM3: 4 })),
+      ).toBe(true);
+    });
+
+    it('does not filter on a dimension the shipment omits (weight only)', () => {
+      // Capacity declares only volume; shipment states only weight.
+      const snap = snapshot({
+        capacity: Capacity.create({ weightKg: null, volumeM3: 8 }),
+      });
+      expect(capacityMatchesShipment(snap, criteria({ weightKg: 500 }))).toBe(
+        true,
+      );
+    });
+
+    it('does not filter on a dimension the capacity omits', () => {
+      // Shipment states weight; capacity declares only volume -> cannot
+      // disprove the weight fit, so do not exclude.
+      const snap = snapshot({
+        capacity: Capacity.create({ weightKg: null, volumeM3: 8 }),
+      });
+      expect(
+        capacityMatchesShipment(snap, criteria({ weightKg: 999999 })),
+      ).toBe(true);
+    });
+  });
+
+  describe('window overlap', () => {
+    it('excludes a capacity whose window does not overlap the shipment window', () => {
+      const snap = snapshot({
+        window: CapacityWindow.create({
+          from: '2026-07-01T00:00:00Z',
+          to: '2026-07-31T00:00:00Z',
+        }),
+      });
+      expect(
+        capacityMatchesShipment(
+          snap,
+          criteria({
+            window: { from: '2026-09-01T00:00:00Z', to: '2026-09-30T00:00:00Z' },
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it('includes a capacity whose window overlaps the shipment window', () => {
+      const snap = snapshot({
+        window: CapacityWindow.create({
+          from: '2026-07-01T00:00:00Z',
+          to: '2026-07-31T00:00:00Z',
+        }),
+      });
+      expect(
+        capacityMatchesShipment(
+          snap,
+          criteria({
+            window: { from: '2026-07-10T00:00:00Z', to: '2026-07-20T00:00:00Z' },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('treats an open shipment window as always overlapping', () => {
+      const snap = snapshot({
+        window: CapacityWindow.create({
+          from: '2026-07-01T00:00:00Z',
+          to: '2026-07-31T00:00:00Z',
+        }),
+      });
+      expect(capacityMatchesShipment(snap, criteria())).toBe(true);
+    });
+  });
+
+  describe('constraints', () => {
+    it('excludes a capacity missing a required constraint', () => {
+      const snap = snapshot({ constraints: [] });
+      expect(
+        capacityMatchesShipment(
+          snap,
+          criteria({ requiredConstraints: ['refrigerated'] }),
+        ),
+      ).toBe(false);
+    });
+
+    it('includes a capacity that provides every required constraint', () => {
+      const snap = snapshot({ constraints: ['refrigerated', 'fragile'] });
+      expect(
+        capacityMatchesShipment(
+          snap,
+          criteria({ requiredConstraints: ['refrigerated'] }),
+        ),
+      ).toBe(true);
+    });
+
+    it('does not filter when the shipment requires no constraints', () => {
+      const snap = snapshot({ constraints: [] });
+      expect(capacityMatchesShipment(snap, criteria())).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/contexts/logistics/domain/capacity-match.spec.ts
+++ b/apps/api/src/contexts/logistics/domain/capacity-match.spec.ts
@@ -68,14 +68,20 @@ describe('capacityMatchesShipment', () => {
     it('matches when the required mode equals the capacity mode', () => {
       const snap = snapshot({ mode: TransportMode.Air });
       expect(
-        capacityMatchesShipment(snap, criteria({ requiredMode: TransportMode.Air })),
+        capacityMatchesShipment(
+          snap,
+          criteria({ requiredMode: TransportMode.Air }),
+        ),
       ).toBe(true);
     });
 
     it('excludes when the required mode differs from the capacity mode', () => {
       const snap = snapshot({ mode: TransportMode.Road });
       expect(
-        capacityMatchesShipment(snap, criteria({ requiredMode: TransportMode.Air })),
+        capacityMatchesShipment(
+          snap,
+          criteria({ requiredMode: TransportMode.Air }),
+        ),
       ).toBe(false);
     });
 
@@ -147,7 +153,10 @@ describe('capacityMatchesShipment', () => {
         capacityMatchesShipment(
           snap,
           criteria({
-            window: { from: '2026-09-01T00:00:00Z', to: '2026-09-30T00:00:00Z' },
+            window: {
+              from: '2026-09-01T00:00:00Z',
+              to: '2026-09-30T00:00:00Z',
+            },
           }),
         ),
       ).toBe(false);
@@ -164,7 +173,10 @@ describe('capacityMatchesShipment', () => {
         capacityMatchesShipment(
           snap,
           criteria({
-            window: { from: '2026-07-10T00:00:00Z', to: '2026-07-20T00:00:00Z' },
+            window: {
+              from: '2026-07-10T00:00:00Z',
+              to: '2026-07-20T00:00:00Z',
+            },
           }),
         ),
       ).toBe(true);

--- a/apps/api/src/contexts/logistics/domain/capacity-match.ts
+++ b/apps/api/src/contexts/logistics/domain/capacity-match.ts
@@ -17,7 +17,10 @@ export function capacityMatchesShipment(
   criteria: ShipmentMatchCriteria,
 ): boolean {
   // mode: only when the shipment requires one.
-  if (criteria.requiredMode !== null && capacity.mode !== criteria.requiredMode) {
+  if (
+    criteria.requiredMode !== null &&
+    capacity.mode !== criteria.requiredMode
+  ) {
     return false;
   }
 
@@ -104,10 +107,12 @@ function slackOf(
 ): number {
   let slack = 0;
   if (criteria.weightKg !== null && capacity.capacity.weightKg !== null) {
-    slack += (capacity.capacity.weightKg - criteria.weightKg) / criteria.weightKg;
+    slack +=
+      (capacity.capacity.weightKg - criteria.weightKg) / criteria.weightKg;
   }
   if (criteria.volumeM3 !== null && capacity.capacity.volumeM3 !== null) {
-    slack += (capacity.capacity.volumeM3 - criteria.volumeM3) / criteria.volumeM3;
+    slack +=
+      (capacity.capacity.volumeM3 - criteria.volumeM3) / criteria.volumeM3;
   }
   return slack;
 }

--- a/apps/api/src/contexts/logistics/domain/capacity-match.ts
+++ b/apps/api/src/contexts/logistics/domain/capacity-match.ts
@@ -1,0 +1,188 @@
+import { TransportCapacitySnapshot } from './transport-capacity';
+import { ShipmentMatchCriteria } from './shipment-match-criteria';
+import { CorridorCoverageProps } from './coverage';
+import { capacityWindowOverlaps } from './window-overlap';
+import { haversineMeters } from '../../../shared/domain/geo-distance';
+
+/**
+ * Pure compatibility predicate for #107: does this available capacity satisfy
+ * the shipment's hard requirements? Each dimension is filtered ONLY when the
+ * shipment actually constrains it (and, for size, only when the capacity also
+ * declares that dimension) — a missing constraint never excludes. Coverage is
+ * deliberately NOT a hard filter here; it is a ranking signal (see
+ * {@link rankCapacitiesForShipment}).
+ */
+export function capacityMatchesShipment(
+  capacity: TransportCapacitySnapshot,
+  criteria: ShipmentMatchCriteria,
+): boolean {
+  // mode: only when the shipment requires one.
+  if (criteria.requiredMode !== null && capacity.mode !== criteria.requiredMode) {
+    return false;
+  }
+
+  // capacity >= load, per dimension, only when BOTH sides specify it.
+  if (
+    criteria.weightKg !== null &&
+    capacity.capacity.weightKg !== null &&
+    capacity.capacity.weightKg < criteria.weightKg
+  ) {
+    return false;
+  }
+  if (
+    criteria.volumeM3 !== null &&
+    capacity.capacity.volumeM3 !== null &&
+    capacity.capacity.volumeM3 < criteria.volumeM3
+  ) {
+    return false;
+  }
+
+  // window overlap: reuse the SAME semantics as ListCapacities (#105).
+  if (
+    !capacityWindowOverlaps(capacity.window, {
+      from: criteria.window.from ?? undefined,
+      to: criteria.window.to ?? undefined,
+    })
+  ) {
+    return false;
+  }
+
+  // constraints: capacity must provide every constraint the shipment requires.
+  const provided = new Set(capacity.constraints);
+  for (const required of criteria.requiredConstraints) {
+    if (!provided.has(required)) return false;
+  }
+
+  return true;
+}
+
+/** Coordinates of the shipment's origin node, resolved once by the use case. */
+export interface OriginLatLng {
+  latitude: number;
+  longitude: number;
+}
+
+/** Ranking tiers — lower sorts first. */
+const TIER_EXACT_NODE = 0; // corridor endpoint matches a shipment node
+const TIER_PROXIMITY = 1; // corridor with resolvable coords
+const TIER_UNRESOLVED = 2; // area, or no usable coords/node — sort last
+
+export interface RankedCapacity {
+  capacity: TransportCapacitySnapshot;
+  /** Distance origin→corridor-origin in meters, or null when unresolved. */
+  distanceMeters: number | null;
+}
+
+function corridorOf(
+  capacity: TransportCapacitySnapshot,
+): CorridorCoverageProps | null {
+  return capacity.coverage.kind === 'corridor' ? capacity.coverage : null;
+}
+
+/** A corridor endpoint resourceId equals the shipment origin or destination. */
+function matchesShipmentNode(
+  corridor: CorridorCoverageProps,
+  criteria: ShipmentMatchCriteria,
+): boolean {
+  const nodes = [criteria.originResourceId, criteria.destinationResourceId];
+  return (
+    (corridor.originResourceId !== null &&
+      nodes.includes(corridor.originResourceId)) ||
+    (corridor.destinationResourceId !== null &&
+      nodes.includes(corridor.destinationResourceId))
+  );
+}
+
+/**
+ * Spare-capacity measure for the tie-break ("least slack that still fits").
+ * Sums the relative slack on whichever dimensions both sides specify; returns 0
+ * when the load is unknown, so it stays a neutral tiebreak.
+ */
+function slackOf(
+  capacity: TransportCapacitySnapshot,
+  criteria: ShipmentMatchCriteria,
+): number {
+  let slack = 0;
+  if (criteria.weightKg !== null && capacity.capacity.weightKg !== null) {
+    slack += (capacity.capacity.weightKg - criteria.weightKg) / criteria.weightKg;
+  }
+  if (criteria.volumeM3 !== null && capacity.capacity.volumeM3 !== null) {
+    slack += (capacity.capacity.volumeM3 - criteria.volumeM3) / criteria.volumeM3;
+  }
+  return slack;
+}
+
+interface SortKey {
+  tier: number;
+  distanceMeters: number; // Infinity when unresolved
+  slack: number;
+}
+
+function sortKey(
+  capacity: TransportCapacitySnapshot,
+  criteria: ShipmentMatchCriteria,
+  origin: OriginLatLng | null,
+): SortKey {
+  const corridor = corridorOf(capacity);
+  const slack = slackOf(capacity, criteria);
+
+  if (corridor !== null && matchesShipmentNode(corridor, criteria)) {
+    const distanceMeters =
+      origin !== null &&
+      corridor.originLat !== null &&
+      corridor.originLng !== null
+        ? haversineMeters(
+            origin.latitude,
+            origin.longitude,
+            corridor.originLat,
+            corridor.originLng,
+          )
+        : 0;
+    return { tier: TIER_EXACT_NODE, distanceMeters, slack };
+  }
+
+  if (
+    corridor !== null &&
+    origin !== null &&
+    corridor.originLat !== null &&
+    corridor.originLng !== null
+  ) {
+    const distanceMeters = haversineMeters(
+      origin.latitude,
+      origin.longitude,
+      corridor.originLat,
+      corridor.originLng,
+    );
+    return { tier: TIER_PROXIMITY, distanceMeters, slack };
+  }
+
+  return { tier: TIER_UNRESOLVED, distanceMeters: Infinity, slack };
+}
+
+/**
+ * Ranks compatible capacities for a shipment (#107). Order: exact node-matching
+ * corridors first, then corridors by ascending proximity of their origin to the
+ * shipment origin, then area/unresolvable last — each tie broken by the tightest
+ * capacity fit (least slack). Coverage is a ranking signal, never a hard filter.
+ */
+export function rankCapacitiesForShipment(
+  capacities: TransportCapacitySnapshot[],
+  criteria: ShipmentMatchCriteria,
+  origin: OriginLatLng | null,
+): RankedCapacity[] {
+  return capacities
+    .map((capacity) => ({ capacity, key: sortKey(capacity, criteria, origin) }))
+    .sort((a, b) => {
+      if (a.key.tier !== b.key.tier) return a.key.tier - b.key.tier;
+      if (a.key.distanceMeters !== b.key.distanceMeters) {
+        return a.key.distanceMeters - b.key.distanceMeters;
+      }
+      return a.key.slack - b.key.slack;
+    })
+    .map(({ capacity, key }) => ({
+      capacity,
+      distanceMeters: Number.isFinite(key.distanceMeters)
+        ? Math.round(key.distanceMeters)
+        : null,
+    }));
+}

--- a/apps/api/src/contexts/logistics/domain/ports/resource-location-lookup.ts
+++ b/apps/api/src/contexts/logistics/domain/ports/resource-location-lookup.ts
@@ -1,0 +1,23 @@
+/**
+ * Port used by the logistics context to resolve the coordinates of a resource
+ * node (collection point) by id, for the #107 proximity ranking of capacity
+ * suggestions.
+ *
+ * Infrastructure note: satisfied by a Drizzle adapter that reads the `resources`
+ * table — an accepted, documented cross-context infra coupling, mirroring how
+ * the offers context reads the `needs` table via its NeedLookup port.
+ */
+export const RESOURCE_LOCATION_LOOKUP = Symbol('ResourceLocationLookup');
+
+export interface ResourceLatLng {
+  latitude: number;
+  longitude: number;
+}
+
+export interface ResourceLocationLookup {
+  /**
+   * Returns the coordinates of the resource, or null if the resource does not
+   * exist (or has no usable coordinates).
+   */
+  findLatLng(resourceId: string): Promise<ResourceLatLng | null>;
+}

--- a/apps/api/src/contexts/logistics/domain/shipment-match-criteria.ts
+++ b/apps/api/src/contexts/logistics/domain/shipment-match-criteria.ts
@@ -1,0 +1,60 @@
+import { Shipment } from './shipment';
+import { TransportMode } from './transport-capacity-enums';
+
+/**
+ * The compatibility criteria a {@link TransportCapacity} must satisfy to be a
+ * candidate for a given {@link Shipment} (#107). Derived from the shipment by
+ * {@link deriveShipmentMatchCriteria}.
+ *
+ * Every constraining dimension is OPTIONAL on purpose: a Shipment today does not
+ * carry a required mode, a load weight/volume, a time window or restrictions, so
+ * those fields come back "open" and impose NO filter (per the issue: don't
+ * invent data). The matcher honours each one only when present, so the criteria
+ * is future-proof for when shipments start carrying that information.
+ */
+export interface ShipmentMatchCriteria {
+  emergencyId: string;
+  originResourceId: string;
+  destinationResourceId: string;
+  /** Required transport mode, or null to not filter on mode. */
+  requiredMode: TransportMode | null;
+  /** Total load weight in kg, or null when unknown (no size filter on weight). */
+  weightKg: number | null;
+  /** Total load volume in m³, or null when unknown (no size filter on volume). */
+  volumeM3: number | null;
+  /** Time window the move must happen in; null bounds are open-ended. */
+  window: { from: string | null; to: string | null };
+  /** Restrictions the capacity must provide (normalized lowercase). */
+  requiredConstraints: string[];
+}
+
+/**
+ * Total weight/volume of a shipment's cargo. Shipment items do not carry weight
+ * or volume today, so both come back null and the size filter is skipped. When
+ * (and only when) items begin to carry those figures, summing them here makes
+ * the size filter kick in automatically — no change needed at the matcher.
+ */
+function deriveLoad(_shipment: Shipment): {
+  weightKg: number | null;
+  volumeM3: number | null;
+} {
+  // No weight/volume on ShipmentItem yet → unknown load. Do NOT fabricate data.
+  return { weightKg: null, volumeM3: null };
+}
+
+export function deriveShipmentMatchCriteria(
+  shipment: Shipment,
+): ShipmentMatchCriteria {
+  const { weightKg, volumeM3 } = deriveLoad(shipment);
+  return {
+    emergencyId: shipment.emergencyId.value,
+    originResourceId: shipment.originResourceId,
+    destinationResourceId: shipment.destinationResourceId,
+    // Shipment carries no required mode / window / constraints today → open.
+    requiredMode: null,
+    weightKg,
+    volumeM3,
+    window: { from: null, to: null },
+    requiredConstraints: [],
+  };
+}

--- a/apps/api/src/contexts/logistics/domain/window-overlap.ts
+++ b/apps/api/src/contexts/logistics/domain/window-overlap.ts
@@ -1,0 +1,34 @@
+import { CapacityWindowProps } from './capacity-window';
+
+/**
+ * The half-open interval to test a capacity window against. Both bounds are
+ * optional ISO-8601 instants; a missing bound means "no constraint on that
+ * side". Mirrors {@link ListCapacitiesFilter}'s availableFrom/availableTo.
+ */
+export interface WindowInterval {
+  from?: string | undefined;
+  to?: string | undefined;
+}
+
+/**
+ * Single source of truth for capacity-window overlap. A capacity's availability
+ * window overlaps the requested `[from, to]` interval when it does NOT end
+ * before `from` and does NOT start after `to`. Null/undefined bounds on either
+ * side are open-ended and always overlap on that side.
+ *
+ * Extracted from the in-memory repository (#105) so the #107 matching reuses the
+ * exact same semantics rather than re-deriving them. The Drizzle repository
+ * encodes the identical predicate in SQL (isNull/gte/lte) for the DB read path.
+ */
+export function capacityWindowOverlaps(
+  window: CapacityWindowProps,
+  interval: WindowInterval,
+): boolean {
+  if (interval.from !== undefined && window.to !== null) {
+    if (window.to < interval.from) return false;
+  }
+  if (interval.to !== undefined && window.from !== null) {
+    if (window.from > interval.to) return false;
+  }
+  return true;
+}

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-resource-location-lookup.int-spec.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-resource-location-lookup.int-spec.ts
@@ -1,0 +1,69 @@
+import { createDb, Db } from '../../../../shared/db';
+import { resourcesTable } from '../../../resources/infrastructure/drizzle/schema';
+import { DrizzleResourceRepository } from '../../../resources/infrastructure/drizzle/drizzle-resource.repository';
+import { Resource } from '../../../resources/domain/resource';
+import { ResourceId } from '../../../resources/domain/resource-id';
+import {
+  ResourceStage,
+  ResourceType,
+} from '../../../resources/domain/resource-enums';
+import { Location } from '../../../../shared/domain/location';
+import { EmergencyId } from '../../../../shared/domain/emergency-id';
+import { DrizzleResourceLocationLookup } from './drizzle-resource-location-lookup';
+import type { Pool } from 'pg';
+
+const URL =
+  process.env.DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub';
+const EM = '11111111-1111-4111-8111-111111111111';
+const OWNER_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+describe('DrizzleResourceLocationLookup (integration)', () => {
+  let db: Db;
+  let pool: Pool;
+  let resources: DrizzleResourceRepository;
+  let lookup: DrizzleResourceLocationLookup;
+
+  beforeAll(() => {
+    ({ db, pool } = createDb(URL));
+    resources = new DrizzleResourceRepository(db);
+    lookup = new DrizzleResourceLocationLookup(db);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await db.delete(resourcesTable);
+  });
+
+  it('resolves the lat/lng of an existing resource', async () => {
+    const resource = Resource.register({
+      id: ResourceId.create(),
+      emergencyId: EmergencyId.fromString(EM),
+      type: ResourceType.CollectionPoint,
+      stage: ResourceStage.Origin,
+      name: 'Punto de acopio centro',
+      location: Location.create({
+        address: 'Av. Bolívar 1, Caracas',
+        latitude: 10.4806,
+        longitude: -66.9036,
+      }),
+      ownerUserId: OWNER_ID,
+    });
+    await resources.save(resource);
+
+    const latLng = await lookup.findLatLng(resource.id.value);
+    expect(latLng).not.toBeNull();
+    expect(latLng!.latitude).toBeCloseTo(10.4806, 4);
+    expect(latLng!.longitude).toBeCloseTo(-66.9036, 4);
+  });
+
+  it('returns null for an unknown resource id', async () => {
+    const latLng = await lookup.findLatLng(
+      '99999999-9999-4999-8999-999999999999',
+    );
+    expect(latLng).toBeNull();
+  });
+});

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-resource-location-lookup.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-resource-location-lookup.ts
@@ -1,0 +1,27 @@
+import { eq } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import {
+  ResourceLatLng,
+  ResourceLocationLookup,
+} from '../../domain/ports/resource-location-lookup';
+// Cross-context infra coupling: logistics reads the resources table to resolve
+// a node's coordinates for proximity ranking (#107). Accepted and documented in
+// the port interface, mirroring offers' DrizzleNeedLookup.
+import { resourcesTable } from '../../../resources/infrastructure/drizzle/schema';
+
+export class DrizzleResourceLocationLookup implements ResourceLocationLookup {
+  constructor(private readonly db: Db) {}
+
+  async findLatLng(resourceId: string): Promise<ResourceLatLng | null> {
+    const rows = await this.db
+      .select({
+        latitude: resourcesTable.latitude,
+        longitude: resourcesTable.longitude,
+      })
+      .from(resourcesTable)
+      .where(eq(resourcesTable.id, resourceId))
+      .limit(1);
+    if (!rows[0]) return null;
+    return { latitude: rows[0].latitude, longitude: rows[0].longitude };
+  }
+}

--- a/apps/api/src/contexts/logistics/infrastructure/http/shipment.controller.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/shipment.controller.ts
@@ -32,7 +32,9 @@ import { ConfirmShipmentDelivery } from '../../application/confirm-shipment-deli
 import { CancelShipment } from '../../application/cancel-shipment';
 import { ListShipments } from '../../application/list-shipments';
 import { GetMyShipments } from '../../application/get-my-shipments';
+import { SuggestCapacitiesForShipment } from '../../application/suggest-capacities-for-shipment';
 import { ShipmentView } from '../../application/shipment-view';
+import { CapacityView } from '../../application/capacity-view';
 import {
   CreateShipmentDto,
   AssignCapacityToShipmentDto,
@@ -43,6 +45,7 @@ import {
   CreateShipmentResponseDto,
   ShipmentViewDto,
 } from './shipment-response.dto';
+import { CapacityViewDto } from './response.dto';
 import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
 import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
 import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
@@ -72,6 +75,7 @@ export class ShipmentController {
     private readonly cancelShipment: CancelShipment,
     private readonly listShipments: ListShipments,
     private readonly getMyShipments: GetMyShipments,
+    private readonly suggestCapacitiesForShipment: SuggestCapacitiesForShipment,
     @Inject(SHIPMENT_AUTHORIZATION_LOOKUP)
     private readonly shipmentAuthLookup: ShipmentAuthorizationLookup,
     @Inject(MEMBERSHIP_REPOSITORY)
@@ -279,5 +283,27 @@ export class ShipmentController {
       emergencyId,
       ...(query.status !== undefined ? { status: query.status } : {}),
     });
+  }
+
+  @Get('logistics/shipments/:id/capacity-suggestions')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('shipment:read')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Suggest compatible transport capacities for a shipment, ranked (coordinator)',
+  })
+  @ApiParam({ name: 'id', description: 'Shipment UUID', format: 'uuid' })
+  @ApiOkResponse({
+    description: 'Compatible capacities ranked by proximity/coverage fit',
+    type: [CapacityViewDto],
+  })
+  @ApiNotFoundResponse({ description: 'Shipment not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing shipment:read permission' })
+  async capacitySuggestions(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<CapacityView[]> {
+    return this.suggestCapacitiesForShipment.execute({ shipmentId: id });
   }
 }

--- a/apps/api/src/contexts/logistics/infrastructure/in-memory-resource-location-lookup.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/in-memory-resource-location-lookup.ts
@@ -1,0 +1,21 @@
+import {
+  ResourceLatLng,
+  ResourceLocationLookup,
+} from '../domain/ports/resource-location-lookup';
+
+/**
+ * In-memory {@link ResourceLocationLookup} for tests. Seed coordinates per
+ * resource id; unknown ids resolve to null (the "unresolvable coords" path of
+ * the #107 ranking).
+ */
+export class InMemoryResourceLocationLookup implements ResourceLocationLookup {
+  private store = new Map<string, ResourceLatLng>();
+
+  set(resourceId: string, latLng: ResourceLatLng): void {
+    this.store.set(resourceId, latLng);
+  }
+
+  findLatLng(resourceId: string): Promise<ResourceLatLng | null> {
+    return Promise.resolve(this.store.get(resourceId) ?? null);
+  }
+}

--- a/apps/api/src/contexts/logistics/infrastructure/in-memory-transport-capacity.repository.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/in-memory-transport-capacity.repository.ts
@@ -8,24 +8,7 @@ import {
 } from '../domain/transport-capacity';
 import { TransportCapacityId } from '../domain/transport-capacity-id';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
-
-/**
- * A capacity's window overlaps the requested [from, to] interval when it does
- * not end before `from` and does not start after `to`. Null bounds are
- * open-ended and always overlap on that side.
- */
-function windowOverlaps(
-  snap: TransportCapacitySnapshot,
-  filter: ListCapacitiesFilter,
-): boolean {
-  if (filter.availableFrom !== undefined && snap.window.to !== null) {
-    if (snap.window.to < filter.availableFrom) return false;
-  }
-  if (filter.availableTo !== undefined && snap.window.from !== null) {
-    if (snap.window.from > filter.availableTo) return false;
-  }
-  return true;
-}
+import { capacityWindowOverlaps } from '../domain/window-overlap';
 
 export class InMemoryTransportCapacityRepository implements TransportCapacityRepository {
   private store = new Map<string, TransportCapacitySnapshot>();
@@ -48,7 +31,12 @@ export class InMemoryTransportCapacityRepository implements TransportCapacityRep
       .filter((s) => s.emergencyId === emergencyId.value)
       .filter((s) => filter.mode === undefined || s.mode === filter.mode)
       .filter((s) => filter.status === undefined || s.status === filter.status)
-      .filter((s) => windowOverlaps(s, filter))
+      .filter((s) =>
+        capacityWindowOverlaps(s.window, {
+          from: filter.availableFrom,
+          to: filter.availableTo,
+        }),
+      )
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
       .map((s) => TransportCapacity.fromSnapshot(s));
     return Promise.resolve(result);

--- a/apps/api/src/contexts/logistics/infrastructure/logistics.module.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/logistics.module.ts
@@ -15,6 +15,7 @@ import { ConfirmShipmentDelivery } from '../application/confirm-shipment-deliver
 import { CancelShipment } from '../application/cancel-shipment';
 import { ListShipments } from '../application/list-shipments';
 import { GetMyShipments } from '../application/get-my-shipments';
+import { SuggestCapacitiesForShipment } from '../application/suggest-capacities-for-shipment';
 import {
   TRANSPORT_CAPACITY_REPOSITORY,
   TransportCapacityRepository,
@@ -39,10 +40,15 @@ import {
   CAPACITY_EMERGENCY_LOOKUP,
   CapacityEmergencyLookup,
 } from '../domain/ports/capacity-emergency-lookup';
+import {
+  RESOURCE_LOCATION_LOOKUP,
+  ResourceLocationLookup,
+} from '../domain/ports/resource-location-lookup';
 import { DrizzleTransportCapacityRepository } from './drizzle/drizzle-transport-capacity.repository';
 import { DrizzleShipmentRepository } from './drizzle/drizzle-shipment.repository';
 import { DrizzleShipmentAuthorizationLookup } from './drizzle/drizzle-shipment-authorization-lookup';
 import { DrizzleCapacityEmergencyLookup } from './drizzle/drizzle-capacity-emergency-lookup';
+import { DrizzleResourceLocationLookup } from './drizzle/drizzle-resource-location-lookup';
 import { DrizzleEmergencyStatusReader } from '../../../shared/drizzle-emergency-status-reader';
 import { BullMqShipmentEventBus } from './bullmq-shipment-event-bus';
 import { IdentityModule } from '../../identity/infrastructure/identity.module';
@@ -106,6 +112,13 @@ const capacityEmergencyLookupProvider = {
   inject: [DB],
   useFactory: (db: Db): CapacityEmergencyLookup =>
     new DrizzleCapacityEmergencyLookup(db),
+};
+
+const resourceLocationLookupProvider = {
+  provide: RESOURCE_LOCATION_LOOKUP,
+  inject: [DB],
+  useFactory: (db: Db): ResourceLocationLookup =>
+    new DrizzleResourceLocationLookup(db),
 };
 
 const publishCapacityProvider = {
@@ -175,6 +188,25 @@ const getMyShipmentsProvider = {
   useFactory: (repo: ShipmentRepository) => new GetMyShipments(repo),
 };
 
+const suggestCapacitiesForShipmentProvider = {
+  provide: SuggestCapacitiesForShipment,
+  inject: [
+    SHIPMENT_REPOSITORY,
+    TRANSPORT_CAPACITY_REPOSITORY,
+    RESOURCE_LOCATION_LOOKUP,
+  ],
+  useFactory: (
+    shipmentRepo: ShipmentRepository,
+    capacityRepo: TransportCapacityRepository,
+    resourceLocationLookup: ResourceLocationLookup,
+  ) =>
+    new SuggestCapacitiesForShipment(
+      shipmentRepo,
+      capacityRepo,
+      resourceLocationLookup,
+    ),
+};
+
 @Module({
   imports: [DatabaseModule, IdentityModule],
   controllers: [LogisticsController, ShipmentController],
@@ -186,6 +218,7 @@ const getMyShipmentsProvider = {
     shipmentEventBusProvider,
     emergencyStatusReaderProvider,
     capacityEmergencyLookupProvider,
+    resourceLocationLookupProvider,
     publishCapacityProvider,
     withdrawCapacityProvider,
     listCapacitiesProvider,
@@ -196,6 +229,7 @@ const getMyShipmentsProvider = {
     cancelShipmentProvider,
     listShipmentsProvider,
     getMyShipmentsProvider,
+    suggestCapacitiesForShipmentProvider,
   ],
 })
 export class LogisticsModule implements OnModuleDestroy {

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -1273,6 +1273,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/logistics/shipments/{id}/capacity-suggestions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Suggest compatible transport capacities for a shipment, ranked (coordinator) */
+        get: operations["ShipmentController_capacitySuggestions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/emergencies/{emergencyId}/volunteers": {
         parameters: {
             query?: never;
@@ -6637,6 +6654,50 @@ export interface operations {
             };
             /** @description Missing shipment:read permission */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ShipmentController_capacitySuggestions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Shipment UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Compatible capacities ranked by proximity/coverage fit */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CapacityViewDto"][];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing shipment:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Shipment not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Backend de #107. Cierra el bucle logistico: dado un Shipment (#106) que necesita mover carga A->B, sugiere las TransportCapacity (#105) compatibles. Analogo logistico del matching oferta<->necesidad.

Caso de uso SuggestCapacitiesForShipment (solo capa de aplicacion; sin agregado ni migracion): filtra por emergencia + status=available, y cuando el Shipment lo declara, por mode / capacidad>=carga (por dimension) / solape de ventana (mismo helper que ListCapacities #105) / constraints (subconjunto). Coverage NUNCA excluye en duro: rankea (decision abierta del issue -> nodos/area + cercania, geometria de corredor diferida a cuando entren los hubs #108). Orden: tier (match exacto de resourceId > coords resolubles > area/sin coords), luego haversine ascendente (reusa haversineMeters del shared kernel, el mismo de /nearby), desempate por menor holgura de capacidad.

Endpoint GET /logistics/shipments/{id}/capacity-suggestions -> CapacityView[] rankeado, permiso shipment:read (consistente con asignar capacidad a una expedicion). Puerto minimo ResourceLocationLookup (resuelve resourceId->lat/lng contra la tabla resources, como el NeedLookup de offers). gen:api regenerado. TDD: 25 tests nuevos + int-spec. Gate verde: 994/994 tests.

Cierra el EPIC de backend logistico (#105 capacidad + #106 expedicion + #107 matching). Los frontends (form 'Ofrezco transporte', panel de expediciones + vista transportista, sugerencias en la expedicion) van en PRs aparte.