### PR TITLE
feat: admin · listado global de organizaciones + ficha de detalle (#175)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3100,6 +3100,87 @@
         ]
       }
     },
+    "/organizations/admin": {
+      "get": {
+        "operationId": "OrganizationsController_listAdmin",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "All organizations (admin view)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrganizationAdminListItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing org:read permission"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Admin global list of ALL organizations, enriched with member count and accreditation status (org:read)",
+        "tags": [
+          "organizations"
+        ]
+      }
+    },
+    "/organizations/{id}": {
+      "get": {
+        "operationId": "OrganizationsController_detail",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization detail (admin view)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationAdminDetailDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing org:read permission"
+          },
+          "404": {
+            "description": "Organization not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Admin detail of one organization: members, service accounts/API keys, accreditations and emergencies (org:read)",
+        "tags": [
+          "organizations"
+        ]
+      }
+    },
     "/organizations/{id}/members": {
       "get": {
         "operationId": "OrganizationsController_listMembers",
@@ -9366,6 +9447,66 @@
           "verificationLevel"
         ]
       },
+      "OrganizationAdminListItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "ngo",
+              "company",
+              "public_admin",
+              "association",
+              "transport_operator",
+              "other"
+            ]
+          },
+          "taxId": {
+            "type": "object",
+            "nullable": true,
+            "example": "ES-12345678"
+          },
+          "contactEmail": {
+            "type": "object",
+            "nullable": true,
+            "example": "contact@org.example"
+          },
+          "verificationLevel": {
+            "type": "string",
+            "example": "unverified"
+          },
+          "memberCount": {
+            "type": "number",
+            "example": 3
+          },
+          "accreditationStatus": {
+            "type": "string",
+            "enum": [
+              "global",
+              "emergency",
+              "none"
+            ],
+            "example": "none"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "taxId",
+          "contactEmail",
+          "verificationLevel",
+          "memberCount",
+          "accreditationStatus"
+        ]
+      },
       "OrganizationMemberDto": {
         "type": "object",
         "properties": {
@@ -9395,6 +9536,157 @@
           "email",
           "name",
           "role"
+        ]
+      },
+      "OrganizationServiceAccountDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp"
+          },
+          "keyCount": {
+            "type": "number",
+            "example": 2
+          },
+          "activeKeyCount": {
+            "type": "number",
+            "example": 1
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "createdAt",
+          "keyCount",
+          "activeKeyCount"
+        ]
+      },
+      "OrganizationAccreditationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "scope": {
+            "type": "object",
+            "description": "\"global\" or an object with the emergency UUID",
+            "example": "global"
+          },
+          "grantedByUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "grantedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp"
+          },
+          "evidence": {
+            "type": "object",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "scope",
+          "grantedByUserId",
+          "grantedAt",
+          "evidence"
+        ]
+      },
+      "OrganizationAdminDetailDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "ngo",
+              "company",
+              "public_admin",
+              "association",
+              "transport_operator",
+              "other"
+            ]
+          },
+          "taxId": {
+            "type": "object",
+            "nullable": true
+          },
+          "contactEmail": {
+            "type": "object",
+            "nullable": true
+          },
+          "verificationLevel": {
+            "type": "string",
+            "example": "unverified"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp"
+          },
+          "accreditationStatus": {
+            "type": "string",
+            "enum": [
+              "global",
+              "emergency",
+              "none"
+            ],
+            "example": "none"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationMemberDto"
+            }
+          },
+          "serviceAccounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationServiceAccountDto"
+            }
+          },
+          "accreditations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationAccreditationDto"
+            }
+          },
+          "emergencyIds": {
+            "description": "UUIDs of emergencies the organization participates in",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "taxId",
+          "contactEmail",
+          "verificationLevel",
+          "createdAt",
+          "accreditationStatus",
+          "members",
+          "serviceAccounts",
+          "accreditations",
+          "emergencyIds"
         ]
       },
       "AddMemberDto": {

--- a/apps/api/src/contexts/accreditation/infrastructure/accreditation.module.ts
+++ b/apps/api/src/contexts/accreditation/infrastructure/accreditation.module.ts
@@ -46,5 +46,6 @@ const listProvider = {
     revokeProvider,
     listProvider,
   ],
+  exports: [ACCREDITATION_REPOSITORY],
 })
 export class AccreditationModule {}

--- a/apps/api/src/contexts/organizations/application/get-organization-admin-detail.ts
+++ b/apps/api/src/contexts/organizations/application/get-organization-admin-detail.ts
@@ -1,0 +1,80 @@
+import { OrganizationRepository } from '../domain/ports/organization.repository';
+import { OrganizationMemberRepository } from '../domain/ports/organization-member.repository';
+import { UserDirectory } from '../domain/ports/user-directory';
+import { AccreditationReader } from '../domain/ports/accreditation-reader';
+import { ServiceAccountReader } from '../domain/ports/service-account-reader';
+import { OrganizationId } from '../domain/organization-id';
+import { OrganizationNotFoundError } from '../domain/errors';
+import {
+  OrganizationAdminDetail,
+  OrganizationAdminMember,
+  deriveAccreditationStatus,
+} from './organization-admin-view';
+
+export interface GetOrganizationAdminDetailQuery {
+  organizationId: string;
+}
+
+/**
+ * Admin detail of a single organization: core fields + members (with roles) +
+ * service accounts / API keys + accreditations + emergencies it participates
+ * in. Reuses the existing member, user-directory, accreditation and
+ * service-account reads; adds no new domain logic. Gated by `org:read`.
+ */
+export class GetOrganizationAdminDetail {
+  constructor(
+    private readonly orgRepo: OrganizationRepository,
+    private readonly memberRepo: OrganizationMemberRepository,
+    private readonly userDirectory: UserDirectory,
+    private readonly accreditations: AccreditationReader,
+    private readonly serviceAccounts: ServiceAccountReader,
+  ) {}
+
+  async execute(
+    query: GetOrganizationAdminDetailQuery,
+  ): Promise<OrganizationAdminDetail> {
+    const org = await this.orgRepo.findById(
+      OrganizationId.fromString(query.organizationId),
+    );
+    if (!org) {
+      throw new OrganizationNotFoundError(query.organizationId);
+    }
+
+    const [entries, accreditations, serviceAccounts] = await Promise.all([
+      this.memberRepo.listMembers(org.id.value),
+      this.accreditations.listForOrganization(org.id.value),
+      this.serviceAccounts.listForOrganization(org.id.value),
+    ]);
+
+    const members: OrganizationAdminMember[] = [];
+    for (const entry of entries) {
+      const user = await this.userDirectory.findById(entry.userId);
+      members.push({
+        userId: entry.userId,
+        email: user?.email ?? '',
+        name: user?.name ?? '',
+        role: entry.role,
+      });
+    }
+
+    const emergencyIds = accreditations
+      .map((a) => (a.scope === 'global' ? null : a.scope.emergencyId))
+      .filter((id): id is string => id !== null);
+    const uniqueEmergencyIds = [...new Set(emergencyIds)];
+
+    return {
+      id: org.id.value,
+      name: org.name,
+      type: org.type,
+      taxId: org.taxId,
+      contactEmail: org.contactEmail,
+      verificationLevel: org.verificationLevel,
+      createdAt: org.createdAt.toISOString(),
+      accreditationStatus: deriveAccreditationStatus(accreditations),
+      members,
+      serviceAccounts,
+      accreditations,
+      emergencyIds: uniqueEmergencyIds,
+    };
+  }
+}

--- a/apps/api/src/contexts/organizations/application/list-organizations-admin.ts
+++ b/apps/api/src/contexts/organizations/application/list-organizations-admin.ts
@@ -1,0 +1,46 @@
+import { OrganizationRepository } from '../domain/ports/organization.repository';
+import { OrganizationMemberRepository } from '../domain/ports/organization-member.repository';
+import { AccreditationReader } from '../domain/ports/accreditation-reader';
+import {
+  OrganizationAdminListItem,
+  deriveAccreditationStatus,
+} from './organization-admin-view';
+
+/**
+ * Admin global list of ALL organizations, enriched with member count and
+ * accreditation status. Gated by `org:read` at the controller (admin-only in
+ * practice; platform_operator/platform_admin hold it at platform scope).
+ */
+export class ListOrganizationsAdmin {
+  constructor(
+    private readonly orgRepo: OrganizationRepository,
+    private readonly memberRepo: OrganizationMemberRepository,
+    private readonly accreditations: AccreditationReader,
+  ) {}
+
+  async execute(): Promise<OrganizationAdminListItem[]> {
+    const orgs = await this.orgRepo.listAll();
+
+    const items = await Promise.all(
+      orgs.map(async (org): Promise<OrganizationAdminListItem> => {
+        const [members, accreditations] = await Promise.all([
+          this.memberRepo.listMembers(org.id.value),
+          this.accreditations.listForOrganization(org.id.value),
+        ]);
+        return {
+          id: org.id.value,
+          name: org.name,
+          type: org.type,
+          taxId: org.taxId,
+          contactEmail: org.contactEmail,
+          verificationLevel: org.verificationLevel,
+          memberCount: members.length,
+          accreditationStatus: deriveAccreditationStatus(accreditations),
+        };
+      }),
+    );
+
+    items.sort((a, b) => a.name.localeCompare(b.name));
+    return items;
+  }
+}

--- a/apps/api/src/contexts/organizations/application/organization-admin-view.ts
+++ b/apps/api/src/contexts/organizations/application/organization-admin-view.ts
@@ -1,0 +1,56 @@
+import { OrganizationRole } from '../domain/organization-enums';
+import { OrganizationAccreditation } from '../domain/ports/accreditation-reader';
+import { OrganizationServiceAccount } from '../domain/ports/service-account-reader';
+
+/**
+ * Accreditation status of an organization, derived from its accreditations:
+ * - `global`: holds a platform-wide accreditation (covers every emergency);
+ * - `emergency`: holds at least one emergency-scoped accreditation;
+ * - `none`: no accreditations.
+ */
+export type AccreditationStatus = 'global' | 'emergency' | 'none';
+
+export function deriveAccreditationStatus(
+  accreditations: readonly OrganizationAccreditation[],
+): AccreditationStatus {
+  if (accreditations.some((a) => a.scope === 'global')) return 'global';
+  if (accreditations.length > 0) return 'emergency';
+  return 'none';
+}
+
+/** Row of the admin organization list. */
+export interface OrganizationAdminListItem {
+  id: string;
+  name: string;
+  type: string;
+  taxId: string | null;
+  contactEmail: string | null;
+  verificationLevel: string;
+  memberCount: number;
+  accreditationStatus: AccreditationStatus;
+}
+
+export interface OrganizationAdminMember {
+  userId: string;
+  email: string;
+  name: string;
+  role: OrganizationRole;
+}
+
+/** Full admin detail of a single organization. */
+export interface OrganizationAdminDetail {
+  id: string;
+  name: string;
+  type: string;
+  taxId: string | null;
+  contactEmail: string | null;
+  verificationLevel: string;
+  /** ISO 8601 timestamp. */
+  createdAt: string;
+  accreditationStatus: AccreditationStatus;
+  members: OrganizationAdminMember[];
+  serviceAccounts: OrganizationServiceAccount[];
+  accreditations: OrganizationAccreditation[];
+  /** Emergencies the organization participates in (emergency-scoped accreditations). */
+  emergencyIds: string[];
+}

