### PR TITLE
feat(web): panel de expediciones (coordinacion) + vista transportista (frontend #106)

### DIFF
--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
@@ -1,0 +1,271 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { api } from '@/lib/api';
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { getT } from '@/i18n/server';
+import type { components } from '@reliefhub/api-client';
+
+export type ActionResult =
+  | { status: 'idle' }
+  | { status: 'success' }
+  | { status: 'error'; message: string };
+
+type ShipmentItemInput = components['schemas']['ShipmentItemDto'];
+
+/**
+ * Creates a shipment / expedición for the given emergency (coordinator).
+ * `emergencyId` is bound server-side in the page so it is never trusted from
+ * the client form. Origin/destination are resource ids picked from a select.
+ */
+export async function createShipment(
+  emergencyId: string,
+  slug: string,
+  input: {
+    originResourceId: string;
+    destinationResourceId: string;
+    items: ShipmentItemInput[];
+    manifest?: string;
+  },
+): Promise<ActionResult> {
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+  }
+
+  const { t } = await getT();
+  const ts = t.coord;
+
+  if (input.originResourceId === '' || input.destinationResourceId === '') {
+    return { status: 'error', message: ts.ship_err_endpoints_required };
+  }
+  if (input.originResourceId === input.destinationResourceId) {
+    return { status: 'error', message: ts.ship_err_same_endpoint };
+  }
+  if (input.items.length === 0) {
+    return { status: 'error', message: ts.ship_err_items_required };
+  }
+
+  const { error, response } = await api.POST('/logistics/shipments', {
+    body: {
+      emergencyId,
+      originResourceId: input.originResourceId,
+      destinationResourceId: input.destinationResourceId,
+      items: input.items,
+      ...(input.manifest !== undefined && input.manifest !== ''
+        ? { manifest: input.manifest }
+        : {}),
+    },
+    headers: authHeaders(token),
+  });
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    }
+    if (response.status === 403) {
+      return { status: 'error', message: ts.ship_err_no_permission_create };
+    }
+    if (response.status === 409) {
+      return { status: 'error', message: t.common.intake_paused };
+    }
+    return { status: 'error', message: ts.ship_err_create_failed };
+  }
+
+  revalidatePath(`/e/${slug}/coordinacion/expediciones`);
+  revalidatePath(`/e/${slug}/coordinacion`);
+  return { status: 'success' };
+}
+
+/**
+ * Assigns a transport capacity to a planned shipment (coordinator).
+ * #107 FE replaces the plain capacity select with ranked suggestions — here we
+ * just earmark the chosen capacity; carrier assignment is left to the backend.
+ */
+export async function assignCapacity(
+  shipmentId: string,
+  capacityId: string,
+  slug: string,
+): Promise<ActionResult> {
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+  }
+
+  const { t } = await getT();
+  const ts = t.coord;
+
+  if (capacityId === '') {
+    return { status: 'error', message: ts.ship_err_capacity_required };
+  }
+
+  const { error, response } = await api.POST(
+    '/logistics/shipments/{id}/assign-capacity',
+    {
+      params: { path: { id: shipmentId } },
+      body: { assignedCapacityId: capacityId },
+      headers: authHeaders(token),
+    },
+  );
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    }
+    if (response.status === 403) {
+      return { status: 'error', message: ts.ship_err_no_permission_assign };
+    }
+    if (response.status === 404) {
+      return { status: 'error', message: ts.ship_err_not_found };
+    }
+    if (response.status === 409) {
+      return { status: 'error', message: ts.ship_err_not_planned };
+    }
+    return { status: 'error', message: ts.ship_err_assign_failed };
+  }
+
+  revalidatePath(`/e/${slug}/coordinacion/expediciones`);
+  return { status: 'success' };
+}
+
+/**
+ * Marks an assigned shipment as in transit (assigned carrier or coordinator).
+ */
+export async function markInTransit(
+  shipmentId: string,
+  slug: string,
+  /** Where to bounce on 401 — defaults to the coordinator panel. */
+  loginNext = `/e/${slug}/coordinacion/expediciones`,
+  /** Path to revalidate after the transition. */
+  revalidate = `/e/${slug}/coordinacion/expediciones`,
+): Promise<ActionResult> {
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=${loginNext}`);
+  }
+
+  const { t } = await getT();
+  const ts = t.coord;
+
+  const { error, response } = await api.POST(
+    '/logistics/shipments/{id}/in-transit',
+    {
+      params: { path: { id: shipmentId } },
+      headers: authHeaders(token),
+    },
+  );
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(`/login?next=${loginNext}`);
+    }
+    if (response.status === 403) {
+      return { status: 'error', message: ts.ship_err_no_permission_act };
+    }
+    if (response.status === 404) {
+      return { status: 'error', message: ts.ship_err_not_found };
+    }
+    if (response.status === 409) {
+      return { status: 'error', message: ts.ship_err_not_assigned };
+    }
+    return { status: 'error', message: ts.ship_err_transit_failed };
+  }
+
+  revalidatePath(revalidate);
+  return { status: 'success' };
+}
+
+/**
+ * Confirms a shipment delivery (assigned carrier or coordinator).
+ */
+export async function confirmDelivery(
+  shipmentId: string,
+  slug: string,
+  loginNext = `/e/${slug}/coordinacion/expediciones`,
+  revalidate = `/e/${slug}/coordinacion/expediciones`,
+): Promise<ActionResult> {
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=${loginNext}`);
+  }
+
+  const { t } = await getT();
+  const ts = t.coord;
+
+  const { error, response } = await api.POST(
+    '/logistics/shipments/{id}/deliver',
+    {
+      params: { path: { id: shipmentId } },
+      headers: authHeaders(token),
+    },
+  );
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(`/login?next=${loginNext}`);
+    }
+    if (response.status === 403) {
+      return { status: 'error', message: ts.ship_err_no_permission_act };
+    }
+    if (response.status === 404) {
+      return { status: 'error', message: ts.ship_err_not_found };
+    }
+    if (response.status === 409) {
+      return { status: 'error', message: ts.ship_err_not_in_transit };
+    }
+    return { status: 'error', message: ts.ship_err_deliver_failed };
+  }
+
+  revalidatePath(revalidate);
+  return { status: 'success' };
+}
+
+/**
+ * Cancels a planned/assigned shipment (coordinator).
+ */
+export async function cancelShipment(
+  shipmentId: string,
+  slug: string,
+): Promise<ActionResult> {
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+  }
+
+  const { t } = await getT();
+  const ts = t.coord;
+
+  const { error, response } = await api.POST(
+    '/logistics/shipments/{id}/cancel',
+    {
+      params: { path: { id: shipmentId } },
+      headers: authHeaders(token),
+    },
+  );
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    }
+    if (response.status === 403) {
+      return { status: 'error', message: ts.ship_err_no_permission_cancel };
+    }
+    if (response.status === 404) {
+      return { status: 'error', message: ts.ship_err_not_found };
+    }
+    if (response.status === 409) {
+      return { status: 'error', message: ts.ship_err_cannot_cancel };
+    }
+    return { status: 'error', message: ts.ship_err_cancel_failed };
+  }
+
+  revalidatePath(`/e/${slug}/coordinacion/expediciones`);
+  revalidatePath(`/e/${slug}/coordinacion`);
+  return { status: 'success' };
+}

