### PR TITLE
feat(web): form publico 'Ofrezco transporte' (frontend #105)

### DIFF
--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
@@ -1,0 +1,160 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { api } from '@/lib/api';
+import type { components } from '@reliefhub/api-client';
+import { getToken, authHeaders, clearToken } from '@/lib/auth';
+import { getT } from '@/i18n/server';
+
+type CapacityMode = components['schemas']['PublishCapacityDto']['mode'];
+
+export type CapacityState =
+  | { status: 'idle' }
+  | { status: 'success'; id: string }
+  | { status: 'error'; message: string };
+
+const VALID_MODES: CapacityMode[] = ['road', 'sea', 'air'];
+
+function isMode(value: unknown): value is CapacityMode {
+  return VALID_MODES.includes(value as CapacityMode);
+}
+
+// ponytail: restricciones libres v1 — lista cerrada de checkboxes en la UI; el
+// API acepta string[] arbitrario, así que sólo dejamos pasar las tres conocidas.
+const VALID_CONSTRAINTS = ['refrigerated', 'hazmat', 'fragile'] as const;
+
+/**
+ * Parses a positive finite number from a FormData string value.
+ * Returns `undefined` when the field is empty and `null` when it is present but
+ * not a valid positive number (so the caller can distinguish "omitted" from
+ * "invalid").
+ */
+function parsePositive(raw: FormDataEntryValue | null): number | undefined | null {
+  if (typeof raw !== 'string' || raw.trim() === '') return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
+/**
+ * Publishes a transport-capacity offer for the given emergency on behalf of the
+ * current user (provider type `volunteer`). `emergencyId` and `providerId` are
+ * bound server-side in the page so neither is trusted from the client form.
+ */
+export async function submitCapacity(
+  emergencyId: string,
+  providerId: string,
+  _prev: CapacityState,
+  formData: FormData,
+): Promise<CapacityState> {
+  const token = await getToken();
+  if (!token) {
+    redirect('/login');
+  }
+
+  const { t } = await getT();
+  const tt = t.ofrecerTransporte;
+
+  const rawMode = formData.get('mode');
+  if (!isMode(rawMode)) {
+    return { status: 'error', message: tt.err_invalid_mode };
+  }
+
+  const weightKg = parsePositive(formData.get('weightKg'));
+  const volumeM3 = parsePositive(formData.get('volumeM3'));
+
+  if (weightKg === null || volumeM3 === null) {
+    return { status: 'error', message: tt.err_capacity_invalid };
+  }
+  if (weightKg === undefined && volumeM3 === undefined) {
+    return { status: 'error', message: tt.err_capacity_required };
+  }
+
+  const rawCoverage = formData.get('coverageArea');
+  const coverageArea = typeof rawCoverage === 'string' ? rawCoverage.trim() : '';
+  if (coverageArea === '') {
+    return { status: 'error', message: tt.err_coverage_required };
+  }
+
+  // Window (optional). datetime-local gives a value without timezone; convert
+  // to ISO. Omit the whole window unless at least one bound is present.
+  const rawFrom = formData.get('windowFrom');
+  const rawTo = formData.get('windowTo');
+  const fromStr = typeof rawFrom === 'string' ? rawFrom.trim() : '';
+  const toStr = typeof rawTo === 'string' ? rawTo.trim() : '';
+
+  const fromIso = fromStr !== '' ? new Date(fromStr).toISOString() : undefined;
+  const toIso = toStr !== '' ? new Date(toStr).toISOString() : undefined;
+
+  if (
+    fromIso !== undefined &&
+    toIso !== undefined &&
+    new Date(toIso).getTime() <= new Date(fromIso).getTime()
+  ) {
+    return { status: 'error', message: tt.err_window_invalid };
+  }
+
+  const window =
+    fromIso !== undefined || toIso !== undefined
+      ? {
+          ...(fromIso !== undefined ? { from: fromIso } : {}),
+          ...(toIso !== undefined ? { to: toIso } : {}),
+        }
+      : undefined;
+
+  const constraints = VALID_CONSTRAINTS.filter(
+    (c) => formData.get(`constraint_${c}`) === 'on',
+  );
+
+  const rawNotes = formData.get('notes');
+  const notes =
+    typeof rawNotes === 'string' && rawNotes.trim() !== ''
+      ? rawNotes.trim()
+      : undefined;
+
+  const { data, error, response } = await api.POST('/logistics/capacities', {
+    headers: authHeaders(token),
+    body: {
+      emergencyId,
+      // ponytail: el proveedor es siempre el ciudadano autenticado (volunteer);
+      // sin selector de proveedor ni org-as-provider en esta pantalla (#105).
+      provider: { type: 'volunteer', id: providerId },
+      mode: rawMode,
+      capacity: {
+        ...(weightKg !== undefined ? { weightKg } : {}),
+        ...(volumeM3 !== undefined ? { volumeM3 } : {}),
+      },
+      // ponytail: área libre v1; corredor por coords/resource-picking diferido —
+      // el matching #107 admite áreas (rankea más abajo).
+      coverage: { kind: 'area', area: coverageArea },
+      ...(window !== undefined ? { window } : {}),
+      ...(constraints.length > 0 ? { constraints } : {}),
+      ...(notes !== undefined ? { notes } : {}),
+    },
+  });
+
+  if (response.status === 401) {
+    await clearToken();
+    redirect('/login');
+  }
+
+  if (response.status === 409) {
+    return {
+      status: 'error',
+      message: t.common.intake_paused,
+    };
+  }
+
+  if (error !== undefined || data === undefined) {
+    const msg =
+      typeof error === 'object' &&
+      error !== null &&
+      'message' in error &&
+      typeof (error as { message: unknown }).message === 'string'
+        ? (error as { message: string }).message
+        : tt.err_submit_failed;
+    return { status: 'error', message: msg };
+  }
+
+  return { status: 'success', id: data.id };
+}

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/ofrecer-transporte-form.tsx
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/ofrecer-transporte-form.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useActionState, useState, useEffect } from 'react';
+import type { CapacityState } from './actions';
+import { Button } from '@/components/atoms/button';
+import { Input } from '@/components/atoms/input';
+import { Textarea } from '@/components/atoms/textarea';
+import { ErrorMessage } from '@/components/atoms/error-message';
+import { FormField } from '@/components/molecules/form-field';
+import { FormSuccessScreen } from '@/components/molecules/form-success-screen';
+import { DraftRestoredBanner } from '@/components/atoms/draft-restored-banner';
+import { useFormDraft } from '@/lib/use-form-draft';
+import type { Messages } from '@/i18n/messages/es';
+
+const INITIAL_STATE: CapacityState = { status: 'idle' };
+
+type BoundAction = (
+  prev: CapacityState,
+  formData: FormData,
+) => Promise<CapacityState>;
+
+interface OfrecerTransporteFormProps {
+  action: BoundAction;
+  slug: string;
+  t: Messages['ofrecerTransporte'];
+  backToEmergencyLabel: string;
+}
+
+export function OfrecerTransporteForm({
+  action,
+  slug,
+  t,
+  backToEmergencyLabel,
+}: OfrecerTransporteFormProps) {
+  const [state, formAction, pending] = useActionState<CapacityState, FormData>(
+    action,
+    INITIAL_STATE,
+  );
+
+  const [mode, setMode] = useState('road');
+  const [weightKg, setWeightKg] = useState('');
+  const [volumeM3, setVolumeM3] = useState('');
+  const [coverageArea, setCoverageArea] = useState('');
+  const [notes, setNotes] = useState('');
+
+  // Draft persistence — only the text/number fields (constraints + window are
+  // transient). Mirrors donar/peticion.
+  const draftValues = { mode, weightKg, volumeM3, coverageArea, notes };
+  const draftSetters = {
+    mode: setMode,
+    weightKg: setWeightKg,
+    volumeM3: setVolumeM3,
+    coverageArea: setCoverageArea,
+    notes: setNotes,
+  };
+  const { clearDraft, wasRestored } = useFormDraft(
+    `ofrecer-transporte-${slug}`,
+    draftValues,
+    draftSetters,
+  );
+
+  useEffect(() => {
+    if (state.status === 'success') clearDraft();
+  }, [state.status, clearDraft]);
+
+  const modes = [
+    { value: 'road', label: t.mode_road },
+    { value: 'sea', label: t.mode_sea },
+    { value: 'air', label: t.mode_air },
+  ] as const;
+
+  const constraints = [
+    { name: 'constraint_refrigerated', label: t.constraint_refrigerated },
+    { name: 'constraint_hazmat', label: t.constraint_hazmat },
+    { name: 'constraint_fragile', label: t.constraint_fragile },
+  ] as const;
+
+  if (state.status === 'success') {
+    return (
+      <FormSuccessScreen
+        message={t.success_message}
+        primaryHref={`/e/${slug}/ofrecer-transporte`}
+        primaryLabel={t.success_offer_again}
+        secondaryHref={`/e/${slug}`}
+        secondaryLabel={backToEmergencyLabel}
+      />
+    );
+  }
+
+  return (
+    <form action={formAction} className="flex flex-col gap-6" noValidate>
+      {wasRestored && <DraftRestoredBanner />}
+
+      {state.status === 'error' && (
+        <ErrorMessage message={state.message ?? t.error_fallback} />
+      )}
+
+      <p className="text-sm text-muted">{t.intro}</p>
+
+      {/* Modo de transporte — segmentado (radios) */}
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
+          {t.mode_label} <span aria-hidden="true">*</span>
+        </legend>
+        <div className="grid grid-cols-3 gap-2" role="radiogroup">
+          {modes.map(({ value, label }) => {
+            const selected = mode === value;
+            return (
+              <label
+                key={value}
+                className={`flex min-h-[44px] cursor-pointer items-center justify-center rounded-lg border-[1.5px] px-3 py-2.5 text-center text-sm font-semibold transition-colors focus-within:ring-2 focus-within:ring-accent/40 ${
+                  selected
+                    ? 'border-navy bg-navy text-white'
+                    : 'border-line-strong bg-white text-ink hover:bg-surface'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="mode"
+                  value={value}
+                  checked={selected}
+                  onChange={(e) => setMode(e.target.value)}
+                  className="sr-only"
+                />
+                {label}
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* Capacidad — peso y/o volumen */}
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
+          {t.capacity_legend} <span aria-hidden="true">*</span>
+        </legend>
+        <p className="text-xs text-muted">{t.capacity_hint}</p>
+        <div className="flex gap-3">
+          <div className="flex-1">
+            <FormField htmlFor="weightKg" label={t.weight_label}>
+              <Input
+                id="weightKg"
+                name="weightKg"
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="any"
+                placeholder={t.weight_placeholder}
+                value={weightKg}
+                onChange={(e) => setWeightKg(e.target.value)}
+              />
+            </FormField>
+          </div>
+          <div className="flex-1">
+            <FormField htmlFor="volumeM3" label={t.volume_label}>
+              <Input
+                id="volumeM3"
+                name="volumeM3"
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="any"
+                placeholder={t.volume_placeholder}
+                value={volumeM3}
+                onChange={(e) => setVolumeM3(e.target.value)}
+              />
+            </FormField>
+          </div>
+        </div>
+      </fieldset>
+
+      {/* Cobertura — área/ruta libre */}
+      <FormField
+        htmlFor="coverageArea"
+        label={<>{t.coverage_label} <span aria-hidden="true">*</span></>}
+      >
+        <Input
+          id="coverageArea"
+          name="coverageArea"
+          type="text"
+          required
+          placeholder={t.coverage_placeholder}
+          value={coverageArea}
+          onChange={(e) => setCoverageArea(e.target.value)}
+        />
+      </FormField>
+
+      {/* Ventana de disponibilidad (opcional) */}
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
+          {t.window_legend}{' '}
+          <span className="text-muted-soft font-normal normal-case">(opcional)</span>
+        </legend>
+        <div className="flex gap-3">
+          <div className="flex-1">
+            <FormField htmlFor="windowFrom" label={t.window_from_label}>
+              <Input
+                id="windowFrom"
+                name="windowFrom"
+                type="datetime-local"
+              />
+            </FormField>
+          </div>
+          <div className="flex-1">
+            <FormField htmlFor="windowTo" label={t.window_to_label}>
+              <Input id="windowTo" name="windowTo" type="datetime-local" />
+            </FormField>
+          </div>
+        </div>
+      </fieldset>
+
+      {/* Restricciones (opcional) */}
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
+          {t.constraints_legend}{' '}
+          <span className="text-muted-soft font-normal normal-case">(opcional)</span>
+        </legend>
+        <div className="flex flex-col gap-1">
+          {constraints.map(({ name, label }) => (
+            <label
+              key={name}
+              className="flex min-h-[44px] cursor-pointer items-center gap-3 rounded-lg px-1 text-base text-ink"
+            >
+              <input
+                type="checkbox"
+                name={name}
+                className="h-5 w-5 rounded border-line-strong text-navy focus:ring-2 focus:ring-accent/40"
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Notas (opcional) */}
+      <FormField
+        htmlFor="notes"
+        label={
+          <>
+            {t.notes_label}{' '}
+            <span className="text-muted-soft font-normal normal-case">(opcional)</span>
+          </>
+        }
+      >
+        <Textarea
+          id="notes"
+          name="notes"
+          rows={3}
+          placeholder={t.notes_placeholder}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+        />
+      </FormField>
+
+      <Button type="submit" disabled={pending} fullWidth>
+        {pending ? t.submitting : t.submit}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { getToken } from '@/lib/auth';
+import { getMe } from '@/lib/navigation-data';
+import { submitCapacity } from './actions';
+import { OfrecerTransporteForm } from './ofrecer-transporte-form';
+import { PageHeaderBand } from '@/components/molecules/page-header-band';
+import { getT } from '@/i18n/server';
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const emergency = await getEmergencyBySlug(slug);
+  const { t } = await getT();
+
+  if (!emergency) {
+    return { title: 'Emergencia no encontrada · ResponseGrid' };
+  }
+
+  return {
+    title: t.ofrecerTransporte.meta_title.replace('{emergencyName}', emergency.name),
+    description: t.ofrecerTransporte.meta_description.replace(
+      '{emergencyName}',
+      emergency.name,
+    ),
+  };
+}
+
+export default async function OfrecerTransportePage({ params }: Props) {
+  const { slug } = await params;
+  const { t } = await getT();
+
+  // Publishing a capacity REQUIRES auth (capacity:publish, citizen-grade).
+  const token = await getToken();
+  if (!token) {
+    redirect(`/login?next=/e/${slug}/ofrecer-transporte`);
+  }
+
+  // Resolve the current user — they are the provider (type: volunteer).
+  const me = await getMe();
+  if (me == null) {
+    redirect(`/login?next=/e/${slug}/ofrecer-transporte`);
+  }
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) {
+    notFound();
+  }
+
+  // Bind both the emergency and the provider id server-side so neither is
+  // trusted from the client form.
+  const boundAction = submitCapacity.bind(null, emergency.id, me.id);
+
+  return (
+    <main className="flex-1 bg-surface">
+      <div className="mx-auto w-full max-w-md">
+        <PageHeaderBand
+          backHref={`/e/${slug}`}
+          backLabel={t.common.back_to_emergency}
+          title={t.ofrecerTransporte.page_title}
+          subtitle={t.ofrecerTransporte.page_subtitle.replace(
+            '{emergencyName}',
+            emergency.name,
+          )}
+        />
+        <div className="flex flex-col gap-8 px-4 pb-12 pt-6">
+          <OfrecerTransporteForm
+            action={boundAction}
+            slug={slug}
+            t={t.ofrecerTransporte}
+            backToEmergencyLabel={t.common.back_to_emergency}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -276,6 +276,12 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
                   title={te.action_submit_petition}
                   subtitle={te.help_petition_subtitle}
                 />
+                <HelpActionRow
+                  href={`/e/${slug}/ofrecer-transporte`}
+                  icon="🚚"
+                  title={te.action_offer_transport}
+                  subtitle={te.help_transport_subtitle}
+                />
               </div>
             ) : (
               <p className="rounded-card border border-line bg-surface-alt px-4 py-4 text-sm text-muted">

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -133,6 +133,7 @@ export const en = {
     help_offer_subtitle: 'Warehouse · transport · space',
     help_volunteer_subtitle: 'Availability and skills',
     help_petition_subtitle: 'Request validated supplies',
+    help_transport_subtitle: 'Road · sea · air',
 
     // What NOT to do
     dont_do_heading: 'What NOT to do right now',
@@ -166,6 +167,7 @@ export const en = {
     action_submit_petition: 'Submit a request',
     action_donate: 'Donate supplies',
     action_volunteer: 'Sign up as a volunteer',
+    action_offer_transport: 'I can offer transport',
     actions_paused:
       'Resource and request registration is paused. Check the available information and come back later.',
 
@@ -531,6 +533,65 @@ export const en = {
     err_invalid_quantity: 'Quantity must be a positive whole number.',
     err_location_required: 'Select a location.',
     err_submit_failed: 'Couldn’t submit the offer. Please try again.',
+  },
+
+  // ── Offer transport (#105) ────────────────────────────────────────────────
+  ofrecerTransporte: {
+    page_title: 'I can offer transport',
+    page_subtitle: '{emergencyName} · Make your transport capacity available to the operation.',
+    meta_title: 'Offer transport — {emergencyName} · ResponseGrid',
+    meta_description: 'Offer transport capacity to move supplies for {emergencyName}.',
+
+    intro:
+      'Tell us how much cargo you can move and where. Coordination will match your capacity with the shipments that need it.',
+
+    // Transport mode
+    mode_label: 'Transport mode',
+    mode_road: 'Road',
+    mode_sea: 'Sea',
+    mode_air: 'Air',
+
+    // Capacity
+    capacity_legend: 'Cargo capacity',
+    capacity_hint: 'Provide at least weight or volume.',
+    weight_label: 'Weight (kg)',
+    weight_placeholder: 'e.g. 1500',
+    volume_label: 'Volume (m³)',
+    volume_placeholder: 'e.g. 12',
+
+    // Coverage
+    coverage_label: 'Which area or route do you cover?',
+    coverage_placeholder: 'e.g. Caracas → La Guaira, or Vargas State',
+
+    // Availability window
+    window_legend: 'Availability',
+    window_from_label: 'From',
+    window_to_label: 'To',
+
+    // Constraints
+    constraints_legend: 'Cargo conditions',
+    constraint_refrigerated: 'Refrigerated',
+    constraint_hazmat: 'Hazardous materials',
+    constraint_fragile: 'Fragile',
+
+    // Notes
+    notes_label: 'Additional notes',
+    notes_placeholder: 'e.g. Daily departure at 08:00',
+
+    submit: 'Publish capacity',
+    submitting: 'Publishing…',
+    success_message:
+      'Transport capacity published. Coordination will take it into account for this emergency’s shipments.',
+    success_offer_again: 'Publish another capacity',
+    error_fallback: 'Error publishing the capacity',
+
+    // server-action messages
+    err_invalid_mode: 'Select a valid transport mode.',
+    err_capacity_required: 'Provide at least weight (kg) or volume (m³).',
+    err_capacity_invalid: 'Weight and volume must be positive numbers.',
+    err_coverage_required: 'Enter the area or route you cover.',
+    err_window_invalid: 'The end date must be after the start date.',
+    err_submit_failed: 'Couldn’t publish the capacity. Please try again.',
   },
 
   voluntario: {

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -134,6 +134,7 @@ export const es = {
     help_offer_subtitle: 'Almacén · transporte · espacio',
     help_volunteer_subtitle: 'Disponibilidad y habilidades',
     help_petition_subtitle: 'Solicitar material validado',
+    help_transport_subtitle: 'Carretera · marítimo · aéreo',
 
     // Qué NO hacer ahora
     dont_do_heading: 'Qué NO hacer ahora',
@@ -170,6 +171,7 @@ export const es = {
     action_submit_petition: 'Poner una petición',
     action_donate: 'Donar material',
     action_volunteer: 'Apuntarme como voluntario',
+    action_offer_transport: 'Ofrezco transporte',
     actions_paused:
       'El alta de recursos y peticiones está en pausa. Consulta la información disponible y vuelve más tarde.',
 
@@ -555,6 +557,65 @@ export const es = {
     err_invalid_quantity: 'La cantidad debe ser un número entero positivo.',
     err_location_required: 'Selecciona una ubicación.',
     err_submit_failed: 'Error al enviar la oferta. Inténtalo de nuevo.',
+  },
+
+  // ── Ofrecer transporte (#105) ─────────────────────────────────────────────
+  ofrecerTransporte: {
+    page_title: 'Ofrezco transporte',
+    page_subtitle: '{emergencyName} · Pon tu capacidad de transporte a disposición del operativo.',
+    meta_title: 'Ofrezco transporte — {emergencyName} · ResponseGrid',
+    meta_description: 'Ofrece capacidad de transporte para mover material en {emergencyName}.',
+
+    intro:
+      'Indica cuánta carga puedes mover y por qué zona. Coordinación casará tu capacidad con los envíos que la necesiten.',
+
+    // Modo de transporte
+    mode_label: 'Modo de transporte',
+    mode_road: 'Carretera',
+    mode_sea: 'Marítimo',
+    mode_air: 'Aéreo',
+
+    // Capacidad
+    capacity_legend: 'Capacidad de carga',
+    capacity_hint: 'Indica al menos peso o volumen.',
+    weight_label: 'Peso (kg)',
+    weight_placeholder: 'Ej. 1500',
+    volume_label: 'Volumen (m³)',
+    volume_placeholder: 'Ej. 12',
+
+    // Cobertura
+    coverage_label: '¿Qué zona o ruta cubres?',
+    coverage_placeholder: 'Ej. Caracas → La Guaira, o Estado Vargas',
+
+    // Ventana de disponibilidad
+    window_legend: 'Disponibilidad',
+    window_from_label: 'Desde',
+    window_to_label: 'Hasta',
+
+    // Restricciones
+    constraints_legend: 'Condiciones de la carga',
+    constraint_refrigerated: 'Refrigerado',
+    constraint_hazmat: 'Mercancías peligrosas',
+    constraint_fragile: 'Frágil',
+
+    // Notas
+    notes_label: 'Notas adicionales',
+    notes_placeholder: 'Ej. Salida diaria a las 08:00',
+
+    submit: 'Publicar capacidad',
+    submitting: 'Publicando…',
+    success_message:
+      'Capacidad de transporte publicada. Coordinación la tendrá en cuenta para los envíos de esta emergencia.',
+    success_offer_again: 'Publicar otra capacidad',
+    error_fallback: 'Error al publicar la capacidad',
+
+    // server-action messages
+    err_invalid_mode: 'Selecciona un modo de transporte válido.',
+    err_capacity_required: 'Indica al menos peso (kg) o volumen (m³).',
+    err_capacity_invalid: 'El peso y el volumen deben ser números positivos.',
+    err_coverage_required: 'Indica la zona o ruta que cubres.',
+    err_window_invalid: 'La fecha de fin debe ser posterior a la de inicio.',
+    err_submit_failed: 'Error al publicar la capacidad. Inténtalo de nuevo.',
   },
 
   // ── Voluntario form ───────────────────────────────────────────────────────


### PR DESCRIPTION
Frontend de #105. Form mobile-first para que un ciudadano publique capacidad de transporte en una emergencia — analogo de servicio del form de donacion material (/donar).

Pagina /e/{slug}/ofrecer-transporte (server component + server action + client form con useActionState y persistencia de borrador). Requiere login (redirige a /login si no hay sesion); el proveedor se fija server-side como provider {type:'volunteer', id:<usuario>}. Campos -> POST /logistics/capacities: modo (carretera/maritimo/aereo), capacidad (peso/volumen, al menos uno), cobertura (texto de zona/ruta -> coverage area), ventana opcional (datetime-local), restricciones (refrigerado/peligroso/fragil), notas. Maneja 409 (emergencia sin intake) como /donar. CTA 'Ofrezco transporte' en la landing /e/{slug}. i18n es/en.

Simplificaciones (ponytail, marcadas en codigo): cobertura solo area v1 (corredor por coords diferido; el matching #107 admite areas); proveedor siempre el ciudadano (sin org); sin listado de capacidades aqui (va en el panel de logistica de coordinacion, #106).

Parte de #105 (el listado/filtrado por coordinacion llega con el panel de logistica de #106). Gate verde: api-client build + web build + web lint.