--- a/apps/api/src/contexts/organizations/application/organization-admin.spec.ts
+++ b/apps/api/src/contexts/organizations/application/organization-admin.spec.ts
@@ -1,0 +1,336 @@
+import { ListOrganizationsAdmin } from './list-organizations-admin';
+import { GetOrganizationAdminDetail } from './get-organization-admin-detail';
+import { CreateOrganization } from './create-organization';
+import { InMemoryOrganizationRepository } from '../infrastructure/in-memory-organization.repository';
+import { InMemoryOrganizationMemberRepository } from '../infrastructure/in-memory-organization-member.repository';
+import { InMemoryUserDirectory } from '../infrastructure/in-memory-user-directory';
+import { OrganizationType, OrganizationRole } from '../domain/organization-enums';
+import { OrganizationNotFoundError } from '../domain/errors';
+import {
+  AccreditationReader,
+  OrganizationAccreditation,
+} from '../domain/ports/accreditation-reader';
+import {
+  ServiceAccountReader,
+  OrganizationServiceAccount,
+} from '../domain/ports/service-account-reader';
+
+class FakeAccreditationReader implements AccreditationReader {
+  private byOrg = new Map<string, OrganizationAccreditation[]>();
+
+  set(organizationId: string, accs: OrganizationAccreditation[]): void {
+    this.byOrg.set(organizationId, accs);
+  }
+
+  listForOrganization(
+    organizationId: string,
+  ): Promise<OrganizationAccreditation[]> {
+    return Promise.resolve(this.byOrg.get(organizationId) ?? []);
+  }
+}
+
+class FakeServiceAccountReader implements ServiceAccountReader {
+  private byOrg = new Map<string, OrganizationServiceAccount[]>();
+
+  set(organizationId: string, sas: OrganizationServiceAccount[]): void {
+    this.byOrg.set(organizationId, sas);
+  }
+
+  listForOrganization(
+    organizationId: string,
+  ): Promise<OrganizationServiceAccount[]> {
+    return Promise.resolve(this.byOrg.get(organizationId) ?? []);
+  }
+}
+
+const EMERGENCY_ID = '99999999-9999-4999-8999-999999999999';
+
+async function seedOrg(
+  create: CreateOrganization,
+  name: string,
+  type: OrganizationType,
+  creatorUserId: string,
+  opts: { taxId?: string | null; contactEmail?: string | null } = {},
+): Promise<string> {
+  const { id } = await create.execute({
+    name,
+    type,
+    taxId: opts.taxId ?? null,
+    contactEmail: opts.contactEmail ?? null,
+    creatorUserId,
+  });
+  return id;
+}
+
+describe('ListOrganizationsAdmin', () => {
+  it('returns an empty list when there are no organizations', async () => {
+    const orgRepo = new InMemoryOrganizationRepository();
+    const memberRepo = new InMemoryOrganizationMemberRepository(orgRepo);
+    const accreditations = new FakeAccreditationReader();
+    const useCase = new ListOrganizationsAdmin(
+      orgRepo,
+      memberRepo,
+      accreditations,
+    );
+
+    expect(await useCase.execute()).toEqual([]);
+  });
+
+  it('lists every organization with member count and accreditation status, sorted by name', async () => {
+    const orgRepo = new InMemoryOrganizationRepository();
+    const memberRepo = new InMemoryOrganizationMemberRepository(orgRepo);
+    const create = new CreateOrganization(orgRepo, memberRepo);
+    const accreditations = new FakeAccreditationReader();
+    const useCase = new ListOrganizationsAdmin(
+      orgRepo,
+      memberRepo,
+      accreditations,
+    );
+
+    const ownerB = 'bbbbbbbb-0000-4000-8000-000000000001';
+    const ownerA = 'aaaaaaaa-0000-4000-8000-000000000001';
+
+    const orgBId = await seedOrg(create, 'Zebra Aid', OrganizationType.Ngo, ownerB, {
+      taxId: 'B-1',
+      contactEmail: 'z@aid.example',
+    });
+    const orgAId = await seedOrg(
+      create,
+      'Alpha Relief',
+      OrganizationType.Company,
+      ownerA,
+    );
+
+    // org A gets a second member (creator already counts as one)
+    await memberRepo.add(
+      orgAId,
+      'cccccccc-0000-4000-8000-000000000001',
+      OrganizationRole.Member,
+    );
+
+    accreditations.set(orgAId, [
+      {
+        id: 'acc-1',
+        scope: 'global',
+        grantedByUserId: ownerA,
+        grantedAt: '2026-01-01T00:00:00.000Z',
+        evidence: null,
+      },
+    ]);
+    // org B has none
+
+    const result = await useCase.execute();
+
+    expect(result.map((o) => o.name)).toEqual(['Alpha Relief', 'Zebra Aid']);
+
+    const alpha = result.find((o) => o.id === orgAId)!;
+    expect(alpha.memberCount).toBe(2);
+    expect(alpha.accreditationStatus).toBe('global');
+    expect(alpha.type).toBe(OrganizationType.Company);
+
+    const zebra = result.find((o) => o.id === orgBId)!;
+    expect(zebra.memberCount).toBe(1);
+    expect(zebra.accreditationStatus).toBe('none');
+    expect(zebra.taxId).toBe('B-1');
+    expect(zebra.contactEmail).toBe('z@aid.example');
+  });
+
+  it('reports emergency accreditation status when only emergency-scoped accreditations exist', async () => {
+    const orgRepo = new InMemoryOrganizationRepository();
+    const memberRepo = new InMemoryOrganizationMemberRepository(orgRepo);
+    const create = new CreateOrganization(orgRepo, memberRepo);
+    const accreditations = new FakeAccreditationReader();
+    const useCase = new ListOrganizationsAdmin(
+      orgRepo,
+      memberRepo,
+      accreditations,
+    );
+
+    const orgId = await seedOrg(
+      create,
+      'Org',
+      OrganizationType.Ngo,
+      'dddddddd-0000-4000-8000-000000000001',
+    );
+    accreditations.set(orgId, [
+      {
+        id: 'acc-2',
+        scope: { emergencyId: EMERGENCY_ID },
+        grantedByUserId: 'dddddddd-0000-4000-8000-000000000001',
+        grantedAt: '2026-01-02T00:00:00.000Z',
+        evidence: 'doc',
+      },
+    ]);
+
+    const [item] = await useCase.execute();
+    expect(item.accreditationStatus).toBe('emergency');
+  });
+});
+
+describe('GetOrganizationAdminDetail', () => {
+  function buildUseCase() {
+    const orgRepo = new InMemoryOrganizationRepository();
+    const memberRepo = new InMemoryOrganizationMemberRepository(orgRepo);
+    const userDirectory = new InMemoryUserDirectory();
+    const accreditations = new FakeAccreditationReader();
+    const serviceAccounts = new FakeServiceAccountReader();
+    const create = new CreateOrganization(orgRepo, memberRepo);
+    const useCase = new GetOrganizationAdminDetail(
+      orgRepo,
+      memberRepo,
+      userDirectory,
+      accreditations,
+      serviceAccounts,
+    );
+    return {
+      orgRepo,
+      memberRepo,
+      userDirectory,
+      accreditations,
+      serviceAccounts,
+      create,
+      useCase,
+    };
+  }
+
+  it('throws OrganizationNotFoundError for an unknown organization', async () => {
+    const { useCase } = buildUseCase();
+    await expect(
+      useCase.execute({
+        organizationId: '11111111-1111-4111-8111-111111111111',
+      }),
+    ).rejects.toBeInstanceOf(OrganizationNotFoundError);
+  });
+
+  it('throws on an invalid (non-UUID) organization id', async () => {
+    const { useCase } = buildUseCase();
+    await expect(
+      useCase.execute({ organizationId: 'not-a-uuid' }),
+    ).rejects.toThrow();
+  });
+
+  it('aggregates members (with roles + user details), service accounts, accreditations and emergencies', async () => {
+    const {
+      memberRepo,
+      userDirectory,
+      accreditations,
+      serviceAccounts,
+      create,
+      useCase,
+    } = buildUseCase();
+
+    const ownerId = 'aaaaaaaa-0000-4000-8000-000000000001';
+    const memberId = 'bbbbbbbb-0000-4000-8000-000000000001';
+    userDirectory.seed({
+      id: ownerId,
+      email: 'owner@org.example',
+      name: 'Owner One',
+    });
+    userDirectory.seed({
+      id: memberId,
+      email: 'member@org.example',
+      name: 'Member Two',
+    });
+
+    const orgId = await seedOrg(create, 'Cruz Roja', OrganizationType.Ngo, ownerId, {
+      taxId: 'ES-1',
+      contactEmail: 'info@cruzroja.example',
+    });
+    await memberRepo.add(orgId, memberId, OrganizationRole.Member);
+
+    accreditations.set(orgId, [
+      {
+        id: 'acc-1',
+        scope: { emergencyId: EMERGENCY_ID },
+        grantedByUserId: ownerId,
+        grantedAt: '2026-02-01T00:00:00.000Z',
+        evidence: null,
+      },
+    ]);
+    serviceAccounts.set(orgId, [
+      {
+        id: 'sa-1',
+        name: 'Integración',
+        createdAt: '2026-01-10T00:00:00.000Z',
+        keyCount: 3,
+        activeKeyCount: 1,
+      },
+    ]);
+
+    const detail = await useCase.execute({ organizationId: orgId });
+
+    expect(detail.id).toBe(orgId);
+    expect(detail.name).toBe('Cruz Roja');
+    expect(detail.taxId).toBe('ES-1');
+    expect(detail.contactEmail).toBe('info@cruzroja.example');
+    expect(detail.accreditationStatus).toBe('emergency');
+
+    expect(detail.members).toHaveLength(2);
+    const owner = detail.members.find((m) => m.userId === ownerId)!;
+    expect(owner.role).toBe(OrganizationRole.Owner);
+    expect(owner.email).toBe('owner@org.example');
+    expect(owner.name).toBe('Owner One');
+
+    expect(detail.serviceAccounts).toEqual([
+      {
+        id: 'sa-1',
+        name: 'Integración',
+        createdAt: '2026-01-10T00:00:00.000Z',
+        keyCount: 3,
+        activeKeyCount: 1,
+      },
+    ]);
+
+    expect(detail.accreditations).toHaveLength(1);
+    expect(detail.emergencyIds).toEqual([EMERGENCY_ID]);
+  });
+
+  it('tolerates members whose user record is missing from the directory', async () => {
+    const { memberRepo, create, useCase } = buildUseCase();
+    const ownerId = 'aaaaaaaa-0000-4000-8000-000000000001';
+    const orgId = await seedOrg(create, 'Org', OrganizationType.Other, ownerId);
+    await memberRepo.add(
+      orgId,
+      'cccccccc-0000-4000-8000-000000000001',
+      OrganizationRole.Member,
+    );
+
+    const detail = await useCase.execute({ organizationId: orgId });
+    expect(detail.members).toHaveLength(2);
+    // owner has no seeded directory entry either → empty email/name, no throw
+    expect(detail.members.every((m) => typeof m.email === 'string')).toBe(true);
+  });
+
+  it('deduplicates emergencies across multiple accreditations and ignores global scope', async () => {
+    const { accreditations, create, useCase } = buildUseCase();
+    const ownerId = 'aaaaaaaa-0000-4000-8000-000000000001';
+    const orgId = await seedOrg(create, 'Org', OrganizationType.Ngo, ownerId);
+    accreditations.set(orgId, [
+      {
+        id: 'a1',
+        scope: { emergencyId: EMERGENCY_ID },
+        grantedByUserId: ownerId,
+        grantedAt: '2026-02-01T00:00:00.000Z',
+        evidence: null,
+      },
+      {
+        id: 'a2',
+        scope: { emergencyId: EMERGENCY_ID },
+        grantedByUserId: ownerId,
+        grantedAt: '2026-02-02T00:00:00.000Z',
+        evidence: null,
+      },
+      {
+        id: 'a3',
+        scope: 'global',
+        grantedByUserId: ownerId,
+        grantedAt: '2026-02-03T00:00:00.000Z',
+        evidence: null,
+      },
+    ]);
+
+    const detail = await useCase.execute({ organizationId: orgId });
+    expect(detail.emergencyIds).toEqual([EMERGENCY_ID]);
+    expect(detail.accreditationStatus).toBe('global');
+  });
+});

