### PR TITLE
Pre-registro acopio: deep link y QR por acopio

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4196,6 +4196,105 @@
         ]
       }
     },
+    "/resources/{resourceId}/intake-link": {
+      "get": {
+        "operationId": "DonationIntakesController_getIntakeLink",
+        "parameters": [
+          {
+            "name": "resourceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntakeDeepLinkDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing intake:read"
+          },
+          "404": {
+            "description": "Resource not found"
+          },
+          "422": {
+            "description": "Resource is not a published collection point"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get the public deep link for pre-registering at this acopio",
+        "tags": [
+          "donation-intakes"
+        ]
+      }
+    },
+    "/resources/{resourceId}/intake-qr": {
+      "get": {
+        "operationId": "DonationIntakesController_getIntakeQr",
+        "parameters": [
+          {
+            "name": "resourceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PNG image",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing intake:read"
+          },
+          "404": {
+            "description": "Resource not found"
+          },
+          "422": {
+            "description": "Resource is not a published collection point"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Generate a QR code PNG for the intake deep link of this acopio",
+        "tags": [
+          "donation-intakes"
+        ]
+      }
+    },
     "/resources/{resourceId}/donation-intakes/pending": {
       "get": {
         "operationId": "DonationIntakesController_listPending",
@@ -10230,6 +10329,33 @@
           "targetResourceId",
           "itemCount",
           "createdAt"
+        ]
+      },
+      "IntakeDeepLinkDto": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "example": "http://localhost:3001/e/mexico-demo/donar-acopio?resourceId=33333333-3333-4333-8333-333333333331"
+          },
+          "resourceName": {
+            "type": "string",
+            "example": "Acopio CDMX Norte"
+          },
+          "slug": {
+            "type": "string",
+            "example": "mexico-demo"
+          },
+          "resourceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "url",
+          "resourceName",
+          "slug",
+          "resourceId"
         ]
       },
       "ReceiveDonationIntakeDto": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,6 +43,7 @@
     "passport-facebook": "^3.0.0",
     "passport-google-oauth20": "^2.0.0",
     "pg": "^8.22.0",
+    "qrcode": "^1.5.4",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },
@@ -61,6 +62,7 @@
     "@types/passport-facebook": "^3.0.4",
     "@types/passport-google-oauth20": "^2.0.17",
     "@types/pg": "^8.20.0",
+    "@types/qrcode": "^1.5.6",
     "@types/supertest": "^7.0.0",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9.18.0",