--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/create-shipment.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/create-shipment.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { createShipment } from './actions';
+import { Button } from '@/components/atoms/button';
+import { Input } from '@/components/atoms/input';
+import { Select } from '@/components/atoms/select';
+import { Textarea } from '@/components/atoms/textarea';
+import { ErrorMessage } from '@/components/atoms/error-message';
+import { FormField } from '@/components/molecules/form-field';
+import { DetailDrawer } from '@/components/organisms/detail-drawer';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+/** A resource option for the origin/destination selects. */
+export interface ResourceOption {
+  id: string;
+  name: string;
+}
+
+interface ItemRow {
+  description: string;
+  quantity: string;
+  unit: string;
+}
+
+const EMPTY_ROW: ItemRow = { description: '', quantity: '', unit: '' };
+
+interface CreateShipmentProps {
+  emergencyId: string;
+  slug: string;
+  resources: ResourceOption[];
+}
+
+/**
+ * "Crear expedición" — a button that opens a drawer with a minimal create form:
+ * origin/destination selects (from the emergency's resources), repeatable item
+ * rows (descripción + cantidad + unidad) and a free-text manifiesto. On success
+ * the drawer closes and the route refreshes so the new shipment appears.
+ *
+ * ponytail: selects planos para origen/destino (sin map-resource-picker) y form
+ * mínimo — sin draft persistence ni categoría por línea de carga en v1.
+ */
+export function CreateShipment({
+  emergencyId,
+  slug,
+  resources,
+}: CreateShipmentProps) {
+  const tc = getMessages(useLocale()).coord;
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const [originId, setOriginId] = useState('');
+  const [destinationId, setDestinationId] = useState('');
+  const [rows, setRows] = useState<ItemRow[]>([{ ...EMPTY_ROW }]);
+  const [manifest, setManifest] = useState('');
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  function reset() {
+    setOriginId('');
+    setDestinationId('');
+    setRows([{ ...EMPTY_ROW }]);
+    setManifest('');
+    setError(undefined);
+  }
+
+  function updateRow(index: number, patch: Partial<ItemRow>) {
+    setRows((prev) =>
+      prev.map((row, i) => (i === index ? { ...row, ...patch } : row)),
+    );
+  }
+
+  function addRow() {
+    setRows((prev) => [...prev, { ...EMPTY_ROW }]);
+  }
+
+  function removeRow(index: number) {
+    setRows((prev) =>
+      prev.length === 1 ? prev : prev.filter((_, i) => i !== index),
+    );
+  }
+
+  function handleSubmit() {
+    setError(undefined);
+
+    const items = rows
+      .map((row) => {
+        const description = row.description.trim();
+        if (description === '') return null;
+        const qtyRaw = row.quantity.trim();
+        const quantity = qtyRaw === '' ? undefined : Number(qtyRaw);
+        if (quantity !== undefined && (!Number.isFinite(quantity) || quantity <= 0)) {
+          return undefined; // sentinel for "invalid quantity"
+        }
+        const unit = row.unit.trim();
+        return {
+          description,
+          ...(quantity !== undefined ? { quantity } : {}),
+          ...(unit !== '' ? { unit } : {}),
+        };
+      })
+      .filter((x) => x !== null);
+
+    if (items.some((x) => x === undefined)) {
+      setError(tc.ship_err_quantity_invalid);
+      return;
+    }
+    const cleanItems = items as { description: string; quantity?: number; unit?: string }[];
+    if (cleanItems.length === 0) {
+      setError(tc.ship_err_items_required);
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await createShipment(emergencyId, slug, {
+        originResourceId: originId,
+        destinationResourceId: destinationId,
+        items: cleanItems,
+        ...(manifest.trim() !== '' ? { manifest: manifest.trim() } : {}),
+      });
+      if (result.status === 'success') {
+        reset();
+        setOpen(false);
+        router.refresh();
+      } else if (result.status === 'error') {
+        setError(result.message);
+      }
+    });
+  }
+
+  const footer = (
+    <div className="flex flex-col gap-3">
+      {error !== undefined && <ErrorMessage message={error} />}
+      <Button
+        type="button"
+        onClick={handleSubmit}
+        disabled={pending}
+        fullWidth
+        size="lg"
+      >
+        {pending ? tc.ship_creating : tc.ship_create_submit}
+      </Button>
+    </div>
+  );
+
+  return (
+    <>
+      <Button type="button" onClick={() => setOpen(true)} variant="secondary">
+        {tc.ship_create_cta}
+      </Button>
+
+      {open && (
+        <DetailDrawer
+          open={open}
+          onClose={() => setOpen(false)}
+          title={tc.ship_create_title}
+          footer={footer}
+        >
+          <div className="flex flex-col gap-5">
+            <FormField
+              htmlFor="ship-origin"
+              label={
+                <>
+                  {tc.ship_field_origin} <span aria-hidden="true">*</span>
+                </>
+              }
+            >
+              <Select
+                id="ship-origin"
+                value={originId}
+                onChange={(e) => setOriginId(e.target.value)}
+              >
+                <option value="" disabled>
+                  {tc.ship_select_resource_placeholder}
+                </option>
+                {resources.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.name}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+
+            <FormField
+              htmlFor="ship-destination"
+              label={
+                <>
+                  {tc.ship_field_destination} <span aria-hidden="true">*</span>
+                </>
+              }
+            >
+              <Select
+                id="ship-destination"
+                value={destinationId}
+                onChange={(e) => setDestinationId(e.target.value)}
+              >
+                <option value="" disabled>
+                  {tc.ship_select_resource_placeholder}
+                </option>
+                {resources.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.name}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+
+            {/* Repeatable cargo lines */}
+            <fieldset className="flex flex-col gap-3">
+              <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
+                {tc.ship_items_legend} <span aria-hidden="true">*</span>
+              </legend>
+              {rows.map((row, index) => (
+                <div
+                  key={index}
+                  className="flex flex-col gap-2 rounded-lg border border-line p-3"
+                >
+                  <Input
+                    aria-label={tc.ship_item_description_label}
+                    placeholder={tc.ship_item_description_placeholder}
+                    value={row.description}
+                    onChange={(e) =>
+                      updateRow(index, { description: e.target.value })
+                    }
+                  />
+                  <div className="flex gap-2">
+                    <Input
+                      aria-label={tc.ship_item_quantity_label}
+                      type="number"
+                      inputMode="decimal"
+                      min={0}
+                      step="any"
+                      placeholder={tc.ship_item_quantity_placeholder}
+                      value={row.quantity}
+                      onChange={(e) =>
+                        updateRow(index, { quantity: e.target.value })
+                      }
+                    />
+                    <Input
+                      aria-label={tc.ship_item_unit_label}
+                      placeholder={tc.ship_item_unit_placeholder}
+                      value={row.unit}
+                      onChange={(e) => updateRow(index, { unit: e.target.value })}
+                    />
+                  </div>
+                  {rows.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => removeRow(index)}
+                      className="self-start text-xs font-semibold text-danger underline underline-offset-2 focus:outline-none focus:ring-2 focus:ring-danger rounded"
+                    >
+                      {tc.ship_item_remove}
+                    </button>
+                  )}
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={addRow}
+                className="self-start text-sm font-semibold text-navy underline underline-offset-2 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 rounded"
+              >
+                {tc.ship_item_add}
+              </button>
+            </fieldset>
+
+            <FormField
+              htmlFor="ship-manifest"
+              label={
+                <>
+                  {tc.ship_field_manifest}{' '}
+                  <span className="text-muted-soft font-normal normal-case">
+                    {tc.optional}
+                  </span>
+                </>
+              }
+            >
+              <Textarea
+                id="ship-manifest"
+                rows={3}
+                placeholder={tc.ship_manifest_placeholder}
+                value={manifest}
+                onChange={(e) => setManifest(e.target.value)}
+              />
+            </FormField>
+          </div>
+        </DetailDrawer>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/page.tsx
@@ -1,0 +1,244 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { getMe, getRoles } from '@/lib/navigation-data';
+import {
+  resolveEmergencyAccess,
+  type EmergencyAccess,
+} from '@/lib/emergency-permissions';
+import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
+import type { components } from '@reliefhub/api-client';
+import { ShipmentsList } from '@/components/organisms/shipments-list';
+import { CapacitiesPanel } from '@/components/organisms/capacities-panel';
+import { ShipmentsFilter } from '@/components/molecules/shipments-filter';
+import { CapacitiesFilter } from '@/components/molecules/capacities-filter';
+import { CreateShipment } from './create-shipment';
+import { getT } from '@/i18n/server';
+
+export const dynamic = 'force-dynamic';
+
+type ShipmentStatus = components['schemas']['ShipmentViewDto']['status'];
+type CapacityMode = components['schemas']['CapacityViewDto']['mode'];
+type CapacityStatus = components['schemas']['CapacityViewDto']['status'];
+
+const VALID_SHIPMENT_STATUSES: ShipmentStatus[] = [
+  'planned',
+  'assigned',
+  'in_transit',
+  'delivered',
+  'failed',
+  'cancelled',
+];
+const VALID_CAP_MODES: CapacityMode[] = ['road', 'sea', 'air'];
+const VALID_CAP_STATUSES: CapacityStatus[] = [
+  'available',
+  'reserved',
+  'withdrawn',
+];
+
+// Resources usable as shipment origin/destination — collection/warehouse nodes.
+const RESOURCE_PAGE_SIZE = 100;
+
+type Props = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const { t } = await getT();
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) return { title: t.coord.meta_not_found };
+  return {
+    title: t.coord.shipments_section_meta_title.replace('{name}', emergency.name),
+    description: t.coord.shipments_section_meta_description.replace(
+      '{name}',
+      emergency.name,
+    ),
+  };
+}
+
+export default async function CoordinacionExpedicionesPage({
+  params,
+  searchParams,
+}: Props) {
+  const { slug } = await params;
+  const resolvedSearchParams = await searchParams;
+
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+  }
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) {
+    notFound();
+  }
+
+  const emergencyId = emergency.id;
+  const headers = authHeaders(token);
+
+  const [me, roles] = await Promise.all([getMe(), getRoles()]);
+  if (me == null) {
+    await clearToken();
+    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+  }
+
+  const access: EmergencyAccess = resolveEmergencyAccess(
+    emergencyId,
+    (me.grants ?? []) as MeGrant[],
+    roles as RoleCatalogEntry[],
+  );
+
+  // Permission gate: a principal without shipment:read is bounced to the hub.
+  if (!access.canCoordinateLogistics) {
+    redirect(`/e/${slug}/coordinacion`);
+  }
+
+  const canCreate = access.permissions.has('shipment:create');
+
+  // --- Parse filter params ----------------------------------------------
+  const rawStatus =
+    typeof resolvedSearchParams.status === 'string'
+      ? resolvedSearchParams.status
+      : undefined;
+  const status = VALID_SHIPMENT_STATUSES.includes(rawStatus as ShipmentStatus)
+    ? (rawStatus as ShipmentStatus)
+    : undefined;
+
+  const rawCapMode =
+    typeof resolvedSearchParams.capMode === 'string'
+      ? resolvedSearchParams.capMode
+      : undefined;
+  const capMode = VALID_CAP_MODES.includes(rawCapMode as CapacityMode)
+    ? (rawCapMode as CapacityMode)
+    : undefined;
+
+  const rawCapStatus =
+    typeof resolvedSearchParams.capStatus === 'string'
+      ? resolvedSearchParams.capStatus
+      : undefined;
+  const capStatus = VALID_CAP_STATUSES.includes(rawCapStatus as CapacityStatus)
+    ? (rawCapStatus as CapacityStatus)
+    : undefined;
+
+  const { t } = await getT();
+  const tc = t.coord;
+
+  const onUnauthorized = async (statusCode: number): Promise<void> => {
+    if (statusCode === 401) {
+      await clearToken();
+      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    }
+  };
+
+  // --- Fetch shipments + capacities + resources (for names/selects) -----
+  const [shipments, capacities, resourcesPage] = await Promise.all([
+    api
+      .GET('/emergencies/{emergencyId}/logistics/shipments', {
+        params: {
+          path: { emergencyId },
+          query: { ...(status !== undefined && { status }) },
+        },
+        headers,
+      })
+      .then(async (r) => {
+        await onUnauthorized(r.response.status);
+        if (r.response.status === 403) redirect(`/e/${slug}/coordinacion`);
+        return r.data ?? [];
+      }),
+    api
+      .GET('/emergencies/{emergencyId}/logistics/capacities', {
+        params: {
+          path: { emergencyId },
+          query: {
+            ...(capMode !== undefined && { mode: capMode }),
+            ...(capStatus !== undefined && { status: capStatus }),
+          },
+        },
+        headers,
+      })
+      .then(async (r) => {
+        await onUnauthorized(r.response.status);
+        return r.data ?? [];
+      }),
+    // ponytail: origen/destino se eligen de un <select> poblado con la lista
+    // pública de recursos (sin map-resource-picker). Tomamos la primera página
+    // (límite 100); paginación de recursos en el selector queda fuera de v1.
+    api
+      .GET('/emergencies/{emergencyId}/public/resources', {
+        params: {
+          path: { emergencyId },
+          query: { page: 1, limit: RESOURCE_PAGE_SIZE },
+        },
+      })
+      .then((r) => r.data?.items ?? []),
+  ]);
+
+  const resourceNames: Record<string, string> = {};
+  for (const r of resourcesPage) resourceNames[r.id] = r.name;
+  const resourceOptions = resourcesPage.map((r) => ({ id: r.id, name: r.name }));
+
+  // Available capacities the coordinator can assign from a shipment drawer.
+  const assignableCapacities = capacities.filter((c) => c.status === 'available');
+
+  const isShipmentsFiltered = status !== undefined;
+
+  return (
+    <section aria-labelledby="shipments-heading" className="flex flex-col gap-8">
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 id="shipments-heading" className="text-xl font-bold text-ink">
+            {tc.shipments_heading}
+          </h2>
+          {canCreate && (
+            <CreateShipment
+              emergencyId={emergencyId}
+              slug={slug}
+              resources={resourceOptions}
+            />
+          )}
+        </div>
+
+        <ShipmentsFilter />
+
+        <ShipmentsList
+          shipments={shipments}
+          slug={slug}
+          resourceNames={resourceNames}
+          capacities={assignableCapacities}
+          canManage
+          listLabel={tc.shipments_list_label}
+          emptyTitle={
+            isShipmentsFiltered
+              ? tc.shipments_no_match_title
+              : tc.shipments_empty_title
+          }
+          emptyDescription={
+            isShipmentsFiltered
+              ? tc.shipments_no_match_description
+              : tc.shipments_empty_description
+          }
+        />
+      </div>
+
+      {/* ── Capacidades disponibles (read-only, #105) ──────────────────── */}
+      <div className="flex flex-col gap-5 border-t border-line pt-6">
+        <h2 className="text-xl font-bold text-ink">{tc.cap_heading}</h2>
+        <p className="text-sm text-muted">{tc.cap_subtitle}</p>
+
+        <CapacitiesFilter />
+
+        <CapacitiesPanel
+          capacities={capacities}
+          tc={tc}
+          listLabel={tc.cap_list_label}
+          emptyTitle={tc.cap_empty_title}
+          emptyDescription={tc.cap_empty_description}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
@@ -113,6 +113,7 @@ export default async function CoordinacionLayout({
               canVerifyResources: access.canVerifyResources,
               canValidateNeeds: access.canValidateNeeds,
               canMatchOffers: access.canMatchOffers,
+              canCoordinateLogistics: access.canCoordinateLogistics,
               canCoordinate: access.canCoordinate,
             }}
           />

--- a/apps/web/src/app/e/[slug]/coordinacion/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/page.tsx
@@ -73,7 +73,8 @@ export default async function CoordinacionPage({ params }: Props) {
 
   // --- Pending counters for each actionable section ---------------------
   // Resources: ask for one row only — we just need the `total`.
-  const [resourcesPending, needsPending, offersPending] = await Promise.all([
+  const [resourcesPending, needsPending, offersPending, shipmentsActive] =
+    await Promise.all([
     access.canVerifyResources
       ? api
           .GET('/emergencies/{emergencyId}/coordination/queue', {
@@ -105,6 +106,20 @@ export default async function CoordinacionPage({ params }: Props) {
           .then(async (r) => {
             await onUnauthorized(r.response.status);
             return r.data?.length ?? 0;
+          })
+      : Promise.resolve(null),
+    access.canCoordinateLogistics
+      ? api
+          .GET('/emergencies/{emergencyId}/logistics/shipments', {
+            params: { path: { emergencyId } },
+            headers,
+          })
+          .then(async (r) => {
+            await onUnauthorized(r.response.status);
+            // Count only the in-flight shipments (not delivered/cancelled).
+            return (r.data ?? []).filter(
+              (s) => s.status !== 'delivered' && s.status !== 'cancelled',
+            ).length;
           })
       : Promise.resolve(null),
   ]);
@@ -147,6 +162,15 @@ export default async function CoordinacionPage({ params }: Props) {
               description={tc.hub_offers_description}
               count={offersPending}
               countAria={tc.hub_count_aria}
+            />
+          )}
+          {shipmentsActive !== null && (
+            <CoordinationSectionLink
+              href={`${base}/expediciones`}
+              label={tc.hub_shipments_label}
+              description={tc.hub_shipments_description}
+              count={shipmentsActive}
+              countAria={tc.hub_shipments_count_aria}
             />
           )}
           {access.canCoordinate && (

--- a/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { ShipmentsList } from '@/components/organisms/shipments-list';
+import { PageHeaderBand } from '@/components/molecules/page-header-band';
+import { getT } from '@/i18n/server';
+
+export const dynamic = 'force-dynamic';
+
+const RESOURCE_PAGE_SIZE = 100;
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const { t } = await getT();
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) return { title: t.account.emergency_not_found };
+  return {
+    title: t.account.ship_meta_title.replace('{name}', emergency.name),
+    description: t.account.ship_meta_description.replace('{name}', emergency.name),
+  };
+}
+
+export default async function MisExpedicionesPage({ params }: Props) {
+  const { slug } = await params;
+  const { t } = await getT();
+  const ta = t.account;
+
+  // --- Auth guard -----------------------------------------------------------
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/mis-expediciones`);
+  }
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) {
+    notFound();
+  }
+
+  const emergencyId = emergency.id;
+  const headers = authHeaders(token);
+
+  // --- Fetch my shipments + resource names in parallel ----------------------
+  const [shipments, resourcesPage] = await Promise.all([
+    api
+      .GET('/logistics/shipments/mine', {
+        params: { query: { emergencyId } },
+        headers,
+      })
+      .then(async (r) => {
+        if (r.response.status === 401) {
+          await clearToken();
+          redirect(`/login?next=/e/${slug}/mis-expediciones`);
+        }
+        return r.data ?? [];
+      }),
+    api
+      .GET('/emergencies/{emergencyId}/public/resources', {
+        params: {
+          path: { emergencyId },
+          query: { page: 1, limit: RESOURCE_PAGE_SIZE },
+        },
+      })
+      .then((r) => r.data?.items ?? []),
+  ]);
+
+  const resourceNames: Record<string, string> = {};
+  for (const r of resourcesPage) resourceNames[r.id] = r.name;
+
+  return (
+    <main className="flex-1 bg-surface">
+      <div className="mx-auto w-full max-w-xl">
+        <PageHeaderBand
+          backHref={`/e/${slug}`}
+          backLabel={emergency.name}
+          title={ta.ship_title}
+          subtitle={ta.ship_subtitle}
+        />
+        <div className="flex flex-col gap-6 px-4 pb-12 pt-6">
+          <ShipmentsList
+            shipments={shipments}
+            slug={slug}
+            resourceNames={resourceNames}
+            capacities={[]}
+            canManage={false}
+            listLabel={ta.ship_list_label}
+            emptyTitle={ta.ship_empty_title}
+            emptyDescription={ta.ship_empty_description}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/molecules/capacities-filter.tsx
+++ b/apps/web/src/components/molecules/capacities-filter.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+/**
+ * Lean mode + status filter for the read-only "Capacidades disponibles" panel.
+ * Drives the `capMode` and `capStatus` search params; the expediciones page
+ * applies them to the fetched capacities. Mirrors {@link OffersFilter}.
+ */
+import type { ChangeEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Select } from '@/components/atoms/select';
+import { FilterField } from '@/components/molecules/filter-field';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+const MODE_VALUES = ['road', 'sea', 'air'] as const;
+const STATUS_VALUES = ['available', 'reserved', 'withdrawn'] as const;
+
+export function CapacitiesFilter() {
+  const tc = getMessages(useLocale()).coord;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentMode = searchParams.get('capMode') ?? '';
+  const currentStatus = searchParams.get('capStatus') ?? '';
+
+  const MODE_LABELS: Record<(typeof MODE_VALUES)[number], string> = {
+    road: tc.ship_mode_road,
+    sea: tc.ship_mode_sea,
+    air: tc.ship_mode_air,
+  };
+  const STATUS_LABELS: Record<(typeof STATUS_VALUES)[number], string> = {
+    available: tc.cap_status_available,
+    reserved: tc.cap_status_reserved,
+    withdrawn: tc.cap_status_withdrawn,
+  };
+
+  function updateParam(key: string, value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === '') params.delete(key);
+    else params.set(key, value);
+    const qs = params.toString();
+    router.replace(qs === '' ? '?' : `?${qs}`, { scroll: false });
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-3"
+      role="group"
+      aria-label={tc.cap_filter_group_label}
+    >
+      <FilterField label={tc.cap_filter_mode_label}>
+        <Select
+          value={currentMode}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+            updateParam('capMode', e.target.value)
+          }
+          aria-label={tc.cap_filter_mode_aria}
+        >
+          <option value="">{tc.cap_filter_mode_all}</option>
+          {MODE_VALUES.map((value) => (
+            <option key={value} value={value}>
+              {MODE_LABELS[value]}
+            </option>
+          ))}
+        </Select>
+      </FilterField>
+
+      <FilterField label={tc.cap_filter_status_label}>
+        <Select
+          value={currentStatus}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+            updateParam('capStatus', e.target.value)
+          }
+          aria-label={tc.cap_filter_status_aria}
+        >
+          <option value="">{tc.cap_filter_status_all}</option>
+          {STATUS_VALUES.map((value) => (
+            <option key={value} value={value}>
+              {STATUS_LABELS[value]}
+            </option>
+          ))}
+        </Select>
+      </FilterField>
+    </div>
+  );
+}

--- a/apps/web/src/components/molecules/emergency-quick-links.tsx
+++ b/apps/web/src/components/molecules/emergency-quick-links.tsx
@@ -31,6 +31,7 @@ export function EmergencyQuickLinks({ slug, te, authed }: EmergencyQuickLinksPro
         <div className="flex flex-wrap gap-x-4 gap-y-1.5">
           <Link href={`/e/${slug}/mis-puntos`} className={linkClass}>{te.footer_my_points}</Link>
           <Link href={`/e/${slug}/mi-voluntariado`} className={linkClass}>{te.footer_my_volunteer}</Link>
+          <Link href={`/e/${slug}/mis-expediciones`} className={linkClass}>{te.footer_my_shipments}</Link>
           <Link href={`/e/${slug}/reportar`} className={linkClass}>{te.footer_report}</Link>
         </div>
       )}

--- a/apps/web/src/components/molecules/shipments-filter.tsx
+++ b/apps/web/src/components/molecules/shipments-filter.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+/**
+ * Status filter for the coordination Expediciones list. Drives the `status`
+ * search param; the page passes it to the shipments endpoint. Mirrors
+ * {@link OffersFilter}'s URL-sync approach.
+ */
+import type { ChangeEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Select } from '@/components/atoms/select';
+import { FilterField } from '@/components/molecules/filter-field';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+const STATUS_VALUES = [
+  'planned',
+  'assigned',
+  'in_transit',
+  'delivered',
+  'failed',
+  'cancelled',
+] as const;
+
+export function ShipmentsFilter() {
+  const tc = getMessages(useLocale()).coord;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentStatus = searchParams.get('status') ?? '';
+
+  const STATUS_LABELS: Record<(typeof STATUS_VALUES)[number], string> = {
+    planned: tc.ship_status_planned,
+    assigned: tc.ship_status_assigned,
+    in_transit: tc.ship_status_in_transit,
+    delivered: tc.ship_status_delivered,
+    failed: tc.ship_status_failed,
+    cancelled: tc.ship_status_cancelled,
+  };
+
+  function updateParam(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === '') params.delete('status');
+    else params.set('status', value);
+    const qs = params.toString();
+    router.replace(qs === '' ? '?' : `?${qs}`, { scroll: false });
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-3"
+      role="group"
+      aria-label={tc.shipments_filter_group_label}
+    >
+      <FilterField label={tc.shipments_filter_status_label}>
+        <Select
+          value={currentStatus}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+            updateParam(e.target.value)
+          }
+          aria-label={tc.shipments_filter_status_aria}
+        >
+          <option value="">{tc.shipments_filter_status_all}</option>
+          {STATUS_VALUES.map((value) => (
+            <option key={value} value={value}>
+              {STATUS_LABELS[value]}
+            </option>
+          ))}
+        </Select>
+      </FilterField>
+    </div>
+  );
+}

--- a/apps/web/src/components/organisms/capacities-panel.tsx
+++ b/apps/web/src/components/organisms/capacities-panel.tsx
@@ -1,0 +1,132 @@
+import type { components } from '@reliefhub/api-client';
+import type { Messages } from '@/i18n/messages/es';
+import { Badge } from '@/components/atoms/badge';
+import { EmptyState } from '@/components/molecules/empty-state';
+
+type CapacityView = components['schemas']['CapacityViewDto'];
+type CapacityMode = CapacityView['mode'];
+type CapacityStatus = CapacityView['status'];
+
+const STATUS_BADGE: Record<
+  CapacityStatus,
+  'offer-open' | 'offer-matched' | 'offer-cancelled'
+> = {
+  available: 'offer-open',
+  reserved: 'offer-matched',
+  withdrawn: 'offer-cancelled',
+};
+
+interface CapacitiesPanelProps {
+  capacities: CapacityView[];
+  tc: Messages['coord'];
+  listLabel: string;
+  emptyTitle: string;
+  emptyDescription: string;
+}
+
+/**
+ * Read-only "Capacidades disponibles" panel (#105's coordinator-visible view):
+ * each capacity card shows mode, capacity (peso/volumen), coverage area, window
+ * and status. No actions — coordination assigns capacities from the shipment
+ * detail drawer, not here.
+ */
+export function CapacitiesPanel({
+  capacities,
+  tc,
+  listLabel,
+  emptyTitle,
+  emptyDescription,
+}: CapacitiesPanelProps) {
+  if (capacities.length === 0) {
+    return <EmptyState title={emptyTitle} description={emptyDescription} />;
+  }
+
+  const MODE_LABELS: Record<CapacityMode, string> = {
+    road: tc.ship_mode_road,
+    sea: tc.ship_mode_sea,
+    air: tc.ship_mode_air,
+  };
+  const STATUS_LABELS: Record<CapacityStatus, string> = {
+    available: tc.cap_status_available,
+    reserved: tc.cap_status_reserved,
+    withdrawn: tc.cap_status_withdrawn,
+  };
+
+  return (
+    <ul className="flex flex-col gap-4" aria-label={listLabel}>
+      {capacities.map((c) => {
+        const amount = formatAmount(c.capacity);
+        const area =
+          typeof c.coverage.area === 'string' && c.coverage.area !== ''
+            ? c.coverage.area
+            : null;
+        const window = formatWindow(c.window);
+        return (
+          <li
+            key={c.id}
+            className="flex flex-col gap-2 rounded-lg border-2 border-line bg-white p-5"
+          >
+            <div className="flex w-full items-start justify-between gap-3">
+              <span className="text-base font-bold leading-tight text-ink">
+                {MODE_LABELS[c.mode]}
+              </span>
+              <Badge variant={STATUS_BADGE[c.status]}>
+                {STATUS_LABELS[c.status]}
+              </Badge>
+            </div>
+            <dl className="flex flex-col gap-1 text-sm text-muted">
+              {amount !== '' && (
+                <div className="flex gap-2">
+                  <dt className="font-semibold text-ink">{tc.cap_field_capacity}</dt>
+                  <dd>{amount}</dd>
+                </div>
+              )}
+              {area !== null && (
+                <div className="flex gap-2">
+                  <dt className="font-semibold text-ink">{tc.cap_field_coverage}</dt>
+                  <dd className="break-words">{area}</dd>
+                </div>
+              )}
+              {window !== null && (
+                <div className="flex gap-2">
+                  <dt className="font-semibold text-ink">{tc.cap_field_window}</dt>
+                  <dd>{window}</dd>
+                </div>
+              )}
+            </dl>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function formatAmount(
+  amount: components['schemas']['CapacityAmountResponseDto'],
+): string {
+  const parts: string[] = [];
+  if (typeof amount.weightKg === 'number') parts.push(`${amount.weightKg} kg`);
+  if (typeof amount.volumeM3 === 'number') parts.push(`${amount.volumeM3} m³`);
+  return parts.join(' · ');
+}
+
+function formatWindow(
+  window: components['schemas']['CapacityWindowResponseDto'],
+): string | null {
+  const from =
+    typeof window.from === 'string' ? formatDate(window.from) : null;
+  const to = typeof window.to === 'string' ? formatDate(window.to) : null;
+  if (from === null && to === null) return null;
+  if (from !== null && to !== null) return `${from} → ${to}`;
+  return from ?? to;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}

--- a/apps/web/src/components/organisms/coordination-tabs.tsx
+++ b/apps/web/src/components/organisms/coordination-tabs.tsx
@@ -16,6 +16,7 @@ export interface CoordinationTabsAccess {
   canVerifyResources: boolean;
   canValidateNeeds: boolean;
   canMatchOffers: boolean;
+  canCoordinateLogistics: boolean;
   canCoordinate: boolean;
 }
 
@@ -40,6 +41,9 @@ export function CoordinationTabs({ slug, access }: CoordinationTabsProps) {
   }
   if (access.canMatchOffers) {
     tabs.push({ href: `${base}/ofertas`, label: tc.tab_offers, exact: false });
+  }
+  if (access.canCoordinateLogistics) {
+    tabs.push({ href: `${base}/expediciones`, label: tc.tab_shipments, exact: false });
   }
   if (access.canCoordinate) {
     tabs.push({ href: `${base}/voluntarios`, label: tc.tab_volunteers, exact: false });

--- a/apps/web/src/components/organisms/shipment-detail.tsx
+++ b/apps/web/src/components/organisms/shipment-detail.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import { useActionState, useState, useEffect } from 'react';
+import {
+  assignCapacity,
+  markInTransit,
+  confirmDelivery,
+  cancelShipment,
+  type ActionResult,
+} from '@/app/e/[slug]/coordinacion/expediciones/actions';
+import type { components } from '@reliefhub/api-client';
+import { Badge } from '@/components/atoms/badge';
+import { Button } from '@/components/atoms/button';
+import { Select } from '@/components/atoms/select';
+import { ErrorMessage } from '@/components/atoms/error-message';
+import { DetailDrawer } from '@/components/organisms/detail-drawer';
+import { DetailField, DetailSection } from '@/components/molecules/detail-field';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+type ShipmentViewDto = components['schemas']['ShipmentViewDto'];
+type CapacityViewDto = components['schemas']['CapacityViewDto'];
+type ShipmentStatus = ShipmentViewDto['status'];
+
+const STATUS_BADGE: Record<
+  ShipmentStatus,
+  | 'offer-open'
+  | 'offer-matched'
+  | 'offer-fulfilled'
+  | 'offer-cancelled'
+  | 'role-member'
+> = {
+  planned: 'offer-open',
+  assigned: 'offer-matched',
+  in_transit: 'role-member',
+  delivered: 'offer-fulfilled',
+  failed: 'offer-cancelled',
+  cancelled: 'offer-cancelled',
+};
+
+const INITIAL_STATE: ActionResult = { status: 'idle' };
+
+interface ShipmentDetailProps {
+  shipment: ShipmentViewDto;
+  slug: string;
+  /** Resolve a resource id to its display name (origin/destination). */
+  resourceName: (id: string) => string;
+  /** Available capacities to assign (for planned shipments). Empty for carriers. */
+  capacities: CapacityViewDto[];
+  /** Whether the user may assign/cancel (coordinator). Carriers pass false. */
+  canManage: boolean;
+  open: boolean;
+  onClose: () => void;
+  onActionSuccess: () => void;
+}
+
+export function ShipmentDetail({
+  shipment,
+  slug,
+  resourceName,
+  capacities,
+  canManage,
+  open,
+  onClose,
+  onActionSuccess,
+}: ShipmentDetailProps) {
+  const tc = getMessages(useLocale()).coord;
+
+  const STATUS_LABELS: Record<ShipmentStatus, string> = {
+    planned: tc.ship_status_planned,
+    assigned: tc.ship_status_assigned,
+    in_transit: tc.ship_status_in_transit,
+    delivered: tc.ship_status_delivered,
+    failed: tc.ship_status_failed,
+    cancelled: tc.ship_status_cancelled,
+  };
+
+  const CARRIER_LABELS: Record<'volunteer' | 'organization', string> = {
+    volunteer: tc.ship_carrier_volunteer,
+    organization: tc.ship_carrier_organization,
+  };
+
+  const [selectedCapacityId, setSelectedCapacityId] = useState('');
+
+  // Carriers act from /mis-expediciones; coordinators from the panel. The path
+  // only steers the 401-redirect + revalidate target — both views also call
+  // router.refresh() on success, so the visible list updates either way.
+  const carrierBase = `/e/${slug}/mis-expediciones`;
+  const coordBase = `/e/${slug}/coordinacion/expediciones`;
+  const actorPath = canManage ? coordBase : carrierBase;
+
+  const [assignState, assignFormAction, assignPending] = useActionState<
+    ActionResult,
+    FormData
+  >(
+    async () => assignCapacity(shipment.id, selectedCapacityId, slug),
+    INITIAL_STATE,
+  );
+
+  const [transitState, transitFormAction, transitPending] = useActionState<
+    ActionResult,
+    FormData
+  >(
+    async () => markInTransit(shipment.id, slug, actorPath, actorPath),
+    INITIAL_STATE,
+  );
+
+  const [deliverState, deliverFormAction, deliverPending] = useActionState<
+    ActionResult,
+    FormData
+  >(
+    async () => confirmDelivery(shipment.id, slug, actorPath, actorPath),
+    INITIAL_STATE,
+  );
+
+  const [cancelState, cancelFormAction, cancelPending] = useActionState<
+    ActionResult,
+    FormData
+  >(async () => cancelShipment(shipment.id, slug), INITIAL_STATE);
+
+  // Any successful transition mutates the shipment — refresh the list/drawer.
+  useEffect(() => {
+    if (
+      assignState.status === 'success' ||
+      transitState.status === 'success' ||
+      deliverState.status === 'success' ||
+      cancelState.status === 'success'
+    ) {
+      onActionSuccess();
+    }
+  }, [
+    assignState.status,
+    transitState.status,
+    deliverState.status,
+    cancelState.status,
+    onActionSuccess,
+  ]);
+
+  const errorMessage =
+    (assignState.status === 'error' ? assignState.message : undefined) ??
+    (transitState.status === 'error' ? transitState.message : undefined) ??
+    (deliverState.status === 'error' ? deliverState.message : undefined) ??
+    (cancelState.status === 'error' ? cancelState.message : undefined);
+
+  const availableCapacities = capacities.filter(
+    (c) => c.status === 'available',
+  );
+
+  // Lifecycle actions by status. Coordinators (canManage) get the full set;
+  // carriers only get the in-transit / deliver transitions on their own legs.
+  const canCancel =
+    canManage &&
+    (shipment.status === 'planned' || shipment.status === 'assigned');
+
+  const actions = (
+    <div className="flex flex-col gap-3">
+      {canManage && shipment.status === 'planned' && (
+        // ponytail: select plano de capacidades — #107 lo sustituye por
+        // sugerencias rankeadas; aquí NO construimos el ranking.
+        <form action={assignFormAction} className="flex flex-col gap-2">
+          <Select
+            id={`capacity-select-${shipment.id}`}
+            name="capacityId"
+            aria-label={tc.ship_assign_select_label}
+            value={selectedCapacityId}
+            onChange={(e) => setSelectedCapacityId(e.target.value)}
+          >
+            <option value="" disabled>
+              {availableCapacities.length > 0
+                ? tc.ship_assign_placeholder
+                : tc.ship_assign_none}
+            </option>
+            {availableCapacities.map((c) => (
+              <option key={c.id} value={c.id}>
+                {capacityLabel(c, tc)}
+              </option>
+            ))}
+          </Select>
+          <Button
+            type="submit"
+            disabled={assignPending || selectedCapacityId === ''}
+            fullWidth
+            size="lg"
+          >
+            {assignPending ? tc.processing : tc.ship_assign_cta}
+          </Button>
+        </form>
+      )}
+
+      {shipment.status === 'assigned' && (
+        <form action={transitFormAction}>
+          <Button type="submit" disabled={transitPending} fullWidth size="lg">
+            {transitPending ? tc.processing : tc.ship_mark_in_transit}
+          </Button>
+        </form>
+      )}
+
+      {shipment.status === 'in_transit' && (
+        <form action={deliverFormAction}>
+          <Button type="submit" disabled={deliverPending} fullWidth size="lg">
+            {deliverPending ? tc.processing : tc.ship_confirm_delivery}
+          </Button>
+        </form>
+      )}
+
+      {canCancel && (
+        <form action={cancelFormAction}>
+          <Button
+            type="submit"
+            disabled={cancelPending}
+            fullWidth
+            size="lg"
+            variant="danger-outline"
+          >
+            {cancelPending ? tc.cancelling : tc.ship_cancel}
+          </Button>
+        </form>
+      )}
+    </div>
+  );
+
+  const hasActions =
+    (canManage && shipment.status === 'planned') ||
+    shipment.status === 'assigned' ||
+    shipment.status === 'in_transit' ||
+    canCancel;
+
+  const footer =
+    hasActions || errorMessage !== undefined ? (
+      <div className="flex flex-col gap-3">
+        {errorMessage !== undefined && <ErrorMessage message={errorMessage} />}
+        {hasActions && actions}
+      </div>
+    ) : undefined;
+
+  const originName = resourceName(shipment.originResourceId);
+  const destinationName = resourceName(shipment.destinationResourceId);
+  const title = tc.ship_route.replace('{origin}', originName).replace(
+    '{destination}',
+    destinationName,
+  );
+
+  const carrier =
+    shipment.carrierType != null && shipment.carrierId != null
+      ? `${CARRIER_LABELS[shipment.carrierType]} · ${shipment.carrierId}`
+      : null;
+
+  return (
+    <DetailDrawer
+      open={open}
+      onClose={onClose}
+      title={title}
+      ariaLabel={tc.ship_drawer_open.replace('{route}', title)}
+      titleAdornment={
+        <Badge variant={STATUS_BADGE[shipment.status]}>
+          {STATUS_LABELS[shipment.status]}
+        </Badge>
+      }
+      footer={footer}
+    >
+      <DetailSection title={tc.ship_section_route}>
+        <DetailField label={tc.ship_field_origin} value={originName} />
+        <DetailField
+          label={tc.ship_field_destination}
+          value={destinationName}
+        />
+        <DetailField
+          label={tc.detail_field_status}
+          value={STATUS_LABELS[shipment.status]}
+        />
+      </DetailSection>
+
+      <DetailSection title={tc.ship_section_items}>
+        {shipment.items.length === 0 ? (
+          <DetailField label={tc.ship_field_items} value={tc.detail_value_none} />
+        ) : (
+          <ul className="flex flex-col gap-1 py-2 text-sm text-ink">
+            {shipment.items.map((item, idx) => (
+              <li key={idx} className="break-words">
+                {formatItem(item)}
+              </li>
+            ))}
+          </ul>
+        )}
+        <DetailField label={tc.ship_field_manifest} value={shipment.manifest} />
+      </DetailSection>
+
+      <DetailSection title={tc.ship_section_assignment}>
+        <DetailField
+          label={tc.ship_field_capacity}
+          value={shipment.assignedCapacityId}
+        />
+        <DetailField label={tc.ship_field_carrier} value={carrier} />
+      </DetailSection>
+    </DetailDrawer>
+  );
+}
+
+type Tc = ReturnType<typeof getMessages>['coord'];
+
+function formatItem(item: components['schemas']['ShipmentItemResponseDto']): string {
+  const qty =
+    typeof item.quantity === 'number' && Number.isFinite(item.quantity)
+      ? `${item.quantity}${typeof item.unit === 'string' && item.unit !== '' ? ` ${item.unit}` : ''}`
+      : '';
+  return qty !== '' ? `${item.description} · ${qty}` : item.description;
+}
+
+/** Short label for a capacity option: mode + weight/volume. */
+function capacityLabel(c: components['schemas']['CapacityViewDto'], tc: Tc): string {
+  const MODE_LABELS: Record<'road' | 'sea' | 'air', string> = {
+    road: tc.ship_mode_road,
+    sea: tc.ship_mode_sea,
+    air: tc.ship_mode_air,
+  };
+  const parts: string[] = [MODE_LABELS[c.mode]];
+  if (typeof c.capacity.weightKg === 'number') {
+    parts.push(`${c.capacity.weightKg} kg`);
+  }
+  if (typeof c.capacity.volumeM3 === 'number') {
+    parts.push(`${c.capacity.volumeM3} m³`);
+  }
+  const area =
+    typeof c.coverage.area === 'string' && c.coverage.area !== ''
+      ? c.coverage.area
+      : '';
+  return area !== '' ? `${parts.join(' · ')} — ${area}` : parts.join(' · ');
+}

--- a/apps/web/src/components/organisms/shipments-list.tsx
+++ b/apps/web/src/components/organisms/shipments-list.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+/**
+ * Clickable shipments / expediciones list. Each row is a full-surface tap
+ * target (≥44px, no hover-only affordances) that opens the mobile-first
+ * {@link ShipmentDetail} drawer with the shipment's full detail + the lifecycle
+ * actions allowed in its current status.
+ *
+ * Unlike the offers/needs queues, a shipment is NOT removed when acted on — its
+ * lifecycle has several steps (planned → assigned → in_transit → delivered), so
+ * after a successful transition we close the drawer and refresh the route (the
+ * server action has already revalidated) to reflect the new status server-side.
+ */
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { components } from '@reliefhub/api-client';
+import { Badge } from '@/components/atoms/badge';
+import { EmptyState } from '@/components/molecules/empty-state';
+import { ShipmentDetail } from '@/components/organisms/shipment-detail';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+type ShipmentView = components['schemas']['ShipmentViewDto'];
+type CapacityView = components['schemas']['CapacityViewDto'];
+type ShipmentStatus = ShipmentView['status'];
+
+const SUMMARY_CARD_CLASS =
+  'flex w-full flex-col gap-2 rounded-lg border-2 border-navy bg-white p-5 text-left transition-colors hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2';
+
+const META_ROW_CLASS =
+  'flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted';
+
+const STATUS_BADGE: Record<
+  ShipmentStatus,
+  | 'offer-open'
+  | 'offer-matched'
+  | 'offer-fulfilled'
+  | 'offer-cancelled'
+  | 'role-member'
+> = {
+  planned: 'offer-open',
+  assigned: 'offer-matched',
+  in_transit: 'role-member',
+  delivered: 'offer-fulfilled',
+  failed: 'offer-cancelled',
+  cancelled: 'offer-cancelled',
+};
+
+interface ShipmentsListProps {
+  shipments: ShipmentView[];
+  slug: string;
+  /** id → resource name resolver (origin/destination). */
+  resourceNames: Record<string, string>;
+  /** Capacities available to assign (coordinator). Empty for carriers. */
+  capacities: CapacityView[];
+  /** Coordinator (can assign/cancel) vs carrier (transit/deliver only). */
+  canManage: boolean;
+  listLabel: string;
+  emptyTitle: string;
+  emptyDescription: string;
+}
+
+export function ShipmentsList({
+  shipments,
+  slug,
+  resourceNames,
+  capacities,
+  canManage,
+  listLabel,
+  emptyTitle,
+  emptyDescription,
+}: ShipmentsListProps) {
+  const tc = getMessages(useLocale()).coord;
+  const router = useRouter();
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const STATUS_LABELS: Record<ShipmentStatus, string> = {
+    planned: tc.ship_status_planned,
+    assigned: tc.ship_status_assigned,
+    in_transit: tc.ship_status_in_transit,
+    delivered: tc.ship_status_delivered,
+    failed: tc.ship_status_failed,
+    cancelled: tc.ship_status_cancelled,
+  };
+
+  const resourceName = (id: string): string => resourceNames[id] ?? id;
+
+  if (shipments.length === 0) {
+    return <EmptyState title={emptyTitle} description={emptyDescription} />;
+  }
+
+  return (
+    <>
+      <ul className="flex flex-col gap-4" aria-label={listLabel}>
+        {shipments.map((shipment) => {
+          const route = tc.ship_route
+            .replace('{origin}', resourceName(shipment.originResourceId))
+            .replace('{destination}', resourceName(shipment.destinationResourceId));
+          const firstItem = shipment.items[0];
+          return (
+            <li key={shipment.id}>
+              <button
+                type="button"
+                onClick={() => setOpenId(shipment.id)}
+                className={SUMMARY_CARD_CLASS}
+                aria-label={tc.ship_drawer_open.replace('{route}', route)}
+              >
+                <div className="flex w-full items-start justify-between gap-3">
+                  <span className="text-base font-bold leading-tight text-ink break-words">
+                    {route}
+                  </span>
+                  <Badge variant={STATUS_BADGE[shipment.status]}>
+                    {STATUS_LABELS[shipment.status]}
+                  </Badge>
+                </div>
+                <div className={META_ROW_CLASS}>
+                  {firstItem !== undefined && (
+                    <span className="font-medium break-words">
+                      {firstItem.description}
+                      {shipment.items.length > 1
+                        ? ` +${shipment.items.length - 1}`
+                        : ''}
+                    </span>
+                  )}
+                  <span aria-hidden="true" className="text-muted-soft">
+                    →
+                  </span>
+                  <span className="font-semibold text-navy">
+                    {tc.queue_view_detail}
+                  </span>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {shipments.map((shipment) =>
+        openId === shipment.id ? (
+          <ShipmentDetail
+            key={`drawer-${shipment.id}`}
+            shipment={shipment}
+            slug={slug}
+            resourceName={resourceName}
+            capacities={capacities}
+            canManage={canManage}
+            open
+            onClose={() => setOpenId(null)}
+            onActionSuccess={() => {
+              setOpenId(null);
+              router.refresh();
+            }}
+          />
+        ) : null,
+      )}
+    </>
+  );
+}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -201,6 +201,7 @@ export const en = {
 
     footer_my_points: 'My points',
     footer_my_volunteer: 'My volunteering',
+    footer_my_shipments: 'My shipments',
     footer_report: 'Report',
     footer_coordination: 'Coordination access',
 
@@ -1257,6 +1258,16 @@ export const en = {
 
     update_status_forbidden: 'You do not have permission to change the status of this point.',
     update_status_failed: 'Could not update the status. Please try again.',
+
+    // My shipments (carrier) — metadata + header + list
+    ship_meta_title: 'My shipments — {name} · ResponseGrid',
+    ship_meta_description: 'The shipments assigned to you in {name}.',
+    ship_title: 'My shipments',
+    ship_subtitle: 'The shipments assigned to you as a carrier.',
+    ship_list_label: 'My shipments list',
+    ship_empty_title: 'You have no assigned shipments.',
+    ship_empty_description:
+      'When coordination assigns you a shipment it will appear here so you can mark it in transit and confirm delivery.',
   },
 
   admin: {
@@ -1608,6 +1619,7 @@ export const en = {
     tab_resources: 'Resources',
     tab_needs: 'Requests',
     tab_offers: 'Offers',
+    tab_shipments: 'Shipments',
     tab_volunteers: 'Volunteers',
     tab_reports: 'Reports',
     tabs_aria: 'Coordination sections',
@@ -1624,6 +1636,9 @@ export const en = {
     hub_volunteers_description: 'Coordinate the roster and assign tasks.',
     hub_reports_label: 'Field reports',
     hub_reports_description: 'Review reports sent from the field.',
+    hub_shipments_label: 'Shipments',
+    hub_shipments_description: 'Plan and track material shipments between points.',
+    hub_shipments_count_aria: 'in progress',
 
     search_placeholder: 'Search…',
     search_aria: 'Search',
@@ -1787,6 +1802,97 @@ export const en = {
     personnel_fields_specialty_placeholder: 'e.g. pediatric emergency physician',
     personnel_fields_count_label: 'People needed',
 
+    // ── Shipments / Expediciones (#106) ───────────────────────────────
+    shipments_heading: 'Shipments',
+    shipments_list_label: 'Shipments list',
+    shipments_empty_title: 'No shipments yet.',
+    shipments_empty_description:
+      'Create a shipment to move material between the emergency’s points.',
+    shipments_no_match_title: 'No shipments with this status.',
+    shipments_no_match_description: 'Change the status filter to see more.',
+    shipments_section_meta_title:
+      'Shipments — {name} coordination · ResponseGrid',
+    shipments_section_meta_description:
+      'Planning and tracking of {name} material shipments.',
+
+    shipments_filter_group_label: 'Shipment filters',
+    shipments_filter_status_label: 'Status',
+    shipments_filter_status_aria: 'Filter by status',
+    shipments_filter_status_all: 'All statuses',
+
+    ship_route: '{origin} → {destination}',
+    ship_drawer_open: 'View shipment detail: {route}',
+    ship_section_route: 'Route',
+    ship_section_items: 'Cargo',
+    ship_section_assignment: 'Assignment',
+    ship_field_origin: 'Origin',
+    ship_field_destination: 'Destination',
+    ship_field_items: 'Items',
+    ship_field_manifest: 'Manifest',
+    ship_field_capacity: 'Assigned capacity',
+    ship_field_carrier: 'Carrier',
+
+    ship_status_planned: 'Planned',
+    ship_status_assigned: 'Assigned',
+    ship_status_in_transit: 'In transit',
+    ship_status_delivered: 'Delivered',
+    ship_status_failed: 'Failed',
+    ship_status_cancelled: 'Cancelled',
+
+    ship_carrier_volunteer: 'Volunteer',
+    ship_carrier_organization: 'Organization',
+
+    ship_mode_road: 'Road',
+    ship_mode_sea: 'Sea',
+    ship_mode_air: 'Air',
+
+    // Lifecycle actions
+    ship_assign_select_label: 'Select a capacity to assign',
+    ship_assign_placeholder: 'Select a capacity…',
+    ship_assign_none: 'No capacities available',
+    ship_assign_cta: 'Assign capacity',
+    ship_mark_in_transit: 'Mark in transit',
+    ship_confirm_delivery: 'Confirm delivery',
+    ship_cancel: 'Cancel shipment',
+
+    // Create shipment
+    ship_create_cta: '+ Create shipment',
+    ship_create_title: 'New shipment',
+    ship_create_submit: 'Create shipment',
+    ship_creating: 'Creating…',
+    ship_select_resource_placeholder: 'Select a point…',
+    ship_items_legend: 'Cargo',
+    ship_item_description_label: 'Item description',
+    ship_item_description_placeholder: 'e.g. Water boxes',
+    ship_item_quantity_label: 'Quantity',
+    ship_item_quantity_placeholder: 'Quantity',
+    ship_item_unit_label: 'Unit',
+    ship_item_unit_placeholder: 'Unit',
+    ship_item_add: '+ Add item',
+    ship_item_remove: 'Remove',
+    ship_manifest_placeholder: 'Manifest notes: fragile cargo, instructions…',
+
+    // Available capacities (read-only, #105)
+    cap_heading: 'Available capacities',
+    cap_subtitle: 'Transport offered for this emergency. Assign it from a shipment.',
+    cap_list_label: 'Transport capacities list',
+    cap_empty_title: 'No transport capacities.',
+    cap_empty_description:
+      'When someone offers transport for this emergency it will appear here.',
+    cap_field_capacity: 'Capacity:',
+    cap_field_coverage: 'Coverage:',
+    cap_field_window: 'Window:',
+    cap_status_available: 'Available',
+    cap_status_reserved: 'Reserved',
+    cap_status_withdrawn: 'Withdrawn',
+    cap_filter_group_label: 'Capacity filters',
+    cap_filter_mode_label: 'Mode',
+    cap_filter_mode_aria: 'Filter by transport mode',
+    cap_filter_mode_all: 'All modes',
+    cap_filter_status_label: 'Status',
+    cap_filter_status_aria: 'Filter by status',
+    cap_filter_status_all: 'All statuses',
+
     // server-action messages
     err_no_permission_match: 'You don’t have permission to assign this offer.',
     err_offer_not_open: 'The offer isn’t in an open state.',
@@ -1836,6 +1942,27 @@ export const en = {
     vol_err_no_permission_cancel: 'You don’t have permission to cancel this task.',
     vol_err_already_completed: 'The task is already completed.',
     vol_err_cancel_failed: 'Couldn’t cancel the task. Please try again.',
+
+    // Shipments (#106) — server-action messages
+    ship_err_endpoints_required: 'Select an origin and a destination.',
+    ship_err_same_endpoint: 'Origin and destination must be different.',
+    ship_err_items_required: 'Add at least one cargo item.',
+    ship_err_quantity_invalid: 'Quantities must be positive numbers.',
+    ship_err_capacity_required: 'Select a capacity to assign.',
+    ship_err_no_permission_create: 'You don’t have permission to create shipments.',
+    ship_err_create_failed: 'Couldn’t create the shipment. Please try again.',
+    ship_err_no_permission_assign: 'You don’t have permission to assign capacity.',
+    ship_err_no_permission_act: 'You don’t have permission to update this shipment.',
+    ship_err_no_permission_cancel: 'You don’t have permission to cancel this shipment.',
+    ship_err_not_found: 'Shipment not found.',
+    ship_err_not_planned: 'The shipment is no longer in a planned state.',
+    ship_err_not_assigned: 'The shipment isn’t in an assigned state.',
+    ship_err_not_in_transit: 'The shipment isn’t in transit.',
+    ship_err_cannot_cancel: 'The shipment can’t be cancelled in its current state.',
+    ship_err_assign_failed: 'Couldn’t assign the capacity. Please try again.',
+    ship_err_transit_failed: 'Couldn’t mark in transit. Please try again.',
+    ship_err_deliver_failed: 'Couldn’t confirm delivery. Please try again.',
+    ship_err_cancel_failed: 'Couldn’t cancel the shipment. Please try again.',
   },
 
   // Shared leaf-component strings

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -209,6 +209,7 @@ export const es = {
     // Footer links
     footer_my_points: 'Mis puntos',
     footer_my_volunteer: 'Mi voluntariado',
+    footer_my_shipments: 'Mis expediciones',
     footer_report: 'Reportar',
     footer_coordination: 'Acceso de coordinación',
 
@@ -1285,6 +1286,16 @@ export const es = {
 
     update_status_forbidden: 'No tienes permisos para cambiar el estado de este punto.',
     update_status_failed: 'No se pudo actualizar el estado. Inténtalo de nuevo.',
+
+    // Mis expediciones (transportista) — metadata + header + lista
+    ship_meta_title: 'Mis expediciones — {name} · ResponseGrid',
+    ship_meta_description: 'Las expediciones que tienes asignadas en {name}.',
+    ship_title: 'Mis expediciones',
+    ship_subtitle: 'Los envíos que tienes asignados como transportista.',
+    ship_list_label: 'Lista de mis expediciones',
+    ship_empty_title: 'No tienes expediciones asignadas.',
+    ship_empty_description:
+      'Cuando coordinación te asigne un envío aparecerá aquí para que lo marques en tránsito y confirmes la entrega.',
   },
 
   admin: {
@@ -1637,6 +1648,7 @@ export const es = {
     tab_resources: 'Recursos',
     tab_needs: 'Peticiones',
     tab_offers: 'Ofertas',
+    tab_shipments: 'Expediciones',
     tab_volunteers: 'Voluntarios',
     tab_reports: 'Reportes',
     tabs_aria: 'Secciones de coordinación',
@@ -1653,6 +1665,9 @@ export const es = {
     hub_volunteers_description: 'Coordina el roster y asigna tareas.',
     hub_reports_label: 'Reportes de campo',
     hub_reports_description: 'Revisa los partes enviados desde el terreno.',
+    hub_shipments_label: 'Expediciones',
+    hub_shipments_description: 'Planifica y sigue los envíos de material entre puntos.',
+    hub_shipments_count_aria: 'en curso',
 
     search_placeholder: 'Buscar…',
     search_aria: 'Buscar',
@@ -1818,6 +1833,97 @@ export const es = {
     personnel_fields_specialty_placeholder: 'Ej. médico urgencias pediátricas',
     personnel_fields_count_label: 'Personas necesarias',
 
+    // ── Expediciones / Shipment (#106) ────────────────────────────────
+    shipments_heading: 'Expediciones',
+    shipments_list_label: 'Lista de expediciones',
+    shipments_empty_title: 'Todavía no hay expediciones.',
+    shipments_empty_description:
+      'Crea una expedición para mover material entre puntos de la emergencia.',
+    shipments_no_match_title: 'Sin expediciones con este estado.',
+    shipments_no_match_description: 'Cambia el filtro de estado para ver más.',
+    shipments_section_meta_title:
+      'Expediciones — Coordinación de {name} · ResponseGrid',
+    shipments_section_meta_description:
+      'Planificación y seguimiento de envíos de material de {name}.',
+
+    shipments_filter_group_label: 'Filtros de expediciones',
+    shipments_filter_status_label: 'Estado',
+    shipments_filter_status_aria: 'Filtrar por estado',
+    shipments_filter_status_all: 'Todos los estados',
+
+    ship_route: '{origin} → {destination}',
+    ship_drawer_open: 'Ver detalle de la expedición: {route}',
+    ship_section_route: 'Ruta',
+    ship_section_items: 'Carga',
+    ship_section_assignment: 'Asignación',
+    ship_field_origin: 'Origen',
+    ship_field_destination: 'Destino',
+    ship_field_items: 'Artículos',
+    ship_field_manifest: 'Manifiesto',
+    ship_field_capacity: 'Capacidad asignada',
+    ship_field_carrier: 'Transportista',
+
+    ship_status_planned: 'Planificada',
+    ship_status_assigned: 'Asignada',
+    ship_status_in_transit: 'En tránsito',
+    ship_status_delivered: 'Entregada',
+    ship_status_failed: 'Fallida',
+    ship_status_cancelled: 'Cancelada',
+
+    ship_carrier_volunteer: 'Voluntario',
+    ship_carrier_organization: 'Organización',
+
+    ship_mode_road: 'Carretera',
+    ship_mode_sea: 'Marítimo',
+    ship_mode_air: 'Aéreo',
+
+    // Lifecycle actions
+    ship_assign_select_label: 'Seleccionar capacidad para asignar',
+    ship_assign_placeholder: 'Selecciona una capacidad…',
+    ship_assign_none: 'No hay capacidades disponibles',
+    ship_assign_cta: 'Asignar capacidad',
+    ship_mark_in_transit: 'Marcar en tránsito',
+    ship_confirm_delivery: 'Confirmar entrega',
+    ship_cancel: 'Cancelar expedición',
+
+    // Crear expedición
+    ship_create_cta: '+ Crear expedición',
+    ship_create_title: 'Nueva expedición',
+    ship_create_submit: 'Crear expedición',
+    ship_creating: 'Creando…',
+    ship_select_resource_placeholder: 'Selecciona un punto…',
+    ship_items_legend: 'Carga',
+    ship_item_description_label: 'Descripción del artículo',
+    ship_item_description_placeholder: 'Ej. Cajas de agua',
+    ship_item_quantity_label: 'Cantidad',
+    ship_item_quantity_placeholder: 'Cantidad',
+    ship_item_unit_label: 'Unidad',
+    ship_item_unit_placeholder: 'Unidad',
+    ship_item_add: '+ Añadir artículo',
+    ship_item_remove: 'Quitar',
+    ship_manifest_placeholder: 'Notas del manifiesto: carga frágil, instrucciones…',
+
+    // Capacidades disponibles (read-only, #105)
+    cap_heading: 'Capacidades disponibles',
+    cap_subtitle: 'Transporte ofrecido para esta emergencia. Asígnalo desde una expedición.',
+    cap_list_label: 'Lista de capacidades de transporte',
+    cap_empty_title: 'No hay capacidades de transporte.',
+    cap_empty_description:
+      'Cuando alguien ofrezca transporte para esta emergencia aparecerá aquí.',
+    cap_field_capacity: 'Capacidad:',
+    cap_field_coverage: 'Cobertura:',
+    cap_field_window: 'Ventana:',
+    cap_status_available: 'Disponible',
+    cap_status_reserved: 'Reservada',
+    cap_status_withdrawn: 'Retirada',
+    cap_filter_group_label: 'Filtros de capacidades',
+    cap_filter_mode_label: 'Modo',
+    cap_filter_mode_aria: 'Filtrar por modo de transporte',
+    cap_filter_mode_all: 'Todos los modos',
+    cap_filter_status_label: 'Estado',
+    cap_filter_status_aria: 'Filtrar por estado',
+    cap_filter_status_all: 'Todos los estados',
+
     // server-action messages
     err_no_permission_match: 'No tienes permisos para asignar esta oferta.',
     err_offer_not_open: 'La oferta no está en estado abierto.',
@@ -1867,6 +1973,27 @@ export const es = {
     vol_err_no_permission_cancel: 'No tienes permisos para cancelar esta tarea.',
     vol_err_already_completed: 'La tarea ya está completada.',
     vol_err_cancel_failed: 'No se pudo cancelar la tarea. Inténtalo de nuevo.',
+
+    // Expediciones (#106) — server-action messages
+    ship_err_endpoints_required: 'Selecciona origen y destino.',
+    ship_err_same_endpoint: 'El origen y el destino deben ser distintos.',
+    ship_err_items_required: 'Añade al menos un artículo a la carga.',
+    ship_err_quantity_invalid: 'Las cantidades deben ser números positivos.',
+    ship_err_capacity_required: 'Selecciona una capacidad para asignar.',
+    ship_err_no_permission_create: 'No tienes permisos para crear expediciones.',
+    ship_err_create_failed: 'No se pudo crear la expedición. Inténtalo de nuevo.',
+    ship_err_no_permission_assign: 'No tienes permisos para asignar capacidad.',
+    ship_err_no_permission_act: 'No tienes permisos para actualizar esta expedición.',
+    ship_err_no_permission_cancel: 'No tienes permisos para cancelar esta expedición.',
+    ship_err_not_found: 'Expedición no encontrada.',
+    ship_err_not_planned: 'La expedición ya no está en estado planificada.',
+    ship_err_not_assigned: 'La expedición no está en estado asignada.',
+    ship_err_not_in_transit: 'La expedición no está en tránsito.',
+    ship_err_cannot_cancel: 'La expedición no puede cancelarse en su estado actual.',
+    ship_err_assign_failed: 'No se pudo asignar la capacidad. Inténtalo de nuevo.',
+    ship_err_transit_failed: 'No se pudo marcar en tránsito. Inténtalo de nuevo.',
+    ship_err_deliver_failed: 'No se pudo confirmar la entrega. Inténtalo de nuevo.',
+    ship_err_cancel_failed: 'No se pudo cancelar la expedición. Inténtalo de nuevo.',
   },
 
   // Shared leaf-component strings

--- a/apps/web/src/lib/emergency-permissions.ts
+++ b/apps/web/src/lib/emergency-permissions.ts
@@ -21,6 +21,8 @@ export interface EmergencyAccess {
   canValidateNeeds: boolean;
   canVerifyResources: boolean;
   canMatchOffers: boolean;
+  /** Can read the logistics shipments/capacities surfaces (#106). */
+  canCoordinateLogistics: boolean;
   /** Any coordinator-grade capability (volunteers / reports / renew …). */
   canCoordinate: boolean;
   /** True when the principal can act on at least one coordination queue. */
@@ -64,6 +66,9 @@ export function resolveEmergencyAccess(
   const canValidateNeeds = permissions.has('need:validate');
   const canVerifyResources = permissions.has('resource:verify');
   const canMatchOffers = permissions.has('offer:match');
+  // The expediciones panel needs read access to shipments; creating/assigning
+  // gates the write actions inside the panel (shipment:create / :assign).
+  const canCoordinateLogistics = permissions.has('shipment:read');
   const canCoordinate = COORDINATOR_PERMISSIONS.some((p) => permissions.has(p));
 
   return {
@@ -72,6 +77,7 @@ export function resolveEmergencyAccess(
     canValidateNeeds,
     canVerifyResources,
     canMatchOffers,
+    canCoordinateLogistics,
     canCoordinate,
     canActOnAnyQueue: canValidateNeeds || canVerifyResources || canMatchOffers,
   };


### PR DESCRIPTION
Frontend de #106 (Expediciones / Shipment), mobile-first, mirror de ofertas (coordinador) y mi-voluntariado (transportista).

Panel coordinador /e/{slug}/coordinacion/expediciones: lista de expediciones (filtro por estado) + seccion read-only 'Capacidades disponibles' (filtro modo/estado) + 'Crear expedicion' (origen/destino desde recursos, items, manifiesto). Detalle en el detail-drawer con acciones de ciclo de vida segun estado: planned->asignar capacidad (select), assigned->en transito, in_transit->confirmar entrega, planned|assigned->cancelar. Server actions con auth + revalidate + manejo 401/403/404/409. Pestaña 'Expediciones' gateada por nuevo flag canCoordinateLogistics (shipment:read) en resolveEmergencyAccess; el boton crear chequea shipment:create.

Vista transportista /e/{slug}/mis-expediciones (GET /logistics/shipments/mine): solo sus expediciones, acciones marcar-en-transito y confirmar-entrega. Enlazada desde la landing. i18n es/en.

La seccion 'Capacidades disponibles' entrega la parte 'visible/filtrable por coordinacion' de #105 -> con esto #105 queda completo (form publico #136 + listado aqui).

Simplificaciones (ponytail): asignar = select plano (las sugerencias rankeadas llegan en #107); origen/destino selects de recursos (sin picker en mapa); crear minimo. Gate verde: api-client build + web build + web lint.

Closes #105
Closes #106