--- a/apps/api/src/contexts/organizations/application/organization-admin.spec.ts
+++ b/apps/api/src/contexts/organizations/application/organization-admin.spec.ts
@@ -4,7 +4,10 @@ import { CreateOrganization } from './create-organization';
 import { InMemoryOrganizationRepository } from '../infrastructure/in-memory-organization.repository';
 import { InMemoryOrganizationMemberRepository } from '../infrastructure/in-memory-organization-member.repository';
 import { InMemoryUserDirectory } from '../infrastructure/in-memory-user-directory';
-import { OrganizationType, OrganizationRole } from '../domain/organization-enums';
+import {
+  OrganizationType,
+  OrganizationRole,
+} from '../domain/organization-enums';
 import { OrganizationNotFoundError } from '../domain/errors';
 import {
   AccreditationReader,
@@ -90,10 +93,16 @@ describe('ListOrganizationsAdmin', () => {
     const ownerB = 'bbbbbbbb-0000-4000-8000-000000000001';
     const ownerA = 'aaaaaaaa-0000-4000-8000-000000000001';
 
-    const orgBId = await seedOrg(create, 'Zebra Aid', OrganizationType.Ngo, ownerB, {
-      taxId: 'B-1',
-      contactEmail: 'z@aid.example',
-    });
+    const orgBId = await seedOrg(
+      create,
+      'Zebra Aid',
+      OrganizationType.Ngo,
+      ownerB,
+      {
+        taxId: 'B-1',
+        contactEmail: 'z@aid.example',
+      },
+    );
     const orgAId = await seedOrg(
       create,
       'Alpha Relief',
@@ -232,10 +241,16 @@ describe('GetOrganizationAdminDetail', () => {
       name: 'Member Two',
     });
 
-    const orgId = await seedOrg(create, 'Cruz Roja', OrganizationType.Ngo, ownerId, {
-      taxId: 'ES-1',
-      contactEmail: 'info@cruzroja.example',
-    });
+    const orgId = await seedOrg(
+      create,
+      'Cruz Roja',
+      OrganizationType.Ngo,
+      ownerId,
+      {
+        taxId: 'ES-1',
+        contactEmail: 'info@cruzroja.example',
+      },
+    );
     await memberRepo.add(orgId, memberId, OrganizationRole.Member);
 
     accreditations.set(orgId, [

--- a/apps/api/src/contexts/organizations/domain/errors.ts
+++ b/apps/api/src/contexts/organizations/domain/errors.ts
@@ -32,3 +32,10 @@ export class CannotRemoveSelfError extends Error {
     this.name = 'CannotRemoveSelfError';
   }
 }
+
+export class OrganizationNotFoundError extends Error {
+  constructor(id: string) {
+    super(`No organization found with id: ${id}`);
+    this.name = 'OrganizationNotFoundError';
+  }
+}

--- a/apps/api/src/contexts/organizations/domain/ports/accreditation-reader.ts
+++ b/apps/api/src/contexts/organizations/domain/ports/accreditation-reader.ts
@@ -1,0 +1,22 @@
+export const ACCREDITATION_READER = Symbol('AccreditationReader');
+
+/** Accreditation as seen from the organizations context (read-only projection). */
+export interface OrganizationAccreditation {
+  id: string;
+  scope: 'global' | { emergencyId: string };
+  grantedByUserId: string;
+  /** ISO 8601 timestamp. */
+  grantedAt: string;
+  evidence: string | null;
+}
+
+/**
+ * Output port: lets the organizations context read an organization's
+ * accreditations without depending on the accreditation context's internals.
+ * Wired in the module to a thin adapter over the accreditation repository (DIP).
+ */
+export interface AccreditationReader {
+  listForOrganization(
+    organizationId: string,
+  ): Promise<OrganizationAccreditation[]>;
+}

--- a/apps/api/src/contexts/organizations/domain/ports/service-account-reader.ts
+++ b/apps/api/src/contexts/organizations/domain/ports/service-account-reader.ts
@@ -1,0 +1,25 @@
+export const SERVICE_ACCOUNT_READER = Symbol('ServiceAccountReader');
+
+/** Service account (machine principal) owned by an organization, with key tallies. */
+export interface OrganizationServiceAccount {
+  id: string;
+  name: string;
+  /** ISO 8601 timestamp. */
+  createdAt: string;
+  /** Total API keys ever issued for this service account. */
+  keyCount: number;
+  /** API keys currently active (not revoked, not expired). */
+  activeKeyCount: number;
+}
+
+/**
+ * Output port: lets the organizations context read the service accounts (and
+ * their API-key tallies) owned by an organization without reaching into the
+ * identity context's internals. Wired to an adapter over the identity
+ * service-account / api-key repositories (DIP).
+ */
+export interface ServiceAccountReader {
+  listForOrganization(
+    organizationId: string,
+  ): Promise<OrganizationServiceAccount[]>;
+}

--- a/apps/api/src/contexts/organizations/infrastructure/accreditation-reader.adapter.ts
+++ b/apps/api/src/contexts/organizations/infrastructure/accreditation-reader.adapter.ts
@@ -1,0 +1,33 @@
+import { AccreditationRepository } from '../../accreditation/domain/ports/accreditation.repository';
+import {
+  AccreditationReader,
+  OrganizationAccreditation,
+} from '../domain/ports/accreditation-reader';
+
+/**
+ * Adapts the accreditation context's repository to the organizations context's
+ * {@link AccreditationReader} output port (anti-corruption / DIP). The
+ * application depends on the port; this adapter is wired in the module.
+ */
+export class AccreditationReaderAdapter implements AccreditationReader {
+  constructor(private readonly repo: AccreditationRepository) {}
+
+  async listForOrganization(
+    organizationId: string,
+  ): Promise<OrganizationAccreditation[]> {
+    const accreditations = await this.repo.list({ organizationId });
+    return accreditations.map((a) => {
+      const scope = a.scope.toPlain();
+      return {
+        id: a.id,
+        scope:
+          scope.kind === 'global'
+            ? 'global'
+            : { emergencyId: scope.emergencyId },
+        grantedByUserId: a.grantedByUserId,
+        grantedAt: a.grantedAt.toISOString(),
+        evidence: a.evidence,
+      };
+    });
+  }
+}

--- a/apps/api/src/contexts/organizations/infrastructure/drizzle/drizzle-organization-admin.int-spec.ts
+++ b/apps/api/src/contexts/organizations/infrastructure/drizzle/drizzle-organization-admin.int-spec.ts
@@ -18,7 +18,10 @@ import { ListOrganizationsAdmin } from '../../application/list-organizations-adm
 import { GetOrganizationAdminDetail } from '../../application/get-organization-admin-detail';
 import { Organization } from '../../domain/organization';
 import { OrganizationId } from '../../domain/organization-id';
-import { OrganizationType, OrganizationRole } from '../../domain/organization-enums';
+import {
+  OrganizationType,
+  OrganizationRole,
+} from '../../domain/organization-enums';
 import { ServiceAccount } from '../../../identity/domain/service-account';
 import { ApiKey } from '../../../identity/domain/api-key';
 import { Accreditation } from '../../../accreditation/domain/accreditation';

--- a/apps/api/src/contexts/organizations/infrastructure/drizzle/drizzle-organization-admin.int-spec.ts
+++ b/apps/api/src/contexts/organizations/infrastructure/drizzle/drizzle-organization-admin.int-spec.ts
@@ -1,0 +1,221 @@
+import { createDb, Db } from '../../../../shared/db';
+import { organizationsTable, organizationMembersTable } from './schema';
+import {
+  serviceAccountsTable,
+  apiKeysTable,
+  usersTable,
+} from '../../../identity/infrastructure/drizzle/schema';
+import { accreditationsTable } from '../../../accreditation/infrastructure/drizzle/schema';
+import { DrizzleOrganizationRepository } from './drizzle-organization.repository';
+import { DrizzleOrganizationMemberRepository } from './drizzle-organization-member.repository';
+import { DrizzleUserDirectory } from './drizzle-user-directory';
+import { DrizzleAccreditationRepository } from '../../../accreditation/infrastructure/drizzle/drizzle-accreditation.repository';
+import { DrizzleServiceAccountRepository } from '../../../identity/infrastructure/drizzle/drizzle-service-account.repository';
+import { DrizzleApiKeyRepository } from '../../../identity/infrastructure/drizzle/drizzle-api-key.repository';
+import { AccreditationReaderAdapter } from '../accreditation-reader.adapter';
+import { ServiceAccountReaderAdapter } from '../service-account-reader.adapter';
+import { ListOrganizationsAdmin } from '../../application/list-organizations-admin';
+import { GetOrganizationAdminDetail } from '../../application/get-organization-admin-detail';
+import { Organization } from '../../domain/organization';
+import { OrganizationId } from '../../domain/organization-id';
+import { OrganizationType, OrganizationRole } from '../../domain/organization-enums';
+import { ServiceAccount } from '../../../identity/domain/service-account';
+import { ApiKey } from '../../../identity/domain/api-key';
+import { Accreditation } from '../../../accreditation/domain/accreditation';
+import { AccreditationScope } from '../../../accreditation/domain/value-objects/accreditation-scope';
+import { randomUUID } from 'node:crypto';
+import type { Pool } from 'pg';
+
+const URL =
+  process.env.DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub';
+
+const OWNER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const MEMBER_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const EMERGENCY_ID = '99999999-9999-4999-8999-999999999999';
+
+describe('Organization admin reads (integration)', () => {
+  let db: Db;
+  let pool: Pool;
+  let orgRepo: DrizzleOrganizationRepository;
+  let memberRepo: DrizzleOrganizationMemberRepository;
+  let userDirectory: DrizzleUserDirectory;
+  let accreditationReader: AccreditationReaderAdapter;
+  let serviceAccountReader: ServiceAccountReaderAdapter;
+  let listAdmin: ListOrganizationsAdmin;
+  let getDetail: GetOrganizationAdminDetail;
+
+  beforeAll(() => {
+    ({ db, pool } = createDb(URL));
+    orgRepo = new DrizzleOrganizationRepository(db);
+    memberRepo = new DrizzleOrganizationMemberRepository(db);
+    userDirectory = new DrizzleUserDirectory(db);
+    const accreditationRepo = new DrizzleAccreditationRepository(db);
+    const serviceAccountRepo = new DrizzleServiceAccountRepository(db);
+    const apiKeyRepo = new DrizzleApiKeyRepository(db);
+    accreditationReader = new AccreditationReaderAdapter(accreditationRepo);
+    serviceAccountReader = new ServiceAccountReaderAdapter(
+      serviceAccountRepo,
+      apiKeyRepo,
+    );
+    listAdmin = new ListOrganizationsAdmin(
+      orgRepo,
+      memberRepo,
+      accreditationReader,
+    );
+    getDetail = new GetOrganizationAdminDetail(
+      orgRepo,
+      memberRepo,
+      userDirectory,
+      accreditationReader,
+      serviceAccountReader,
+    );
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await db.delete(apiKeysTable);
+    await db.delete(serviceAccountsTable);
+    await db.delete(accreditationsTable);
+    await db.delete(organizationMembersTable);
+    await db.delete(organizationsTable);
+    await db.delete(usersTable);
+  });
+
+  async function seedOrg(
+    name: string,
+    type: OrganizationType,
+    taxId: string | null = null,
+    contactEmail: string | null = null,
+  ): Promise<string> {
+    const org = Organization.create({
+      id: OrganizationId.create(),
+      name,
+      type,
+      taxId,
+      contactEmail,
+    });
+    await orgRepo.save(org);
+    return org.id.value;
+  }
+
+  it('lists all organizations with member count and accreditation status', async () => {
+    const orgAId = await seedOrg(
+      'Alpha',
+      OrganizationType.Ngo,
+      'A-1',
+      'a@x.example',
+    );
+    const orgBId = await seedOrg('Beta', OrganizationType.Company);
+
+    await memberRepo.add(orgAId, OWNER_ID, OrganizationRole.Owner);
+    await memberRepo.add(orgAId, MEMBER_ID, OrganizationRole.Member);
+
+    await new DrizzleAccreditationRepository(db).save(
+      Accreditation.grant({
+        id: randomUUID(),
+        organizationId: orgAId,
+        scope: AccreditationScope.global(),
+        grantedByUserId: OWNER_ID,
+      }),
+    );
+
+    const result = await listAdmin.execute();
+    expect(result.map((o) => o.name)).toEqual(['Alpha', 'Beta']);
+
+    const alpha = result.find((o) => o.id === orgAId)!;
+    expect(alpha.memberCount).toBe(2);
+    expect(alpha.accreditationStatus).toBe('global');
+    expect(alpha.taxId).toBe('A-1');
+    expect(alpha.contactEmail).toBe('a@x.example');
+
+    const beta = result.find((o) => o.id === orgBId)!;
+    expect(beta.memberCount).toBe(0);
+    expect(beta.accreditationStatus).toBe('none');
+  });
+
+  it('returns full detail aggregating members, service accounts/keys, accreditations and emergencies', async () => {
+    await db.insert(usersTable).values([
+      { id: OWNER_ID, email: 'owner@x.example', name: 'Owner', isAdmin: false },
+      {
+        id: MEMBER_ID,
+        email: 'member@x.example',
+        name: 'Member',
+        isAdmin: false,
+      },
+    ]);
+
+    const orgId = await seedOrg(
+      'Cruz Roja',
+      OrganizationType.Ngo,
+      'ES-1',
+      'info@cr.example',
+    );
+    await memberRepo.add(orgId, OWNER_ID, OrganizationRole.Owner);
+    await memberRepo.add(orgId, MEMBER_ID, OrganizationRole.Member);
+
+    const accRepo = new DrizzleAccreditationRepository(db);
+    await accRepo.save(
+      Accreditation.grant({
+        id: randomUUID(),
+        organizationId: orgId,
+        scope: AccreditationScope.forEmergency(EMERGENCY_ID),
+        grantedByUserId: OWNER_ID,
+        evidence: 'cert.pdf',
+      }),
+    );
+
+    const saRepo = new DrizzleServiceAccountRepository(db);
+    const keyRepo = new DrizzleApiKeyRepository(db);
+    const saId = randomUUID();
+    await saRepo.save(
+      ServiceAccount.create({
+        id: saId,
+        name: 'Integración',
+        ownerOrganizationId: orgId,
+        createdByUserId: OWNER_ID,
+      }),
+    );
+    // one active key, one revoked key
+    await keyRepo.save(
+      ApiKey.issue({
+        id: randomUUID(),
+        prefix: 'rh_live_active01',
+        hashedSecret: 'h1',
+        serviceAccountId: saId,
+        createdByUserId: OWNER_ID,
+      }),
+    );
+    const revoked = ApiKey.issue({
+      id: randomUUID(),
+      prefix: 'rh_live_revoked1',
+      hashedSecret: 'h2',
+      serviceAccountId: saId,
+      createdByUserId: OWNER_ID,
+    }).revoke(new Date());
+    await keyRepo.save(revoked);
+
+    const detail = await getDetail.execute({ organizationId: orgId });
+
+    expect(detail.name).toBe('Cruz Roja');
+    expect(detail.taxId).toBe('ES-1');
+    expect(detail.accreditationStatus).toBe('emergency');
+    expect(detail.emergencyIds).toEqual([EMERGENCY_ID]);
+
+    expect(detail.members).toHaveLength(2);
+    const owner = detail.members.find((m) => m.userId === OWNER_ID)!;
+    expect(owner.role).toBe(OrganizationRole.Owner);
+    expect(owner.email).toBe('owner@x.example');
+    expect(owner.name).toBe('Owner');
+
+    expect(detail.serviceAccounts).toHaveLength(1);
+    expect(detail.serviceAccounts[0].keyCount).toBe(2);
+    expect(detail.serviceAccounts[0].activeKeyCount).toBe(1);
+
+    expect(detail.accreditations).toHaveLength(1);
+    expect(detail.accreditations[0].evidence).toBe('cert.pdf');
+  });
+});

--- a/apps/api/src/contexts/organizations/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/organizations/infrastructure/http/dto.ts
@@ -63,3 +63,109 @@ export class OrganizationMemberDto {
   @ApiProperty({ enum: OrganizationRole, example: OrganizationRole.Member })
   role!: OrganizationRole;
 }
+
+const ACCREDITATION_STATUSES = ['global', 'emergency', 'none'] as const;
+
+export class OrganizationAdminListItemDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ enum: OrganizationType })
+  type!: string;
+
+  @ApiProperty({ nullable: true, example: 'ES-12345678' })
+  taxId!: string | null;
+
+  @ApiProperty({ nullable: true, example: 'contact@org.example' })
+  contactEmail!: string | null;
+
+  @ApiProperty({ example: 'unverified' })
+  verificationLevel!: string;
+
+  @ApiProperty({ example: 3 })
+  memberCount!: number;
+
+  @ApiProperty({ enum: ACCREDITATION_STATUSES, example: 'none' })
+  accreditationStatus!: 'global' | 'emergency' | 'none';
+}
+
+class OrganizationServiceAccountDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ description: 'ISO 8601 timestamp' })
+  createdAt!: string;
+
+  @ApiProperty({ example: 2 })
+  keyCount!: number;
+
+  @ApiProperty({ example: 1 })
+  activeKeyCount!: number;
+}
+
+class OrganizationAccreditationDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({
+    description: '"global" or an object with the emergency UUID',
+    example: 'global',
+  })
+  scope!: 'global' | { emergencyId: string };
+
+  @ApiProperty({ format: 'uuid' })
+  grantedByUserId!: string;
+
+  @ApiProperty({ description: 'ISO 8601 timestamp' })
+  grantedAt!: string;
+
+  @ApiProperty({ nullable: true })
+  evidence!: string | null;
+}
+
+export class OrganizationAdminDetailDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ enum: OrganizationType })
+  type!: string;
+
+  @ApiProperty({ nullable: true })
+  taxId!: string | null;
+
+  @ApiProperty({ nullable: true })
+  contactEmail!: string | null;
+
+  @ApiProperty({ example: 'unverified' })
+  verificationLevel!: string;
+
+  @ApiProperty({ description: 'ISO 8601 timestamp' })
+  createdAt!: string;
+
+  @ApiProperty({ enum: ACCREDITATION_STATUSES, example: 'none' })
+  accreditationStatus!: 'global' | 'emergency' | 'none';
+
+  @ApiProperty({ type: [OrganizationMemberDto] })
+  members!: OrganizationMemberDto[];
+
+  @ApiProperty({ type: [OrganizationServiceAccountDto] })
+  serviceAccounts!: OrganizationServiceAccountDto[];
+
+  @ApiProperty({ type: [OrganizationAccreditationDto] })
+  accreditations!: OrganizationAccreditationDto[];
+
+  @ApiProperty({
+    type: [String],
+    description: 'UUIDs of emergencies the organization participates in',
+  })
+  emergencyIds!: string[];
+}

