### PR TITLE
feat(web): acceso a validacion desde el panel del admin (#178)

### DIFF
--- a/apps/web/src/app/panel/page.tsx
+++ b/apps/web/src/app/panel/page.tsx
@@ -8,6 +8,7 @@ import {
   getMe,
   getRoles,
   getMyEmergencies,
+  getActiveEmergencies,
   getNotificationUnread,
 } from '@/lib/navigation-data';
 import {
@@ -15,6 +16,7 @@ import {
   type MeGrant,
   type RoleCatalogEntry,
 } from '@/lib/admin-scopes';
+import { canCoordinateAtPlatform } from '@/lib/emergency-permissions';
 import { Card } from '@/components/atoms/card';
 import { Badge } from '@/components/atoms/badge';
 import { SectionHeading } from '@/components/atoms/section-heading';
@@ -37,20 +39,32 @@ export default async function PanelPage() {
   const { t } = await getT();
   const tp = t.panel;
 
-  const [roles, myEmergencies, unread, groupsRes, orgsRes] = await Promise.all([
-    getRoles(),
-    getMyEmergencies(),
-    getNotificationUnread(),
-    api.GET('/groups/mine', { headers: authHeaders(token) }),
-    api.GET('/organizations/mine', { headers: authHeaders(token) }),
-  ]);
+  const [roles, myEmergencies, activeEmergencies, unread, groupsRes, orgsRes] =
+    await Promise.all([
+      getRoles(),
+      getMyEmergencies(),
+      getActiveEmergencies(),
+      getNotificationUnread(),
+      api.GET('/groups/mine', { headers: authHeaders(token) }),
+      api.GET('/organizations/mine', { headers: authHeaders(token) }),
+    ]);
 
   const roleDesc = new Map(roles.map((r) => [r.id, r.description ?? r.id]));
   const groups = groupsRes.data ?? [];
   const orgs = orgsRes.data ?? [];
-  const isManager =
-    me.isAdmin === true ||
-    canAdminister((me.grants ?? []) as MeGrant[], roles as RoleCatalogEntry[]);
+  const grants = (me.grants ?? []) as MeGrant[];
+  const roleCatalog = roles as RoleCatalogEntry[];
+  const isManager = me.isAdmin === true || canAdminister(grants, roleCatalog);
+
+  // Platform-level overlay: an admin/operator holds platform-scoped coordination
+  // grants but no emergency-scoped grant, so "Mis emergencias" is empty. Surface
+  // every active emergency they can validate, minus the ones already listed
+  // above (de-dupe by id) to avoid showing the same emergency twice.
+  const myEmergencyIds = new Set(myEmergencies.map((e) => e.id));
+  const validationEmergencies =
+    me.isAdmin === true || canCoordinateAtPlatform(grants, roleCatalog)
+      ? activeEmergencies.filter((e) => !myEmergencyIds.has(e.id))
+      : [];
 
   const sectionGap = 'flex flex-col gap-3';
 
@@ -123,6 +137,41 @@ export default async function PanelPage() {
           )}
         </section>
 
+        {/* Coordination / validation — platform-level overlay. Only rendered
+            for platform coordinators/admins with active emergencies to reach. */}
+        {validationEmergencies.length > 0 && (
+          <section aria-labelledby="val-heading" className={sectionGap}>
+            <div className="flex flex-col gap-1">
+              <SectionHeading id="val-heading" size="sm">
+                {tp.validation_heading}
+              </SectionHeading>
+              <p className="text-sm text-muted">{tp.validation_hint}</p>
+            </div>
+            <ul className="grid gap-3 sm:grid-cols-2" role="list">
+              {validationEmergencies.map((e) => (
+                <li key={e.id}>
+                  <Card as="article" className="flex h-full flex-col gap-3 p-4">
+                    <div className="flex flex-col gap-2">
+                      <span className="font-display text-base font-bold text-navy">
+                        {e.name}
+                      </span>
+                      <div className="flex flex-wrap gap-1.5">
+                        <Badge variant="active">{statusLabel(tp, e.status)}</Badge>
+                      </div>
+                    </div>
+                    <Link
+                      href={`/e/${e.slug}/coordinacion`}
+                      className="mt-auto inline-flex w-fit items-center rounded-lg bg-navy px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-navy-700"
+                    >
+                      {tp.enter_validation}
+                    </Link>
+                  </Card>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
         {/* My groups */}
         <section aria-labelledby="grp-heading" className={sectionGap}>
           <SectionHeading id="grp-heading" size="sm">
@@ -185,6 +234,15 @@ export default async function PanelPage() {
       </div>
     </main>
   );
+}
+
+function statusLabel(
+  tp: { status_active: string; status_paused: string; status_closed: string },
+  status: 'active' | 'paused' | 'closed',
+): string {
+  if (status === 'paused') return tp.status_paused;
+  if (status === 'closed') return tp.status_closed;
+  return tp.status_active;
 }
 
 function QuickAction({ href, label }: { href: string; label: string }) {

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -2106,6 +2106,13 @@ export const en = {
     emergencies_heading: 'My emergencies',
     emergencies_empty: 'You are not part of any active emergency.',
     enter_coordination: 'Go to coordination',
+    validation_heading: 'Coordination / validation',
+    validation_hint:
+      'As a platform admin you can validate any active emergency.',
+    enter_validation: 'Validate',
+    status_active: 'Active',
+    status_paused: 'Paused',
+    status_closed: 'Closed',
     groups_heading: 'My groups',
     groups_empty: 'You are not a member of any group.',
     group_pending: 'Pending',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -2137,6 +2137,13 @@ export const es = {
     emergencies_heading: 'Mis emergencias',
     emergencies_empty: 'No participas en ninguna emergencia activa.',
     enter_coordination: 'Ir a coordinación',
+    validation_heading: 'Coordinación / validación',
+    validation_hint:
+      'Como administrador de la plataforma puedes validar cualquier emergencia activa.',
+    enter_validation: 'Validar',
+    status_active: 'Activa',
+    status_paused: 'En pausa',
+    status_closed: 'Cerrada',
     groups_heading: 'Mis grupos',
     groups_empty: 'No perteneces a ningún grupo.',
     group_pending: 'Pendiente',

--- a/apps/web/src/lib/emergency-permissions.test.ts
+++ b/apps/web/src/lib/emergency-permissions.test.ts
@@ -1,0 +1,129 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resolveEmergencyAccess,
+  canCoordinateAtPlatform,
+} from './emergency-permissions.ts';
+
+const ROLES = [
+  {
+    id: 'platform_admin',
+    permissions: [
+      'need:validate',
+      'need:prioritize',
+      'resource:verify',
+      'offer:match',
+      'audit:read',
+      'role:grant',
+    ],
+  },
+  {
+    id: 'platform_operator',
+    permissions: ['need:validate', 'resource:verify'],
+  },
+  {
+    id: 'emergency_coordinator',
+    permissions: ['need:validate', 'need:prioritize', 'offer:match', 'audit:read'],
+  },
+  { id: 'need_verifier', permissions: ['need:validate'] },
+  // A platform-scoped role with no coordination power (read-only).
+  { id: 'platform_viewer', permissions: ['org:read'] },
+  // A citizen — only the implicit self perms, never coordination.
+  { id: 'volunteer', permissions: ['task:read'] },
+];
+
+const E1 = '11111111-1111-4111-8111-111111111111';
+
+test('resolveEmergencyAccess: platform grant applies to any emergency', () => {
+  const access = resolveEmergencyAccess(
+    E1,
+    [{ roleId: 'platform_admin', scopeType: 'platform', scopeId: null }],
+    ROLES,
+  );
+  assert.equal(access.canValidateNeeds, true);
+  assert.equal(access.canVerifyResources, true);
+  assert.equal(access.canActOnAnyQueue, true);
+});
+
+test('canCoordinateAtPlatform: platform_admin → true', () => {
+  assert.equal(
+    canCoordinateAtPlatform(
+      [{ roleId: 'platform_admin', scopeType: 'platform', scopeId: null }],
+      ROLES,
+    ),
+    true,
+  );
+});
+
+test('canCoordinateAtPlatform: platform_operator (need:validate/resource:verify) → true', () => {
+  assert.equal(
+    canCoordinateAtPlatform(
+      [{ roleId: 'platform_operator', scopeType: 'platform', scopeId: null }],
+      ROLES,
+    ),
+    true,
+  );
+});
+
+test('canCoordinateAtPlatform: a plain citizen → false', () => {
+  assert.equal(
+    canCoordinateAtPlatform(
+      [{ roleId: 'volunteer', scopeType: 'platform', scopeId: null }],
+      ROLES,
+    ),
+    false,
+  );
+});
+
+test('canCoordinateAtPlatform: emergency-scoped coordinator → false (not platform-level)', () => {
+  // They reach their own emergency via "Mis emergencias"; the overlay is for
+  // platform principals only.
+  assert.equal(
+    canCoordinateAtPlatform(
+      [{ roleId: 'emergency_coordinator', scopeType: 'emergency', scopeId: E1 }],
+      ROLES,
+    ),
+    false,
+  );
+});
+
+test('canCoordinateAtPlatform: a platform-scoped read-only role → false', () => {
+  assert.equal(
+    canCoordinateAtPlatform(
+      [{ roleId: 'platform_viewer', scopeType: 'platform', scopeId: null }],
+      ROLES,
+    ),
+    false,
+  );
+});
+
+test('canCoordinateAtPlatform: expired platform grant is ignored', () => {
+  assert.equal(
+    canCoordinateAtPlatform(
+      [
+        {
+          roleId: 'platform_admin',
+          scopeType: 'platform',
+          scopeId: null,
+          expiresAt: '2000-01-01T00:00:00.000Z',
+        },
+      ],
+      ROLES,
+    ),
+    false,
+  );
+});
+
+test('canCoordinateAtPlatform: unknown roleId contributes nothing', () => {
+  assert.equal(
+    canCoordinateAtPlatform(
+      [{ roleId: 'wizard', scopeType: 'platform', scopeId: null }],
+      ROLES,
+    ),
+    false,
+  );
+});
+
+test('canCoordinateAtPlatform: no grants → false', () => {
+  assert.equal(canCoordinateAtPlatform([], ROLES), false);
+});

--- a/apps/web/src/lib/emergency-permissions.ts
+++ b/apps/web/src/lib/emergency-permissions.ts
@@ -90,3 +90,42 @@ export function resolveEmergencyAccess(
     canViewAudit,
   };
 }
+
+/**
+ * Permissions that mean "this principal can validate or coordinate an
+ * emergency". Any one of them grants reach into a coordination/validation
+ * queue — `need:validate` / `resource:verify` (the validation surfaces),
+ * `offer:match`, plus the coordinator-grade capabilities.
+ */
+const PLATFORM_COORDINATION_PERMISSIONS = [
+  'need:validate',
+  'resource:verify',
+  'offer:match',
+  ...COORDINATOR_PERMISSIONS,
+];
+
+/**
+ * True when the principal can coordinate/validate at the PLATFORM level —
+ * i.e. holds a non-expired **platform-scoped** grant whose role confers any
+ * coordination/validation permission. Because platform grants resolve as an
+ * ancestor of every emergency, such a principal (e.g. `platform_admin`,
+ * `platform_operator`) can validate ANY active emergency even with no
+ * emergency-scoped grant. Used to surface the active-emergencies overlay in
+ * the panel so admins/operators reach validation in one click; a plain
+ * citizen (no platform coordination grant) gets `false` and never sees it.
+ */
+export function canCoordinateAtPlatform(
+  grants: MeGrant[],
+  roles: RoleCatalogEntry[],
+  now: number = Date.now(),
+): boolean {
+  const permsByRole = new Map(roles.map((r) => [r.id, new Set(r.permissions)]));
+  for (const g of grants) {
+    if (g.scopeType !== 'platform') continue;
+    if (g.expiresAt && new Date(g.expiresAt).getTime() <= now) continue;
+    const perms = permsByRole.get(g.roleId);
+    if (perms == null) continue;
+    if (PLATFORM_COORDINATION_PERMISSIONS.some((p) => perms.has(p))) return true;
+  }
+  return false;
+}

--- a/apps/web/src/lib/navigation-data.ts
+++ b/apps/web/src/lib/navigation-data.ts
@@ -57,6 +57,33 @@ export const getMyEmergencies = cache(async (): Promise<MyEmergencyNav[]> => {
   }));
 });
 
+/** An active emergency, slimmed to what the panel overlay renders. */
+export interface ActiveEmergencyNav {
+  id: string;
+  slug: string;
+  name: string;
+  status: 'active' | 'paused' | 'closed';
+}
+
+/**
+ * The publicly listed ACTIVE emergencies, backed by `GET /emergencies` (the
+ * same list the landing uses). Unauthenticated — the endpoint is public — so
+ * it never needs the principal's token. The panel uses this to give platform
+ * coordinators/admins (who hold no emergency-scoped grant) a one-click path
+ * into any emergency's coordination/validation queues.
+ */
+export const getActiveEmergencies = cache(
+  async (): Promise<ActiveEmergencyNav[]> => {
+    const { data } = await api.GET('/emergencies', {});
+    return (data ?? []).map((e) => ({
+      id: e.id,
+      slug: e.slug,
+      name: e.name,
+      status: e.status,
+    }));
+  },
+);
+
 /** Everything the dashboard shell needs in one cached call. */
 export const getNavContext = cache(async () => {
   const [me, roles, myEmergencies, notificationUnread] = await Promise.all([


### PR DESCRIPTION
Implementa #178. El platform_admin/operator no tenia forma de llegar a la validacion desde el panel ('No participas en ninguna emergencia activa', porque /emergencies/mine solo lista grants de emergencia).

Anade en /panel una seccion **'Coordinacion / validacion'** que lista las **emergencias activas** con enlace directo a su coordinacion (/e/{slug}/coordinacion), visible **solo** para quien puede coordinar/validar a nivel plataforma — nuevo helper `canCoordinateAtPlatform` (grant platform-scope con need:validate / resource:verify / offer:match / perms de coordinador). De-dup contra 'Mis emergencias' por id; se omite si no hay nada. i18n es/en. Sin endpoint nuevo (reusa GET /emergencies).

Gate verde: api-client + web build + lint + **30/30 tests** (9 nuevos del helper).

Closes #178