--- a/apps/api/src/contexts/offers/application/create-donation-intake.ts
+++ b/apps/api/src/contexts/offers/application/create-donation-intake.ts
@@ -3,19 +3,13 @@ import { DonationIntake, generateIntakeCode } from '../domain/donation-intake';
 import { DonationIntakeId } from '../domain/donation-intake-id';
 import { DonationIntakeRepository } from '../domain/ports/donation-intake.repository';
 import { OfferEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
-import {
-  IntakeResourceLookup,
-  IntakeResourceInfo,
-} from '../domain/ports/intake-resource-lookup';
-import { InvalidIntakeTargetResourceError } from '../domain/donation-intake-errors';
+import { IntakeResourceLookup } from '../domain/ports/intake-resource-lookup';
 import { EmergencyNotAcceptingIntakeError } from '../../emergencies/domain/emergency-not-accepting-intake.error';
 import { SupplyLineProps } from '../../supplies/domain/supply-line';
-
-const ACTIVE_STATUS = 'active';
-const COLLECTION_TYPES = new Set([
-  'collection_point',
-  'collection_and_delivery',
-]);
+import {
+  INTAKE_ACTIVE_STATUS,
+  resolveIntakeTargetResource,
+} from './resolve-intake-target-resource';
 
 export interface CreateDonationIntakeCommand {
   emergencyId: string;
@@ -38,14 +32,18 @@ export class CreateDonationIntake {
     cmd: CreateDonationIntakeCommand,
   ): Promise<{ id: string; intakeCode: string; status: string }> {
     const status = await this.emergencyStatusReader.getStatus(cmd.emergencyId);
-    if (status !== ACTIVE_STATUS) {
+    if (status !== INTAKE_ACTIVE_STATUS) {
       throw new EmergencyNotAcceptingIntakeError(
         cmd.emergencyId,
         status ?? 'not-found',
       );
     }
 
-    await this.assertValidTarget(cmd.emergencyId, cmd.targetResourceId);
+    await resolveIntakeTargetResource(
+      this.resourceLookup,
+      cmd.targetResourceId,
+      cmd.emergencyId,
+    );
 
     const emergencyId = EmergencyId.fromString(cmd.emergencyId);
     const intakeCode = await this.allocateCode(emergencyId);
@@ -76,34 +74,6 @@ export class CreateDonationIntake {
     };
   }
 
-  private async assertValidTarget(
-    emergencyId: string,
-    resourceId: string,
-  ): Promise<void> {
-    const resource = await this.resourceLookup.findForIntake(resourceId);
-    if (!resource) {
-      throw new InvalidIntakeTargetResourceError(resourceId, 'not found');
-    }
-    if (resource.emergencyId !== emergencyId) {
-      throw new InvalidIntakeTargetResourceError(
-        resourceId,
-        'belongs to another emergency',
-      );
-    }
-    if (!COLLECTION_TYPES.has(resource.type)) {
-      throw new InvalidIntakeTargetResourceError(
-        resourceId,
-        `type '${resource.type}' is not a collection point`,
-      );
-    }
-    if (resource.publicStatus !== ACTIVE_STATUS) {
-      throw new InvalidIntakeTargetResourceError(
-        resourceId,
-        `public status is '${resource.publicStatus}'`,
-      );
-    }
-  }
-
   private async allocateCode(emergencyId: EmergencyId): Promise<string> {
     for (let attempt = 0; attempt < 10; attempt++) {
       const code = generateIntakeCode();
@@ -112,14 +82,4 @@ export class CreateDonationIntake {
     }
     throw new Error('Failed to allocate unique intake code');
   }
-}
-
-export function isValidIntakeResource(
-  resource: IntakeResourceInfo | null,
-  emergencyId: string,
-): resource is IntakeResourceInfo {
-  if (!resource) return false;
-  if (resource.emergencyId !== emergencyId) return false;
-  if (!COLLECTION_TYPES.has(resource.type)) return false;
-  return resource.publicStatus === ACTIVE_STATUS;
 }

--- a/apps/api/src/contexts/offers/application/donation-intake.use-cases.spec.ts
+++ b/apps/api/src/contexts/offers/application/donation-intake.use-cases.spec.ts
@@ -25,6 +25,8 @@ import {
 } from '../domain/donation-intake-errors';
 import { FakeOfferEventBus } from '../infrastructure/fake-event-bus';
 import { DonationIntakeId } from '../domain/donation-intake-id';
+import { GetIntakeDeepLink } from './get-intake-deep-link';
+import { IntakeQrEncoder } from '../domain/ports/intake-qr-encoder';
 
 const EM = '11111111-1111-4111-8111-111111111111';
 const RESOURCE = '33333333-3333-4333-8333-333333333331';
@@ -43,9 +45,17 @@ class FakeResourceLookup implements IntakeResourceLookup {
   }
 }
 
+class FakeQrEncoder implements IntakeQrEncoder {
+  encodeToPng(url: string): Promise<Buffer> {
+    return Promise.resolve(Buffer.from(`qr:${url}`));
+  }
+}
+
 const validResource: IntakeResourceInfo = {
   id: RESOURCE,
   emergencyId: EM,
+  emergencySlug: 'mexico-demo',
+  name: 'Acopio CDMX Norte',
   type: 'collection_point',
   publicStatus: 'active',
 };
@@ -266,6 +276,51 @@ describe('DonationIntake use cases', () => {
       );
       expect(() => saved!.confirmReception('vol-2', null, null)).toThrow(
         DonationIntakeAlreadyProcessedError,
+      );
+    });
+  });
+
+  describe('GetIntakeDeepLink', () => {
+    it('builds the canonical donar-acopio URL for a published collection point', async () => {
+      const uc = new GetIntakeDeepLink(
+        new FakeResourceLookup(validResource),
+        'http://localhost:3001',
+        new FakeQrEncoder(),
+      );
+
+      const result = await uc.execute(RESOURCE);
+
+      expect(result).toEqual({
+        url: `http://localhost:3001/e/mexico-demo/donar-acopio?resourceId=${RESOURCE}`,
+        resourceName: 'Acopio CDMX Norte',
+        slug: 'mexico-demo',
+        resourceId: RESOURCE,
+      });
+    });
+
+    it('rejects a non-collection resource', async () => {
+      const uc = new GetIntakeDeepLink(
+        new FakeResourceLookup({ ...validResource, type: 'delivery_point' }),
+        'http://localhost:3001',
+        new FakeQrEncoder(),
+      );
+
+      await expect(uc.execute(RESOURCE)).rejects.toBeInstanceOf(
+        InvalidIntakeTargetResourceError,
+      );
+    });
+
+    it('generates QR bytes from the deep link URL', async () => {
+      const uc = new GetIntakeDeepLink(
+        new FakeResourceLookup(validResource),
+        'http://localhost:3001',
+        new FakeQrEncoder(),
+      );
+
+      const png = await uc.generateQr(RESOURCE);
+
+      expect(png.toString()).toBe(
+        `qr:http://localhost:3001/e/mexico-demo/donar-acopio?resourceId=${RESOURCE}`,
       );
     });
   });

