### PR TITLE
Ficha 15: evidencia en la cola de duda (#154) + enlace de reporte en el mapa (#155)

### DIFF
--- a/apps/web/src/app/e/[slug]/coordinacion/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/actions.ts
@@ -579,6 +579,47 @@ export async function resolveDispute(
   return { status: 'success' };
 }
 
+type ValidityReport = components['schemas']['ValidityReportDto'];
+
+export type ValidityReportsResult =
+  | { status: 'success'; reports: ValidityReport[] }
+  | { status: 'error'; message: string };
+
+/**
+ * Loads the individual citizen validity reports of a disputed resource so a
+ * coordinator can review the evidence (reason · note · photos) before
+ * resolving (#154). Coordinator-only (`resource:read`); photos are
+ * coordination-only by design (ficha 15 §6).
+ */
+export async function getValidityReports(
+  resourceId: string,
+  slug: string,
+): Promise<ValidityReportsResult> {
+  const token = await getToken();
+  if (token === null)
+    redirect(`/login?next=/e/${slug}/coordinacion/puntos-en-duda`);
+
+  const { t } = await getT();
+
+  const { data, error, response } = await api.GET(
+    '/resources/{resourceId}/validity-reports',
+    {
+      params: { path: { resourceId } },
+      headers: authHeaders(token),
+    },
+  );
+
+  if (error !== undefined || data === undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(`/login?next=/e/${slug}/coordinacion/puntos-en-duda`);
+    }
+    return { status: 'error', message: t.coord.err_load_reports_failed };
+  }
+
+  return { status: 'success', reports: data };
+}
+
 export async function editOffer(
   offerId: string,
   slug: string,

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -229,6 +229,7 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
           <EmergencyMapWrapper
             points={mapPoints}
             emergencyId={emergencyId}
+            slug={slug}
             containerClassName="h-[44vh] min-h-[300px] max-h-[480px] border-y border-line lg:h-full lg:min-h-0 lg:max-h-none lg:border-y-0 lg:border-r"
           />
           {/* Leyenda flotante sobre el mapa */}

--- a/apps/web/src/components/organisms/disputed-queue.tsx
+++ b/apps/web/src/components/organisms/disputed-queue.tsx
@@ -11,11 +11,13 @@ import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
 import type { Messages } from '@/i18n/messages/es';
 import {
+  getValidityReports,
   resolveDispute,
   type DisputeResolution,
 } from '@/app/e/[slug]/coordinacion/actions';
 
 type DisputedResource = components['schemas']['DisputedResourceDto'];
+type ValidityReport = components['schemas']['ValidityReportDto'];
 
 const INPUT_CLASS =
   'w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink focus:border-navy focus:outline-none';
@@ -72,6 +74,10 @@ function DisputedCard({
   const [error, setError] = useState<string | null>(null);
   const [active, setActive] = useState<DisputeResolution | null>(null);
   const [reason, setReason] = useState('');
+  const [evidenceOpen, setEvidenceOpen] = useState(false);
+  const [evidence, setEvidence] = useState<ValidityReport[] | null>(null);
+  const [evidenceLoading, setEvidenceLoading] = useState(false);
+  const [evidenceError, setEvidenceError] = useState<string | null>(null);
 
   const r = item.resource;
   const reasonLabels: Record<string, string> = {
@@ -103,6 +109,23 @@ function DisputedCard({
       } else if (res.status === 'error') {
         setError(res.message ?? tc.error_unknown);
       }
+    });
+  }
+
+  function toggleEvidence(): void {
+    if (evidenceOpen) {
+      setEvidenceOpen(false);
+      return;
+    }
+    setEvidenceOpen(true);
+    // Lazy-load once; keep the result cached across toggles.
+    if (evidence !== null || evidenceLoading) return;
+    setEvidenceLoading(true);
+    setEvidenceError(null);
+    void getValidityReports(r.id, slug).then((res) => {
+      setEvidenceLoading(false);
+      if (res.status === 'success') setEvidence(res.reports);
+      else setEvidenceError(res.message);
     });
   }
 
@@ -141,6 +164,73 @@ function DisputedCard({
               new Date(item.lastReportedAt).toLocaleDateString(),
             )}
       </p>
+
+      <div className="flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={toggleEvidence}
+          aria-expanded={evidenceOpen}
+          className="w-fit text-xs font-semibold text-navy hover:underline focus:outline-none"
+        >
+          {evidenceOpen ? tc.disputes_evidence_hide : tc.disputes_evidence_show}
+        </button>
+
+        {evidenceOpen && (
+          <div className="flex flex-col gap-2">
+            {evidenceLoading && (
+              <p className="text-xs text-muted">
+                {tc.disputes_evidence_loading}
+              </p>
+            )}
+            {evidenceError !== null && <ErrorMessage message={evidenceError} />}
+            {evidence !== null && evidence.length === 0 && (
+              <p className="text-xs text-muted">
+                {tc.disputes_evidence_empty}
+              </p>
+            )}
+            {evidence?.map((report) => (
+              <div
+                key={report.id}
+                className="rounded-md border border-line bg-surface-alt p-2 text-xs"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-semibold text-warning">
+                    {reasonLabels[report.reason] ?? report.reason}
+                  </span>
+                  <span className="text-muted">
+                    {new Date(report.createdAt).toLocaleDateString()}
+                  </span>
+                </div>
+                {report.note != null && report.note.trim() !== '' ? (
+                  <p className="mt-1 text-ink">{report.note}</p>
+                ) : (
+                  <p className="mt-1 italic text-muted">
+                    {tc.disputes_evidence_no_note}
+                  </p>
+                )}
+                {report.photoUrls.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-2">
+                    {report.photoUrls.map((url, i) => (
+                      <a
+                        key={url}
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-info underline"
+                      >
+                        {tc.disputes_evidence_photo.replace(
+                          '{n}',
+                          String(i + 1),
+                        )}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       {error !== null && <ErrorMessage message={error} />}
 

--- a/apps/web/src/components/organisms/emergency-map-wrapper.tsx
+++ b/apps/web/src/components/organisms/emergency-map-wrapper.tsx
@@ -16,6 +16,9 @@ interface EmergencyMapWrapperProps {
   emergencyId?: string;
   /** Tailwind classes for the map container (forwarded to EmergencyMap). */
   containerClassName?: string;
+  /** Emergency slug — forwarded to the map so resource popups can link to the
+   * detail page and the "report a problem" flow (ficha 15, #155). */
+  slug?: string;
 }
 
 const API_BASE = (process.env.NEXT_PUBLIC_API_URL ?? '').replace(/\/$/, '');
@@ -59,7 +62,7 @@ function createDebounced(fn: (map: LeafletMap) => void) {
   return invoke;
 }
 
-export function EmergencyMapWrapper({ points, emergencyId, containerClassName }: EmergencyMapWrapperProps) {
+export function EmergencyMapWrapper({ points, emergencyId, containerClassName, slug }: EmergencyMapWrapperProps) {
   // allMapPoints drives what the map renders. Initially = SSR prop (resources +
   // needs, page 1); once the map is ready it is replaced by viewport queries.
   const [allMapPoints, setAllMapPoints] = useState<MapPoint[]>(points);
@@ -212,6 +215,7 @@ export function EmergencyMapWrapper({ points, emergencyId, containerClassName }:
       points={effectivePoints}
       onMapReady={handleMapReady}
       {...(containerClassName !== undefined && { containerClassName })}
+      {...(slug !== undefined && { slug })}
     />
   );
 }

--- a/apps/web/src/components/organisms/emergency-map.tsx
+++ b/apps/web/src/components/organisms/emergency-map.tsx
@@ -95,6 +95,11 @@ interface EmergencyMapProps {
    * to make the map a full-height hero (mobile) / sticky panel (desktop).
    */
   containerClassName?: string;
+  /**
+   * Emergency slug — when set, resource popups link their name to the public
+   * detail page and offer a "report a problem" CTA (ficha 15, #155).
+   */
+  slug?: string;
 }
 
 // ── Inner component that draws uncertainty circles for approximate needs ──────
@@ -149,7 +154,13 @@ function escapeHtml(s: string): string {
 }
 
 // ── Inner component that renders clustered resource/need markers ──────────────
-function ClusteredMarkersLayer({ points }: { points: MapPoint[] }) {
+function ClusteredMarkersLayer({
+  points,
+  slug,
+}: {
+  points: MapPoint[];
+  slug?: string;
+}) {
   const map = useMap();
   const locale = useLocale();
   const clusterRef = useRef<L.MarkerClusterGroup | null>(null);
@@ -199,7 +210,22 @@ function ClusteredMarkersLayer({ points }: { points: MapPoint[] }) {
           ? `<br/><span style="font-size:11px;color:#b45309;">⚠️ ${escapeHtml(tc.map_disputed)}</span>`
           : '';
 
-      const popupHtml = `<strong>${escapeHtml(point.label)}</strong><br/><span style="font-size:11px;color:#6b7280;">${kindLabel}</span>${typeLabel}${locationLabel}${acceptsLabel}${approximateLabel}${disputedLabel}`;
+      // Resource popups (only on the public landing, where slug is provided)
+      // link the name to the detail page and offer a "report a problem" CTA.
+      const detailHref =
+        point.kind === 'resource' && slug != null && slug !== ''
+          ? `/e/${encodeURIComponent(slug)}/recursos/${encodeURIComponent(point.id)}`
+          : null;
+      const titleHtml =
+        detailHref !== null
+          ? `<a href="${escapeHtml(detailHref)}" style="color:#0f172a;font-weight:700;text-decoration:underline;">${escapeHtml(point.label)}</a>`
+          : `<strong>${escapeHtml(point.label)}</strong>`;
+      const reportLink =
+        detailHref !== null
+          ? `<br/><a href="${escapeHtml(`${detailHref}/reportar-estado`)}" style="font-size:11px;color:#b45309;font-weight:600;">${escapeHtml(tc.map_report_cta)}</a>`
+          : '';
+
+      const popupHtml = `${titleHtml}<br/><span style="font-size:11px;color:#6b7280;">${kindLabel}</span>${typeLabel}${locationLabel}${acceptsLabel}${approximateLabel}${disputedLabel}${reportLink}`;
 
       L.marker([point.lat, point.lng], { icon })
         .bindPopup(popupHtml)
@@ -209,7 +235,7 @@ function ClusteredMarkersLayer({ points }: { points: MapPoint[] }) {
     return () => {
       group.clearLayers();
     };
-  }, [map, points, locale]);
+  }, [map, points, locale, slug]);
 
   // Remove the cluster group when the component unmounts.
   // Read clusterRef.current INSIDE the cleanup so we always get the value
@@ -289,6 +315,7 @@ export default function EmergencyMap({
   points,
   onMapReady,
   containerClassName = 'h-80 rounded-lg border-2 border-line',
+  slug,
 }: EmergencyMapProps) {
   const t = getMessages(useLocale()).ui;
   // Default centre (Spain) used only when there are no points
@@ -311,7 +338,7 @@ export default function EmergencyMap({
         {onMapReady && <MapReadyEmitter onMapReady={onMapReady} />}
         <BoundsFitter points={points} />
         <ApproximateCirclesLayer points={points} />
-        <ClusteredMarkersLayer points={points} />
+        <ClusteredMarkersLayer points={points} slug={slug} />
       </MapContainer>
 
       {/* Empty-state overlay rendered on top of the map */}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -1575,8 +1575,15 @@ export const en = {
     disputes_action_dismiss: 'Dismiss',
     disputes_resolve_confirm: 'Confirm',
     disputes_resolving: 'Working…',
+    disputes_evidence_show: 'View evidence',
+    disputes_evidence_hide: 'Hide evidence',
+    disputes_evidence_loading: 'Loading reports…',
+    disputes_evidence_empty: 'No individual reports.',
+    disputes_evidence_no_note: 'No note',
+    disputes_evidence_photo: 'Photo {n}',
     err_resolve_dispute_failed:
       'Couldn’t resolve the dispute. Please try again.',
+    err_load_reports_failed: 'Couldn’t load the reports.',
     activity_title: 'Activity log',
     activity_subtitle:
       'Traceability of validations and changes in this emergency (coordination only).',
@@ -2069,6 +2076,7 @@ export const en = {
     map_accepts: 'Accepts:',
     map_approx_location: 'Approximate location',
     map_disputed: 'In review · possible closure',
+    map_report_cta: 'Something wrong? Tell us',
     map_no_locations: 'No locations on the map yet.',
   },
 

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -1603,8 +1603,15 @@ export const es = {
     disputes_action_dismiss: 'Descartar',
     disputes_resolve_confirm: 'Confirmar',
     disputes_resolving: 'Procesando…',
+    disputes_evidence_show: 'Ver evidencia',
+    disputes_evidence_hide: 'Ocultar evidencia',
+    disputes_evidence_loading: 'Cargando reportes…',
+    disputes_evidence_empty: 'Sin reportes individuales.',
+    disputes_evidence_no_note: 'Sin nota',
+    disputes_evidence_photo: 'Foto {n}',
     err_resolve_dispute_failed:
       'No se pudo resolver la disputa. Inténtalo de nuevo.',
+    err_load_reports_failed: 'No se pudieron cargar los reportes.',
     activity_title: 'Registro de actividad',
     activity_subtitle:
       'Trazabilidad de validaciones y cambios en esta emergencia (solo coordinación).',
@@ -2100,6 +2107,7 @@ export const es = {
     map_accepts: 'Acepta:',
     map_approx_location: 'Ubicación aproximada',
     map_disputed: 'En verificación · posible cierre',
+    map_report_cta: '¿Algo va mal? Avísanos',
     map_no_locations: 'Aún no hay ubicaciones en el mapa.',
   },
 


### PR DESCRIPTION
## Resumen

Cierra los dos follow-ups de la EPIC #120 (ficha 15), ambos **web-only**:

- **#154 — Coordinación: evidencia por reporte.** La cola "Puntos en duda" permite desplegar, por punto, la evidencia individual de cada reporte ciudadano (**motivo · nota · fotos · fecha**), cargada **bajo demanda** desde `GET /resources/:id/validity-reports` (solo coordinación; las fotos no se exponen en el público — ficha 15 §6). Nueva server action `getValidityReports`.
- **#155 — Mapa: enlace de reporte en el popup.** El popup de un punto de recurso enlaza su **nombre** a la ficha pública y ofrece la CTA **"¿Algo va mal? Avísanos"** → `/recursos/:id/reportar-estado`. Se enhebra el `slug` de la emergencia hasta `EmergencyMap` (props opcionales, sin afectar a otros call sites; el HTML del popup ya se escapa).

i18n es+en para ambos.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `web build` + `web lint` verdes.
- [ ] Verificación manual en navegador **no ejecutada** (solo build); el popup de Leaflet únicamente monta en build de producción / navegador real (artefacto de entorno, AGENTS.md).
- [x] Sin cambios de API/migraciones/cliente — el endpoint `GET …/validity-reports` ya existía; no hace falta `gen:api`.

## Cierre

- Closes #154
- Closes #155
