### PR TITLE
fix(web): KPI 'Necesidades registradas' (coherencia con el listado publicado)

### DIFF
--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -125,7 +125,7 @@ export const en = {
     menu_verify: 'Verify a campaign',
 
     // Metric tiles
-    metric_tile_open: 'Open needs',
+    metric_tile_open: 'Registered needs',
     metric_tile_points: 'Active points',
     metric_tile_covered: 'Covered',
     metric_tile_queue: 'In queue',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -126,7 +126,7 @@ export const es = {
     menu_verify: 'Verificar una campaña',
 
     // Tarjetas de métricas
-    metric_tile_open: 'Necesidades abiertas',
+    metric_tile_open: 'Necesidades registradas',
     metric_tile_points: 'Puntos activos',
     metric_tile_covered: 'Cubiertas',
     metric_tile_queue: 'En cola',


### PR DESCRIPTION
**Bug de coherencia (visto en pruebas):** en la landing, el KPI 'Necesidades abiertas' marcaba **3** (`needs.open` = pendientes + validadas) mientras la lista publica 'Necesidades' marcaba **0** (solo validadas+frescas, por #94). Confuso, y exponia un recuento que incluye no verificadas.

**Fix minimo (relabel i18n es/en):** 'Necesidades abiertas' -> **'Necesidades registradas'** / 'Open needs' -> 'Registered needs'. Asi el KPI se lee como total de necesidades **registradas** (incluye sin verificar) y el listado —con su estado vacio 'Aun no hay necesidades publicadas'— muestra las **publicadas/validadas**: los dos numeros (3 registradas / 0 publicadas) quedan coherentes. Elegi 'registradas' y no 'sin verificar' porque `needs.open` tambien cuenta las validadas, asi que 'sin verificar' no siempre seria exacto.

Sin cambio de backend ni de la cuenta. Gate web verde (build + lint + test).