### PR TITLE
fix: el coordinador puede crear/asignar/cancelar expediciones (autz por membership) (#150)

### DIFF
--- a/apps/api/src/contexts/logistics/infrastructure/http/shipment.controller.spec.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/shipment.controller.spec.ts
@@ -1,0 +1,167 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ShipmentController } from './shipment.controller';
+import { CreateShipmentDto, AssignCapacityToShipmentDto } from './shipment-dto';
+import { CreateShipment } from '../../application/create-shipment';
+import { AssignCapacityToShipment } from '../../application/assign-capacity-to-shipment';
+import { MarkShipmentInTransit } from '../../application/mark-shipment-in-transit';
+import { ConfirmShipmentDelivery } from '../../application/confirm-shipment-delivery';
+import { CancelShipment } from '../../application/cancel-shipment';
+import { ListShipments } from '../../application/list-shipments';
+import { GetMyShipments } from '../../application/get-my-shipments';
+import { SuggestCapacitiesForShipment } from '../../application/suggest-capacities-for-shipment';
+import { MembershipRepository } from '../../../identity/domain/ports/membership.repository';
+
+/**
+ * Regression tests for #150: the shipment write routes carry no scope-resolvable
+ * param, so the global PermissionGuard resolved to the platform scope and 403'd
+ * a legitimate emergency coordinator. They now gate on coordinator membership of
+ * the shipment's emergency (mirroring markInTransit/deliver). Pure controller
+ * unit test — no DB.
+ */
+const EM = '44444444-4444-4444-8444-444444444444';
+const SHIP = '55555555-5555-4555-8555-555555555555';
+const USER = '11111111-1111-4111-8111-111111111111';
+
+type ReqArg = Parameters<ShipmentController['create']>[1];
+
+function req(isAdmin = false): ReqArg {
+  return {
+    user: { id: USER, email: 'coord@example.com', isAdmin },
+  } as unknown as ReqArg;
+}
+
+function createDto(): CreateShipmentDto {
+  return {
+    emergencyId: EM,
+    originResourceId: '22222222-2222-4222-8222-222222222222',
+    destinationResourceId: '33333333-3333-4333-8333-333333333333',
+    items: [{ description: 'agua' }],
+  };
+}
+
+const ASSIGN_DTO = {
+  assignedCapacityId: '66666666-6666-4666-8666-666666666666',
+} as AssignCapacityToShipmentDto;
+
+function setup() {
+  const createShipment = { execute: jest.fn().mockResolvedValue({ id: SHIP }) };
+  const assignCapacity = { execute: jest.fn().mockResolvedValue(undefined) };
+  const cancelShipment = { execute: jest.fn().mockResolvedValue(undefined) };
+  const suggest = { execute: jest.fn().mockResolvedValue([]) };
+  const noop = { execute: jest.fn() };
+  const shipmentAuthLookup = { findAuthorizationFacts: jest.fn() };
+  const membershipRepo = { hasRole: jest.fn() };
+
+  const controller = new ShipmentController(
+    createShipment as unknown as CreateShipment,
+    assignCapacity as unknown as AssignCapacityToShipment,
+    noop as unknown as MarkShipmentInTransit,
+    noop as unknown as ConfirmShipmentDelivery,
+    cancelShipment as unknown as CancelShipment,
+    noop as unknown as ListShipments,
+    noop as unknown as GetMyShipments,
+    suggest as unknown as SuggestCapacitiesForShipment,
+    shipmentAuthLookup,
+    membershipRepo as unknown as MembershipRepository,
+  );
+
+  return {
+    controller,
+    createShipment,
+    assignCapacity,
+    cancelShipment,
+    suggest,
+    shipmentAuthLookup,
+    membershipRepo,
+  };
+}
+
+describe('ShipmentController — authorization gating (#150)', () => {
+  describe('create', () => {
+    it('403s a non-coordinator and does not create', async () => {
+      const t = setup();
+      t.membershipRepo.hasRole.mockResolvedValue(false);
+      await expect(
+        t.controller.create(createDto(), req()),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(t.createShipment.execute).not.toHaveBeenCalled();
+    });
+
+    it('creates for a coordinator of the emergency', async () => {
+      const t = setup();
+      t.membershipRepo.hasRole.mockResolvedValue(true);
+      const res = await t.controller.create(createDto(), req());
+      expect(res).toEqual({ id: SHIP });
+      expect(t.createShipment.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates for a platform admin without checking membership', async () => {
+      const t = setup();
+      await t.controller.create(createDto(), req(true));
+      expect(t.membershipRepo.hasRole).not.toHaveBeenCalled();
+      expect(t.createShipment.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('assignCapacity', () => {
+    it('404s when the shipment does not exist', async () => {
+      const t = setup();
+      t.shipmentAuthLookup.findAuthorizationFacts.mockResolvedValue(null);
+      await expect(
+        t.controller.assignCapacity(SHIP, ASSIGN_DTO, req()),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(t.assignCapacity.execute).not.toHaveBeenCalled();
+    });
+
+    it('403s a non-coordinator of the shipment emergency', async () => {
+      const t = setup();
+      t.shipmentAuthLookup.findAuthorizationFacts.mockResolvedValue({
+        emergencyId: EM,
+        carrierId: null,
+      });
+      t.membershipRepo.hasRole.mockResolvedValue(false);
+      await expect(
+        t.controller.assignCapacity(SHIP, ASSIGN_DTO, req()),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(t.assignCapacity.execute).not.toHaveBeenCalled();
+    });
+
+    it('assigns for a coordinator of the shipment emergency', async () => {
+      const t = setup();
+      t.shipmentAuthLookup.findAuthorizationFacts.mockResolvedValue({
+        emergencyId: EM,
+        carrierId: null,
+      });
+      t.membershipRepo.hasRole.mockResolvedValue(true);
+      await t.controller.assignCapacity(SHIP, ASSIGN_DTO, req());
+      expect(t.assignCapacity.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cancel and capacitySuggestions gate by coordinator too', () => {
+    it('cancel 403s a non-coordinator', async () => {
+      const t = setup();
+      t.shipmentAuthLookup.findAuthorizationFacts.mockResolvedValue({
+        emergencyId: EM,
+        carrierId: null,
+      });
+      t.membershipRepo.hasRole.mockResolvedValue(false);
+      await expect(t.controller.cancel(SHIP, req())).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      expect(t.cancelShipment.execute).not.toHaveBeenCalled();
+    });
+
+    it('capacitySuggestions returns for a coordinator', async () => {
+      const t = setup();
+      t.shipmentAuthLookup.findAuthorizationFacts.mockResolvedValue({
+        emergencyId: EM,
+        carrierId: null,
+      });
+      t.membershipRepo.hasRole.mockResolvedValue(true);
+      const res = await t.controller.capacitySuggestions(SHIP, req());
+      expect(res).toEqual([]);
+      expect(t.suggest.execute).toHaveBeenCalledWith({ shipmentId: SHIP });
+    });
+  });
+});

--- a/apps/api/src/contexts/logistics/infrastructure/http/shipment.controller.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/shipment.controller.ts
@@ -1,9 +1,11 @@
 import {
   Body,
   Controller,
+  ForbiddenException,
   Get,
   HttpCode,
   Inject,
+  NotFoundException,
   Param,
   ParseUUIDPipe,
   Post,
@@ -107,10 +109,57 @@ export class ShipmentController {
     return { isCoordinator };
   }
 
+  /**
+   * Coordinator-or-admin gate for shipment writes whose route carries no
+   * scope-resolvable param (the global PermissionGuard would otherwise fall
+   * back to the platform scope and 403 a legitimate emergency coordinator).
+   * Mirrors how markInTransit/deliver resolve coordinator-ship from the
+   * shipment itself. 404s an unknown shipment before the 403, like the use
+   * cases do.
+   */
+  private async assertShipmentCoordinator(
+    shipmentId: string,
+    req: AuthenticatedRequest,
+  ): Promise<void> {
+    if (req.user.isAdmin) return;
+    const facts =
+      await this.shipmentAuthLookup.findAuthorizationFacts(shipmentId);
+    if (facts === null) {
+      throw new NotFoundException(`shipment ${shipmentId} not found`);
+    }
+    const isCoordinator = await this.membershipRepo.hasRole(
+      UserId.fromString(req.user.id),
+      facts.emergencyId,
+      Role.Coordinator,
+    );
+    if (!isCoordinator) {
+      throw new ForbiddenException(
+        'Only a coordinator of the shipment emergency can perform this action',
+      );
+    }
+  }
+
+  /** Coordinator-or-admin gate for creating a shipment in an emergency. */
+  private async assertEmergencyCoordinator(
+    emergencyId: string,
+    req: AuthenticatedRequest,
+  ): Promise<void> {
+    if (req.user.isAdmin) return;
+    const isCoordinator = await this.membershipRepo.hasRole(
+      UserId.fromString(req.user.id),
+      emergencyId,
+      Role.Coordinator,
+    );
+    if (!isCoordinator) {
+      throw new ForbiddenException(
+        'Only a coordinator of the emergency can create a shipment',
+      );
+    }
+  }
+
   @Post('logistics/shipments')
   @HttpCode(201)
-  @UseGuards(JwtAuthGuard, PermissionGuard)
-  @RequirePermission('shipment:create')
+  @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Create a shipment / expedición (coordinator)',
@@ -121,13 +170,17 @@ export class ShipmentController {
   })
   @ApiBadRequestResponse({ description: 'Invalid request body' })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
-  @ApiForbiddenResponse({ description: 'Missing shipment:create permission' })
+  @ApiForbiddenResponse({
+    description: 'Not a coordinator of the emergency',
+  })
   @ApiConflictResponse({
     description: 'Emergency is not accepting intake (paused/closed)',
   })
   async create(
     @Body() dto: CreateShipmentDto,
+    @Request() req: AuthenticatedRequest,
   ): Promise<CreateShipmentResponseDto> {
+    await this.assertEmergencyCoordinator(dto.emergencyId, req);
     return this.createShipment.execute({
       emergencyId: dto.emergencyId,
       originResourceId: dto.originResourceId,
@@ -144,8 +197,7 @@ export class ShipmentController {
 
   @Post('logistics/shipments/:id/assign-capacity')
   @HttpCode(204)
-  @UseGuards(JwtAuthGuard, PermissionGuard)
-  @RequirePermission('shipment:assign')
+  @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Assign a transport capacity (and optional carrier) (coordinator)',
@@ -156,11 +208,15 @@ export class ShipmentController {
   @ApiNotFoundResponse({ description: 'Shipment not found' })
   @ApiConflictResponse({ description: 'Shipment is not in planned status' })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
-  @ApiForbiddenResponse({ description: 'Missing shipment:assign permission' })
+  @ApiForbiddenResponse({
+    description: 'Not a coordinator of the shipment emergency',
+  })
   async assignCapacity(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: AssignCapacityToShipmentDto,
+    @Request() req: AuthenticatedRequest,
   ): Promise<void> {
+    await this.assertShipmentCoordinator(id, req);
     await this.assignCapacityToShipment.execute({
       shipmentId: id,
       assignedCapacityId: dto.assignedCapacityId,
@@ -226,8 +282,7 @@ export class ShipmentController {
 
   @Post('logistics/shipments/:id/cancel')
   @HttpCode(204)
-  @UseGuards(JwtAuthGuard, PermissionGuard)
-  @RequirePermission('shipment:update')
+  @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Cancel a shipment (coordinator)' })
   @ApiParam({ name: 'id', description: 'Shipment UUID', format: 'uuid' })
@@ -237,8 +292,14 @@ export class ShipmentController {
     description: 'Shipment cannot be cancelled in its current status',
   })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
-  @ApiForbiddenResponse({ description: 'Missing shipment:update permission' })
-  async cancel(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+  @ApiForbiddenResponse({
+    description: 'Not a coordinator of the shipment emergency',
+  })
+  async cancel(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<void> {
+    await this.assertShipmentCoordinator(id, req);
     await this.cancelShipment.execute({ shipmentId: id });
   }
 
@@ -286,8 +347,7 @@ export class ShipmentController {
   }
 
   @Get('logistics/shipments/:id/capacity-suggestions')
-  @UseGuards(JwtAuthGuard, PermissionGuard)
-  @RequirePermission('shipment:read')
+  @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary:
@@ -300,10 +360,14 @@ export class ShipmentController {
   })
   @ApiNotFoundResponse({ description: 'Shipment not found' })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
-  @ApiForbiddenResponse({ description: 'Missing shipment:read permission' })
+  @ApiForbiddenResponse({
+    description: 'Not a coordinator of the shipment emergency',
+  })
   async capacitySuggestions(
     @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: AuthenticatedRequest,
   ): Promise<CapacityView[]> {
+    await this.assertShipmentCoordinator(id, req);
     return this.suggestCapacitiesForShipment.execute({ shipmentId: id });
   }
 }


### PR DESCRIPTION
Aborda el **Hueco 1 de #150** (auditoría del EPIC #103). **No cierra #150** — el Hueco 2 (hub transversal) sigue abierto allí.

## El bug
Las rutas de escritura de expedición usaban `PermissionGuard` + `@RequirePermission`, pero **no llevan un parámetro de scope resoluble** (`POST /logistics/shipments`, `…/:id/assign-capacity`, `…/:id/cancel`, `GET …/:id/capacity-suggestions`). `EntityAwareScopeResolver` no reconoce `shipmentId` → cae a scope **`[platform]`**, así que un `emergency_coordinator` (con `shipment:*` a scope `emergency`) recibía **403**. Solo un `platform_admin` podía operarlas → el flujo central de #106/#107 (crear expedición + asignar capacidad) estaba **roto para el coordinador**. No lo cubría ningún e2e.

## El fix
Gatear esas 4 rutas por **membership de coordinador** de la emergencia del shipment (o admin), reutilizando el patrón que el controller ya usa en `in-transit`/`deliver` (`membershipRepo.hasRole(..., Role.Coordinator)`):
- `create` → `assertEmergencyCoordinator(dto.emergencyId)`.
- `assign-capacity` / `cancel` / `capacity-suggestions` → `assertShipmentCoordinator(id)` (404 si el shipment no existe, 403 si no es coordinador).
- `list` (ya correcto, lleva `:emergencyId`) e `in-transit`/`deliver` (ya con check manual) sin cambios.

**No cambia rutas/DTOs/cliente** → sin `gen:api`, sin tocar frontend ni migración. Solo `shipment.controller.ts` + un test de controller.

## Verificación
- ✅ build (tsc) · eslint · prettier
- ✅ Test de controller nuevo (sin DB): create/assign/cancel/suggestions 403-an a no-coordinadores, 404-an shipment inexistente, y dejan pasar a coordinador/admin. Suite `logistics` local **123/123**.
- 🔄 CI corre el resto contra Postgres.

## Fuera de alcance
**Hueco 2** (#108 / #150): autoridad transversal de `hub` en expediciones — es feature (referencia de hub en la expedición + `gen:api`/UI), queda tracked en #150.