### PR TITLE
fix: el verificador puede publicar recursos (/publish acepta resource:verify)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -884,7 +884,7 @@
             "bearer": []
           }
         ],
-        "summary": "Publish a resource (coordinator of the resource's emergency only)",
+        "summary": "Publish a resource (verifier or coordinator of the resource's emergency)",
         "tags": [
           "resources"
         ]
@@ -3948,7 +3948,7 @@
             "description": "Missing or invalid token"
           },
           "403": {
-            "description": "Missing shipment:create permission"
+            "description": "Not a coordinator of the emergency"
           },
           "409": {
             "description": "Emergency is not accepting intake (paused/closed)"
@@ -4001,7 +4001,7 @@
             "description": "Missing or invalid token"
           },
           "403": {
-            "description": "Missing shipment:assign permission"
+            "description": "Not a coordinator of the shipment emergency"
           },
           "404": {
             "description": "Shipment not found"
@@ -4130,7 +4130,7 @@
             "description": "Missing or invalid token"
           },
           "403": {
-            "description": "Missing shipment:update permission"
+            "description": "Not a coordinator of the shipment emergency"
           },
           "404": {
             "description": "Shipment not found"
@@ -4291,7 +4291,7 @@
             "description": "Missing or invalid token"
           },
           "403": {
-            "description": "Missing shipment:read permission"
+            "description": "Not a coordinator of the shipment emergency"
           },
           "404": {
             "description": "Shipment not found"

--- a/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
@@ -147,11 +147,11 @@ export class ResourcesController {
   @Post('resources/:resourceId/publish')
   @HttpCode(204)
   @UseGuards(JwtAuthGuard, PermissionGuard)
-  @RequirePermission('resource:edit')
+  @RequirePermission('resource:verify')
   @ApiBearerAuth()
   @ApiOperation({
     summary:
-      "Publish a resource (coordinator of the resource's emergency only)",
+      "Publish a resource (verifier or coordinator of the resource's emergency)",
   })
   @ApiParam({
     name: 'resourceId',

--- a/apps/web/src/app/e/[slug]/coordinacion/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/actions.ts
@@ -221,6 +221,10 @@ export async function verifyAndPublish(
       await clearToken();
       redirect(`/login?next=/e/${slug}/coordinacion`);
     }
+    // The verify step already persisted; refresh so the queue/badge reflect the
+    // now-verified state even though publishing failed (avoids a stale "Sin
+    // verificar" and a misleading retry).
+    revalidatePath(`/e/${slug}/coordinacion`);
     return {
       status: 'error',
       message: t.coord.err_publish_resource_failed,

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -322,7 +322,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Publish a resource (coordinator of the resource's emergency only) */
+        /** Publish a resource (verifier or coordinator of the resource's emergency) */
         post: operations["ResourcesController_publishResource"];
         delete?: never;
         options?: never;
@@ -7068,7 +7068,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Missing shipment:create permission */
+            /** @description Not a coordinator of the emergency */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -7121,7 +7121,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Missing shipment:assign permission */
+            /** @description Not a coordinator of the shipment emergency */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -7268,7 +7268,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Missing shipment:update permission */
+            /** @description Not a coordinator of the shipment emergency */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -7389,7 +7389,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Missing shipment:read permission */
+            /** @description Not a coordinator of the shipment emergency */
             403: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Fix de #160. El verificador no podia publicar recursos: POST /resources/:id/verify exige resource:verify (lo tiene) pero POST /resources/:id/publish exigia **resource:edit** (no lo tiene) -> 403 -> 'verificado pero no se pudo publicar', dejando los puntos **verificados-pero-ocultos** (causa de los 574 ocultos).

- **API:** /resources/:id/publish ahora exige **resource:verify** (el verificador publica, coherente con su cola 'Revisa y publica los puntos pendientes'; los coordinadores tambien tienen resource:verify). gen:api regenerado.
- **Web:** en el fallo parcial (verify ok, publish ko) el server action **revalida antes de retornar el error**, asi la UI refleja el estado verificado real (no mas badge 'Sin verificar' enganoso).

Gate verde: api build + 1051 tests + api-client/web build + lint.

Closes #160