--- a/apps/api/src/contexts/offers/application/get-intake-deep-link.ts
+++ b/apps/api/src/contexts/offers/application/get-intake-deep-link.ts
@@ -1,0 +1,40 @@
+import { IntakeQrEncoder } from '../domain/ports/intake-qr-encoder';
+import { IntakeResourceLookup } from '../domain/ports/intake-resource-lookup';
+import { resolveIntakeTargetResource } from './resolve-intake-target-resource';
+
+export interface IntakeDeepLinkResult {
+  url: string;
+  resourceName: string;
+  slug: string;
+  resourceId: string;
+}
+
+export class GetIntakeDeepLink {
+  constructor(
+    private readonly resourceLookup: IntakeResourceLookup,
+    private readonly frontendBaseUrl: string,
+    private readonly qrEncoder: IntakeQrEncoder,
+  ) {}
+
+  async execute(resourceId: string): Promise<IntakeDeepLinkResult> {
+    const resource = await resolveIntakeTargetResource(
+      this.resourceLookup,
+      resourceId,
+    );
+
+    const base = this.frontendBaseUrl.replace(/\/$/, '');
+    const url = `${base}/e/${resource.emergencySlug}/donar-acopio?resourceId=${resourceId}`;
+
+    return {
+      url,
+      resourceName: resource.name,
+      slug: resource.emergencySlug,
+      resourceId: resource.id,
+    };
+  }
+
+  async generateQr(resourceId: string): Promise<Buffer> {
+    const { url } = await this.execute(resourceId);
+    return this.qrEncoder.encodeToPng(url);
+  }
+}

--- a/apps/api/src/contexts/offers/application/resolve-intake-target-resource.ts
+++ b/apps/api/src/contexts/offers/application/resolve-intake-target-resource.ts
@@ -1,0 +1,42 @@
+import { InvalidIntakeTargetResourceError } from '../domain/donation-intake-errors';
+import {
+  IntakeResourceInfo,
+  IntakeResourceLookup,
+} from '../domain/ports/intake-resource-lookup';
+
+export const INTAKE_COLLECTION_TYPES = new Set([
+  'collection_point',
+  'collection_and_delivery',
+]);
+
+export const INTAKE_ACTIVE_STATUS = 'active';
+
+export async function resolveIntakeTargetResource(
+  lookup: IntakeResourceLookup,
+  resourceId: string,
+  emergencyId?: string,
+): Promise<IntakeResourceInfo> {
+  const resource = await lookup.findForIntake(resourceId);
+  if (!resource) {
+    throw new InvalidIntakeTargetResourceError(resourceId, 'not found');
+  }
+  if (emergencyId !== undefined && resource.emergencyId !== emergencyId) {
+    throw new InvalidIntakeTargetResourceError(
+      resourceId,
+      'belongs to another emergency',
+    );
+  }
+  if (!INTAKE_COLLECTION_TYPES.has(resource.type)) {
+    throw new InvalidIntakeTargetResourceError(
+      resourceId,
+      `type '${resource.type}' is not a collection point`,
+    );
+  }
+  if (resource.publicStatus !== INTAKE_ACTIVE_STATUS) {
+    throw new InvalidIntakeTargetResourceError(
+      resourceId,
+      `public status is '${resource.publicStatus}'`,
+    );
+  }
+  return resource;
+}

