### PR TITLE
fix(web): el mapa solo encuadra una vez (deja de robar el zoom)

### DIFF
--- a/apps/web/src/components/organisms/emergency-map.tsx
+++ b/apps/web/src/components/organisms/emergency-map.tsx
@@ -246,12 +246,22 @@ function MapReadyEmitter({
   return null;
 }
 
-// ── Inner component that fits the bounds once the map is ready ────────────────
+// ── Inner component that fits the bounds ONCE, on the first non-empty data ─────
 function BoundsFitter({ points }: { points: MapPoint[] }) {
   const map = useMap();
+  const hasFittedRef = useRef(false);
 
   useEffect(() => {
+    // Fit the view to the data only ONCE (the initial SSR points). The wrapper
+    // re-fetches in-bounds points on every moveend/zoomend and replaces the
+    // marker set, so `points` changes whenever the user pans or zooms. Without
+    // this guard fitBounds re-ran on each fetch, yanking the user's zoom/pan and
+    // looping fit → moveend → fetch → fit (the user could never zoom in).
+    // Markers still update live; only the view is left under the user's control
+    // after the first fit.
+    if (hasFittedRef.current) return;
     if (points.length === 0) return;
+    hasFittedRef.current = true;
 
     if (points.length === 1) {
       const p = points[0];


### PR DESCRIPTION
**Bug (reportado en pruebas):** al navegar o hacer zoom en el mapa de la emergencia, la vista 'perdia capas de zoom' nada mas cargar y nunca dejaba acercarse.

**Causa:** `BoundsFitter` re-ejecutaba `fitBounds`/`setView` cada vez que cambiaban los puntos (deps `[map, points]`), y el wrapper **reemplaza los puntos en cada moveend/zoomend** al re-fetchear los in-bounds → bucle `fit → moveend → fetch → fit` que zarandeaba la vista e impedia fijar el zoom.

**Fix:** encuadrar **una sola vez** (los puntos SSR iniciales) con un `hasFittedRef`. Los marcadores siguen actualizandose en vivo con el re-fetch; solo la vista (zoom/pan) queda bajo control del usuario tras el primer encuadre. Gate web verde (api-client + web build + lint).