### PR TITLE
feat(web): sugerencias de capacidad en la expedicion (frontend #107)

### DIFF
--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
@@ -13,6 +13,12 @@ export type ActionResult =
   | { status: 'error'; message: string };
 
 type ShipmentItemInput = components['schemas']['ShipmentItemDto'];
+type CapacityView = components['schemas']['CapacityViewDto'];
+
+/** Result of fetching ranked capacity suggestions for a shipment (#107). */
+export type SuggestionsResult =
+  | { status: 'success'; capacities: CapacityView[] }
+  | { status: 'error'; message: string };
 
 /**
  * Creates a shipment / expedición for the given emergency (coordinator).
@@ -129,6 +135,48 @@ export async function assignCapacity(
 
   revalidatePath(`/e/${slug}/coordinacion/expediciones`);
   return { status: 'success' };
+}
+
+/**
+ * Fetches ranked compatible capacities for a planned shipment (coordinator, #107).
+ * The API returns them already ordered best-first — we DON'T re-sort. Runs as a
+ * server action so the auth token (httpOnly cookie) never reaches the client.
+ */
+export async function getCapacitySuggestions(
+  shipmentId: string,
+  slug: string,
+): Promise<SuggestionsResult> {
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+  }
+
+  const { t } = await getT();
+  const ts = t.coord;
+
+  const { data, error, response } = await api.GET(
+    '/logistics/shipments/{id}/capacity-suggestions',
+    {
+      params: { path: { id: shipmentId } },
+      headers: authHeaders(token),
+    },
+  );
+
+  if (error !== undefined || data === undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    }
+    if (response.status === 403) {
+      return { status: 'error', message: ts.ship_err_no_permission_assign };
+    }
+    if (response.status === 404) {
+      return { status: 'error', message: ts.ship_err_not_found };
+    }
+    return { status: 'error', message: ts.ship_suggestions_error };
+  }
+
+  return { status: 'success', capacities: data };
 }
 
 /**

--- a/apps/web/src/components/organisms/shipment-detail.tsx
+++ b/apps/web/src/components/organisms/shipment-detail.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useActionState, useState, useEffect } from 'react';
+import { useActionState, useState, useEffect, useTransition } from 'react';
 import {
   assignCapacity,
+  getCapacitySuggestions,
   markInTransit,
   confirmDelivery,
   cancelShipment,
@@ -36,6 +37,15 @@ const STATUS_BADGE: Record<
   delivered: 'offer-fulfilled',
   failed: 'offer-cancelled',
   cancelled: 'offer-cancelled',
+};
+
+const CAP_STATUS_BADGE: Record<
+  CapacityViewDto['status'],
+  'offer-open' | 'offer-matched' | 'offer-cancelled'
+> = {
+  available: 'offer-open',
+  reserved: 'offer-matched',
+  withdrawn: 'offer-cancelled',
 };
 
 const INITIAL_STATE: ActionResult = { status: 'idle' };
@@ -89,6 +99,42 @@ export function ShipmentDetail({
   const coordBase = `/e/${slug}/coordinacion/expediciones`;
   const actorPath = canManage ? coordBase : carrierBase;
 
+  // ── Ranked capacity suggestions (#107) ───────────────────────────────────
+  // Only a coordinator (canManage) assigning a planned shipment sees these.
+  const showSuggestions = canManage && shipment.status === 'planned';
+
+  const [suggestions, setSuggestions] = useState<CapacityViewDto[] | null>(null);
+  const [suggestionsError, setSuggestionsError] = useState<string | null>(null);
+  // ponytail: sugerencias primero, select manual tras un toggle.
+  const [showAllManual, setShowAllManual] = useState(false);
+  const [assigningId, setAssigningId] = useState<string | null>(null);
+  const [, startAssign] = useTransition();
+  // The fetch runs inside a transition (mirrors resource-list.tsx) so its
+  // pending flag drives the loading UI without a synchronous setState in the
+  // effect body.
+  const [suggestionsLoading, startSuggestions] = useTransition();
+
+  // Fetch ranked suggestions when the planned-shipment detail opens. Keyed on
+  // the open shipment id so reopening / switching shipments re-fetches.
+  useEffect(() => {
+    if (!open || !showSuggestions) return;
+    let cancelled = false;
+    startSuggestions(async () => {
+      setSuggestionsError(null);
+      const res = await getCapacitySuggestions(shipment.id, slug);
+      if (cancelled) return;
+      if (res.status === 'success') {
+        // Preserve API order — already ranked best-first.
+        setSuggestions(res.capacities);
+      } else {
+        setSuggestionsError(res.message);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, showSuggestions, shipment.id, slug]);
+
   const [assignState, assignFormAction, assignPending] = useActionState<
     ActionResult,
     FormData
@@ -118,6 +164,26 @@ export function ShipmentDetail({
     FormData
   >(async () => cancelShipment(shipment.id, slug), INITIAL_STATE);
 
+  const [suggestionAssignError, setSuggestionAssignError] = useState<
+    string | null
+  >(null);
+
+  // One-click assign from a ranked suggestion card. Same effect as the manual
+  // select assign: on success the shipment mutates and we refresh the list.
+  function handleAssignSuggestion(capacityId: string) {
+    setSuggestionAssignError(null);
+    setAssigningId(capacityId);
+    startAssign(async () => {
+      const res = await assignCapacity(shipment.id, capacityId, slug);
+      if (res.status === 'success') {
+        onActionSuccess();
+      } else if (res.status === 'error') {
+        setSuggestionAssignError(res.message);
+        setAssigningId(null);
+      }
+    });
+  }
+
   // Any successful transition mutates the shipment — refresh the list/drawer.
   useEffect(() => {
     if (
@@ -140,7 +206,8 @@ export function ShipmentDetail({
     (assignState.status === 'error' ? assignState.message : undefined) ??
     (transitState.status === 'error' ? transitState.message : undefined) ??
     (deliverState.status === 'error' ? deliverState.message : undefined) ??
-    (cancelState.status === 'error' ? cancelState.message : undefined);
+    (cancelState.status === 'error' ? cancelState.message : undefined) ??
+    (suggestionAssignError ?? undefined);
 
   const availableCapacities = capacities.filter(
     (c) => c.status === 'available',
@@ -152,40 +219,94 @@ export function ShipmentDetail({
     canManage &&
     (shipment.status === 'planned' || shipment.status === 'assigned');
 
+  const hasSuggestions = suggestions !== null && suggestions.length > 0;
+
+  // The plain "all available" select — reused as the manual fallback behind a
+  // toggle when the matcher returns nothing (#107).
+  const manualSelect = (
+    <form action={assignFormAction} className="flex flex-col gap-2">
+      <Select
+        id={`capacity-select-${shipment.id}`}
+        name="capacityId"
+        aria-label={tc.ship_assign_select_label}
+        value={selectedCapacityId}
+        onChange={(e) => setSelectedCapacityId(e.target.value)}
+      >
+        <option value="" disabled>
+          {availableCapacities.length > 0
+            ? tc.ship_assign_placeholder
+            : tc.ship_assign_none}
+        </option>
+        {availableCapacities.map((c) => (
+          <option key={c.id} value={c.id}>
+            {capacityLabel(c, tc)}
+          </option>
+        ))}
+      </Select>
+      <Button
+        type="submit"
+        disabled={assignPending || selectedCapacityId === ''}
+        fullWidth
+        size="lg"
+      >
+        {assignPending ? tc.processing : tc.ship_assign_cta}
+      </Button>
+    </form>
+  );
+
+  const suggestionsBlock = (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-sm font-bold text-ink">
+        {tc.ship_suggestions_heading}
+      </h3>
+
+      {suggestionsLoading && (
+        <p className="text-sm text-muted">{tc.ship_suggestions_loading}</p>
+      )}
+
+      {!suggestionsLoading && suggestionsError !== null && (
+        <ErrorMessage message={suggestionsError} />
+      )}
+
+      {!suggestionsLoading && suggestionsError === null && hasSuggestions && (
+        <ul className="flex flex-col gap-3" aria-label={tc.ship_suggestions_heading}>
+          {suggestions!.map((c) => (
+            <li key={c.id}>
+              <SuggestionCard
+                capacity={c}
+                tc={tc}
+                onAssign={() => handleAssignSuggestion(c.id)}
+                assigning={assigningId === c.id}
+                disabled={assigningId !== null}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Empty state: no compatible capacities → offer the manual select. */}
+      {!suggestionsLoading && suggestionsError === null && !hasSuggestions && (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-muted">{tc.ship_suggestions_empty}</p>
+          {showAllManual ? (
+            manualSelect
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowAllManual(true)}
+              className="self-start text-sm font-semibold text-navy underline hover:no-underline focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 rounded"
+            >
+              {tc.ship_suggestions_show_all}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
   const actions = (
     <div className="flex flex-col gap-3">
-      {canManage && shipment.status === 'planned' && (
-        // ponytail: select plano de capacidades — #107 lo sustituye por
-        // sugerencias rankeadas; aquí NO construimos el ranking.
-        <form action={assignFormAction} className="flex flex-col gap-2">
-          <Select
-            id={`capacity-select-${shipment.id}`}
-            name="capacityId"
-            aria-label={tc.ship_assign_select_label}
-            value={selectedCapacityId}
-            onChange={(e) => setSelectedCapacityId(e.target.value)}
-          >
-            <option value="" disabled>
-              {availableCapacities.length > 0
-                ? tc.ship_assign_placeholder
-                : tc.ship_assign_none}
-            </option>
-            {availableCapacities.map((c) => (
-              <option key={c.id} value={c.id}>
-                {capacityLabel(c, tc)}
-              </option>
-            ))}
-          </Select>
-          <Button
-            type="submit"
-            disabled={assignPending || selectedCapacityId === ''}
-            fullWidth
-            size="lg"
-          >
-            {assignPending ? tc.processing : tc.ship_assign_cta}
-          </Button>
-        </form>
-      )}
+      {showSuggestions && suggestionsBlock}
 
       {shipment.status === 'assigned' && (
         <form action={transitFormAction}>
@@ -220,7 +341,7 @@ export function ShipmentDetail({
   );
 
   const hasActions =
-    (canManage && shipment.status === 'planned') ||
+    showSuggestions ||
     shipment.status === 'assigned' ||
     shipment.status === 'in_transit' ||
     canCancel;
@@ -298,6 +419,84 @@ export function ShipmentDetail({
 
 type Tc = ReturnType<typeof getMessages>['coord'];
 
+/**
+ * Compact suggestion card mirroring `capacities-panel.tsx` (mode, capacity,
+ * coverage, window, status) plus a one-click "Asignar" button (#107).
+ */
+function SuggestionCard({
+  capacity,
+  tc,
+  onAssign,
+  assigning,
+  disabled,
+}: {
+  capacity: CapacityViewDto;
+  tc: Tc;
+  onAssign: () => void;
+  assigning: boolean;
+  disabled: boolean;
+}) {
+  const MODE_LABELS: Record<'road' | 'sea' | 'air', string> = {
+    road: tc.ship_mode_road,
+    sea: tc.ship_mode_sea,
+    air: tc.ship_mode_air,
+  };
+  const STATUS_LABELS: Record<CapacityViewDto['status'], string> = {
+    available: tc.cap_status_available,
+    reserved: tc.cap_status_reserved,
+    withdrawn: tc.cap_status_withdrawn,
+  };
+
+  const amount = formatAmount(capacity.capacity);
+  const area =
+    typeof capacity.coverage.area === 'string' && capacity.coverage.area !== ''
+      ? capacity.coverage.area
+      : null;
+  const window = formatWindow(capacity.window);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border-2 border-line bg-white p-4">
+      <div className="flex w-full items-start justify-between gap-3">
+        <span className="text-base font-bold leading-tight text-ink">
+          {MODE_LABELS[capacity.mode]}
+        </span>
+        <Badge variant={CAP_STATUS_BADGE[capacity.status]}>
+          {STATUS_LABELS[capacity.status]}
+        </Badge>
+      </div>
+      <dl className="flex flex-col gap-1 text-sm text-muted">
+        {amount !== '' && (
+          <div className="flex gap-2">
+            <dt className="font-semibold text-ink">{tc.cap_field_capacity}</dt>
+            <dd>{amount}</dd>
+          </div>
+        )}
+        {area !== null && (
+          <div className="flex gap-2">
+            <dt className="font-semibold text-ink">{tc.cap_field_coverage}</dt>
+            <dd className="break-words">{area}</dd>
+          </div>
+        )}
+        {window !== null && (
+          <div className="flex gap-2">
+            <dt className="font-semibold text-ink">{tc.cap_field_window}</dt>
+            <dd>{window}</dd>
+          </div>
+        )}
+      </dl>
+      <Button
+        type="button"
+        onClick={onAssign}
+        disabled={disabled}
+        fullWidth
+        size="lg"
+      >
+        {assigning ? tc.processing : tc.ship_suggestions_assign}
+      </Button>
+    </div>
+  );
+}
+
 function formatItem(item: components['schemas']['ShipmentItemResponseDto']): string {
   const qty =
     typeof item.quantity === 'number' && Number.isFinite(item.quantity)
@@ -325,4 +524,33 @@ function capacityLabel(c: components['schemas']['CapacityViewDto'], tc: Tc): str
       ? c.coverage.area
       : '';
   return area !== '' ? `${parts.join(' · ')} — ${area}` : parts.join(' · ');
+}
+
+function formatAmount(
+  amount: components['schemas']['CapacityAmountResponseDto'],
+): string {
+  const parts: string[] = [];
+  if (typeof amount.weightKg === 'number') parts.push(`${amount.weightKg} kg`);
+  if (typeof amount.volumeM3 === 'number') parts.push(`${amount.volumeM3} m³`);
+  return parts.join(' · ');
+}
+
+function formatWindow(
+  window: components['schemas']['CapacityWindowResponseDto'],
+): string | null {
+  const from = typeof window.from === 'string' ? formatDate(window.from) : null;
+  const to = typeof window.to === 'string' ? formatDate(window.to) : null;
+  if (from === null && to === null) return null;
+  if (from !== null && to !== null) return `${from} → ${to}`;
+  return from ?? to;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
 }

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -1851,6 +1851,13 @@ export const en = {
     ship_assign_placeholder: 'Select a capacity…',
     ship_assign_none: 'No capacities available',
     ship_assign_cta: 'Assign capacity',
+    // Capacity suggestions (#107)
+    ship_suggestions_heading: 'Capacity suggestions',
+    ship_suggestions_loading: 'Finding compatible capacities…',
+    ship_suggestions_error: 'Could not load suggestions. Please try again.',
+    ship_suggestions_empty: 'No compatible capacities',
+    ship_suggestions_show_all: 'Show all available',
+    ship_suggestions_assign: 'Assign',
     ship_mark_in_transit: 'Mark in transit',
     ship_confirm_delivery: 'Confirm delivery',
     ship_cancel: 'Cancel shipment',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -1882,6 +1882,13 @@ export const es = {
     ship_assign_placeholder: 'Selecciona una capacidad…',
     ship_assign_none: 'No hay capacidades disponibles',
     ship_assign_cta: 'Asignar capacidad',
+    // Sugerencias de capacidad (#107)
+    ship_suggestions_heading: 'Sugerencias de capacidad',
+    ship_suggestions_loading: 'Buscando capacidades compatibles…',
+    ship_suggestions_error: 'No se pudieron cargar las sugerencias. Inténtalo de nuevo.',
+    ship_suggestions_empty: 'No hay capacidades compatibles',
+    ship_suggestions_show_all: 'Ver todas las disponibles',
+    ship_suggestions_assign: 'Asignar',
     ship_mark_in_transit: 'Marcar en tránsito',
     ship_confirm_delivery: 'Confirmar entrega',
     ship_cancel: 'Cancelar expedición',


### PR DESCRIPTION
Frontend de #107. En el detalle de una expedicion 'planned' (vista coordinador), sustituye el select plano por la lista rankeada de 'Sugerencias de capacidad' (GET /logistics/shipments/{id}/capacity-suggestions, orden de la API preservado). Cada sugerencia es una tarjeta (modo, capacidad, cobertura, ventana, estado) con boton 'Asignar' -> assignCapacity de un clic. Si no hay compatibles: 'No hay capacidades compatibles' + toggle 'Ver todas las disponibles' que revela el select manual (#106) para asignar a mano.

El endpoint es authed (coordinador) y el token vive en cookie httpOnly, asi que el fetch va por server action con getToken()+authHeaders() (mismo patron que assignCapacity), llamado desde un useEffect. Loading/error con los atoms existentes. i18n es/en.

Cierra el EPIC logistico end-to-end (capacidad #105 + expedicion #106 + matching #107, backend + frontend). Gate verde: api-client build + web build + web lint.

Closes #107