--- a/apps/api/src/contexts/offers/domain/ports/intake-qr-encoder.ts
+++ b/apps/api/src/contexts/offers/domain/ports/intake-qr-encoder.ts
@@ -1,0 +1,5 @@
+export const INTAKE_QR_ENCODER = Symbol('IntakeQrEncoder');
+
+export interface IntakeQrEncoder {
+  encodeToPng(url: string): Promise<Buffer>;
+}

--- a/apps/api/src/contexts/offers/domain/ports/intake-resource-lookup.ts
+++ b/apps/api/src/contexts/offers/domain/ports/intake-resource-lookup.ts
@@ -3,6 +3,8 @@ export const INTAKE_RESOURCE_LOOKUP = Symbol('IntakeResourceLookup');
 export interface IntakeResourceInfo {
   id: string;
   emergencyId: string;
+  emergencySlug: string;
+  name: string;
   type: string;
   publicStatus: string;
 }

--- a/apps/api/src/contexts/offers/infrastructure/drizzle/drizzle-intake-resource-lookup.ts
+++ b/apps/api/src/contexts/offers/infrastructure/drizzle/drizzle-intake-resource-lookup.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm';
 import { Db } from '../../../../shared/db';
 import { resourcesTable } from '../../../resources/infrastructure/drizzle/schema';