--- a/apps/api/src/contexts/organizations/infrastructure/http/organization-exception.filter.ts
+++ b/apps/api/src/contexts/organizations/infrastructure/http/organization-exception.filter.ts
@@ -11,6 +11,7 @@ import {
   AlreadyMemberError,
   NotMemberError,
   CannotRemoveSelfError,
+  OrganizationNotFoundError,
 } from '../../domain/errors';
 
 type OrgDomainError =
@@ -18,7 +19,8 @@ type OrgDomainError =
   | UserNotFoundError
   | AlreadyMemberError
   | NotMemberError
-  | CannotRemoveSelfError;
+  | CannotRemoveSelfError
+  | OrganizationNotFoundError;
 
 @Catch(
   NotOrganizationOwnerError,
@@ -26,6 +28,7 @@ type OrgDomainError =
   AlreadyMemberError,
   NotMemberError,
   CannotRemoveSelfError,
+  OrganizationNotFoundError,
 )
 export class OrganizationExceptionFilter implements ExceptionFilter {
   catch(exception: OrgDomainError, host: ArgumentsHost): void {
@@ -35,6 +38,8 @@ export class OrganizationExceptionFilter implements ExceptionFilter {
     if (exception instanceof NotOrganizationOwnerError) {
       status = HttpStatus.FORBIDDEN;
     } else if (exception instanceof UserNotFoundError) {
+      status = HttpStatus.NOT_FOUND;
+    } else if (exception instanceof OrganizationNotFoundError) {
       status = HttpStatus.NOT_FOUND;
     } else if (exception instanceof AlreadyMemberError) {
       status = HttpStatus.CONFLICT;

--- a/apps/api/src/contexts/organizations/infrastructure/http/organizations.controller.ts
+++ b/apps/api/src/contexts/organizations/infrastructure/http/organizations.controller.ts
@@ -28,9 +28,13 @@ import {
   JwtAuthGuard,
   AuthenticatedUser,
 } from '../../../identity/infrastructure/http/jwt-auth.guard';
+import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
+import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
 import { CreateOrganization } from '../../application/create-organization';
 import { ListMyOrganizations } from '../../application/list-my-organizations';
 import { ListOrganizations } from '../../application/list-organizations';
+import { ListOrganizationsAdmin } from '../../application/list-organizations-admin';
+import { GetOrganizationAdminDetail } from '../../application/get-organization-admin-detail';
 import { AddOrganizationMember } from '../../application/add-organization-member';
 import { RemoveOrganizationMember } from '../../application/remove-organization-member';
 import { ListOrganizationMembers } from '../../application/list-organization-members';
@@ -40,6 +44,8 @@ import {
   OrganizationViewDto,
   AddMemberDto,
   OrganizationMemberDto,
+  OrganizationAdminListItemDto,
+  OrganizationAdminDetailDto,
 } from './dto';
 import { OrganizationExceptionFilter } from './organization-exception.filter';
 
@@ -53,6 +59,8 @@ export class OrganizationsController {
     private readonly createOrganization: CreateOrganization,
     private readonly listMyOrganizations: ListMyOrganizations,
     private readonly listOrganizations: ListOrganizations,
+    private readonly listOrganizationsAdmin: ListOrganizationsAdmin,
+    private readonly getOrganizationAdminDetail: GetOrganizationAdminDetail,
     private readonly addOrganizationMember: AddOrganizationMember,
     private readonly removeOrganizationMember: RemoveOrganizationMember,
     private readonly listOrganizationMembers: ListOrganizationMembers,
@@ -104,6 +112,45 @@ export class OrganizationsController {
   })
   async list(): Promise<OrganizationViewDto[]> {
     return this.listOrganizations.execute();
+  }
+
+  @Get('admin')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('org:read')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Admin global list of ALL organizations, enriched with member count ' +
+      'and accreditation status (org:read)',
+  })
+  @ApiOkResponse({
+    description: 'All organizations (admin view)',
+    type: [OrganizationAdminListItemDto],
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing org:read permission' })
+  async listAdmin(): Promise<OrganizationAdminListItemDto[]> {
+    return this.listOrganizationsAdmin.execute();
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('org:read')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Admin detail of one organization: members, service accounts/API ' +
+      'keys, accreditations and emergencies (org:read)',
+  })
+  @ApiOkResponse({
+    description: 'Organization detail (admin view)',
+    type: OrganizationAdminDetailDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing org:read permission' })
+  @ApiNotFoundResponse({ description: 'Organization not found' })
+  async detail(@Param('id') id: string): Promise<OrganizationAdminDetailDto> {
+    return this.getOrganizationAdminDetail.execute({ organizationId: id });
   }
 
   @Get(':id/members')

--- a/apps/api/src/contexts/organizations/infrastructure/organizations.module.ts
+++ b/apps/api/src/contexts/organizations/infrastructure/organizations.module.ts
@@ -2,6 +2,19 @@ import { Module } from '@nestjs/common';
 import { DB, DatabaseModule } from '../../../shared/database.module';
 import { Db } from '../../../shared/db';
 import { IdentityModule } from '../../identity/infrastructure/identity.module';
+import { AccreditationModule } from '../../accreditation/infrastructure/accreditation.module';
+import {
+  ACCREDITATION_REPOSITORY,
+  AccreditationRepository,
+} from '../../accreditation/domain/ports/accreditation.repository';
+import {
+  SERVICE_ACCOUNT_REPOSITORY,
+  ServiceAccountRepository,
+} from '../../identity/domain/ports/service-account.repository';
+import {
+  API_KEY_REPOSITORY,
+  ApiKeyRepository,
+} from '../../identity/domain/ports/api-key.repository';
 import {
   ORGANIZATION_REPOSITORY,
   OrganizationRepository,
@@ -11,12 +24,24 @@ import {
   OrganizationMemberRepository,
 } from '../domain/ports/organization-member.repository';
 import { USER_DIRECTORY, UserDirectory } from '../domain/ports/user-directory';
+import {
+  ACCREDITATION_READER,
+  AccreditationReader,
+} from '../domain/ports/accreditation-reader';
+import {
+  SERVICE_ACCOUNT_READER,
+  ServiceAccountReader,
+} from '../domain/ports/service-account-reader';
 import { DrizzleOrganizationRepository } from './drizzle/drizzle-organization.repository';
 import { DrizzleOrganizationMemberRepository } from './drizzle/drizzle-organization-member.repository';
 import { DrizzleUserDirectory } from './drizzle/drizzle-user-directory';
+import { AccreditationReaderAdapter } from './accreditation-reader.adapter';
+import { ServiceAccountReaderAdapter } from './service-account-reader.adapter';
 import { CreateOrganization } from '../application/create-organization';
 import { ListMyOrganizations } from '../application/list-my-organizations';
 import { ListOrganizations } from '../application/list-organizations';
+import { ListOrganizationsAdmin } from '../application/list-organizations-admin';
+import { GetOrganizationAdminDetail } from '../application/get-organization-admin-detail';
 import { AddOrganizationMember } from '../application/add-organization-member';
 import { RemoveOrganizationMember } from '../application/remove-organization-member';
 import { ListOrganizationMembers } from '../application/list-organization-members';
@@ -42,6 +67,23 @@ const userDirectoryProvider = {
   useFactory: (db: Db): UserDirectory => new DrizzleUserDirectory(db),
 };
 
+const accreditationReaderProvider = {
+  provide: ACCREDITATION_READER,
+  inject: [ACCREDITATION_REPOSITORY],
+  useFactory: (repo: AccreditationRepository): AccreditationReader =>
+    new AccreditationReaderAdapter(repo),
+};
+
+const serviceAccountReaderProvider = {
+  provide: SERVICE_ACCOUNT_READER,
+  inject: [SERVICE_ACCOUNT_REPOSITORY, API_KEY_REPOSITORY],
+  useFactory: (
+    serviceAccounts: ServiceAccountRepository,
+    apiKeys: ApiKeyRepository,
+  ): ServiceAccountReader =>
+    new ServiceAccountReaderAdapter(serviceAccounts, apiKeys),
+};
+
 const createOrganizationProvider = {
   provide: CreateOrganization,
   inject: [ORGANIZATION_REPOSITORY, ORGANIZATION_MEMBER_REPOSITORY],
@@ -63,6 +105,45 @@ const listOrganizationsProvider = {
   inject: [ORGANIZATION_REPOSITORY],
   useFactory: (orgRepo: OrganizationRepository) =>
     new ListOrganizations(orgRepo),
+};
+
+const listOrganizationsAdminProvider = {
+  provide: ListOrganizationsAdmin,
+  inject: [
+    ORGANIZATION_REPOSITORY,
+    ORGANIZATION_MEMBER_REPOSITORY,
+    ACCREDITATION_READER,
+  ],
+  useFactory: (
+    orgRepo: OrganizationRepository,
+    memberRepo: OrganizationMemberRepository,
+    accreditations: AccreditationReader,
+  ) => new ListOrganizationsAdmin(orgRepo, memberRepo, accreditations),
+};
+
+const getOrganizationAdminDetailProvider = {
+  provide: GetOrganizationAdminDetail,
+  inject: [
+    ORGANIZATION_REPOSITORY,
+    ORGANIZATION_MEMBER_REPOSITORY,
+    USER_DIRECTORY,
+    ACCREDITATION_READER,
+    SERVICE_ACCOUNT_READER,
+  ],
+  useFactory: (
+    orgRepo: OrganizationRepository,
+    memberRepo: OrganizationMemberRepository,
+    userDirectory: UserDirectory,
+    accreditations: AccreditationReader,
+    serviceAccounts: ServiceAccountReader,
+  ) =>
+    new GetOrganizationAdminDetail(
+      orgRepo,
+      memberRepo,
+      userDirectory,
+      accreditations,
+      serviceAccounts,
+    ),
 };
 
 const addOrganizationMemberProvider = {
@@ -91,15 +172,19 @@ const listOrganizationMembersProvider = {
 };
 
 @Module({
-  imports: [DatabaseModule, IdentityModule],
+  imports: [DatabaseModule, IdentityModule, AccreditationModule],
   controllers: [OrganizationsController],
   providers: [
     organizationRepositoryProvider,
     organizationMemberRepositoryProvider,
     userDirectoryProvider,
+    accreditationReaderProvider,
+    serviceAccountReaderProvider,
     createOrganizationProvider,
     listMyOrganizationsProvider,
     listOrganizationsProvider,
+    listOrganizationsAdminProvider,
+    getOrganizationAdminDetailProvider,
     addOrganizationMemberProvider,
     removeOrganizationMemberProvider,
     listOrganizationMembersProvider,

--- a/apps/api/src/contexts/organizations/infrastructure/service-account-reader.adapter.ts
+++ b/apps/api/src/contexts/organizations/infrastructure/service-account-reader.adapter.ts
@@ -1,0 +1,40 @@
+import { ServiceAccountRepository } from '../../identity/domain/ports/service-account.repository';
+import { ApiKeyRepository } from '../../identity/domain/ports/api-key.repository';
+import {
+  ServiceAccountReader,
+  OrganizationServiceAccount,
+} from '../domain/ports/service-account-reader';
+
+/**
+ * Adapts the identity context's service-account / API-key repositories to the
+ * organizations context's {@link ServiceAccountReader} output port. Computes the
+ * per-account key tallies (total + active) so the application orchestrates a
+ * single port (DIP / anti-corruption).
+ */
+export class ServiceAccountReaderAdapter implements ServiceAccountReader {
+  constructor(
+    private readonly serviceAccounts: ServiceAccountRepository,
+    private readonly apiKeys: ApiKeyRepository,
+  ) {}
+
+  async listForOrganization(
+    organizationId: string,
+  ): Promise<OrganizationServiceAccount[]> {
+    const accounts =
+      await this.serviceAccounts.listByOrganization(organizationId);
+    const now = new Date();
+
+    return Promise.all(
+      accounts.map(async (sa): Promise<OrganizationServiceAccount> => {
+        const keys = await this.apiKeys.listByServiceAccount(sa.id);
+        return {
+          id: sa.id,
+          name: sa.name,
+          createdAt: sa.createdAt.toISOString(),
+          keyCount: keys.length,
+          activeKeyCount: keys.filter((k) => k.isActive(now)).length,
+        };
+      }),
+    );
+  }
+}

--- a/apps/api/test/organization-flow.e2e-spec.ts
+++ b/apps/api/test/organization-flow.e2e-spec.ts
@@ -4,6 +4,7 @@ import type { Server } from 'node:http';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
 import { DomainExceptionFilter } from '../src/contexts/resources/infrastructure/http/domain-exception.filter';
+import { OrganizationExceptionFilter } from '../src/contexts/organizations/infrastructure/http/organization-exception.filter';
 import { createDb } from '../src/shared/db';
 import {
   usersTable,
@@ -13,6 +14,8 @@ import {
   organizationMembersTable,
   organizationsTable,
 } from '../src/contexts/organizations/infrastructure/drizzle/schema';
+import { accreditationsTable } from '../src/contexts/accreditation/infrastructure/drizzle/schema';
+import * as bcrypt from 'bcryptjs';
 
 const DB_URL =
   process.env.DATABASE_URL ??
@@ -34,12 +37,16 @@ describe('Organization flow (e2e)', () => {
         transform: true,
       }),
     );
-    app.useGlobalFilters(new DomainExceptionFilter());
+    app.useGlobalFilters(
+      new DomainExceptionFilter(),
+      new OrganizationExceptionFilter(),
+    );
     await app.init();
 
     // clean slate for this test file
     const { db, pool } = createDb(DB_URL);
     try {
+      await db.delete(accreditationsTable);
       await db.delete(organizationMembersTable);
       await db.delete(organizationsTable);
       await db.delete(membershipsTable);
@@ -371,6 +378,127 @@ describe('Organization flow (e2e)', () => {
         .delete(`/organizations/${orgId}/members/${ownerId}`)
         .set('Authorization', `Bearer ${memberToken}`)
         .expect(403);
+    });
+  });
+
+  describe('Admin global organizations: list + detail (org:read)', () => {
+    const ADMIN_ID = 'a0000000-0000-4000-8000-0000000000a1';
+    let adminToken: string;
+    let citizenToken: string;
+    let orgId: string;
+
+    beforeAll(async () => {
+      // Seed a platform admin (isAdmin → platform_admin grant → holds org:read)
+      const { db, pool } = createDb(DB_URL);
+      try {
+        await db.insert(usersTable).values({
+          id: ADMIN_ID,
+          email: 'orgadmin@reliefhub.org',
+          passwordHash: await bcrypt.hash('admin1234', 10),
+          name: 'Org Admin',
+          isAdmin: true,
+        });
+      } finally {
+        await pool.end();
+      }
+
+      const adminLogin = await request(server)
+        .post('/auth/login')
+        .send({ email: 'orgadmin@reliefhub.org', password: 'admin1234' })
+        .expect(200);
+      adminToken = (adminLogin.body as { accessToken: string }).accessToken;
+
+      // A plain citizen (no org:read at platform)
+      const citizenReg = await request(server)
+        .post('/auth/register')
+        .send({
+          email: 'plaincitizen@reliefhub.org',
+          password: 'password123',
+          name: 'Plain Citizen',
+        })
+        .expect(201);
+      citizenToken = (citizenReg.body as { accessToken: string }).accessToken;
+
+      // Admin creates an org → becomes its owner
+      const orgRes = await request(server)
+        .post('/organizations')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Global List Org',
+          type: 'ngo',
+          taxId: 'ES-GLOBAL-1',
+          contactEmail: 'global@org.example',
+        })
+        .expect(201);
+      orgId = (orgRes.body as { id: string }).id;
+    });
+
+    it('GET /organizations/admin requires auth (401)', async () => {
+      await request(server).get('/organizations/admin').expect(401);
+    });
+
+    it('GET /organizations/admin returns 403 for a non-privileged user', async () => {
+      await request(server)
+        .get('/organizations/admin')
+        .set('Authorization', `Bearer ${citizenToken}`)
+        .expect(403);
+    });
+
+    it('GET /organizations/admin returns the enriched global list for an admin', async () => {
+      const res = await request(server)
+        .get('/organizations/admin')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      const items = res.body as Array<{
+        id: string;
+        name: string;
+        taxId: string | null;
+        memberCount: number;
+        accreditationStatus: string;
+      }>;
+      const org = items.find((o) => o.id === orgId);
+      expect(org).toBeDefined();
+      expect(org?.taxId).toBe('ES-GLOBAL-1');
+      expect(org?.memberCount).toBe(1);
+      expect(org?.accreditationStatus).toBe('none');
+    });
+
+    it('GET /organizations/:id returns full detail for an admin', async () => {
+      const res = await request(server)
+        .get(`/organizations/${orgId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      const detail = res.body as {
+        id: string;
+        contactEmail: string | null;
+        members: unknown[];
+        serviceAccounts: unknown[];
+        accreditations: unknown[];
+        emergencyIds: unknown[];
+      };
+      expect(detail.id).toBe(orgId);
+      expect(detail.contactEmail).toBe('global@org.example');
+      expect(Array.isArray(detail.members)).toBe(true);
+      expect(detail.members).toHaveLength(1);
+      expect(Array.isArray(detail.serviceAccounts)).toBe(true);
+      expect(Array.isArray(detail.accreditations)).toBe(true);
+      expect(Array.isArray(detail.emergencyIds)).toBe(true);
+    });
+
+    it('GET /organizations/:id returns 403 for a non-privileged user', async () => {
+      await request(server)
+        .get(`/organizations/${orgId}`)
+        .set('Authorization', `Bearer ${citizenToken}`)
+        .expect(403);
+    });
+
+    it('GET /organizations/:id returns 404 for an unknown organization', async () => {
+      await request(server)
+        .get('/organizations/00000000-0000-4000-8000-0000000000ff')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(404);
     });
   });
 });

--- a/apps/web/src/app/admin/acreditaciones/page.tsx
+++ b/apps/web/src/app/admin/acreditaciones/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
@@ -58,7 +59,13 @@ export default async function AcreditacionesPage() {
         <div className="flex flex-col gap-8 px-4 pb-12 pt-6">
 
         <p className="text-xs text-warning bg-warning-soft border border-warning rounded px-3 py-2">
-          {ta.acc_manual_note}
+          {ta.acc_manual_note}{' '}
+          <Link
+            href="/admin/organizaciones"
+            className="font-semibold underline underline-offset-2 hover:text-ink"
+          >
+            {ta.orgs_link}
+          </Link>
         </p>
 
         {/* ── LISTADO DE ACREDITACIONES ────────────────────────────────── */}

--- a/apps/web/src/app/admin/organizaciones/[id]/page.tsx
+++ b/apps/web/src/app/admin/organizaciones/[id]/page.tsx
@@ -1,0 +1,284 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { getToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { PageHeaderBand } from '@/components/molecules/page-header-band';
+import { EmptyState } from '@/components/molecules/empty-state';
+import { Badge } from '@/components/atoms/badge';
+import { LocalDate } from '@/components/atoms/local-date';
+import { shortId } from '@/lib/permissions';
+import { getT } from '@/i18n/server';
+import { fetchOrganizationDetail } from '../actions';
+import {
+  orgTypeLabel,
+  accreditationLabel,
+  accreditationBadgeVariant,
+  verificationLabel,
+} from '../org-presentation';
+
+export const dynamic = 'force-dynamic';
+
+type Props = { params: Promise<{ id: string }> };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await getT();
+  return { title: t.admin.orgs_detail_meta_title };
+}
+
+export default async function OrganizacionDetailPage({ params }: Props) {
+  const { id } = await params;
+
+  // ── Auth guard ──────────────────────────────────────────────────────────
+  const token = await getToken();
+  if (!token) redirect(`/login?next=/admin/organizaciones/${id}`);
+
+  const { data: me, response: meResponse } = await api.GET('/auth/me', {
+    headers: authHeaders(token),
+  });
+  if (meResponse.status === 401 || !me) {
+    redirect(`/login?next=/admin/organizaciones/${id}`);
+  }
+  if (!me.isAdmin) redirect('/');
+
+  const org = await fetchOrganizationDetail(id);
+
+  const { t } = await getT();
+  const ta = t.admin;
+
+  if (!org) {
+    return (
+      <main className="flex-1 bg-surface">
+        <div className="mx-auto w-full max-w-xl">
+          <PageHeaderBand
+            backHref="/admin/organizaciones"
+            backLabel={ta.orgs_detail_back}
+            title={ta.orgs_title}
+          />
+          <div className="px-4 pb-12 pt-6">
+            <EmptyState title={ta.orgs_detail_not_found} />
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex-1 bg-surface">
+      <div className="mx-auto w-full max-w-xl">
+        <PageHeaderBand
+          backHref="/admin/organizaciones"
+          backLabel={ta.orgs_detail_back}
+          title={org.name}
+        />
+        <div className="flex flex-col gap-8 px-4 pb-12 pt-6">
+          {/* ── Resumen ─────────────────────────────────────────────────── */}
+          <section className="flex flex-col gap-3 rounded-lg border-2 border-navy bg-white p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={accreditationBadgeVariant(org.accreditationStatus)}>
+                {accreditationLabel(org.accreditationStatus, ta)}
+              </Badge>
+              <Badge
+                variant={
+                  org.verificationLevel === 'official'
+                    ? 'verification-official'
+                    : org.verificationLevel === 'verified'
+                      ? 'verification-verified'
+                      : 'unverified'
+                }
+              >
+                {verificationLabel(org.verificationLevel, ta)}
+              </Badge>
+            </div>
+            <dl className="flex flex-col gap-1 text-sm text-gray-700">
+              <div className="flex flex-wrap gap-x-1.5">
+                <dt className="font-semibold text-gray-500">
+                  {ta.orgs_type_label}
+                </dt>
+                <dd>{orgTypeLabel(org.type, ta)}</dd>
+              </div>
+              <div className="flex flex-wrap gap-x-1.5">
+                <dt className="font-semibold text-gray-500">
+                  {ta.orgs_taxid_label}
+                </dt>
+                <dd className="break-all">{org.taxId ?? ta.orgs_none}</dd>
+              </div>
+              <div className="flex flex-wrap gap-x-1.5">
+                <dt className="font-semibold text-gray-500">
+                  {ta.orgs_contact_label}
+                </dt>
+                <dd className="break-all">{org.contactEmail ?? ta.orgs_none}</dd>
+              </div>
+              <div className="flex flex-wrap gap-x-1.5">
+                <dt className="font-semibold text-gray-500">
+                  {ta.orgs_detail_created_label}
+                </dt>
+                <dd>
+                  <LocalDate iso={org.createdAt} />
+                </dd>
+              </div>
+              <div className="flex flex-wrap gap-x-1.5">
+                <dt className="font-semibold text-gray-400">ID</dt>
+                <dd className="break-all text-xs text-gray-400">{org.id}</dd>
+              </div>
+            </dl>
+          </section>
+
+          {/* ── Miembros ────────────────────────────────────────────────── */}
+          <section aria-labelledby="members-heading" className="flex flex-col gap-3">
+            <h2 id="members-heading" className="text-lg font-bold text-ink">
+              {ta.orgs_detail_members_heading.replace(
+                '{count}',
+                String(org.members.length),
+              )}
+            </h2>
+            {org.members.length === 0 ? (
+              <EmptyState title={ta.orgs_detail_members_empty} />
+            ) : (
+              <ul className="flex flex-col gap-2" role="list">
+                {org.members.map((m) => (
+                  <li
+                    key={m.userId}
+                    className="flex items-center justify-between gap-3 rounded-lg border border-line bg-white p-3"
+                  >
+                    <div className="flex min-w-0 flex-col gap-0.5">
+                      <span className="text-sm font-semibold text-gray-900">
+                        {m.name || shortId(m.userId)}
+                      </span>
+                      {m.email && (
+                        <span className="break-all text-xs text-gray-500">
+                          {m.email}
+                        </span>
+                      )}
+                    </div>
+                    <Badge
+                      variant={m.role === 'owner' ? 'role-owner' : 'role-member'}
+                    >
+                      {m.role === 'owner'
+                        ? ta.orgs_detail_role_owner
+                        : ta.orgs_detail_role_member}
+                    </Badge>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* ── Cuentas de servicio / API keys ──────────────────────────── */}
+          <section aria-labelledby="accounts-heading" className="flex flex-col gap-3">
+            <h2 id="accounts-heading" className="text-lg font-bold text-ink">
+              {ta.orgs_detail_accounts_heading.replace(
+                '{count}',
+                String(org.serviceAccounts.length),
+              )}
+            </h2>
+            {org.serviceAccounts.length === 0 ? (
+              <EmptyState title={ta.orgs_detail_accounts_empty} />
+            ) : (
+              <ul className="flex flex-col gap-2" role="list">
+                {org.serviceAccounts.map((sa) => (
+                  <li
+                    key={sa.id}
+                    className="flex items-center justify-between gap-3 rounded-lg border border-line bg-white p-3"
+                  >
+                    <div className="flex min-w-0 flex-col gap-0.5">
+                      <span className="text-sm font-semibold text-gray-900">
+                        {sa.name}
+                      </span>
+                      <span className="text-xs text-gray-500">
+                        {ta.orgs_detail_keys_summary
+                          .replace('{total}', String(sa.keyCount))
+                          .replace('{active}', String(sa.activeKeyCount))}
+                      </span>
+                    </div>
+                    <span className="flex-shrink-0 text-xs text-gray-400">
+                      <LocalDate iso={sa.createdAt} />
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* ── Acreditaciones ──────────────────────────────────────────── */}
+          <section
+            aria-labelledby="accreditations-heading"
+            className="flex flex-col gap-3"
+          >
+            <h2
+              id="accreditations-heading"
+              className="text-lg font-bold text-ink"
+            >
+              {ta.orgs_detail_accreditations_heading.replace(
+                '{count}',
+                String(org.accreditations.length),
+              )}
+            </h2>
+            {org.accreditations.length === 0 ? (
+              <EmptyState title={ta.orgs_detail_accreditations_empty} />
+            ) : (
+              <ul className="flex flex-col gap-2" role="list">
+                {org.accreditations.map((acc) => (
+                  <li
+                    key={acc.id}
+                    className="flex flex-col gap-0.5 rounded-lg border border-line bg-white p-3"
+                  >
+                    <span className="text-sm font-semibold text-gray-900">
+                      {acc.scope === 'global'
+                        ? ta.acc_scope_global
+                        : ta.acc_scope_emergency.replace(
+                            '{id}',
+                            acc.scope.emergencyId,
+                          )}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {ta.acc_granted_label}{' '}
+                      <LocalDate iso={acc.grantedAt} />
+                    </span>
+                    {acc.evidence && (
+                      <span className="break-all text-xs text-gray-500">
+                        {ta.acc_evidence_label} {acc.evidence}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* ── Emergencias en las que participa ────────────────────────── */}
+          <section
+            aria-labelledby="emergencies-heading"
+            className="flex flex-col gap-3"
+          >
+            <h2
+              id="emergencies-heading"
+              className="text-lg font-bold text-ink"
+            >
+              {ta.orgs_detail_emergencies_heading.replace(
+                '{count}',
+                String(org.emergencyIds.length),
+              )}
+            </h2>
+            {org.emergencyIds.length === 0 ? (
+              <EmptyState title={ta.orgs_detail_emergencies_empty} />
+            ) : (
+              <ul className="flex flex-col gap-2" role="list">
+                {org.emergencyIds.map((emergencyId) => (
+                  <li key={emergencyId}>
+                    <Link
+                      href={`/admin/acreditaciones`}
+                      className="block break-all rounded-lg border border-line bg-white p-3 font-mono text-xs text-gray-700 transition-colors hover:bg-gray-50"
+                    >
+                      {emergencyId}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/admin/organizaciones/actions.ts
+++ b/apps/web/src/app/admin/organizaciones/actions.ts
@@ -1,0 +1,108 @@
+'use server';
+
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { api } from '@/lib/api';
+
+export type AccreditationStatus = 'global' | 'emergency' | 'none';
+
+export interface OrganizationListItem {
+  id: string;
+  name: string;
+  type: string;
+  taxId: string | null;
+  contactEmail: string | null;
+  verificationLevel: string;
+  memberCount: number;
+  accreditationStatus: AccreditationStatus;
+}
+
+export interface OrganizationMember {
+  userId: string;
+  email: string;
+  name: string;
+  role: 'owner' | 'member';
+}
+
+export interface OrganizationServiceAccount {
+  id: string;
+  name: string;
+  createdAt: string;
+  keyCount: number;
+  activeKeyCount: number;
+}
+
+export interface OrganizationAccreditation {
+  id: string;
+  scope: 'global' | { emergencyId: string };
+  grantedByUserId: string;
+  grantedAt: string;
+  evidence: string | null;
+}
+
+export interface OrganizationDetail {
+  id: string;
+  name: string;
+  type: string;
+  taxId: string | null;
+  contactEmail: string | null;
+  verificationLevel: string;
+  createdAt: string;
+  accreditationStatus: AccreditationStatus;
+  members: OrganizationMember[];
+  serviceAccounts: OrganizationServiceAccount[];
+  accreditations: OrganizationAccreditation[];
+  emergencyIds: string[];
+}
+
+/**
+ * Fetch the admin global list of organizations (GET /organizations/admin).
+ * On 401 the session is cleared and the user is redirected to login.
+ */
+export async function fetchOrganizations(): Promise<OrganizationListItem[]> {
+  const token = await getToken();
+  if (!token) redirect('/login?next=/admin/organizaciones');
+
+  const { data, error, response } = await api.GET('/organizations/admin', {
+    headers: authHeaders(token),
+  });
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect('/login?next=/admin/organizaciones');
+    }
+    return [];
+  }
+
+  return (data ?? []) as OrganizationListItem[];
+}
+
+/**
+ * Fetch one organization's admin detail (GET /organizations/:id).
+ * Returns null on 404 so the page can render a not-found state.
+ */
+export async function fetchOrganizationDetail(
+  id: string,
+): Promise<OrganizationDetail | null> {
+  const token = await getToken();
+  if (!token) redirect(`/login?next=/admin/organizaciones/${id}`);
+
+  const { data, error, response } = await api.GET('/organizations/{id}', {
+    params: { path: { id } },
+    headers: authHeaders(token),
+  });
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(`/login?next=/admin/organizaciones/${id}`);
+    }
+    if (response.status === 404) return null;
+    return null;
+  }
+
+  // Double-cast via unknown: the runtime shape matches OrganizationDetail, but
+  // the generated schema widens the accreditation `scope` union to an object.
+  return (data ?? null) as unknown as OrganizationDetail | null;
+}

--- a/apps/web/src/app/admin/organizaciones/org-presentation.ts
+++ b/apps/web/src/app/admin/organizaciones/org-presentation.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure presentation helpers for the admin organizations pages: maps backend
+ * enum values to localized labels and to the shared Badge variants. Safe to
+ * import from Server or Client Components.
+ */
+import type { Messages } from '@/i18n/messages/es';
+import type { AccreditationStatus } from './actions';
+
+type AdminMessages = Messages['admin'];
+
+const TYPE_KEYS: Record<string, keyof AdminMessages> = {
+  ngo: 'orgs_type_ngo',
+  company: 'orgs_type_company',
+  public_admin: 'orgs_type_public_admin',
+  association: 'orgs_type_association',
+  transport_operator: 'orgs_type_transport_operator',
+  other: 'orgs_type_other',
+};
+
+export function orgTypeLabel(type: string, ta: AdminMessages): string {
+  const key = TYPE_KEYS[type];
+  return key ? ta[key] : type;
+}
+
+const ACCR_KEYS: Record<AccreditationStatus, keyof AdminMessages> = {
+  global: 'orgs_accr_global',
+  emergency: 'orgs_accr_emergency',
+  none: 'orgs_accr_none',
+};
+
+export function accreditationLabel(
+  status: AccreditationStatus,
+  ta: AdminMessages,
+): string {
+  return ta[ACCR_KEYS[status]];
+}
+
+/** Maps accreditation status to a shared Badge variant. */
+export function accreditationBadgeVariant(
+  status: AccreditationStatus,
+): 'verification-official' | 'verification-verified' | 'unverified' {
+  if (status === 'global') return 'verification-official';
+  if (status === 'emergency') return 'verification-verified';
+  return 'unverified';
+}
+
+const VERIF_KEYS: Record<string, keyof AdminMessages> = {
+  official: 'orgs_verif_official',
+  verified: 'orgs_verif_verified',
+  unverified: 'orgs_verif_unverified',
+};
+
+export function verificationLabel(level: string, ta: AdminMessages): string {
+  const key = VERIF_KEYS[level];
+  return key ? ta[key] : level;
+}

--- a/apps/web/src/app/admin/organizaciones/organizations-list.tsx
+++ b/apps/web/src/app/admin/organizaciones/organizations-list.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import type { Messages } from '@/i18n/messages/es';
+import { Badge } from '@/components/atoms/badge';
+import { EmptyState } from '@/components/molecules/empty-state';
+import type { OrganizationListItem } from './actions';
+import {
+  orgTypeLabel,
+  accreditationLabel,
+  accreditationBadgeVariant,
+} from './org-presentation';
+
+type AdminMessages = Messages['admin'];
+
+interface OrganizationsListProps {
+  organizations: OrganizationListItem[];
+  ta: AdminMessages;
+}
+
+export function OrganizationsList({
+  organizations,
+  ta,
+}: OrganizationsListProps) {
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return organizations;
+    return organizations.filter((o) => {
+      const haystack = [o.name, o.taxId ?? '', o.contactEmail ?? '']
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [organizations, query]);
+
+  if (organizations.length === 0) {
+    return (
+      <EmptyState
+        title={ta.orgs_empty_title}
+        description={ta.orgs_empty_description}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor="org-search"
+          className="text-sm font-semibold text-gray-700"
+        >
+          {ta.orgs_search_label}
+        </label>
+        <input
+          id="org-search"
+          type="search"
+          inputMode="search"
+          autoComplete="off"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={ta.orgs_search_ph}
+          className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-base text-gray-900 placeholder:text-gray-400 focus:border-gray-900 focus:outline-none focus:ring-1 focus:ring-gray-900"
+        />
+      </div>
+
+      <h2 className="text-base font-bold text-gray-900">
+        {ta.orgs_list_heading.replace('{count}', String(filtered.length))}
+      </h2>
+
+      {filtered.length === 0 ? (
+        <EmptyState
+          title={ta.orgs_no_results_title}
+          description={ta.orgs_no_results_description}
+        />
+      ) : (
+        <ul className="flex flex-col gap-3" role="list">
+          {filtered.map((org) => (
+            <li key={org.id}>
+              <Link
+                href={`/admin/organizaciones/${org.id}`}
+                aria-label={org.name}
+                className="flex flex-col gap-2 rounded-lg border-2 border-gray-900 bg-white p-4 transition-colors hover:bg-gray-50"
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <span className="text-base font-bold text-gray-900">
+                    {org.name} →
+                  </span>
+                  <Badge variant={accreditationBadgeVariant(org.accreditationStatus)}>
+                    {accreditationLabel(org.accreditationStatus, ta)}
+                  </Badge>
+                </div>
+                <dl className="flex flex-col gap-0.5 text-sm text-gray-600">
+                  <div className="flex flex-wrap gap-x-1.5">
+                    <dt className="font-semibold text-gray-500">
+                      {ta.orgs_type_label}
+                    </dt>
+                    <dd>{orgTypeLabel(org.type, ta)}</dd>
+                  </div>
+                  {org.taxId && (
+                    <div className="flex flex-wrap gap-x-1.5">
+                      <dt className="font-semibold text-gray-500">
+                        {ta.orgs_taxid_label}
+                      </dt>
+                      <dd className="break-all">{org.taxId}</dd>
+                    </div>
+                  )}
+                  {org.contactEmail && (
+                    <div className="flex flex-wrap gap-x-1.5">
+                      <dt className="font-semibold text-gray-500">
+                        {ta.orgs_contact_label}
+                      </dt>
+                      <dd className="break-all">{org.contactEmail}</dd>
+                    </div>
+                  )}
+                  <div className="flex flex-wrap gap-x-1.5">
+                    <dt className="font-semibold text-gray-500">
+                      {ta.orgs_members_label}
+                    </dt>
+                    <dd>{org.memberCount}</dd>
+                  </div>
+                </dl>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/organizaciones/page.tsx
+++ b/apps/web/src/app/admin/organizaciones/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { PageHeaderBand } from '@/components/molecules/page-header-band';
+import { getT } from '@/i18n/server';
+import { fetchOrganizations } from './actions';
+import { OrganizationsList } from './organizations-list';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await getT();
+  return {
+    title: t.admin.orgs_meta_title,
+    description: t.admin.orgs_meta_description,
+  };
+}
+
+export default async function OrganizacionesPage() {
+  // ── Auth guard ──────────────────────────────────────────────────────────
+  const token = await getToken();
+  if (!token) {
+    redirect('/login?next=/admin/organizaciones');
+  }
+
+  // ── Admin check via GET /auth/me ────────────────────────────────────────
+  const { data: me, response: meResponse } = await api.GET('/auth/me', {
+    headers: authHeaders(token),
+  });
+
+  if (meResponse.status === 401 || !me) {
+    redirect('/login?next=/admin/organizaciones');
+  }
+
+  if (!me.isAdmin) {
+    redirect('/');
+  }
+
+  const organizations = await fetchOrganizations();
+
+  const { t } = await getT();
+  const ta = t.admin;
+
+  return (
+    <main className="flex-1 bg-surface">
+      <div className="mx-auto w-full max-w-xl">
+        <PageHeaderBand
+          backHref="/"
+          backLabel={ta.back}
+          title={ta.orgs_title}
+          subtitle={ta.orgs_subtitle}
+        />
+        <div className="flex flex-col gap-8 px-4 pb-12 pt-6">
+          <OrganizationsList organizations={organizations} ta={ta} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/administracion/page.tsx
+++ b/apps/web/src/app/administracion/page.tsx
@@ -163,12 +163,20 @@ function ScopeCard({
       </div>
       <span className="text-sm text-gray-600">{subtitle}</span>
       {scope.scopeType === 'platform' && (
-        <Link
-          href="/admin/api-keys"
-          className="text-xs font-medium text-gray-500 underline underline-offset-2 hover:text-gray-900"
-        >
-          Cuentas de servicio y API keys →
-        </Link>
+        <div className="flex flex-col gap-1">
+          <Link
+            href="/admin/organizaciones"
+            className="text-xs font-medium text-gray-500 underline underline-offset-2 hover:text-gray-900"
+          >
+            Organizaciones (global) →
+          </Link>
+          <Link
+            href="/admin/api-keys"
+            className="text-xs font-medium text-gray-500 underline underline-offset-2 hover:text-gray-900"
+          >
+            Cuentas de servicio y API keys →
+          </Link>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -1301,7 +1301,7 @@ export const en = {
     acc_meta_description: 'Management of organization accreditations.',
     acc_title: 'Accreditations',
     acc_subtitle: 'Management of organization accreditations. Administrators only.',
-    acc_manual_note: 'Note: the organization ID must be entered manually (no global organization listing is available).',
+    acc_manual_note: 'Note: the organization ID must be entered manually. You can copy it from the global organization list.',
     acc_list_heading: 'Active accreditations ({count})',
     acc_empty_title: 'No active accreditations.',
     acc_empty_description: 'Use the form below to grant the first one.',
@@ -1375,6 +1375,61 @@ export const en = {
     audit_emergency_id_aria: 'Filter by emergency ID',
     audit_card_actor: 'Actor:',
     audit_card_entity: 'Entity:',
+
+    // Organizations (global list + detail)
+    orgs_meta_title: 'Organizations — Admin · ResponseGrid',
+    orgs_meta_description: 'Global list of organizations. Admins only.',
+    orgs_title: 'Organizations',
+    orgs_subtitle: 'Global list of all organizations. Admins only.',
+    orgs_list_heading: 'Organizations ({count})',
+    orgs_search_label: 'Search organization',
+    orgs_search_ph: 'Search by name, tax ID or email…',
+    orgs_empty_title: 'No organizations registered.',
+    orgs_empty_description: 'Organizations will appear here once created.',
+    orgs_no_results_title: 'No results.',
+    orgs_no_results_description: 'No organization matches your search.',
+    orgs_type_label: 'Type:',
+    orgs_taxid_label: 'Tax ID:',
+    orgs_contact_label: 'Contact:',
+    orgs_members_label: 'Members:',
+    orgs_members_count: '{count} members',
+    orgs_none: '—',
+
+    // Organization types
+    orgs_type_ngo: 'NGO',
+    orgs_type_company: 'Company',
+    orgs_type_public_admin: 'Public administration',
+    orgs_type_association: 'Association',
+    orgs_type_transport_operator: 'Transport operator',
+    orgs_type_other: 'Other',
+
+    // Accreditation status
+    orgs_accr_global: 'Accredited (global)',
+    orgs_accr_emergency: 'Accredited (emergency)',
+    orgs_accr_none: 'Not accredited',
+
+    // Verification level
+    orgs_verif_official: 'Official',
+    orgs_verif_verified: 'Verified',
+    orgs_verif_unverified: 'Unverified',
+
+    // Detail view
+    orgs_detail_back: '← Organizations',
+    orgs_detail_meta_title: 'Organization — Admin · ResponseGrid',
+    orgs_detail_not_found: 'Organization not found.',
+    orgs_detail_created_label: 'Created:',
+    orgs_detail_members_heading: 'Members ({count})',
+    orgs_detail_members_empty: 'This organization has no members.',
+    orgs_detail_role_owner: 'Owner',
+    orgs_detail_role_member: 'Member',
+    orgs_detail_accounts_heading: 'Service accounts ({count})',
+    orgs_detail_accounts_empty: 'This organization has no service accounts.',
+    orgs_detail_keys_summary: '{total} keys · {active} active',
+    orgs_detail_accreditations_heading: 'Accreditations ({count})',
+    orgs_detail_accreditations_empty: 'This organization has no accreditations.',
+    orgs_detail_emergencies_heading: 'Participating emergencies ({count})',
+    orgs_detail_emergencies_empty: 'Not participating in any emergency.',
+    orgs_link: 'Organizations (global) →',
   },
 
   templates: {

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -1329,7 +1329,7 @@ export const es = {
     acc_meta_description: 'Gestión de acreditaciones de organizaciones.',
     acc_title: 'Acreditaciones',
     acc_subtitle: 'Gestión de acreditaciones de organizaciones. Solo administradores.',
-    acc_manual_note: 'Nota: el ID de organización debe introducirse manualmente (no hay listado global de organizaciones disponible).',
+    acc_manual_note: 'Nota: el ID de organización debe introducirse manualmente. Puedes copiarlo desde el listado global de organizaciones.',
     acc_list_heading: 'Acreditaciones vigentes ({count})',
     acc_empty_title: 'No hay acreditaciones vigentes.',
     acc_empty_description: 'Usa el formulario de abajo para conceder la primera.',
@@ -1403,6 +1403,61 @@ export const es = {
     audit_emergency_id_aria: 'Filtrar por ID de emergencia',
     audit_card_actor: 'Actor:',
     audit_card_entity: 'Entidad:',
+
+    // Organizaciones (listado global + ficha)
+    orgs_meta_title: 'Organizaciones — Admin · ResponseGrid',
+    orgs_meta_description: 'Listado global de organizaciones. Solo administradores.',
+    orgs_title: 'Organizaciones',
+    orgs_subtitle: 'Listado global de todas las organizaciones. Solo administradores.',
+    orgs_list_heading: 'Organizaciones ({count})',
+    orgs_search_label: 'Buscar organización',
+    orgs_search_ph: 'Buscar por nombre, NIF/CIF o email…',
+    orgs_empty_title: 'No hay organizaciones registradas.',
+    orgs_empty_description: 'Cuando se cree una organización aparecerá aquí.',
+    orgs_no_results_title: 'Sin resultados.',
+    orgs_no_results_description: 'Ninguna organización coincide con la búsqueda.',
+    orgs_type_label: 'Tipo:',
+    orgs_taxid_label: 'NIF/CIF:',
+    orgs_contact_label: 'Contacto:',
+    orgs_members_label: 'Miembros:',
+    orgs_members_count: '{count} miembros',
+    orgs_none: '—',
+
+    // Tipos de organización
+    orgs_type_ngo: 'ONG',
+    orgs_type_company: 'Empresa',
+    orgs_type_public_admin: 'Administración pública',
+    orgs_type_association: 'Asociación',
+    orgs_type_transport_operator: 'Operador de transporte',
+    orgs_type_other: 'Otra',
+
+    // Estado de acreditación
+    orgs_accr_global: 'Acreditada (global)',
+    orgs_accr_emergency: 'Acreditada (emergencia)',
+    orgs_accr_none: 'Sin acreditar',
+
+    // Nivel de verificación
+    orgs_verif_official: 'Oficial',
+    orgs_verif_verified: 'Verificada',
+    orgs_verif_unverified: 'Sin verificar',
+
+    // Ficha de detalle
+    orgs_detail_back: '← Organizaciones',
+    orgs_detail_meta_title: 'Organización — Admin · ResponseGrid',
+    orgs_detail_not_found: 'Organización no encontrada.',
+    orgs_detail_created_label: 'Alta:',
+    orgs_detail_members_heading: 'Miembros ({count})',
+    orgs_detail_members_empty: 'Esta organización no tiene miembros.',
+    orgs_detail_role_owner: 'Propietario',
+    orgs_detail_role_member: 'Miembro',
+    orgs_detail_accounts_heading: 'Cuentas de servicio ({count})',
+    orgs_detail_accounts_empty: 'Esta organización no tiene cuentas de servicio.',
+    orgs_detail_keys_summary: '{total} claves · {active} activas',
+    orgs_detail_accreditations_heading: 'Acreditaciones ({count})',
+    orgs_detail_accreditations_empty: 'Esta organización no tiene acreditaciones.',
+    orgs_detail_emergencies_heading: 'Emergencias en las que participa ({count})',
+    orgs_detail_emergencies_empty: 'No participa en ninguna emergencia.',
+    orgs_link: 'Organizaciones (global) →',
   },
 
   templates: {

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -983,6 +983,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/organizations/admin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Admin global list of ALL organizations, enriched with member count and accreditation status (org:read) */
+        get: operations["OrganizationsController_listAdmin"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Admin detail of one organization: members, service accounts/API keys, accreditations and emergencies (org:read) */
+        get: operations["OrganizationsController_detail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/organizations/{id}/members": {
         parameters: {
             query?: never;
@@ -3266,6 +3300,26 @@ export interface components {
             type: "ngo" | "company" | "public_admin" | "association" | "transport_operator" | "other";
             verificationLevel: string;
         };
+        OrganizationAdminListItemDto: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** @enum {string} */
+            type: "ngo" | "company" | "public_admin" | "association" | "transport_operator" | "other";
+            /** @example ES-12345678 */
+            taxId: Record<string, never> | null;
+            /** @example contact@org.example */
+            contactEmail: Record<string, never> | null;
+            /** @example unverified */
+            verificationLevel: string;
+            /** @example 3 */
+            memberCount: number;
+            /**
+             * @example none
+             * @enum {string}
+             */
+            accreditationStatus: "global" | "emergency" | "none";
+        };
         OrganizationMemberDto: {
             /** @description User UUID */
             userId: string;
@@ -3278,6 +3332,54 @@ export interface components {
              * @enum {string}
              */
             role: "owner" | "member";
+        };
+        OrganizationServiceAccountDto: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** @description ISO 8601 timestamp */
+            createdAt: string;
+            /** @example 2 */
+            keyCount: number;
+            /** @example 1 */
+            activeKeyCount: number;
+        };
+        OrganizationAccreditationDto: {
+            /** Format: uuid */
+            id: string;
+            /**
+             * @description "global" or an object with the emergency UUID
+             * @example global
+             */
+            scope: Record<string, never>;
+            /** Format: uuid */
+            grantedByUserId: string;
+            /** @description ISO 8601 timestamp */
+            grantedAt: string;
+            evidence: Record<string, never> | null;
+        };
+        OrganizationAdminDetailDto: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** @enum {string} */
+            type: "ngo" | "company" | "public_admin" | "association" | "transport_operator" | "other";
+            taxId: Record<string, never> | null;
+            contactEmail: Record<string, never> | null;
+            /** @example unverified */
+            verificationLevel: string;
+            /** @description ISO 8601 timestamp */
+            createdAt: string;
+            /**
+             * @example none
+             * @enum {string}
+             */
+            accreditationStatus: "global" | "emergency" | "none";
+            members: components["schemas"]["OrganizationMemberDto"][];
+            serviceAccounts: components["schemas"]["OrganizationServiceAccountDto"][];
+            accreditations: components["schemas"]["OrganizationAccreditationDto"][];
+            /** @description UUIDs of emergencies the organization participates in */
+            emergencyIds: string[];
         };
         AddMemberDto: {
             /** @example member@example.com */
@@ -6751,6 +6853,83 @@ export interface operations {
             };
             /** @description Missing or invalid token */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    OrganizationsController_listAdmin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All organizations (admin view) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationAdminListItemDto"][];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing org:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    OrganizationsController_detail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Organization detail (admin view) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationAdminDetailDto"];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing org:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Organization not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Implementa #175. El platform_admin ya puede ver **todas** las organizaciones (listado global + buscador) y abrir la ficha de cualquiera — antes /organizaciones solo mostraba las propias.

**Backend:** GET /organizations/admin (listado enriquecido: tipo, NIF, contacto, nº miembros, estado de acreditacion) + GET /organizations/:id (ficha: miembros con roles, cuentas de servicio/API keys, acreditaciones, emergencias). Gated **org:read** (platform_admin). Reusa acreditacion/cuentas-de-servicio via puertos nuevos (DIP), sin duplicar dominio. El GET /organizations publico se deja intacto (contractual + e2e). gen:api regenerado.

**Web:** /admin/organizaciones (listado + buscador) + /admin/organizaciones/[id] (detalle), entrada en /administracion + nota de /admin/acreditaciones actualizada. Fechas via <LocalDate> (#174). i18n es/en.

Gate verde: api build/eslint/prettier + **1125 tests** + api-client/web build + lint.

Closes #175