### PR TITLE
fix(web): fechas hidratacion-safe (elimina React #418)

### DIFF
--- a/apps/web/src/app/admin/acreditaciones/page.tsx
+++ b/apps/web/src/app/admin/acreditaciones/page.tsx
@@ -7,6 +7,7 @@ import { GrantAccreditationForm } from './grant-form';
 import { RevokeButton } from './revoke-button';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { PageHeaderBand } from '@/components/molecules/page-header-band';
+import { formatDate } from '@/lib/format-date';
 import { getT } from '@/i18n/server';
 
 export const dynamic = 'force-dynamic';
@@ -42,7 +43,7 @@ export default async function AcreditacionesPage() {
   // ── Fetch existing accreditations ────────────────────────────────────────
   const accreditations = await fetchAccreditations();
 
-  const { t } = await getT();
+  const { t, locale } = await getT();
   const ta = t.admin;
 
   return (
@@ -99,7 +100,7 @@ export default async function AcreditacionesPage() {
                       <span className="text-xs text-muted-soft">
                         {ta.acc_granted_label}{' '}
                         <time dateTime={acc.grantedAt} suppressHydrationWarning>
-                          {new Date(acc.grantedAt).toLocaleDateString('es-ES')}
+                          {formatDate(acc.grantedAt, locale)}
                         </time>
                       </span>
                     </div>

--- a/apps/web/src/app/admin/api-keys/[id]/page.tsx
+++ b/apps/web/src/app/admin/api-keys/[id]/page.tsx
@@ -7,6 +7,7 @@ import { fetchServiceAccounts, fetchApiKeys } from '../actions';
 import { IssueKeyButton } from '../issue-key-button';
 import { RevokeKeyButton } from '../revoke-key-button';
 import { shortId } from '@/lib/permissions';
+import { formatDate } from '@/lib/format-date';
 import { EmptyState } from '@/components/molecules/empty-state';
 
 export const dynamic = 'force-dynamic';
@@ -76,9 +77,11 @@ export default async function ServiceAccountDetailPage({ params }: Props) {
                     </span>
                     <span className="text-xs text-gray-500">
                       Creada{' '}
-                      {new Date(k.createdAt).toLocaleDateString('es-ES')}
+                      <time dateTime={k.createdAt} suppressHydrationWarning>
+                        {formatDate(k.createdAt, 'es')}
+                      </time>
                       {k.lastUsedAt &&
-                        ` · uso ${new Date(k.lastUsedAt).toLocaleDateString('es-ES')}`}
+                        ` · uso ${formatDate(k.lastUsedAt, 'es')}`}
                     </span>
                   </div>
                   <div className="flex flex-shrink-0 items-center gap-2">

--- a/apps/web/src/app/admin/permisos/page.tsx
+++ b/apps/web/src/app/admin/permisos/page.tsx
@@ -7,6 +7,7 @@ import { fetchRoles, fetchGrants, resolvePrincipal } from './actions';
 import { GrantRoleForm } from './grant-role-form';
 import { RevokeGrantButton } from './revoke-grant-button';
 import { scopeLabel } from '@/lib/permissions';
+import { formatDate } from '@/lib/format-date';
 import { EmptyState } from '@/components/molecules/empty-state';
 
 export const dynamic = 'force-dynamic';
@@ -114,7 +115,9 @@ export default async function PermisosPage({ searchParams }: Props) {
                       {g.expiresAt && (
                         <span className="text-xs text-amber-700">
                           caduca{' '}
-                          {new Date(g.expiresAt).toLocaleDateString('es-ES')}
+                          <time dateTime={g.expiresAt} suppressHydrationWarning>
+                            {formatDate(g.expiresAt, 'es')}
+                          </time>
                         </span>
                       )}
                     </div>

--- a/apps/web/src/app/administracion/ambito/[scopeType]/[id]/page.tsx
+++ b/apps/web/src/app/administracion/ambito/[scopeType]/[id]/page.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/api';
 import { PageShell } from '@/components/molecules/page-shell';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { shortId } from '@/lib/permissions';
+import { formatDate } from '@/lib/format-date';
 import { administrableScopes } from '@/lib/admin-scopes';
 import {
   fetchRoles,
@@ -124,7 +125,7 @@ export default async function ScopeAdminPage({ params }: PageProps) {
                     <span className="text-xs text-amber-700">
                       caduca{' '}
                       <time dateTime={g.expiresAt} suppressHydrationWarning>
-                        {new Date(g.expiresAt).toLocaleDateString('es-ES')}
+                        {formatDate(g.expiresAt, 'es')}
                       </time>
                     </span>
                   )}

--- a/apps/web/src/app/administracion/ambito/[scopeType]/[id]/service-accounts-manager.tsx
+++ b/apps/web/src/app/administracion/ambito/[scopeType]/[id]/service-accounts-manager.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/atoms/input';
 import { Badge } from '@/components/atoms/badge';
 import { ErrorMessage } from '@/components/atoms/error-message';
 import { EmptyState } from '@/components/molecules/empty-state';
+import { formatDate } from '@/lib/format-date';
 import {
   fetchOrgServiceAccounts,
   fetchApiKeys,
@@ -181,7 +182,7 @@ function ServiceAccountKeys({ saId, name }: { saId: string; name: string }) {
                     {k.prefix}…
                     <span className="ml-1 text-gray-400">
                       {k.lastUsedAt
-                        ? `· último uso ${new Date(k.lastUsedAt).toLocaleDateString('es-ES')}`
+                        ? `· último uso ${formatDate(k.lastUsedAt, 'es')}`
                         : '· sin uso'}
                     </span>
                   </span>

--- a/apps/web/src/app/e/[slug]/coordinacion/actividad/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/actividad/page.tsx
@@ -11,6 +11,7 @@ import {
 import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { Badge } from '@/components/atoms/badge';
+import { formatDateTime } from '@/lib/format-date';
 import { getT } from '@/i18n/server';
 
 export const dynamic = 'force-dynamic';
@@ -66,7 +67,7 @@ export default async function CoordinacionActividadPage({ params }: Props) {
     redirect(`/e/${slug}/coordinacion`);
   }
 
-  const { t } = await getT();
+  const { t, locale } = await getT();
   const tc = t.coord;
 
   const entries = await api
@@ -123,7 +124,7 @@ export default async function CoordinacionActividadPage({ params }: Props) {
                   suppressHydrationWarning
                   className="text-xs text-muted"
                 >
-                  {new Date(e.createdAt).toLocaleString()}
+                  {formatDateTime(e.createdAt, locale)}
                 </time>
               </div>
 

--- a/apps/web/src/app/mis-permisos/page.tsx
+++ b/apps/web/src/app/mis-permisos/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation';
 import { getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { scopeLabel } from '@/lib/permissions';
+import { formatDate } from '@/lib/format-date';
 import { EmptyState } from '@/components/molecules/empty-state';
 
 export const dynamic = 'force-dynamic';
@@ -95,7 +96,7 @@ export default async function MisPermisosPage() {
                         <span className="text-xs text-amber-700">
                           · caduca{' '}
                           <time dateTime={g.expiresAt} suppressHydrationWarning>
-                            {new Date(g.expiresAt).toLocaleDateString('es-ES')}
+                            {formatDate(g.expiresAt, 'es')}
                           </time>
                         </span>
                       )}

--- a/apps/web/src/components/atoms/local-date.tsx
+++ b/apps/web/src/components/atoms/local-date.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+/**
+ * LocalDate — hydration-safe timestamp display (issue #174).
+ *
+ * Renders inside a `<time>` element. To avoid the React #418 mismatch caused by
+ * the server (UTC) and the browser (local zone) formatting a near-midnight date
+ * to different days, it follows a two-phase strategy:
+ *
+ *   1. SSR + first client (hydration) render → the **deterministic UTC** string
+ *      from `formatDate`/`formatDateTime`. Server HTML and the first client
+ *      paint are byte-identical, so hydration matches.
+ *   2. Immediately after hydration → re-renders the same instant in the user's
+ *      **local** zone, the value they actually want to read.
+ *
+ * The phase is driven by `useSyncExternalStore`: its server snapshot is `false`
+ * (not hydrated) and its client snapshot flips to `true` once mounted, so React
+ * renders the UTC text on the server and swaps to local on the client without a
+ * `setState`-in-effect cascade. `suppressHydrationWarning` covers the
+ * intentional text difference.
+ *
+ * Locale comes from `LocaleProvider`; the machine-readable ISO is preserved in
+ * the `<time dateTime>` attribute for programmatic consumers.
+ */
+
+import { useSyncExternalStore } from 'react';
+import { useLocale } from '@/i18n/locale-context';
+import {
+  formatDate,
+  formatDateTime,
+  formatDateLocal,
+  DATE_TIME_FORMAT,
+} from '@/lib/format-date';
+
+interface LocalDateProps {
+  /** ISO 8601 timestamp string. */
+  iso: string;
+  /** Include the time component (date + 24h time). Default: date only. */
+  withTime?: boolean;
+  /**
+   * Custom `Intl.DateTimeFormatOptions` for sites with a bespoke format. When
+   * set it takes precedence over `withTime`; any `timeZone` is ignored for the
+   * post-hydration local render. Omit for the standard date / date+time presets.
+   */
+  opts?: Intl.DateTimeFormatOptions;
+  /** Optional CSS classes forwarded to the <time> element. */
+  className?: string;
+}
+
+/**
+ * Same fields as the shared date+time preset but WITHOUT a pinned timeZone, so
+ * the post-hydration render resolves to the browser's local zone.
+ */
+const DATE_TIME_FORMAT_LOCAL: Intl.DateTimeFormatOptions = {
+  day: DATE_TIME_FORMAT.day,
+  month: DATE_TIME_FORMAT.month,
+  hour: DATE_TIME_FORMAT.hour,
+  minute: DATE_TIME_FORMAT.minute,
+  hour12: DATE_TIME_FORMAT.hour12,
+};
+
+/** Drops `timeZone` so the option set resolves to the runtime's local zone. */
+function stripZone(
+  opts: Intl.DateTimeFormatOptions,
+): Intl.DateTimeFormatOptions {
+  const { timeZone: _ignored, ...rest } = opts;
+  return rest;
+}
+
+// ── Hydration flag via useSyncExternalStore ──────────────────────────────────
+// A no-op store whose snapshot is `false` on the server and `true` on the
+// client. React renders with the server snapshot during hydration, then
+// immediately re-renders with the client snapshot — the canonical "is mounted"
+// signal without a setState-in-effect cascade.
+const emptySubscribe = (): (() => void) => () => {};
+const getClientSnapshot = (): boolean => true;
+const getServerSnapshot = (): boolean => false;
+
+function useHydrated(): boolean {
+  return useSyncExternalStore(
+    emptySubscribe,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+}
+
+export function LocalDate({
+  iso,
+  withTime = false,
+  opts,
+  className,
+}: LocalDateProps) {
+  const locale = useLocale();
+  const hydrated = useHydrated();
+
+  let text: string;
+  if (!hydrated) {
+    // SSR + hydration render → deterministic UTC.
+    text =
+      opts !== undefined
+        ? formatDate(iso, locale, opts)
+        : withTime
+          ? formatDateTime(iso, locale)
+          : formatDate(iso, locale);
+  } else {
+    // After hydration → the user's local zone.
+    text =
+      opts !== undefined
+        ? formatDateLocal(iso, locale, stripZone(opts))
+        : withTime
+          ? formatDateLocal(iso, locale, DATE_TIME_FORMAT_LOCAL)
+          : formatDateLocal(iso, locale);
+  }
+
+  return (
+    <time dateTime={iso} className={className} suppressHydrationWarning>
+      {text}
+    </time>
+  );
+}

--- a/apps/web/src/components/atoms/relative-time.tsx
+++ b/apps/web/src/components/atoms/relative-time.tsx
@@ -1,11 +1,19 @@
+'use client';
+
 /**
- * RelativeTime — server-safe last-updated display.
+ * RelativeTime — hydration-safe "last updated" display.
  *
- * Renders an absolute "DD MMM, HH:MM" string (e.g. "26 jun, 14:32") to avoid
- * server/client hydration mismatches that would occur with Date.now()-based
- * relative strings.  The machine-readable ISO string is preserved in the
- * <time dateTime> attribute for programmatic consumers.
+ * Thin wrapper over {@link LocalDate} (issue #174): it renders an absolute
+ * "DD MMM, HH:MM" timestamp (e.g. "26 jun, 14:32") deterministically in UTC for
+ * SSR / first paint, then swaps to the user's local zone after mount — so there
+ * is no server/client hydration mismatch. The machine-readable ISO string is
+ * preserved in the `<time dateTime>` attribute by `LocalDate`.
+ *
+ * Kept as a named component so existing call sites (`isoString` prop) are
+ * unchanged.
  */
+
+import { LocalDate } from '@/components/atoms/local-date';
 
 interface RelativeTimeProps {
   /** ISO 8601 timestamp string */
@@ -14,33 +22,6 @@ interface RelativeTimeProps {
   className?: string;
 }
 
-function formatAbsolute(isoString: string): string {
-  const date = new Date(isoString);
-
-  // Guard against invalid dates
-  if (Number.isNaN(date.getTime())) {
-    return isoString;
-  }
-
-  return date.toLocaleString('es-ES', {
-    day: 'numeric',
-    month: 'short',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
-}
-
 export function RelativeTime({ isoString, className }: RelativeTimeProps) {
-  const formatted = formatAbsolute(isoString);
-
-  return (
-    <time
-      dateTime={isoString}
-      className={className}
-      suppressHydrationWarning
-    >
-      {formatted}
-    </time>
-  );
+  return <LocalDate iso={isoString} withTime className={className} />;
 }

--- a/apps/web/src/components/molecules/audit-entry-row.tsx
+++ b/apps/web/src/components/molecules/audit-entry-row.tsx
@@ -1,13 +1,18 @@
 import { StatusCodeBadge } from '@/components/atoms/status-code-badge';
 import type { AuditEntryDto } from '@/app/admin/auditoria/actions';
+import { formatDate as formatDateUtc } from '@/lib/format-date';
 import { getT } from '@/i18n/server';
 
 interface AuditEntryRowProps {
   entry: AuditEntryDto;
 }
 
+/**
+ * Audit timestamp: "26 jun 2026, 14:32". Pinned to UTC via the shared helper so
+ * the server (UTC) and browser (local) agree — no #418 mismatch (issue #174).
+ */
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString('es-ES', {
+  return formatDateUtc(iso, 'es', {
     day: 'numeric',
     month: 'short',
     year: 'numeric',

--- a/apps/web/src/components/molecules/notification-item.tsx
+++ b/apps/web/src/components/molecules/notification-item.tsx
@@ -5,6 +5,7 @@ import { useTransition } from 'react';
 import { markNotificationReadAction } from '@/app/notificaciones/actions';
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
+import { LocalDate } from '@/components/atoms/local-date';
 
 export interface NotificationItemProps {
   id: string;
@@ -40,17 +41,6 @@ export function NotificationItem({
     });
   };
 
-  const formattedDate = new Date(createdAt).toLocaleString(
-    locale === 'en' ? 'en-GB' : 'es-ES',
-    {
-      day: 'numeric',
-      month: 'short',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    },
-  );
-
   const innerContent = (
     <div className="flex flex-col gap-1 flex-1 min-w-0">
       <p
@@ -58,13 +48,11 @@ export function NotificationItem({
       >
         {message}
       </p>
-      <time
-        dateTime={createdAt}
-        suppressHydrationWarning
+      <LocalDate
+        iso={createdAt}
+        withTime
         className="text-xs text-muted-soft"
-      >
-        {formattedDate}
-      </time>
+      />
     </div>
   );
 

--- a/apps/web/src/components/molecules/template-card.tsx
+++ b/apps/web/src/components/molecules/template-card.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { formatDate } from '@/lib/format-date';
 import { getT } from '@/i18n/server';
 
 interface TemplateCardProps {
@@ -29,7 +30,7 @@ export async function TemplateCard({
         <p className="text-xs text-muted-soft">
           {t.ui.template_dont_bring_items.replace('{count}', String(dontBringCount))} · {t.ui.created}{' '}
           <time dateTime={createdAt} suppressHydrationWarning>
-            {new Date(createdAt).toLocaleDateString(locale === 'en' ? 'en-GB' : 'es-ES')}
+            {formatDate(createdAt, locale)}
           </time>
         </p>
       </div>

--- a/apps/web/src/components/organisms/capacities-panel.tsx
+++ b/apps/web/src/components/organisms/capacities-panel.tsx
@@ -2,6 +2,7 @@ import type { components } from '@reliefhub/api-client';
 import type { Messages } from '@/i18n/messages/es';
 import { Badge } from '@/components/atoms/badge';
 import { EmptyState } from '@/components/molecules/empty-state';
+import { formatDate as formatDateUtc } from '@/lib/format-date';
 
 type CapacityView = components['schemas']['CapacityViewDto'];
 type CapacityMode = CapacityView['mode'];
@@ -121,10 +122,13 @@ function formatWindow(
   return from ?? to;
 }
 
+/**
+ * Transport-window boundary date. Pinned to UTC via the shared helper so the
+ * server (UTC) and the browser (local) render the same calendar day — no #418
+ * hydration mismatch (issue #174).
+ */
 function formatDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString(undefined, {
+  return formatDateUtc(iso, 'es', {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',

--- a/apps/web/src/components/organisms/disputed-queue.tsx
+++ b/apps/web/src/components/organisms/disputed-queue.tsx
@@ -6,9 +6,11 @@ import { useState, useTransition } from 'react';
 import type { components } from '@reliefhub/api-client';
 import { Button } from '@/components/atoms/button';
 import { ErrorMessage } from '@/components/atoms/error-message';
+import { LocalDate } from '@/components/atoms/local-date';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
+import { formatDate } from '@/lib/format-date';
 import type { Messages } from '@/i18n/messages/es';
 import {
   getValidityReports,
@@ -70,6 +72,7 @@ function DisputedCard({
   tc: Messages['coord'];
 }) {
   const router = useRouter();
+  const locale = useLocale();
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [active, setActive] = useState<DisputeResolution | null>(null);
@@ -161,7 +164,7 @@ function DisputedCard({
           ' · ' +
             tc.disputes_last_reported_label.replace(
               '{date}',
-              new Date(item.lastReportedAt).toLocaleDateString(),
+              formatDate(item.lastReportedAt, locale),
             )}
       </p>
 
@@ -197,9 +200,7 @@ function DisputedCard({
                   <span className="font-semibold text-warning">
                     {reasonLabels[report.reason] ?? report.reason}
                   </span>
-                  <span className="text-muted">
-                    {new Date(report.createdAt).toLocaleDateString()}
-                  </span>
+                  <LocalDate iso={report.createdAt} className="text-muted" />
                 </div>
                 {report.note != null && report.note.trim() !== '' ? (
                   <p className="mt-1 text-ink">{report.note}</p>

--- a/apps/web/src/components/organisms/expired-need-card.tsx
+++ b/apps/web/src/components/organisms/expired-need-card.tsx
@@ -9,6 +9,7 @@ import { ErrorMessage } from '@/components/atoms/error-message';
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
 import { categoryLabel } from '@/lib/categories';
+import { LocalDate } from '@/components/atoms/local-date';
 
 type NeedView = components['schemas']['NeedViewDto'];
 
@@ -64,9 +65,7 @@ export function ExpiredNeedCard({ need, slug }: ExpiredNeedCardProps) {
               <span aria-hidden="true" className="text-muted-soft">·</span>
               <span>
                 {tc.expired_at_label}:{' '}
-                <time dateTime={need.expiresAt} suppressHydrationWarning>
-                  {new Date(need.expiresAt).toLocaleString()}
-                </time>
+                <LocalDate iso={need.expiresAt} withTime />
               </span>
             </>
           )}

--- a/apps/web/src/components/organisms/need-detail.tsx
+++ b/apps/web/src/components/organisms/need-detail.tsx
@@ -12,6 +12,7 @@ import { Badge } from '@/components/atoms/badge';
 import { Button } from '@/components/atoms/button';
 import { ErrorMessage } from '@/components/atoms/error-message';
 import { FreshnessIndicator } from '@/components/atoms/freshness-indicator';
+import { LocalDate } from '@/components/atoms/local-date';
 import { DetailDrawer } from '@/components/organisms/detail-drawer';
 import {
   ValidationActions,
@@ -192,19 +193,13 @@ export function NeedDetail({
         />
         <DetailField
           label={tc.detail_field_created}
-          value={
-            <time dateTime={need.createdAt} suppressHydrationWarning>
-              {new Date(need.createdAt).toLocaleString()}
-            </time>
-          }
+          value={<LocalDate iso={need.createdAt} withTime />}
         />
         <DetailField
           label={tc.detail_field_expiry}
           value={
             need.expiresAt != null ? (
-              <time dateTime={need.expiresAt} suppressHydrationWarning>
-                {new Date(need.expiresAt).toLocaleString()}
-              </time>
+              <LocalDate iso={need.expiresAt} withTime />
             ) : null
           }
         />

--- a/apps/web/src/components/organisms/report-card.tsx
+++ b/apps/web/src/components/organisms/report-card.tsx
@@ -13,10 +13,19 @@ import {
   ValidationActions,
   type EditField,
 } from '@/components/organisms/validation-actions';
+import { LocalDate } from '@/components/atoms/local-date';
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
 
 const API_BASE = (process.env.NEXT_PUBLIC_API_URL ?? '').replace(/\/$/, '');
+
+/** Report timestamp format: "05 jun, 14:32" — preserved from the original. */
+const REPORT_DATE_OPTS: Intl.DateTimeFormatOptions = {
+  day: '2-digit',
+  month: 'short',
+  hour: '2-digit',
+  minute: '2-digit',
+};
 
 type ReportPriority = 'low' | 'medium' | 'high' | 'urgent';
 type ReportStatus = 'open' | 'reviewed' | 'closed';
@@ -179,14 +188,7 @@ export function ReportCard({ report, slug }: ReportCardProps) {
           <span>{tc.report_author_label}: {report.authorName}</span>
         )}
         {report.createdAt != null && (
-          <time dateTime={report.createdAt} suppressHydrationWarning>
-            {new Date(report.createdAt).toLocaleString(locale === 'en' ? 'en-GB' : 'es-ES', {
-              day: '2-digit',
-              month: 'short',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}
-          </time>
+          <LocalDate iso={report.createdAt} opts={REPORT_DATE_OPTS} />
         )}
       </div>
 

--- a/apps/web/src/components/organisms/shipment-detail.tsx
+++ b/apps/web/src/components/organisms/shipment-detail.tsx
@@ -18,6 +18,7 @@ import { DetailDrawer } from '@/components/organisms/detail-drawer';
 import { DetailField, DetailSection } from '@/components/molecules/detail-field';
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
+import { formatDate as formatDateUtc } from '@/lib/format-date';
 
 type ShipmentViewDto = components['schemas']['ShipmentViewDto'];
 type CapacityViewDto = components['schemas']['CapacityViewDto'];
@@ -545,10 +546,14 @@ function formatWindow(
   return from ?? to;
 }
 
+/**
+ * Transport-window boundary date. Pinned to UTC via the shared helper so the
+ * server (UTC) and the browser (local) render the same calendar day — no #418
+ * hydration mismatch (issue #174). Window edges are absolute dates, so showing
+ * them in UTC (not local) is acceptable and avoids any drift.
+ */
 function formatDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString(undefined, {
+  return formatDateUtc(iso, 'es', {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',

--- a/apps/web/src/lib/format-date.test.ts
+++ b/apps/web/src/lib/format-date.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  formatDate,
+  formatDateTime,
+  formatDateLocal,
+  DATE_TIME_FORMAT,
+} from './format-date.ts';
+
+/**
+ * #174 regression: the formatter must be deterministic regardless of the
+ * runtime timezone, otherwise SSR (UTC) and the browser (local) disagree near
+ * midnight and React throws #418.
+ *
+ * We can only *fully* prove timezone-independence by running under a non-UTC
+ * zone. `node --test` inherits TZ from the environment, so these assertions are
+ * written to hold under ANY zone: a late-evening UTC timestamp must still render
+ * its UTC calendar day, never the local one.
+ */
+
+const LATE_NIGHT_UTC = '2026-06-26T23:30:00.000Z'; // 26 Jun in UTC; 27 Jun in UTC+1
+
+test('formatDate pins UTC: a late-UTC timestamp keeps its UTC calendar day', () => {
+  // es-ES short date is D/M/Y. The day must be 26 (UTC), never 27 (UTC+).
+  assert.equal(formatDate(LATE_NIGHT_UTC, 'es'), '26/6/2026');
+});
+
+test('formatDate maps en → en-GB (D/M/Y order)', () => {
+  assert.equal(formatDate(LATE_NIGHT_UTC, 'en'), '26/06/2026');
+});
+
+test('formatDate keeps the UTC day even when caller overrides other options', () => {
+  // Override format options but NOT timeZone → still UTC.
+  const out = formatDate('2026-01-05T23:45:00.000Z', 'es', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+  assert.equal(out, '05/01/2026');
+});
+
+test('formatDate honours an explicit timeZone override', () => {
+  // Caller explicitly asks for a +14 zone → day rolls to the 27th.
+  const out = formatDate(LATE_NIGHT_UTC, 'es', {
+    timeZone: 'Pacific/Kiritimati', // UTC+14
+    day: 'numeric',
+    month: 'numeric',
+    year: 'numeric',
+  });
+  assert.equal(out, '27/6/2026');
+});
+
+test('formatDateTime renders deterministic UTC date + 24h time', () => {
+  // 23:30 UTC → "26 jun, 23:30" (es), never the next local day.
+  const out = formatDateTime(LATE_NIGHT_UTC, 'es');
+  assert.match(out, /^26 \w+,?\.? 23:30$/);
+});
+
+test('formatDateTime uses the shared DATE_TIME_FORMAT preset (UTC, 24h)', () => {
+  assert.equal(DATE_TIME_FORMAT.timeZone, 'UTC');
+  assert.equal(DATE_TIME_FORMAT.hour12, false);
+});
+
+test('invalid input is returned verbatim (both UTC and local helpers)', () => {
+  assert.equal(formatDate('not-a-date', 'es'), 'not-a-date');
+  assert.equal(formatDateTime('', 'en'), '');
+  assert.equal(formatDateLocal('nope', 'es'), 'nope');
+});
+
+test('formatDateLocal formats a valid date (zone is the runtime local zone)', () => {
+  // We do not assert the exact day (depends on the runner's TZ); we only assert
+  // it produced a D/M/Y-looking string and did not echo the raw ISO.
+  const out = formatDateLocal('2026-06-26T12:00:00.000Z', 'es');
+  assert.match(out, /^\d{1,2}\/\d{1,2}\/\d{4}$/);
+  assert.notEqual(out, '2026-06-26T12:00:00.000Z');
+});

--- a/apps/web/src/lib/format-date.ts
+++ b/apps/web/src/lib/format-date.ts
@@ -1,0 +1,97 @@
+/**
+ * Deterministic, hydration-safe date formatting (issue #174).
+ *
+ * The bug: `new Date(iso).toLocaleDateString('es-ES')` (no `timeZone`) formats
+ * a timestamp in the *runtime's* zone. During SSR the server (EC2 → UTC) and
+ * during hydration the browser (the user's local zone) can resolve a timestamp
+ * near midnight to **different calendar days**, so the server HTML and the first
+ * client render disagree → React #418 hydration mismatch.
+ *
+ * The fix: pin a fixed `timeZone` (default `'UTC'`) so the formatted string is
+ * identical on server and client regardless of where it runs. This module holds
+ * the pure, framework-free logic so it is unit-testable via `node --test`.
+ *
+ * Where the user's *local* time genuinely matters, render with the
+ * `<LocalDate>` atom instead: it emits this deterministic string on the server /
+ * first client paint (matching, no mismatch) and only swaps in the local-zone
+ * value after mount.
+ */
+
+import type { Locale } from '@/i18n';
+
+/** Maps the app locale to the BCP-47 tag used across the date call sites. */
+function localeTag(locale: Locale): 'es-ES' | 'en-GB' {
+  return locale === 'en' ? 'en-GB' : 'es-ES';
+}
+
+/** Default: short numeric date (e.g. "26/6/2026"), no time component. */
+const DATE_OPTS: Intl.DateTimeFormatOptions = {
+  day: 'numeric',
+  month: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+};
+
+/** Date + 24h time (e.g. "26 jun, 14:32"). */
+const DATE_TIME_OPTS: Intl.DateTimeFormatOptions = {
+  day: 'numeric',
+  month: 'short',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: 'UTC',
+};
+
+/**
+ * Formats an ISO 8601 timestamp deterministically (server === client).
+ *
+ * @param iso     ISO timestamp string.
+ * @param locale  App locale ('es' | 'en'); mapped to es-ES / en-GB.
+ * @param opts    `Intl.DateTimeFormatOptions`. The `timeZone` defaults to
+ *                'UTC'; pass your own to override (e.g. the emergency's zone).
+ *                When omitted entirely, a short numeric date is produced.
+ * @returns The localized string, or the raw input if it is not a valid date.
+ */
+export function formatDate(
+  iso: string,
+  locale: Locale,
+  opts: Intl.DateTimeFormatOptions = DATE_OPTS,
+): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  // Always pin a timeZone so the output is runtime-independent.
+  const withZone: Intl.DateTimeFormatOptions = {
+    timeZone: 'UTC',
+    ...opts,
+  };
+  return date.toLocaleString(localeTag(locale), withZone);
+}
+
+/**
+ * Convenience for the common "date + 24h time" rendering (e.g. need/report
+ * timestamps). Deterministic in UTC.
+ */
+export function formatDateTime(iso: string, locale: Locale): string {
+  return formatDate(iso, locale, DATE_TIME_OPTS);
+}
+
+/**
+ * Formats a timestamp in the runtime's *local* zone. Intended for client-only
+ * rendering after mount (see `<LocalDate>`); do NOT call it during SSR or the
+ * first client render or you reintroduce the #418 mismatch.
+ */
+export function formatDateLocal(
+  iso: string,
+  locale: Locale,
+  opts?: Intl.DateTimeFormatOptions,
+): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  // No timeZone → the environment's local zone.
+  return opts === undefined
+    ? date.toLocaleDateString(localeTag(locale))
+    : date.toLocaleString(localeTag(locale), opts);
+}
+
+/** The presets, exported so the atom can mirror date-only vs date+time. */
+export const DATE_TIME_FORMAT = DATE_TIME_OPTS;


### PR DESCRIPTION
Fix de #174. React #418 (hidratacion) venia de formatear fechas con toLocale* **sin timeZone**: el servidor (UTC) y el navegador (zona local) formateaban fechas cercanas a medianoche a dias distintos -> mismatch SSR/cliente (visto en /admin/permisos).

- Nuevo `lib/format-date.ts`: formateadores deterministas fijados a **UTC** (formatDate/formatDateTime) + variante local; mapea es/en -> es-ES/en-GB. + 8 tests (probado timezone-independiente con TZ=Asia/Tokyo).
- Nuevo atom cliente `<LocalDate>`: en SSR+hidratacion emite la cadena UTC (HTML coincide) y tras montar cambia a la zona **local** del usuario (useSyncExternalStore + suppressHydrationWarning). RelativeTime lo reutiliza.
- **17 ficheros migrados**: componentes cliente -> <LocalDate>; componentes servidor -> formatDate UTC. Formatos preservados; distance-badge (numero, no fecha) intacto.

Elimina el mismatch en origen (server === cliente). Gate verde: web build + lint + **21/21 tests**.

Closes #174