+import { emergenciesTable } from '../../../emergencies/infrastructure/drizzle/schema';
 import {
   IntakeResourceInfo,
   IntakeResourceLookup,
@@ -14,10 +15,16 @@ export class DrizzleIntakeResourceLookup implements IntakeResourceLookup {
       .select({
         id: resourcesTable.id,
         emergencyId: resourcesTable.emergencyId,
+        emergencySlug: emergenciesTable.slug,
+        name: resourcesTable.name,
         type: resourcesTable.type,
         publicStatus: resourcesTable.publicStatus,
       })
       .from(resourcesTable)
+      .innerJoin(
+        emergenciesTable,
+        eq(resourcesTable.emergencyId, emergenciesTable.id),
+      )
       .where(eq(resourcesTable.id, resourceId))
       .limit(1);
 
@@ -27,6 +34,8 @@ export class DrizzleIntakeResourceLookup implements IntakeResourceLookup {
     return {
       id: row.id,
       emergencyId: row.emergencyId,
+      emergencySlug: row.emergencySlug,
+      name: row.name,
       type: row.type,
       publicStatus: row.publicStatus,
     };

--- a/apps/api/src/contexts/offers/infrastructure/http/donation-intake-response.dto.ts
+++ b/apps/api/src/contexts/offers/infrastructure/http/donation-intake-response.dto.ts
@@ -33,6 +33,23 @@ export class PendingIntakeSummaryDto {
   createdAt!: Date;
 }
 
+export class IntakeDeepLinkDto {
+  @ApiProperty({
+    example:
+      'http://localhost:3001/e/mexico-demo/donar-acopio?resourceId=33333333-3333-4333-8333-333333333331',
+  })
+  url!: string;
+
+  @ApiProperty({ example: 'Acopio CDMX Norte' })
+  resourceName!: string;
+
+  @ApiProperty({ example: 'mexico-demo' })
+  slug!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  resourceId!: string;
+}
+
 export class LookupDonorByContactResponseDto {
   @ApiPropertyOptional({ example: 'María López', nullable: true, type: String })
   donorName!: string | null;

--- a/apps/api/src/contexts/offers/infrastructure/http/donation-intakes.controller.ts
+++ b/apps/api/src/contexts/offers/infrastructure/http/donation-intakes.controller.ts
@@ -9,6 +9,7 @@ import {
   Post,
   Query,
   Request,
+  StreamableFile,
   UseGuards,
 } from '@nestjs/common';
 import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
@@ -37,6 +38,7 @@ import { ListPendingIntakesByResource } from '../../application/list-pending-int
 import { ConfirmIntakeReception } from '../../application/confirm-intake-reception';
 import { RejectIntake } from '../../application/reject-intake';
 import { MarkIntakeIncomplete } from '../../application/mark-intake-incomplete';
+import { GetIntakeDeepLink } from '../../application/get-intake-deep-link';
 import {
   CreateDonationIntakeDto,
   LookupDonorByContactDto,
@@ -51,6 +53,7 @@ import {
   LookupDonorByContactResponseDto,
   DonationIntakeViewDto,
   DonationIntakeSearchHitDto,
+  IntakeDeepLinkDto,
 } from './donation-intake-response.dto';
 import {
   JwtAuthGuard,
@@ -88,6 +91,7 @@ export class DonationIntakesController {
     private readonly confirmIntakeReception: ConfirmIntakeReception,
     private readonly rejectIntake: RejectIntake,
     private readonly markIntakeIncomplete: MarkIntakeIncomplete,
+    private readonly getIntakeDeepLink: GetIntakeDeepLink,
   ) {}
 
   @Post('emergencies/:emergencyId/donation-intakes')
@@ -207,6 +211,55 @@ export class DonationIntakesController {
     @Param('intakeId', ParseUUIDPipe) intakeId: string,
   ): Promise<DonationIntakeViewDto> {
     return this.getDonationIntakeById.execute(intakeId);
+  }
+
+  @Get('resources/:resourceId/intake-link')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('intake:read')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get the public deep link for pre-registering at this acopio',
+  })
+  @ApiParam({ name: 'resourceId', format: 'uuid' })
+  @ApiOkResponse({ type: IntakeDeepLinkDto })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing intake:read' })
+  @ApiNotFoundResponse({ description: 'Resource not found' })
+  @ApiUnprocessableEntityResponse({
+    description: 'Resource is not a published collection point',
+  })
+  async getIntakeLink(
+    @Param('resourceId', ParseUUIDPipe) resourceId: string,
+  ): Promise<IntakeDeepLinkDto> {
+    return this.getIntakeDeepLink.execute(resourceId);
+  }
+
+  @Get('resources/:resourceId/intake-qr')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('intake:read')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Generate a QR code PNG for the intake deep link of this acopio',
+  })
+  @ApiParam({ name: 'resourceId', format: 'uuid' })
+  @ApiOkResponse({
+    description: 'PNG image',
+    content: { 'image/png': { schema: { type: 'string', format: 'binary' } } },
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing intake:read' })
+  @ApiNotFoundResponse({ description: 'Resource not found' })
+  @ApiUnprocessableEntityResponse({
+    description: 'Resource is not a published collection point',
+  })
+  async getIntakeQr(
+    @Param('resourceId', ParseUUIDPipe) resourceId: string,
+  ): Promise<StreamableFile> {
+    const png = await this.getIntakeDeepLink.generateQr(resourceId);
+    return new StreamableFile(png, {
+      type: 'image/png',
+      disposition: `inline; filename="intake-${resourceId}.png"`,
+    });
   }
 
   @Get('resources/:resourceId/donation-intakes/pending')

--- a/apps/api/src/contexts/offers/infrastructure/offers.module.ts
+++ b/apps/api/src/contexts/offers/infrastructure/offers.module.ts
@@ -24,6 +24,12 @@ import { ListPendingIntakesByResource } from '../application/list-pending-intake
 import { ConfirmIntakeReception } from '../application/confirm-intake-reception';
 import { RejectIntake } from '../application/reject-intake';
 import { MarkIntakeIncomplete } from '../application/mark-intake-incomplete';
+import { GetIntakeDeepLink } from '../application/get-intake-deep-link';
+import {
+  INTAKE_QR_ENCODER,
+  IntakeQrEncoder,
+} from '../domain/ports/intake-qr-encoder';
+import { QrcodeIntakeQrEncoder } from './qrcode-intake-qr-encoder';
 import {
   OFFER_REPOSITORY,
   OfferRepository,
@@ -261,6 +267,22 @@ const markIntakeIncompleteProvider = {
     new MarkIntakeIncomplete(repo),
 };
 
+const intakeQrEncoderProvider = {
+  provide: INTAKE_QR_ENCODER,
+  useFactory: (): IntakeQrEncoder => new QrcodeIntakeQrEncoder(),
+};
+
+const getIntakeDeepLinkProvider = {
+  provide: GetIntakeDeepLink,
+  inject: [INTAKE_RESOURCE_LOOKUP, INTAKE_QR_ENCODER],
+  useFactory: (lookup: IntakeResourceLookup, encoder: IntakeQrEncoder) =>
+    new GetIntakeDeepLink(
+      lookup,
+      process.env.FRONTEND_URL ?? 'http://localhost:3001',
+      encoder,
+    ),
+};
+
 @Module({
   imports: [DatabaseModule, IdentityModule, NotificationsModule],
   controllers: [OffersController, DonationIntakesController],
@@ -291,6 +313,8 @@ const markIntakeIncompleteProvider = {
     confirmIntakeReceptionProvider,
     rejectIntakeProvider,
     markIntakeIncompleteProvider,
+    intakeQrEncoderProvider,
+    getIntakeDeepLinkProvider,
   ],
 })
 export class OffersModule implements OnModuleDestroy {

--- a/apps/api/src/contexts/offers/infrastructure/qrcode-intake-qr-encoder.ts
+++ b/apps/api/src/contexts/offers/infrastructure/qrcode-intake-qr-encoder.ts
@@ -1,0 +1,8 @@
+import QRCode from 'qrcode';
+import { IntakeQrEncoder } from '../domain/ports/intake-qr-encoder';
+
+export class QrcodeIntakeQrEncoder implements IntakeQrEncoder {
+  encodeToPng(url: string): Promise<Buffer> {
+    return QRCode.toBuffer(url, { type: 'png', margin: 2, width: 512 });
+  }
+}

--- a/apps/api/test/donation-intake.e2e-spec.ts
+++ b/apps/api/test/donation-intake.e2e-spec.ts
@@ -304,4 +304,41 @@ describe('Donation intake flow (e2e)', () => {
       .send({ volunteerNotes: 'Faltan bolsas' })
       .expect(204);
   });
+
+  it('returns intake deep link for a published collection point', async () => {
+    const res = await request(server)
+      .get(`/resources/${RESOURCE}/intake-link`)
+      .set('Authorization', `Bearer ${coordToken}`)
+      .expect(200);
+
+    const body = res.body as {
+      url: string;
+      resourceName: string;
+      slug: string;
+      resourceId: string;
+    };
+    expect(body.resourceName).toBe('Acopio E2E');
+    expect(body.slug).toBe('intake-e2e-emergency');
+    expect(body.resourceId).toBe(RESOURCE);
+    expect(body.url).toBe(
+      `http://localhost:3001/e/intake-e2e-emergency/donar-acopio?resourceId=${RESOURCE}`,
+    );
+  });
+
+  it('returns PNG QR for intake deep link', async () => {
+    const res = await request(server)
+      .get(`/resources/${RESOURCE}/intake-qr`)
+      .set('Authorization', `Bearer ${coordToken}`)
+      .expect(200);
+
+    expect(res.headers['content-type']).toMatch(/image\/png/);
+    expect((res.body as Buffer).length).toBeGreaterThan(100);
+  });
+
+  it('returns 404 for intake link on unknown resource', async () => {
+    await request(server)
+      .get(`/resources/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/intake-link`)
+      .set('Authorization', `Bearer ${coordToken}`)
+      .expect(404);
+  });
 });

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -1326,6 +1326,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/resources/{resourceId}/intake-link": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the public deep link for pre-registering at this acopio */
+        get: operations["DonationIntakesController_getIntakeLink"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/resources/{resourceId}/intake-qr": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Generate a QR code PNG for the intake deep link of this acopio */
+        get: operations["DonationIntakesController_getIntakeQr"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/resources/{resourceId}/donation-intakes/pending": {
         parameters: {
             query?: never;
@@ -3624,6 +3658,16 @@ export interface components {
             itemCount: number;
             /** Format: date-time */
             createdAt: string;
+        };
+        IntakeDeepLinkDto: {
+            /** @example http://localhost:3001/e/mexico-demo/donar-acopio?resourceId=33333333-3333-4333-8333-333333333331 */
+            url: string;
+            /** @example Acopio CDMX Norte */
+            resourceName: string;
+            /** @example mexico-demo */
+            slug: string;
+            /** Format: uuid */
+            resourceId: string;
         };
         ReceiveDonationIntakeDto: {
             volunteerNotes?: string | null;
@@ -7739,6 +7783,105 @@ export interface operations {
             };
             /** @description Missing intake:read */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    DonationIntakesController_getIntakeLink: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntakeDeepLinkDto"];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing intake:read */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource is not a published collection point */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    DonationIntakesController_getIntakeQr: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description PNG image */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/png": string;
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing intake:read */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource is not a published collection point */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       pg:
         specifier: ^8.22.0
         version: 8.22.0
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -128,6 +131,9 @@ importers:
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@types/supertest':
         specifier: ^7.0.0
         version: 7.2.0
@@ -2219,6 +2225,9 @@ packages:
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
 
@@ -2861,6 +2870,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -3008,6 +3020,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -3060,6 +3076,9 @@ packages:
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -4759,6 +4778,10 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -4820,6 +4843,11 @@ packages:
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -4895,6 +4923,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -4987,6 +5018,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5531,6 +5565,9 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which-typed-array@1.1.22:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
@@ -5570,6 +5607,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -5580,9 +5620,17 @@ packages:
   yaml-ast-parser@0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
@@ -7551,6 +7599,10 @@ snapshots:
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 24.13.2
+
   '@types/qs@6.15.1': {}
 
   '@types/range-parser@1.2.7': {}
@@ -8237,6 +8289,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -8376,6 +8434,8 @@ snapshots:
     optionalDependencies:
       supports-color: 10.2.2
 
+  decamelize@1.2.0: {}
+
   dedent@1.7.2: {}
 
   deep-is@0.1.4: {}
@@ -8414,6 +8474,8 @@ snapshots:
       wrappy: 1.0.2
 
   diff@4.0.4: {}
+
+  dijkstrajs@1.0.3: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -10473,6 +10535,8 @@ snapshots:
 
   pluralize@8.0.0: {}
 
+  pngjs@5.0.0: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.4.31:
@@ -10529,6 +10593,12 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@7.0.1: {}
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   qs@6.15.3:
     dependencies:
@@ -10605,6 +10675,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-main-filename@2.0.0: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -10722,6 +10794,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -11363,6 +11437,8 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
+  which-module@2.0.1: {}
+
   which-typed-array@1.1.22:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -11408,13 +11484,34 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
   yaml-ast-parser@0.0.43: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.3:
     dependencies:


### PR DESCRIPTION
## :test_tube: Pre-registro acopio: deep link y QR por acopio

## :sparkles: Cambios realizados

### :pushpin: Endpoints de pre-registro por acopio
- Se agregaron los endpoints `GET /resources/{resourceId}/intake-link` y `GET /resources/{resourceId}/intake-qr`.
- Se habilitó la generación del deep link público para pre-registrar donaciones en un acopio específico.
- Se habilitó la generación de un código QR en formato PNG a partir del deep link del acopio.
- Se protegieron ambos endpoints con autenticación JWT y permiso `intake:read`.

### :gear: Caso de uso `GetIntakeDeepLink`
- Se agregó el caso de uso para construir la URL canónica de pre-registro:
  `/e/{slug}/donar-acopio?resourceId={resourceId}`.
- Se agregó soporte para generar el QR asociado al deep link.
- Se centralizó el uso de `FRONTEND_URL`, con fallback a `http://localhost:3001`.

### :gear: Validación de recursos para intake
- Se extrajo la lógica de validación del recurso objetivo a `resolve-intake-target-resource`.
- Se reutilizó la validación tanto para la creación de donation intakes como para la generación del deep link y QR.
- Se validan recursos inexistentes, recursos de otra emergencia, tipos no compatibles y recursos no publicados.

### :pushpin: Lookup de recursos
- Se extendió `IntakeResourceInfo` para incluir `emergencySlug` y `name`.
- Se actualizó `DrizzleIntakeResourceLookup` para obtener información de la emergencia mediante join con `emergenciesTable`.

### :gear: Generación de QR
- Se agregó el puerto `IntakeQrEncoder`.
- Se agregó la implementación `QrcodeIntakeQrEncoder` usando la librería `qrcode`.
- Se incorporaron las dependencias `qrcode` y `@types/qrcode`.

### :memo: DTOs, OpenAPI y cliente API
- Se agregó `IntakeDeepLinkDto`.
- Se actualizó la especificación OpenAPI con los nuevos endpoints y schemas.
- Se regeneró el cliente API para incluir los tipos y operaciones correspondientes.

### :white_check_mark: Pruebas
- Se agregaron pruebas unitarias para:
  - Construcción del deep link.
  - Rechazo de recursos no válidos.
  - Generación de bytes del QR.
- Se agregaron pruebas e2e para:
  - Obtener el deep link de un acopio publicado.
  - Obtener el QR en formato PNG.
  - Retornar `404` cuando el recurso no existe.

---

## :memo: Notas adicionales 

- El deep link se construye usando `FRONTEND_URL`; si la variable no está definida, se utiliza `http://localhost:3001`.
- El QR se retorna como `image/png` con disposición inline.
- La validación considera como recursos válidos los tipos `collection_point` y `collection_and_delivery`, siempre que estén publicados con estado `active`.