### PR TITLE
docs(agents): claim de issues (label in-progress) para evitar colisiones entre agentes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,13 +43,24 @@ Hexagonal bounded contexts in `apps/api/src/contexts/` (18):
 
 **There is NO direct push to `main`.** Multiple parallel agent sessions merge here, so `main` moves fast. Every change:
 
-1. Sync: `git checkout main && git fetch origin && git merge --ff-only origin/main`.
-2. Branch: `git checkout -b feature/NN-short` (or `fix/...`, `docs/...`).
-3. Implement (TDD). Run the **full gate locally** (below) — the CI enforces all of it and a red check blocks the merge.
-4. `git push -u origin <branch>` → `gh pr create --base main --body "Closes #NN …"` → `gh pr merge <branch> --auto --squash`.
-5. CI runs the 4 required checks (`Format check`, `Lint`, `Build`, `Test`); on green it **auto-merges (squash)**, closes the linked issue, **deletes the branch**, and triggers the deploy.
+1. **Claim the issue** so no two agents take the same one — see **Claiming an issue** below. Only start one that is open, has no `in-progress` label, and is not already linked by an open PR.
+2. Sync: `git checkout main && git fetch origin && git merge --ff-only origin/main`.
+3. Branch: `git checkout -b feature/NN-short` (or `fix/...`, `docs/...`).
+4. Implement (TDD). Run the **full gate locally** (below) — the CI enforces all of it and a red check blocks the merge.
+5. `git push -u origin <branch>` → `gh pr create --base main --body "Closes #NN …"` → `gh pr merge <branch> --auto --squash`.
+6. CI runs the 4 required checks (`Format check`, `Lint`, `Build`, `Test`); on green it **auto-merges (squash)**, closes the linked issue, **deletes the branch**, and triggers the deploy.
 
 Repo settings: squash-only, delete-branch-on-merge, auto-merge ON, `strict=false` (no up-to-date requirement — but always sync `main` before push to minimise drift), 0 required approvals (the CI is the gate, not human review). Work from GitHub issues; put `Closes #NN` in the PR body.
+
+### Claiming an issue (parallel-agent coordination)
+
+Several agent sessions (Claude, Codex, …) run at once and share one GitHub identity, so **claim an issue before working it** — the `in-progress` label is the lock. Skip this only for ad-hoc work with no issue.
+
+1. **Check it's free:** the issue is open, has **no `in-progress` label**, and **no open PR links it** (`gh pr list --state open --search "NN in:body"`).
+2. **Claim it:** `gh issue edit NN --add-label in-progress`, then leave a claim comment — `gh issue comment NN --body "🤖 WIP · <branch> · $(date -u +%FT%TZ)"`. The session identity goes in the comment (not the assignee), since sessions share a token.
+3. **Confirm you won the race:** re-read it (`gh issue view NN --comments`). If another claim comment **predates yours**, you lost — remove the label only if you added it (`gh issue edit NN --remove-label in-progress`), retract your comment, and pick a different issue.
+4. **Release:** when your PR merges, `Closes #NN` closes the issue and the lock is moot. If you **abandon** it, `gh issue edit NN --remove-label in-progress` and comment why, so it's free again.
+5. **Stale claim:** an `in-progress` issue with **no linked open PR and no claim/branch activity for >24h** counts as abandoned — remove the stale label and re-claim it.
 
 ## The gate (run locally before pushing — CI runs ALL of these)
 


### PR DESCRIPTION
Varias sesiones de IA (Claude, Codex...) trabajan el repo en paralelo y comparten identidad de GitHub, asi que pueden coger la misma issue. Esto anade a AGENTS.md un protocolo de **claim** con un label **in-progress** como lock:

- Nuevo **paso 1 del workflow**: reclamar la issue antes de ramificar.
- Seccion **'Claiming an issue'**: check (open, sin label, sin PR que la enlace) -> claim (label + comentario con rama+timestamp) -> confirmar que ganaste la carrera (si hay claim anterior, ceder) -> release (al mergear o al abandonar) -> stale (>24h sin PR ni actividad = reclamable).
- Label `in-progress` creado en el repo (color amarillo).

Convencion pura: la cumplen todas las IAs porque AGENTS.md es de lectura obligatoria. Sin infra extra (la opcion de una Action que lo fuerce de forma atomica queda como mejora futura).