### PR TITLE
feat(supplies): empaquetado rastreable (Container palet/caja/lote) reusando SupplyLine (#140)

### DIFF
--- a/apps/api/drizzle/0032_containers.sql
+++ b/apps/api/drizzle/0032_containers.sql
@@ -1,0 +1,33 @@
+-- Empaquetado rastreable (#140): un contenedor (palet/caja/lote) con identidad
+-- propia, su código legible/QR generado (PAL-0001…), composición por referencia
+-- (parent_container_id, self-FK), contenido en líneas SupplyLine (jsonb),
+-- peso/volumen declarados, holder polimórfico (resource|shipment, sin FK) y
+-- estado open→sealed. Vive en supplies (upstream), reutilizable por logística e
+-- inventario. Self-FK ON DELETE SET NULL: borrar un padre desancla a los hijos.
+CREATE TABLE IF NOT EXISTS "containers" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"emergency_id" uuid NOT NULL,
+	"code" text NOT NULL,
+	"type" text NOT NULL,
+	"parent_container_id" uuid REFERENCES "containers"("id") ON DELETE SET NULL,
+	"lines" jsonb NOT NULL,
+	"gross_weight_kg" double precision,
+	"gross_volume_m3" double precision,
+	"holder_type" text,
+	"holder_id" uuid,
+	"status" text NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "containers_emergency_code_uniq" ON "containers" ("emergency_id","code");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "containers_emergency_id_idx" ON "containers" ("emergency_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "containers_parent_container_id_idx" ON "containers" ("parent_container_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "containers_holder_idx" ON "containers" ("holder_type","holder_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "containers_type_idx" ON "containers" ("type");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "containers_status_idx" ON "containers" ("status");

--- a/apps/api/drizzle/0033_container_code_sequences.sql
+++ b/apps/api/drizzle/0033_container_code_sequences.sql
@@ -1,0 +1,13 @@
+-- Allocator monótono de códigos de contenedor por (emergencia, tipo) — refuerza
+-- el "Código Único" de #140. Sustituye el conteo count(*)+1 (no atómico: dos
+-- creaciones concurrentes generaban el mismo código y la 2ª violaba el índice
+-- único; borrar un contenedor reutilizaba un código). El reparto se hace con un
+-- upsert atómico (INSERT … ON CONFLICT (emergency_id, type) DO UPDATE SET
+-- last_value = last_value + 1 RETURNING last_value), monótono y a prueba de
+-- concurrencia y de borrados.
+CREATE TABLE IF NOT EXISTS "container_code_sequences" (
+	"emergency_id" uuid NOT NULL,
+	"type" text NOT NULL,
+	"last_value" integer NOT NULL,
+	CONSTRAINT "container_code_sequences_pkey" PRIMARY KEY ("emergency_id","type")
+);

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -6622,6 +6622,462 @@
           "categories"
         ]
       }
+    },
+    "/supplies/containers": {
+      "post": {
+        "operationId": "ContainerController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContainerDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Container created (open), with a generated code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateContainerResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not a coordinator of the emergency"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Create a trackable container (palet/caja/lote) (coordinator)",
+        "tags": [
+          "supplies"
+        ]
+      }
+    },
+    "/supplies/containers/{id}/lines": {
+      "post": {
+        "operationId": "ContainerController_addLine",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Container UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SupplyLineDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Line added"
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not a coordinator of the emergency"
+          },
+          "404": {
+            "description": "Container not found"
+          },
+          "409": {
+            "description": "Container is sealed (lines immutable)"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Add a supply line to a container (coordinator)",
+        "tags": [
+          "supplies"
+        ]
+      }
+    },
+    "/supplies/containers/{id}/lines/{index}": {
+      "delete": {
+        "operationId": "ContainerController_removeLine",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Container UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "index",
+            "required": true,
+            "in": "path",
+            "description": "Zero-based line index",
+            "schema": {
+              "example": 0,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Line removed"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not a coordinator of the emergency"
+          },
+          "404": {
+            "description": "Container not found"
+          },
+          "409": {
+            "description": "Container is sealed (lines immutable)"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Remove the supply line at an index from a container (coordinator)",
+        "tags": [
+          "supplies"
+        ]
+      }
+    },
+    "/supplies/containers/{id}/nest": {
+      "post": {
+        "operationId": "ContainerController_nest",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Container UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NestContainerDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Container re-parented"
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not a coordinator of the emergency"
+          },
+          "404": {
+            "description": "Container or parent not found"
+          },
+          "409": {
+            "description": "Would create a cycle, or parent is a different emergency"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Nest a container under a parent, or un-nest it (coordinator)",
+        "tags": [
+          "supplies"
+        ]
+      }
+    },
+    "/supplies/containers/{id}/seal": {
+      "post": {
+        "operationId": "ContainerController_seal",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Container UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Container sealed"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not a coordinator of the emergency"
+          },
+          "404": {
+            "description": "Container not found"
+          },
+          "409": {
+            "description": "Container is already sealed"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Seal (precintar) a container (coordinator)",
+        "tags": [
+          "supplies"
+        ]
+      }
+    },
+    "/supplies/containers/{id}/move": {
+      "post": {
+        "operationId": "ContainerController_move",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Container UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveContainerDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Container moved"
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not a coordinator of the emergency"
+          },
+          "404": {
+            "description": "Container not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Move a container to a holder (resource ↔ shipment) (coordinator)",
+        "tags": [
+          "supplies"
+        ]
+      }
+    },
+    "/supplies/containers/{id}": {
+      "get": {
+        "operationId": "ContainerController_get",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Container UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Container tree",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContainerTreeViewDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not a coordinator/verifier of the emergency"
+          },
+          "404": {
+            "description": "Container not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get a container tree with aggregated weight/volume (coordinator/verifier)",
+        "tags": [
+          "supplies"
+        ]
+      }
+    },
+    "/emergencies/{emergencyId}/supplies/containers": {
+      "get": {
+        "operationId": "ContainerController_list",
+        "parameters": [
+          {
+            "name": "emergencyId",
+            "required": true,
+            "in": "path",
+            "description": "Emergency UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pallet",
+                "box",
+                "lote"
+              ]
+            }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "sealed"
+              ]
+            }
+          },
+          {
+            "name": "holderType",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "resource",
+                "shipment"
+              ]
+            }
+          },
+          {
+            "name": "holderId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "topLevelOnly",
+            "required": false,
+            "in": "query",
+            "description": "Only top-level containers (the roots of the trees)",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Containers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContainerViewDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing container:read permission"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List containers for an emergency (coordinator/verifier)",
+        "tags": [
+          "supplies"
+        ]
+      }
     }
   },
   "info": {
@@ -11772,6 +12228,314 @@
           "parentSlug",
           "vertical",
           "sort"
+        ]
+      },
+      "ContainerHolderDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "resource",
+              "shipment"
+            ],
+            "example": "resource"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Resource node or shipment id (polymorphic, no FK)"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ]
+      },
+      "CreateContainerDto": {
+        "type": "object",
+        "properties": {
+          "emergencyId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Emergency this container serves"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "pallet",
+              "box",
+              "lote"
+            ],
+            "example": "pallet"
+          },
+          "lines": {
+            "description": "Optional initial loose supply lines",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupplyLineDto"
+            }
+          },
+          "grossWeightKg": {
+            "type": "number",
+            "example": 120,
+            "description": "Declared gross weight in kg (positive)"
+          },
+          "grossVolumeM3": {
+            "type": "number",
+            "example": 1.2,
+            "description": "Declared gross volume in m³ (positive)"
+          },
+          "holder": {
+            "description": "Optional initial holder (e.g. the hub it is created at)",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContainerHolderDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "emergencyId",
+          "type"
+        ]
+      },
+      "CreateContainerResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "code": {
+            "type": "string",
+            "example": "PAL-0001",
+            "description": "Generated trackable code"
+          }
+        },
+        "required": [
+          "id",
+          "code"
+        ]
+      },
+      "NestContainerDto": {
+        "type": "object",
+        "properties": {
+          "parentContainerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "New parent container, or null to un-nest (make it top-level)"
+          }
+        }
+      },
+      "MoveContainerDto": {
+        "type": "object",
+        "properties": {
+          "holder": {
+            "nullable": true,
+            "description": "New holder (resource ↔ shipment), or null to detach",
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContainerHolderDto"
+              }
+            ]
+          }
+        }
+      },
+      "ContainerTreeViewDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "code": {
+            "type": "string",
+            "example": "PAL-0001"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "pallet",
+              "box",
+              "lote"
+            ],
+            "example": "pallet"
+          },
+          "emergencyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentContainerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "lines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupplyLineResponseDto"
+            }
+          },
+          "grossWeightKg": {
+            "type": "number",
+            "example": 120,
+            "nullable": true
+          },
+          "grossVolumeM3": {
+            "type": "number",
+            "example": 1.2,
+            "nullable": true
+          },
+          "holderType": {
+            "type": "string",
+            "enum": [
+              "resource",
+              "shipment"
+            ],
+            "nullable": true,
+            "example": "resource"
+          },
+          "holderId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "sealed"
+            ],
+            "example": "open"
+          },
+          "createdAt": {
+            "type": "string",
+            "example": "2026-07-01T00:00:00.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "example": "2026-07-01T00:00:00.000Z"
+          },
+          "children": {
+            "description": "Direct children (recursive)",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContainerTreeViewDto"
+            }
+          },
+          "totalWeightKg": {
+            "type": "number",
+            "example": 145,
+            "nullable": true,
+            "description": "Aggregated weight (own + Σ children), null if none declared"
+          },
+          "totalVolumeM3": {
+            "type": "number",
+            "example": 2.5,
+            "nullable": true,
+            "description": "Aggregated volume (own + Σ children), null if none declared"
+          }
+        },
+        "required": [
+          "id",
+          "code",
+          "type",
+          "emergencyId",
+          "lines",
+          "status",
+          "createdAt",
+          "updatedAt",
+          "children"
+        ]
+      },
+      "ContainerViewDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "code": {
+            "type": "string",
+            "example": "PAL-0001"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "pallet",
+              "box",
+              "lote"
+            ],
+            "example": "pallet"
+          },
+          "emergencyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentContainerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "lines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupplyLineResponseDto"
+            }
+          },
+          "grossWeightKg": {
+            "type": "number",
+            "example": 120,
+            "nullable": true
+          },
+          "grossVolumeM3": {
+            "type": "number",
+            "example": 1.2,
+            "nullable": true
+          },
+          "holderType": {
+            "type": "string",
+            "enum": [
+              "resource",
+              "shipment"
+            ],
+            "nullable": true,
+            "example": "resource"
+          },
+          "holderId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "sealed"
+            ],
+            "example": "open"
+          },
+          "createdAt": {
+            "type": "string",
+            "example": "2026-07-01T00:00:00.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "example": "2026-07-01T00:00:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "code",
+          "type",
+          "emergencyId",
+          "lines",
+          "status",
+          "createdAt",
+          "updatedAt"
         ]
       }
     }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -6819,7 +6819,7 @@
           "404": {
             "description": "Container or parent not found"
           },
-          "409": {
+          "422": {
             "description": "Would create a cycle, or parent is a different emergency"
           }
         },

--- a/apps/api/src/contexts/identity/domain/authorization/permission.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/permission.ts
@@ -44,6 +44,10 @@ export const PERMISSION_CATALOG = {
   // grado ciudadano (como 'offer:create'); 'read' lo consume la coordinación.
   capacity: ['publish', 'read'],
   intake: ['create', 'read', 'receive', 'update'],
+  // Empaquetado rastreable (#140): contenedores palet/caja/lote en supplies.
+  // 'manage' = crear/anidar/precintar/mover (coordinador / responsable de punto,
+  // mirror de capacity:* y shipment:*); 'read' lo consume coordinación/verificación.
+  container: ['manage', 'read'],
 } as const;
 
 type Catalog = typeof PERMISSION_CATALOG;

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.spec.ts
@@ -72,6 +72,19 @@ describe('ROLE_CATALOG', () => {
     );
   });
 
+  it('wires the trackable-container permissions (#140)', () => {
+    const coordinator = new Set(permissionsForRole('emergency_coordinator'));
+    expect(coordinator.has('container:manage')).toBe(true);
+    expect(coordinator.has('container:read')).toBe(true);
+    // the hub manager manages logistics packaging too
+    const hubManager = new Set(permissionsForRole('hub_manager'));
+    expect(hubManager.has('container:manage')).toBe(true);
+    // the verifier reads but does not manage
+    const verifier = new Set(permissionsForRole('emergency_verifier'));
+    expect(verifier.has('container:read')).toBe(true);
+    expect(verifier.has('container:manage')).toBe(false);
+  });
+
   it('every role only references permissions that exist in the catalog', () => {
     const valid = new Set<string>(ALL_PERMISSIONS);
     for (const role of Object.values(ROLE_CATALOG)) {

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
@@ -97,6 +97,8 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       'shipment:assign',
       'shipment:update',
       'shipment:read',
+      'container:manage',
+      'container:read',
       'campaign:read',
       'campaign:verify',
       'campaign:block',
@@ -132,6 +134,7 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       'campaign:verify',
       'offer:read',
       'capacity:read',
+      'container:read',
     ],
   },
   group_manager: {
@@ -185,6 +188,8 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       'shipment:read',
       'shipment:track',
       'manifest:sign',
+      'container:manage',
+      'container:read',
     ],
   },
   viewer: {

--- a/apps/api/src/contexts/offers/infrastructure/http/domain-exception.filter.ts
+++ b/apps/api/src/contexts/offers/infrastructure/http/domain-exception.filter.ts
@@ -23,7 +23,6 @@ import {
 } from '../../application/submit-offer';
 import { NeedForSuggestNotFoundError } from '../../application/suggest-offers-for-need';
 import { DonationIntakeNotFoundError } from '../../application/donation-intake-not-found.error';
-import { SupplyLineValidationError } from '../../../supplies/domain/supply-line';
 import {
   DonationIntakeAlreadyProcessedError,
   DonationIntakeContactMismatchError,
@@ -51,8 +50,7 @@ type DomainError =
   | DonationIntakeContactMismatchError
   | InvalidDonationIntakeContactError
   | InvalidIntakeTargetResourceError
-  | DonationIntakeLineLimitError
-  | SupplyLineValidationError;
+  | DonationIntakeLineLimitError;
 
 @Catch(
   OfferNotFoundError,
@@ -74,7 +72,6 @@ type DomainError =
   InvalidDonationIntakeContactError,
   InvalidIntakeTargetResourceError,
   DonationIntakeLineLimitError,
-  SupplyLineValidationError,
 )
 export class OffersDomainExceptionFilter implements ExceptionFilter {
   catch(exception: DomainError, host: ArgumentsHost): void {
@@ -100,18 +97,15 @@ export class OffersDomainExceptionFilter implements ExceptionFilter {
                         ? HttpStatus.BAD_REQUEST
                         : exception instanceof DonationIntakeLineLimitError
                           ? HttpStatus.BAD_REQUEST
-                          : exception instanceof SupplyLineValidationError
-                            ? HttpStatus.BAD_REQUEST
-                            : exception instanceof
-                                EmergencyNotAcceptingIntakeError
-                              ? HttpStatus.CONFLICT
+                          : exception instanceof
+                              EmergencyNotAcceptingIntakeError
+                            ? HttpStatus.CONFLICT
+                            : exception instanceof OfferCancelUnauthorizedError
+                              ? HttpStatus.FORBIDDEN
                               : exception instanceof
-                                  OfferCancelUnauthorizedError
+                                  DonationIntakeContactMismatchError
                                 ? HttpStatus.FORBIDDEN
-                                : exception instanceof
-                                    DonationIntakeContactMismatchError
-                                  ? HttpStatus.FORBIDDEN
-                                  : HttpStatus.CONFLICT;
+                                : HttpStatus.CONFLICT;
     response
       .status(statusCode)
       .json({ statusCode, message: exception.message });

--- a/apps/api/src/contexts/supplies/application/add-line-to-container.spec.ts
+++ b/apps/api/src/contexts/supplies/application/add-line-to-container.spec.ts
@@ -1,0 +1,88 @@
+import { AddLineToContainer } from './add-line-to-container';
+import { RemoveLineFromContainer } from './remove-line-from-container';
+import { SealContainer } from './seal-container';
+import { InMemoryContainerRepository } from '../infrastructure/in-memory-container.repository';
+import { Container } from '../domain/container';
+import { ContainerId } from '../domain/container-id';
+import { ContainerType } from '../domain/container-enums';
+import { ContainerSealedError } from '../domain/container-errors';
+import { Category } from '../domain/category';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const MISSING = '99999999-9999-4999-8999-999999999999';
+
+function seed(repo: InMemoryContainerRepository): Container {
+  const c = Container.create({
+    id: ContainerId.create(),
+    code: 'CAJ-0001',
+    type: ContainerType.Box,
+    emergencyId: EmergencyId.fromString(EM),
+  });
+  void repo.save(c);
+  return c;
+}
+
+const LINE = {
+  name: 'Agua',
+  quantity: 10,
+  unit: 'botellas',
+  category: Category.Water,
+};
+
+describe('Add/RemoveLineToContainer', () => {
+  it('adds a line to an open container', async () => {
+    const repo = new InMemoryContainerRepository();
+    const c = seed(repo);
+    await new AddLineToContainer(repo).execute({
+      containerId: c.id.value,
+      line: LINE,
+    });
+    const saved = await repo.findById(c.id);
+    expect(saved!.lines).toHaveLength(1);
+    expect(saved!.lines[0].name).toBe('Agua');
+  });
+
+  it('removes a line by index', async () => {
+    const repo = new InMemoryContainerRepository();
+    const c = seed(repo);
+    await new AddLineToContainer(repo).execute({
+      containerId: c.id.value,
+      line: LINE,
+    });
+    await new AddLineToContainer(repo).execute({
+      containerId: c.id.value,
+      line: { ...LINE, name: 'Mantas', category: Category.Shelter },
+    });
+    await new RemoveLineFromContainer(repo).execute({
+      containerId: c.id.value,
+      index: 0,
+    });
+    const saved = await repo.findById(c.id);
+    expect(saved!.lines).toHaveLength(1);
+    expect(saved!.lines[0].name).toBe('Mantas');
+  });
+
+  it('refuses to add a line to a sealed container', async () => {
+    const repo = new InMemoryContainerRepository();
+    const c = seed(repo);
+    await new SealContainer(repo).execute({ containerId: c.id.value });
+    await expect(
+      new AddLineToContainer(repo).execute({
+        containerId: c.id.value,
+        line: LINE,
+      }),
+    ).rejects.toThrow(ContainerSealedError);
+  });
+
+  it('404s an unknown container', async () => {
+    const repo = new InMemoryContainerRepository();
+    await expect(
+      new AddLineToContainer(repo).execute({
+        containerId: MISSING,
+        line: LINE,
+      }),
+    ).rejects.toThrow(ContainerNotFoundError);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/add-line-to-container.ts
+++ b/apps/api/src/contexts/supplies/application/add-line-to-container.ts
@@ -1,0 +1,24 @@
+import { ContainerRepository } from '../domain/ports/container.repository';
+import { ContainerId } from '../domain/container-id';
+import { SupplyLine, SupplyLineProps } from '../domain/supply-line';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+export interface AddLineToContainerCommand {
+  containerId: string;
+  line: SupplyLineProps;
+}
+
+/** Adds a loose supply line to an open container. */
+export class AddLineToContainer {
+  constructor(private readonly repo: ContainerRepository) {}
+
+  async execute(cmd: AddLineToContainerCommand): Promise<void> {
+    const container = await this.repo.findById(
+      ContainerId.fromString(cmd.containerId),
+    );
+    if (!container) throw new ContainerNotFoundError(cmd.containerId);
+
+    container.addLine(SupplyLine.create(cmd.line));
+    await this.repo.save(container);
+  }
+}

--- a/apps/api/src/contexts/supplies/application/container-not-found.error.ts
+++ b/apps/api/src/contexts/supplies/application/container-not-found.error.ts
@@ -1,0 +1,7 @@
+/** Raised when a container id does not resolve. The HTTP layer maps it to 404. */
+export class ContainerNotFoundError extends Error {
+  constructor(containerId: string) {
+    super(`Container ${containerId} not found`);
+    this.name = 'ContainerNotFoundError';
+  }
+}

--- a/apps/api/src/contexts/supplies/application/container-view.ts
+++ b/apps/api/src/contexts/supplies/application/container-view.ts
@@ -1,0 +1,78 @@
+import { Container } from '../domain/container';
+import { SupplyLineSnapshot } from '../domain/supply-line';
+
+export interface ContainerLineView {
+  name: string;
+  quantity: number;
+  unit: string | null;
+  category: string;
+  presentation: string | null;
+}
+
+export interface ContainerView {
+  id: string;
+  code: string;
+  type: string;
+  emergencyId: string;
+  parentContainerId: string | null;
+  lines: ContainerLineView[];
+  grossWeightKg: number | null;
+  grossVolumeM3: number | null;
+  holderType: string | null;
+  holderId: string | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * A container with its sub-tree and the aggregated weight/volume (own + Σ
+ * children). The total is `null` only when nothing in the sub-tree declared
+ * that magnitude.
+ */
+export interface ContainerTreeView extends ContainerView {
+  children: ContainerTreeView[];
+  totalWeightKg: number | null;
+  totalVolumeM3: number | null;
+}
+
+function toLineView(l: SupplyLineSnapshot): ContainerLineView {
+  return {
+    name: l.name,
+    quantity: l.quantity,
+    unit: l.unit,
+    category: l.category,
+    presentation: l.presentation ?? null,
+  };
+}
+
+export function toContainerView(c: Container): ContainerView {
+  const snap = c.toSnapshot();
+  return {
+    id: snap.id,
+    code: snap.code,
+    type: snap.type,
+    emergencyId: snap.emergencyId,
+    parentContainerId: snap.parentContainerId,
+    lines: snap.lines.map(toLineView),
+    grossWeightKg: snap.grossWeightKg,
+    grossVolumeM3: snap.grossVolumeM3,
+    holderType: snap.holderType,
+    holderId: snap.holderId,
+    status: snap.status,
+    createdAt: snap.createdAt.toISOString(),
+    updatedAt: snap.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Adds two optional magnitudes treating "not declared" (null) as absent: the
+ * result is null only if both are null, otherwise the numeric sum.
+ */
+export function addOptionalAmounts(
+  a: number | null,
+  b: number | null,
+): number | null {
+  if (a === null && b === null) return null;
+  return (a ?? 0) + (b ?? 0);
+}

--- a/apps/api/src/contexts/supplies/application/create-container.spec.ts
+++ b/apps/api/src/contexts/supplies/application/create-container.spec.ts
@@ -1,0 +1,88 @@
+import { CreateContainer } from './create-container';
+import { InMemoryContainerRepository } from '../infrastructure/in-memory-container.repository';
+import { ContainerId } from '../domain/container-id';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '../domain/container-enums';
+import { Category } from '../domain/category';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const OTHER_EM = '22222222-2222-4222-8222-222222222222';
+const RESOURCE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+describe('CreateContainer', () => {
+  it('creates an open, top-level container with a generated code', async () => {
+    const repo = new InMemoryContainerRepository();
+    const useCase = new CreateContainer(repo);
+
+    const { id, code } = await useCase.execute({
+      emergencyId: EM,
+      type: ContainerType.Pallet,
+    });
+
+    expect(code).toBe('PAL-0001');
+    const saved = await repo.findById(ContainerId.fromString(id));
+    expect(saved).not.toBeNull();
+    expect(saved!.status).toBe(ContainerStatus.Open);
+    expect(saved!.parentContainerId).toBeNull();
+    expect(saved!.type).toBe(ContainerType.Pallet);
+  });
+
+  it('allocates a per-(emergency, type) sequence', async () => {
+    const repo = new InMemoryContainerRepository();
+    const useCase = new CreateContainer(repo);
+
+    const a = await useCase.execute({
+      emergencyId: EM,
+      type: ContainerType.Pallet,
+    });
+    const b = await useCase.execute({
+      emergencyId: EM,
+      type: ContainerType.Pallet,
+    });
+    const box = await useCase.execute({
+      emergencyId: EM,
+      type: ContainerType.Box,
+    });
+    const other = await useCase.execute({
+      emergencyId: OTHER_EM,
+      type: ContainerType.Pallet,
+    });
+
+    expect(a.code).toBe('PAL-0001');
+    expect(b.code).toBe('PAL-0002');
+    expect(box.code).toBe('CAJ-0001');
+    expect(other.code).toBe('PAL-0001');
+  });
+
+  it('accepts initial lines, declared weight/volume and a holder', async () => {
+    const repo = new InMemoryContainerRepository();
+    const useCase = new CreateContainer(repo);
+
+    const { id } = await useCase.execute({
+      emergencyId: EM,
+      type: ContainerType.Box,
+      lines: [
+        {
+          name: 'Agua',
+          quantity: 24,
+          unit: 'botellas',
+          category: Category.Water,
+        },
+      ],
+      grossWeightKg: 18,
+      grossVolumeM3: 0.2,
+      holder: { type: ContainerHolderType.Resource, id: RESOURCE },
+    });
+
+    const saved = await repo.findById(ContainerId.fromString(id));
+    expect(saved!.lines).toHaveLength(1);
+    expect(saved!.grossWeightKg).toBe(18);
+    expect(saved!.holder).toEqual({
+      type: ContainerHolderType.Resource,
+      id: RESOURCE,
+    });
+  });
+});

--- a/apps/api/src/contexts/supplies/application/create-container.ts
+++ b/apps/api/src/contexts/supplies/application/create-container.ts
@@ -1,0 +1,48 @@
+import { ContainerRepository } from '../domain/ports/container.repository';
+import { Container, ContainerHolder } from '../domain/container';
+import { ContainerId } from '../domain/container-id';
+import { ContainerType } from '../domain/container-enums';
+import { formatContainerCode } from '../domain/container-code';
+import { SupplyLine, SupplyLineProps } from '../domain/supply-line';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+
+export interface CreateContainerCommand {
+  emergencyId: string;
+  type: ContainerType;
+  lines?: SupplyLineProps[];
+  grossWeightKg?: number | null;
+  grossVolumeM3?: number | null;
+  holder?: ContainerHolder | null;
+}
+
+/**
+ * Creates a top-level (parent-less) container with a generated trackable code
+ * (`PAL-0001`, sequence per emergency + type). Nesting and holder moves are
+ * separate operations; an initial holder/lines may be provided for ergonomics
+ * (a box created already filled, at a hub).
+ */
+export class CreateContainer {
+  constructor(private readonly repo: ContainerRepository) {}
+
+  async execute(
+    cmd: CreateContainerCommand,
+  ): Promise<{ id: string; code: string }> {
+    const emergencyId = EmergencyId.fromString(cmd.emergencyId);
+    const sequence = await this.repo.nextSequence(emergencyId, cmd.type);
+    const code = formatContainerCode(cmd.type, sequence);
+
+    const container = Container.create({
+      id: ContainerId.create(),
+      code,
+      type: cmd.type,
+      emergencyId,
+      lines: (cmd.lines ?? []).map((l) => SupplyLine.create(l)),
+      grossWeightKg: cmd.grossWeightKg ?? null,
+      grossVolumeM3: cmd.grossVolumeM3 ?? null,
+      holder: cmd.holder ?? null,
+    });
+
+    await this.repo.save(container);
+    return { id: container.id.value, code: container.code };
+  }
+}

--- a/apps/api/src/contexts/supplies/application/get-container.spec.ts
+++ b/apps/api/src/contexts/supplies/application/get-container.spec.ts
@@ -1,0 +1,88 @@
+import { CreateContainer } from './create-container';
+import { AddLineToContainer } from './add-line-to-container';
+import { NestContainer } from './nest-container';
+import { SealContainer } from './seal-container';
+import { GetContainer } from './get-container';
+import { InMemoryContainerRepository } from '../infrastructure/in-memory-container.repository';
+import { ContainerStatus, ContainerType } from '../domain/container-enums';
+import { Category } from '../domain/category';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const MISSING = '99999999-9999-4999-8999-999999999999';
+
+/**
+ * Acceptance (issue #140): create a pallet, put boxes in it, put lines into the
+ * boxes, seal it, and read the tree with aggregated weight/volume.
+ */
+describe('GetContainer (tree + totals)', () => {
+  it('assembles the sub-tree and aggregates weight/volume', async () => {
+    const repo = new InMemoryContainerRepository();
+    const create = new CreateContainer(repo);
+    const nest = new NestContainer(repo);
+    const addLine = new AddLineToContainer(repo);
+    const seal = new SealContainer(repo);
+
+    const pallet = await create.execute({
+      emergencyId: EM,
+      type: ContainerType.Pallet,
+      grossWeightKg: 15, // the empty pallet itself
+    });
+    const boxA = await create.execute({
+      emergencyId: EM,
+      type: ContainerType.Box,
+      grossWeightKg: 20,
+      grossVolumeM3: 0.3,
+    });
+    const boxB = await create.execute({
+      emergencyId: EM,
+      type: ContainerType.Box,
+      grossWeightKg: 10,
+    });
+
+    await nest.execute({ containerId: boxA.id, parentContainerId: pallet.id });
+    await nest.execute({ containerId: boxB.id, parentContainerId: pallet.id });
+    await addLine.execute({
+      containerId: boxA.id,
+      line: {
+        name: 'Agua',
+        quantity: 24,
+        unit: 'botellas',
+        category: Category.Water,
+      },
+    });
+    await seal.execute({ containerId: boxA.id });
+
+    const tree = await new GetContainer(repo).execute({
+      containerId: pallet.id,
+    });
+
+    expect(tree.code).toBe('PAL-0001');
+    expect(tree.children).toHaveLength(2);
+    expect(tree.totalWeightKg).toBe(45); // 15 + 20 + 10
+    expect(tree.totalVolumeM3).toBe(0.3); // only boxA declared volume
+    const sealedChild = tree.children.find((c) => c.code === boxA.code);
+    expect(sealedChild!.status).toBe(ContainerStatus.Sealed);
+    expect(sealedChild!.lines[0].name).toBe('Agua');
+  });
+
+  it('reports null totals when nothing in the sub-tree declared a magnitude', async () => {
+    const repo = new InMemoryContainerRepository();
+    const create = new CreateContainer(repo);
+    const { id } = await create.execute({
+      emergencyId: EM,
+      type: ContainerType.Lote,
+    });
+    const tree = await new GetContainer(repo).execute({ containerId: id });
+    expect(tree.totalWeightKg).toBeNull();
+    expect(tree.totalVolumeM3).toBeNull();
+    expect(tree.children).toHaveLength(0);
+  });
+
+  it('404s an unknown container', async () => {
+    const repo = new InMemoryContainerRepository();
+    await expect(
+      new GetContainer(repo).execute({ containerId: MISSING }),
+    ).rejects.toThrow(ContainerNotFoundError);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/get-container.ts
+++ b/apps/api/src/contexts/supplies/application/get-container.ts
@@ -1,0 +1,53 @@
+import { ContainerRepository } from '../domain/ports/container.repository';
+import { Container } from '../domain/container';
+import { ContainerId } from '../domain/container-id';
+import {
+  addOptionalAmounts,
+  ContainerTreeView,
+  toContainerView,
+} from './container-view';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+export interface GetContainerCommand {
+  containerId: string;
+}
+
+/**
+ * Reads a container as a tree: its direct children (recursively) plus the
+ * aggregated weight/volume (own + Σ children). The composition is stored by
+ * reference, so the tree is assembled here in the read model.
+ */
+export class GetContainer {
+  constructor(private readonly repo: ContainerRepository) {}
+
+  async execute(cmd: GetContainerCommand): Promise<ContainerTreeView> {
+    const root = await this.repo.findById(
+      ContainerId.fromString(cmd.containerId),
+    );
+    if (!root) throw new ContainerNotFoundError(cmd.containerId);
+    return this.buildTree(root, new Set<string>());
+  }
+
+  private async buildTree(
+    container: Container,
+    seen: Set<string>,
+  ): Promise<ContainerTreeView> {
+    seen.add(container.id.value);
+    const view = toContainerView(container);
+
+    let totalWeightKg = container.grossWeightKg;
+    let totalVolumeM3 = container.grossVolumeM3;
+    const children: ContainerTreeView[] = [];
+
+    for (const child of await this.repo.findChildren(container.id)) {
+      // Defensive: the Nest use case prevents cycles, but never loop forever.
+      if (seen.has(child.id.value)) continue;
+      const subtree = await this.buildTree(child, seen);
+      children.push(subtree);
+      totalWeightKg = addOptionalAmounts(totalWeightKg, subtree.totalWeightKg);
+      totalVolumeM3 = addOptionalAmounts(totalVolumeM3, subtree.totalVolumeM3);
+    }
+
+    return { ...view, children, totalWeightKg, totalVolumeM3 };
+  }
+}

--- a/apps/api/src/contexts/supplies/application/list-containers.spec.ts
+++ b/apps/api/src/contexts/supplies/application/list-containers.spec.ts
@@ -1,0 +1,73 @@
+import { CreateContainer } from './create-container';
+import { NestContainer } from './nest-container';
+import { SealContainer } from './seal-container';
+import { ListContainers } from './list-containers';
+import { InMemoryContainerRepository } from '../infrastructure/in-memory-container.repository';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '../domain/container-enums';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const SHIPMENT = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+describe('ListContainers', () => {
+  it('filters by type, status, holder and top-level', async () => {
+    const repo = new InMemoryContainerRepository();
+    const create = new CreateContainer(repo);
+    const nest = new NestContainer(repo);
+    const seal = new SealContainer(repo);
+
+    const pallet = await create.execute({
+      emergencyId: EM,
+      type: ContainerType.Pallet,
+      holder: { type: ContainerHolderType.Shipment, id: SHIPMENT },
+    });
+    const box = await create.execute({
+      emergencyId: EM,
+      type: ContainerType.Box,
+    });
+    await nest.execute({ containerId: box.id, parentContainerId: pallet.id });
+    await seal.execute({ containerId: pallet.id });
+
+    const all = await new ListContainers(repo).execute({ emergencyId: EM });
+    expect(all).toHaveLength(2);
+
+    const pallets = await new ListContainers(repo).execute({
+      emergencyId: EM,
+      type: ContainerType.Pallet,
+    });
+    expect(pallets).toHaveLength(1);
+    expect(pallets[0].code).toBe('PAL-0001');
+
+    const sealed = await new ListContainers(repo).execute({
+      emergencyId: EM,
+      status: ContainerStatus.Sealed,
+    });
+    expect(sealed).toHaveLength(1);
+
+    const topLevel = await new ListContainers(repo).execute({
+      emergencyId: EM,
+      topLevelOnly: true,
+    });
+    expect(topLevel).toHaveLength(1);
+    expect(topLevel[0].id).toBe(pallet.id);
+
+    const inShipment = await new ListContainers(repo).execute({
+      emergencyId: EM,
+      holderType: ContainerHolderType.Shipment,
+      holderId: SHIPMENT,
+    });
+    expect(inShipment).toHaveLength(1);
+    expect(inShipment[0].id).toBe(pallet.id);
+  });
+
+  it('returns an empty list for an emergency with no containers', async () => {
+    const repo = new InMemoryContainerRepository();
+    const list = await new ListContainers(repo).execute({
+      emergencyId: '33333333-3333-4333-8333-333333333333',
+    });
+    expect(list).toEqual([]);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/list-containers.ts
+++ b/apps/api/src/contexts/supplies/application/list-containers.ts
@@ -1,0 +1,43 @@
+import {
+  ContainerRepository,
+  ListContainersFilter,
+} from '../domain/ports/container.repository';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '../domain/container-enums';
+import { ContainerView, toContainerView } from './container-view';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+
+export interface ListContainersCommand {
+  emergencyId: string;
+  type?: ContainerType;
+  status?: ContainerStatus;
+  holderType?: ContainerHolderType;
+  holderId?: string;
+  topLevelOnly?: boolean;
+}
+
+/** Lists containers of an emergency (flat), filtered and newest-first. */
+export class ListContainers {
+  constructor(private readonly repo: ContainerRepository) {}
+
+  async execute(cmd: ListContainersCommand): Promise<ContainerView[]> {
+    const filter: ListContainersFilter = {
+      ...(cmd.type !== undefined ? { type: cmd.type } : {}),
+      ...(cmd.status !== undefined ? { status: cmd.status } : {}),
+      ...(cmd.holderType !== undefined ? { holderType: cmd.holderType } : {}),
+      ...(cmd.holderId !== undefined ? { holderId: cmd.holderId } : {}),
+      ...(cmd.topLevelOnly !== undefined
+        ? { topLevelOnly: cmd.topLevelOnly }
+        : {}),
+    };
+
+    const containers = await this.repo.findByEmergency(
+      EmergencyId.fromString(cmd.emergencyId),
+      filter,
+    );
+    return containers.map(toContainerView);
+  }
+}

--- a/apps/api/src/contexts/supplies/application/move-container.spec.ts
+++ b/apps/api/src/contexts/supplies/application/move-container.spec.ts
@@ -1,0 +1,51 @@
+import { MoveContainer } from './move-container';
+import { InMemoryContainerRepository } from '../infrastructure/in-memory-container.repository';
+import { Container } from '../domain/container';
+import { ContainerId } from '../domain/container-id';
+import { ContainerHolderType, ContainerType } from '../domain/container-enums';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const RESOURCE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SHIPMENT = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const MISSING = '99999999-9999-4999-8999-999999999999';
+
+function seed(repo: InMemoryContainerRepository): Container {
+  const c = Container.create({
+    id: ContainerId.create(),
+    code: 'PAL-0001',
+    type: ContainerType.Pallet,
+    emergencyId: EmergencyId.fromString(EM),
+    holder: { type: ContainerHolderType.Resource, id: RESOURCE },
+  });
+  void repo.save(c);
+  return c;
+}
+
+describe('MoveContainer', () => {
+  it('moves from a resource to a shipment and detaches', async () => {
+    const repo = new InMemoryContainerRepository();
+    const c = seed(repo);
+    const useCase = new MoveContainer(repo);
+
+    await useCase.execute({
+      containerId: c.id.value,
+      holder: { type: ContainerHolderType.Shipment, id: SHIPMENT },
+    });
+    expect((await repo.findById(c.id))!.holder).toEqual({
+      type: ContainerHolderType.Shipment,
+      id: SHIPMENT,
+    });
+
+    await useCase.execute({ containerId: c.id.value, holder: null });
+    expect((await repo.findById(c.id))!.holder).toBeNull();
+  });
+
+  it('404s an unknown container', async () => {
+    const repo = new InMemoryContainerRepository();
+    await expect(
+      new MoveContainer(repo).execute({ containerId: MISSING, holder: null }),
+    ).rejects.toThrow(ContainerNotFoundError);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/move-container.ts
+++ b/apps/api/src/contexts/supplies/application/move-container.ts
@@ -1,0 +1,28 @@
+import { ContainerRepository } from '../domain/ports/container.repository';
+import { ContainerHolder } from '../domain/container';
+import { ContainerId } from '../domain/container-id';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+export interface MoveContainerCommand {
+  containerId: string;
+  /** New holder (resource ↔ shipment), or `null` to detach. */
+  holder: ContainerHolder | null;
+}
+
+/**
+ * Moves a container to a holder (a resource node or a shipment) or detaches it.
+ * Composition is preserved — children follow their parent by reference.
+ */
+export class MoveContainer {
+  constructor(private readonly repo: ContainerRepository) {}
+
+  async execute(cmd: MoveContainerCommand): Promise<void> {
+    const container = await this.repo.findById(
+      ContainerId.fromString(cmd.containerId),
+    );
+    if (!container) throw new ContainerNotFoundError(cmd.containerId);
+
+    container.moveToHolder(cmd.holder);
+    await this.repo.save(container);
+  }
+}

--- a/apps/api/src/contexts/supplies/application/nest-container.spec.ts
+++ b/apps/api/src/contexts/supplies/application/nest-container.spec.ts
@@ -1,0 +1,123 @@
+import { NestContainer } from './nest-container';
+import { InMemoryContainerRepository } from '../infrastructure/in-memory-container.repository';
+import { Container } from '../domain/container';
+import { ContainerId } from '../domain/container-id';
+import { ContainerType } from '../domain/container-enums';
+import {
+  ContainerCycleError,
+  ContainerEmergencyMismatchError,
+} from '../domain/container-errors';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const OTHER_EM = '22222222-2222-4222-8222-222222222222';
+const MISSING = '99999999-9999-4999-8999-999999999999';
+
+function make(
+  repo: InMemoryContainerRepository,
+  type: ContainerType,
+  emergencyId = EM,
+): Container {
+  const c = Container.create({
+    id: ContainerId.create(),
+    code: `${type}-x`,
+    type,
+    emergencyId: EmergencyId.fromString(emergencyId),
+  });
+  void repo.save(c);
+  return c;
+}
+
+describe('NestContainer', () => {
+  it('nests a box under a pallet and un-nests it', async () => {
+    const repo = new InMemoryContainerRepository();
+    const useCase = new NestContainer(repo);
+    const pallet = make(repo, ContainerType.Pallet);
+    const box = make(repo, ContainerType.Box);
+
+    await useCase.execute({
+      containerId: box.id.value,
+      parentContainerId: pallet.id.value,
+    });
+    expect((await repo.findById(box.id))!.parentContainerId?.value).toBe(
+      pallet.id.value,
+    );
+    expect(await repo.findChildren(pallet.id)).toHaveLength(1);
+
+    await useCase.execute({
+      containerId: box.id.value,
+      parentContainerId: null,
+    });
+    expect((await repo.findById(box.id))!.parentContainerId).toBeNull();
+  });
+
+  it('rejects a direct cycle (parent === child)', async () => {
+    const repo = new InMemoryContainerRepository();
+    const useCase = new NestContainer(repo);
+    const c = make(repo, ContainerType.Pallet);
+    await expect(
+      useCase.execute({
+        containerId: c.id.value,
+        parentContainerId: c.id.value,
+      }),
+    ).rejects.toThrow(ContainerCycleError);
+  });
+
+  it('rejects an indirect cycle (parent is a descendant of the child)', async () => {
+    const repo = new InMemoryContainerRepository();
+    const useCase = new NestContainer(repo);
+    const a = make(repo, ContainerType.Pallet);
+    const b = make(repo, ContainerType.Box);
+    const c = make(repo, ContainerType.Box);
+
+    await useCase.execute({
+      containerId: b.id.value,
+      parentContainerId: a.id.value,
+    });
+    await useCase.execute({
+      containerId: c.id.value,
+      parentContainerId: b.id.value,
+    });
+
+    // a → b → c already; nesting a under c would close the loop.
+    await expect(
+      useCase.execute({
+        containerId: a.id.value,
+        parentContainerId: c.id.value,
+      }),
+    ).rejects.toThrow(ContainerCycleError);
+  });
+
+  it('rejects nesting across emergencies', async () => {
+    const repo = new InMemoryContainerRepository();
+    const useCase = new NestContainer(repo);
+    const pallet = make(repo, ContainerType.Pallet, EM);
+    const box = make(repo, ContainerType.Box, OTHER_EM);
+    await expect(
+      useCase.execute({
+        containerId: box.id.value,
+        parentContainerId: pallet.id.value,
+      }),
+    ).rejects.toThrow(ContainerEmergencyMismatchError);
+  });
+
+  it('404s an unknown child or parent', async () => {
+    const repo = new InMemoryContainerRepository();
+    const useCase = new NestContainer(repo);
+    const pallet = make(repo, ContainerType.Pallet);
+
+    await expect(
+      useCase.execute({
+        containerId: MISSING,
+        parentContainerId: pallet.id.value,
+      }),
+    ).rejects.toThrow(ContainerNotFoundError);
+    await expect(
+      useCase.execute({
+        containerId: pallet.id.value,
+        parentContainerId: MISSING,
+      }),
+    ).rejects.toThrow(ContainerNotFoundError);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/nest-container.ts
+++ b/apps/api/src/contexts/supplies/application/nest-container.ts
@@ -1,0 +1,72 @@
+import { ContainerRepository } from '../domain/ports/container.repository';
+import { Container } from '../domain/container';
+import { ContainerId } from '../domain/container-id';
+import {
+  ContainerCycleError,
+  ContainerEmergencyMismatchError,
+} from '../domain/container-errors';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+export interface NestContainerCommand {
+  containerId: string;
+  /** New parent, or `null` to un-nest (make it top-level). */
+  parentContainerId: string | null;
+}
+
+/**
+ * Nests a container under a parent (or un-nests it when `parentContainerId` is
+ * null). Enforces the cross-aggregate invariants the aggregate cannot see on
+ * its own: same emergency, and no cycle — walking up from the proposed parent,
+ * we must never reach the child.
+ */
+export class NestContainer {
+  constructor(private readonly repo: ContainerRepository) {}
+
+  async execute(cmd: NestContainerCommand): Promise<void> {
+    const child = await this.repo.findById(
+      ContainerId.fromString(cmd.containerId),
+    );
+    if (!child) throw new ContainerNotFoundError(cmd.containerId);
+
+    if (cmd.parentContainerId === null) {
+      child.setParent(null);
+      await this.repo.save(child);
+      return;
+    }
+
+    const parentId = ContainerId.fromString(cmd.parentContainerId);
+    const parent = await this.repo.findById(parentId);
+    if (!parent) throw new ContainerNotFoundError(cmd.parentContainerId);
+
+    if (!parent.emergencyId.equals(child.emergencyId)) {
+      throw new ContainerEmergencyMismatchError(
+        'A container and its parent must belong to the same emergency',
+      );
+    }
+
+    await this.assertNoCycle(child, parent);
+
+    child.setParent(parentId);
+    await this.repo.save(child);
+  }
+
+  /** Walks ancestors of `parent`; reaching `child` would close a cycle. */
+  private async assertNoCycle(
+    child: Container,
+    parent: Container,
+  ): Promise<void> {
+    let cursor: Container | null = parent;
+    const seen = new Set<string>();
+    while (cursor) {
+      if (cursor.id.equals(child.id)) {
+        throw new ContainerCycleError(
+          `Nesting ${child.id.value} under ${parent.id.value} would create a cycle`,
+        );
+      }
+      if (seen.has(cursor.id.value)) break;
+      seen.add(cursor.id.value);
+      const parentRef: ContainerId | null = cursor.parentContainerId;
+      cursor = parentRef ? await this.repo.findById(parentRef) : null;
+    }
+  }
+}

--- a/apps/api/src/contexts/supplies/application/remove-line-from-container.ts
+++ b/apps/api/src/contexts/supplies/application/remove-line-from-container.ts
@@ -1,0 +1,23 @@
+import { ContainerRepository } from '../domain/ports/container.repository';
+import { ContainerId } from '../domain/container-id';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+export interface RemoveLineFromContainerCommand {
+  containerId: string;
+  index: number;
+}
+
+/** Removes the supply line at `index` from an open container. */
+export class RemoveLineFromContainer {
+  constructor(private readonly repo: ContainerRepository) {}
+
+  async execute(cmd: RemoveLineFromContainerCommand): Promise<void> {
+    const container = await this.repo.findById(
+      ContainerId.fromString(cmd.containerId),
+    );
+    if (!container) throw new ContainerNotFoundError(cmd.containerId);
+
+    container.removeLineAt(cmd.index);
+    await this.repo.save(container);
+  }
+}

--- a/apps/api/src/contexts/supplies/application/seal-container.spec.ts
+++ b/apps/api/src/contexts/supplies/application/seal-container.spec.ts
@@ -1,0 +1,48 @@
+import { SealContainer } from './seal-container';
+import { InMemoryContainerRepository } from '../infrastructure/in-memory-container.repository';
+import { Container } from '../domain/container';
+import { ContainerId } from '../domain/container-id';
+import { ContainerStatus, ContainerType } from '../domain/container-enums';
+import { ContainerSealedError } from '../domain/container-errors';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const MISSING = '99999999-9999-4999-8999-999999999999';
+
+function seed(repo: InMemoryContainerRepository): Container {
+  const c = Container.create({
+    id: ContainerId.create(),
+    code: 'PAL-0001',
+    type: ContainerType.Pallet,
+    emergencyId: EmergencyId.fromString(EM),
+  });
+  void repo.save(c);
+  return c;
+}
+
+describe('SealContainer', () => {
+  it('seals an open container', async () => {
+    const repo = new InMemoryContainerRepository();
+    const c = seed(repo);
+    await new SealContainer(repo).execute({ containerId: c.id.value });
+    expect((await repo.findById(c.id))!.status).toBe(ContainerStatus.Sealed);
+  });
+
+  it('rejects sealing an already sealed container', async () => {
+    const repo = new InMemoryContainerRepository();
+    const c = seed(repo);
+    const useCase = new SealContainer(repo);
+    await useCase.execute({ containerId: c.id.value });
+    await expect(useCase.execute({ containerId: c.id.value })).rejects.toThrow(
+      ContainerSealedError,
+    );
+  });
+
+  it('404s an unknown container', async () => {
+    const repo = new InMemoryContainerRepository();
+    await expect(
+      new SealContainer(repo).execute({ containerId: MISSING }),
+    ).rejects.toThrow(ContainerNotFoundError);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/seal-container.ts
+++ b/apps/api/src/contexts/supplies/application/seal-container.ts
@@ -1,0 +1,22 @@
+import { ContainerRepository } from '../domain/ports/container.repository';
+import { ContainerId } from '../domain/container-id';
+import { ContainerNotFoundError } from './container-not-found.error';
+
+export interface SealContainerCommand {
+  containerId: string;
+}
+
+/** Seals (precinta) a container: open → sealed, freezing its lines. */
+export class SealContainer {
+  constructor(private readonly repo: ContainerRepository) {}
+
+  async execute(cmd: SealContainerCommand): Promise<void> {
+    const container = await this.repo.findById(
+      ContainerId.fromString(cmd.containerId),
+    );
+    if (!container) throw new ContainerNotFoundError(cmd.containerId);
+
+    container.seal();
+    await this.repo.save(container);
+  }
+}

--- a/apps/api/src/contexts/supplies/domain/container-code.spec.ts
+++ b/apps/api/src/contexts/supplies/domain/container-code.spec.ts
@@ -1,0 +1,27 @@
+import { formatContainerCode } from './container-code';
+import { ContainerType } from './container-enums';
+import { ContainerValidationError } from './container-errors';
+
+describe('formatContainerCode', () => {
+  it('formats a per-type prefix with a 4-digit zero-padded sequence', () => {
+    expect(formatContainerCode(ContainerType.Pallet, 1)).toBe('PAL-0001');
+    expect(formatContainerCode(ContainerType.Box, 42)).toBe('CAJ-0042');
+    expect(formatContainerCode(ContainerType.Lote, 7)).toBe('LOT-0007');
+  });
+
+  it('does not truncate sequences beyond 4 digits', () => {
+    expect(formatContainerCode(ContainerType.Pallet, 12345)).toBe('PAL-12345');
+  });
+
+  it('rejects a non-positive or non-integer sequence', () => {
+    expect(() => formatContainerCode(ContainerType.Pallet, 0)).toThrow(
+      ContainerValidationError,
+    );
+    expect(() => formatContainerCode(ContainerType.Pallet, -1)).toThrow(
+      ContainerValidationError,
+    );
+    expect(() => formatContainerCode(ContainerType.Pallet, 1.5)).toThrow(
+      ContainerValidationError,
+    );
+  });
+});

--- a/apps/api/src/contexts/supplies/domain/container-code.ts
+++ b/apps/api/src/contexts/supplies/domain/container-code.ts
@@ -1,0 +1,32 @@
+import { ContainerType } from './container-enums';
+import { ContainerValidationError } from './container-errors';
+
+/**
+ * Human-readable prefix per container type. The full code (e.g. `PAL-0001`) is
+ * the legible label / QR payload printed on the physical unit — the "Código
+ * Único" validated in the field (see #140). Spanish-leaning to match the
+ * working language: PAL (palet), CAJ (caja), LOT (lote).
+ */
+const CODE_PREFIX: Record<ContainerType, string> = {
+  [ContainerType.Pallet]: 'PAL',
+  [ContainerType.Box]: 'CAJ',
+  [ContainerType.Lote]: 'LOT',
+};
+
+/**
+ * Builds the trackable code from a per-(emergency, type) sequence number,
+ * zero-padded to 4 digits (`PAL-0001`, `CAJ-0042`). Pure: the sequence itself
+ * is allocated by the repository (infrastructure); this only formats it so the
+ * format stays a single, testable domain rule.
+ */
+export function formatContainerCode(
+  type: ContainerType,
+  sequence: number,
+): string {
+  if (!Number.isInteger(sequence) || sequence < 1) {
+    throw new ContainerValidationError(
+      'Container code sequence must be a positive integer',
+    );
+  }
+  return `${CODE_PREFIX[type]}-${String(sequence).padStart(4, '0')}`;
+}

--- a/apps/api/src/contexts/supplies/domain/container-enums.ts
+++ b/apps/api/src/contexts/supplies/domain/container-enums.ts
@@ -32,17 +32,3 @@ export enum ContainerHolderType {
   Resource = 'resource',
   Shipment = 'shipment',
 }
-
-export function isContainerType(value: string): value is ContainerType {
-  return (Object.values(ContainerType) as string[]).includes(value);
-}
-
-export function isContainerStatus(value: string): value is ContainerStatus {
-  return (Object.values(ContainerStatus) as string[]).includes(value);
-}
-
-export function isContainerHolderType(
-  value: string,
-): value is ContainerHolderType {
-  return (Object.values(ContainerHolderType) as string[]).includes(value);
-}

--- a/apps/api/src/contexts/supplies/domain/container-enums.ts
+++ b/apps/api/src/contexts/supplies/domain/container-enums.ts
@@ -1,0 +1,48 @@
+/**
+ * What kind of trackable packaging unit a {@link Container} is. A `pallet`
+ * groups boxes/lines, a `box` (caja) groups lines and usually rides a pallet,
+ * a `lote` is a logical batch. The taxonomy is intentionally small; the
+ * composition is by reference (`parentContainerId`), so any type can hold any
+ * other — the type is descriptive, not a structural constraint.
+ */
+export enum ContainerType {
+  Pallet = 'pallet',
+  Box = 'box',
+  Lote = 'lote',
+}
+
+/**
+ * Packing lifecycle. `open` while it is being filled; `sealed` (precintado)
+ * once closed — its lines become immutable. The "in transit / delivered"
+ * stages are NOT modelled here: a sealed container inherits them from the
+ * {@link Shipment} it is loaded onto (its holder).
+ */
+export enum ContainerStatus {
+  Open = 'open',
+  Sealed = 'sealed',
+}
+
+/**
+ * Where a container physically is *right now*. `resource` = parked at a
+ * collection point / warehouse (becomes that place's inventory); `shipment` =
+ * loaded onto an expedition. Polymorphic by design (no FK), mirroring how a
+ * shipment models its carrier. Null when it is held by neither.
+ */
+export enum ContainerHolderType {
+  Resource = 'resource',
+  Shipment = 'shipment',
+}
+
+export function isContainerType(value: string): value is ContainerType {
+  return (Object.values(ContainerType) as string[]).includes(value);
+}
+
+export function isContainerStatus(value: string): value is ContainerStatus {
+  return (Object.values(ContainerStatus) as string[]).includes(value);
+}
+
+export function isContainerHolderType(
+  value: string,
+): value is ContainerHolderType {
+  return (Object.values(ContainerHolderType) as string[]).includes(value);
+}

--- a/apps/api/src/contexts/supplies/domain/container-errors.ts
+++ b/apps/api/src/contexts/supplies/domain/container-errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Raised on invalid container input (empty code, non-positive weight/volume,
+ * out-of-range line index, empty holder id). The HTTP layer maps it to 422.
+ */
+export class ContainerValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContainerValidationError';
+  }
+}
+
+/**
+ * Raised when mutating the lines of a sealed (precintado) container, or sealing
+ * one that is already sealed. A sealed container's content is immutable; the
+ * HTTP layer maps this to 409 Conflict.
+ */
+export class ContainerSealedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContainerSealedError';
+  }
+}
+
+/**
+ * Raised when nesting would create a cycle — a container cannot be its own
+ * ancestor (nor its own parent). Keeps the composition tree acyclic.
+ */
+export class ContainerCycleError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContainerCycleError';
+  }
+}
+
+/**
+ * Raised when nesting a container under a parent that belongs to a different
+ * emergency. A container and its parent must share the same `emergencyId`.
+ */
+export class ContainerEmergencyMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContainerEmergencyMismatchError';
+  }
+}

--- a/apps/api/src/contexts/supplies/domain/container-id.ts
+++ b/apps/api/src/contexts/supplies/domain/container-id.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from 'node:crypto';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Identity of a {@link Container} (palet/caja/lote). Like the other aggregate
+ * ids in the platform it is a UUID value object — a container is a *trackable*
+ * aggregate (it moves between hubs and shipments and keeps its identity), so it
+ * owns an id rather than being an embedded value object.
+ */
+export class ContainerId {
+  private constructor(public readonly value: string) {}
+
+  static create(): ContainerId {
+    return new ContainerId(randomUUID());
+  }
+
+  static fromString(s: string): ContainerId {
+    if (!UUID_RE.test(s)) throw new Error(`Invalid ContainerId: ${s}`);
+    return new ContainerId(s);
+  }
+
+  equals(o: ContainerId): boolean {
+    return this.value === o.value;
+  }
+}

--- a/apps/api/src/contexts/supplies/domain/container.spec.ts
+++ b/apps/api/src/contexts/supplies/domain/container.spec.ts
@@ -1,0 +1,179 @@
+import { Container } from './container';
+import { ContainerId } from './container-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from './container-enums';
+import {
+  ContainerCycleError,
+  ContainerSealedError,
+  ContainerValidationError,
+} from './container-errors';
+import { SupplyLine } from './supply-line';
+import { Category } from './category';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const RESOURCE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SHIPMENT = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+function line(name = 'Agua', quantity = 10): SupplyLine {
+  return SupplyLine.create({
+    name,
+    quantity,
+    unit: 'botellas',
+    category: Category.Water,
+  });
+}
+
+function makeContainer(
+  overrides: Partial<Parameters<typeof Container.create>[0]> = {},
+): Container {
+  return Container.create({
+    id: ContainerId.create(),
+    code: 'PAL-0001',
+    type: ContainerType.Pallet,
+    emergencyId: EmergencyId.fromString(EM),
+    ...overrides,
+  });
+}
+
+describe('Container', () => {
+  describe('create', () => {
+    it('starts open, top-level, with no holder', () => {
+      const c = makeContainer();
+      expect(c.status).toBe(ContainerStatus.Open);
+      expect(c.parentContainerId).toBeNull();
+      expect(c.holder).toBeNull();
+      expect(c.lines).toHaveLength(0);
+    });
+
+    it('rejects an empty code', () => {
+      expect(() => makeContainer({ code: '   ' })).toThrow(
+        ContainerValidationError,
+      );
+    });
+
+    it('rejects a non-positive declared weight or volume', () => {
+      expect(() => makeContainer({ grossWeightKg: 0 })).toThrow(
+        ContainerValidationError,
+      );
+      expect(() => makeContainer({ grossVolumeM3: -2 })).toThrow(
+        ContainerValidationError,
+      );
+    });
+
+    it('accepts optional initial lines, weight, volume and holder', () => {
+      const c = makeContainer({
+        lines: [line()],
+        grossWeightKg: 120,
+        grossVolumeM3: 1.5,
+        holder: { type: ContainerHolderType.Resource, id: RESOURCE },
+      });
+      expect(c.lines).toHaveLength(1);
+      expect(c.grossWeightKg).toBe(120);
+      expect(c.grossVolumeM3).toBe(1.5);
+      expect(c.holder).toEqual({
+        type: ContainerHolderType.Resource,
+        id: RESOURCE,
+      });
+    });
+  });
+
+  describe('lines', () => {
+    it('adds and removes lines while open', () => {
+      const c = makeContainer();
+      c.addLine(line('Agua'));
+      c.addLine(line('Mantas'));
+      expect(c.lines).toHaveLength(2);
+      c.removeLineAt(0);
+      expect(c.lines).toHaveLength(1);
+      expect(c.lines[0].name).toBe('Mantas');
+    });
+
+    it('rejects removing an out-of-range line', () => {
+      const c = makeContainer({ lines: [line()] });
+      expect(() => c.removeLineAt(5)).toThrow(ContainerValidationError);
+    });
+  });
+
+  describe('nesting', () => {
+    it('repoints the parent', () => {
+      const child = makeContainer({ type: ContainerType.Box });
+      const parentId = ContainerId.create();
+      child.setParent(parentId);
+      expect(child.parentContainerId?.value).toBe(parentId.value);
+      child.setParent(null);
+      expect(child.parentContainerId).toBeNull();
+    });
+
+    it('refuses to be its own parent (cycle guard)', () => {
+      const c = makeContainer();
+      expect(() => c.setParent(c.id)).toThrow(ContainerCycleError);
+    });
+  });
+
+  describe('holder', () => {
+    it('moves between a resource and a shipment without losing composition', () => {
+      const c = makeContainer({ lines: [line()] });
+      const parentId = ContainerId.create();
+      c.setParent(parentId);
+      c.moveToHolder({ type: ContainerHolderType.Resource, id: RESOURCE });
+      c.moveToHolder({ type: ContainerHolderType.Shipment, id: SHIPMENT });
+      expect(c.holder).toEqual({
+        type: ContainerHolderType.Shipment,
+        id: SHIPMENT,
+      });
+      expect(c.parentContainerId?.value).toBe(parentId.value);
+      expect(c.lines).toHaveLength(1);
+      c.moveToHolder(null);
+      expect(c.holder).toBeNull();
+    });
+  });
+
+  describe('sealing', () => {
+    it('open → sealed freezes the lines but not the position', () => {
+      const c = makeContainer({ lines: [line()] });
+      c.seal();
+      expect(c.status).toBe(ContainerStatus.Sealed);
+      expect(() => c.addLine(line('Extra'))).toThrow(ContainerSealedError);
+      expect(() => c.removeLineAt(0)).toThrow(ContainerSealedError);
+      // position / holder still mutable
+      const parentId = ContainerId.create();
+      expect(() => c.setParent(parentId)).not.toThrow();
+      expect(() =>
+        c.moveToHolder({ type: ContainerHolderType.Shipment, id: SHIPMENT }),
+      ).not.toThrow();
+    });
+
+    it('rejects sealing an already sealed container', () => {
+      const c = makeContainer();
+      c.seal();
+      expect(() => c.seal()).toThrow(ContainerSealedError);
+    });
+  });
+
+  describe('snapshot', () => {
+    it('round-trips through a snapshot', () => {
+      const c = makeContainer({
+        lines: [line('Agua', 5)],
+        grossWeightKg: 80,
+        holder: { type: ContainerHolderType.Resource, id: RESOURCE },
+      });
+      const parentId = ContainerId.create();
+      c.setParent(parentId);
+      c.seal();
+
+      const restored = Container.fromSnapshot(c.toSnapshot());
+      expect(restored.toSnapshot()).toEqual(c.toSnapshot());
+      expect(restored.parentContainerId?.value).toBe(parentId.value);
+      expect(restored.status).toBe(ContainerStatus.Sealed);
+      expect(restored.lines[0].name).toBe('Agua');
+      expect(restored.holder).toEqual({
+        type: ContainerHolderType.Resource,
+        id: RESOURCE,
+      });
+    });
+  });
+});

--- a/apps/api/src/contexts/supplies/domain/container.ts
+++ b/apps/api/src/contexts/supplies/domain/container.ts
@@ -80,7 +80,7 @@ export class Container {
   ) {}
 
   static create(props: CreateContainerProps): Container {
-    const code = props.code?.trim() ?? '';
+    const code = props.code.trim();
     if (code.length === 0) {
       throw new ContainerValidationError('Container code must not be empty');
     }
@@ -158,10 +158,6 @@ export class Container {
 
   get status(): ContainerStatus {
     return this._status;
-  }
-
-  get isSealed(): boolean {
-    return this._status === ContainerStatus.Sealed;
   }
 
   get updatedAt(): Date {

--- a/apps/api/src/contexts/supplies/domain/container.ts
+++ b/apps/api/src/contexts/supplies/domain/container.ts
@@ -1,0 +1,251 @@
+import { ContainerId } from './container-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from './container-enums';
+import {
+  ContainerCycleError,
+  ContainerSealedError,
+  ContainerValidationError,
+} from './container-errors';
+import { SupplyLine, SupplyLineSnapshot } from './supply-line';
+
+/**
+ * Where the container is held right now. Polymorphic reference (no FK), like a
+ * shipment's carrier: the `type` discriminates the target table. Null holder =
+ * held by neither a resource nor a shipment.
+ */
+export interface ContainerHolder {
+  type: ContainerHolderType;
+  id: string;
+}
+
+export interface CreateContainerProps {
+  id: ContainerId;
+  code: string;
+  type: ContainerType;
+  emergencyId: EmergencyId;
+  lines?: SupplyLine[];
+  grossWeightKg?: number | null;
+  grossVolumeM3?: number | null;
+  holder?: ContainerHolder | null;
+}
+
+export interface ContainerSnapshot {
+  id: string;
+  code: string;
+  type: ContainerType;
+  emergencyId: string;
+  parentContainerId: string | null;
+  lines: SupplyLineSnapshot[];
+  grossWeightKg: number | null;
+  grossVolumeM3: number | null;
+  holderType: ContainerHolderType | null;
+  holderId: string | null;
+  status: ContainerStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Aggregate root for a trackable packaging unit (palet/caja/lote) — the
+ * "empaquetado rastreable" of #140. It groups {@link SupplyLine}s directly and
+ * composes with other containers **by reference** (`parentContainerId`): a box
+ * inside a pallet just points at the pallet; moving = repointing the parent;
+ * children are queried by parent. The tree is kept acyclic and single-emergency
+ * (the cross-aggregate checks live in the Nest use case, which can walk the
+ * tree; the aggregate guards the local invariants — no self-parent, lines only
+ * mutable while open).
+ *
+ * Weight/volume are *declared* per container (not yet derived from a catalogue);
+ * the aggregated total (own + Σ children) is assembled by the GetContainer read
+ * model, since children are separate aggregates.
+ */
+export class Container {
+  private constructor(
+    public readonly id: ContainerId,
+    public readonly code: string,
+    public readonly type: ContainerType,
+    public readonly emergencyId: EmergencyId,
+    private _parentContainerId: ContainerId | null,
+    private _lines: SupplyLine[],
+    public readonly grossWeightKg: number | null,
+    public readonly grossVolumeM3: number | null,
+    private _holder: ContainerHolder | null,
+    private _status: ContainerStatus,
+    public readonly createdAt: Date,
+    private _updatedAt: Date,
+  ) {}
+
+  static create(props: CreateContainerProps): Container {
+    const code = props.code?.trim() ?? '';
+    if (code.length === 0) {
+      throw new ContainerValidationError('Container code must not be empty');
+    }
+    Container.assertOptionalAmount(props.grossWeightKg, 'grossWeightKg');
+    Container.assertOptionalAmount(props.grossVolumeM3, 'grossVolumeM3');
+    const holder = props.holder ?? null;
+    if (holder !== null) Container.assertHolder(holder);
+    const now = new Date();
+    return new Container(
+      props.id,
+      code,
+      props.type,
+      props.emergencyId,
+      null,
+      [...(props.lines ?? [])],
+      props.grossWeightKg ?? null,
+      props.grossVolumeM3 ?? null,
+      holder,
+      ContainerStatus.Open,
+      now,
+      now,
+    );
+  }
+
+  static fromSnapshot(s: ContainerSnapshot): Container {
+    return new Container(
+      ContainerId.fromString(s.id),
+      s.code,
+      s.type,
+      EmergencyId.fromString(s.emergencyId),
+      s.parentContainerId ? ContainerId.fromString(s.parentContainerId) : null,
+      s.lines.map((l) => SupplyLine.fromSnapshot(l)),
+      s.grossWeightKg,
+      s.grossVolumeM3,
+      s.holderType !== null && s.holderId !== null
+        ? { type: s.holderType, id: s.holderId }
+        : null,
+      s.status,
+      s.createdAt,
+      s.updatedAt,
+    );
+  }
+
+  private static assertOptionalAmount(
+    value: number | null | undefined,
+    field: string,
+  ): void {
+    if (value === undefined || value === null) return;
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new ContainerValidationError(
+        `${field} must be a positive number when provided`,
+      );
+    }
+  }
+
+  private static assertHolder(holder: ContainerHolder): void {
+    if (!holder.id || holder.id.trim().length === 0) {
+      throw new ContainerValidationError(
+        'Container holder id must not be empty',
+      );
+    }
+  }
+
+  get parentContainerId(): ContainerId | null {
+    return this._parentContainerId;
+  }
+
+  get lines(): readonly SupplyLine[] {
+    return this._lines;
+  }
+
+  get holder(): ContainerHolder | null {
+    return this._holder;
+  }
+
+  get status(): ContainerStatus {
+    return this._status;
+  }
+
+  get isSealed(): boolean {
+    return this._status === ContainerStatus.Sealed;
+  }
+
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+
+  /** Adds a loose supply line. Forbidden once sealed (content is immutable). */
+  addLine(line: SupplyLine): void {
+    this.assertOpen('add a line to');
+    this._lines.push(line);
+    this.touch();
+  }
+
+  /** Removes the line at `index`. Forbidden once sealed. */
+  removeLineAt(index: number): void {
+    this.assertOpen('remove a line from');
+    if (!Number.isInteger(index) || index < 0 || index >= this._lines.length) {
+      throw new ContainerValidationError(`Line index ${index} is out of range`);
+    }
+    this._lines.splice(index, 1);
+    this.touch();
+  }
+
+  /**
+   * Repoints (or clears) the parent. This is nest/unnest; the cross-aggregate
+   * cycle and same-emergency checks belong to the Nest use case (it can walk
+   * the tree). Here we only guard the local invariant: no self-parent. Allowed
+   * while sealed — sealing freezes the content, not the position.
+   */
+  setParent(parentContainerId: ContainerId | null): void {
+    if (parentContainerId !== null && parentContainerId.equals(this.id)) {
+      throw new ContainerCycleError('A container cannot be its own parent');
+    }
+    this._parentContainerId = parentContainerId;
+    this.touch();
+  }
+
+  /**
+   * Moves the container to a holder (resource ↔ shipment) or detaches it
+   * (null). Allowed while sealed — a sealed box still travels. Composition is
+   * untouched: children follow their parent by reference.
+   */
+  moveToHolder(holder: ContainerHolder | null): void {
+    if (holder !== null) Container.assertHolder(holder);
+    this._holder = holder;
+    this.touch();
+  }
+
+  /** open → sealed. Idempotent re-sealing is a conflict, not a no-op. */
+  seal(): void {
+    if (this._status === ContainerStatus.Sealed) {
+      throw new ContainerSealedError('Container is already sealed');
+    }
+    this._status = ContainerStatus.Sealed;
+    this.touch();
+  }
+
+  private assertOpen(action: string): void {
+    if (this._status === ContainerStatus.Sealed) {
+      throw new ContainerSealedError(
+        `Cannot ${action} a sealed container (lines are immutable)`,
+      );
+    }
+  }
+
+  private touch(): void {
+    this._updatedAt = new Date();
+  }
+
+  toSnapshot(): ContainerSnapshot {
+    return {
+      id: this.id.value,
+      code: this.code,
+      type: this.type,
+      emergencyId: this.emergencyId.value,
+      parentContainerId: this._parentContainerId?.value ?? null,
+      lines: this._lines.map((l) => l.toSnapshot()),
+      grossWeightKg: this.grossWeightKg,
+      grossVolumeM3: this.grossVolumeM3,
+      holderType: this._holder?.type ?? null,
+      holderId: this._holder?.id ?? null,
+      status: this._status,
+      createdAt: this.createdAt,
+      updatedAt: this._updatedAt,
+    };
+  }
+}

--- a/apps/api/src/contexts/supplies/domain/ports/container-authorization-lookup.ts
+++ b/apps/api/src/contexts/supplies/domain/ports/container-authorization-lookup.ts
@@ -1,0 +1,19 @@
+export const CONTAINER_AUTHORIZATION_LOOKUP = Symbol(
+  'ContainerAuthorizationLookup',
+);
+
+export interface ContainerAuthorizationFacts {
+  emergencyId: string;
+}
+
+/**
+ * Resolves the emergency a container belongs to, for the HTTP layer's
+ * coordinator-membership gate on the `/supplies/containers/{id}/...` write
+ * routes (which carry no scope-resolvable param). Mirrors the logistics
+ * ShipmentAuthorizationLookup.
+ */
+export interface ContainerAuthorizationLookup {
+  findAuthorizationFacts(
+    containerId: string,
+  ): Promise<ContainerAuthorizationFacts | null>;
+}

--- a/apps/api/src/contexts/supplies/domain/ports/container.repository.ts
+++ b/apps/api/src/contexts/supplies/domain/ports/container.repository.ts
@@ -1,0 +1,36 @@
+import { Container } from '../container';
+import { ContainerId } from '../container-id';
+import { EmergencyId } from '../../../../shared/domain/emergency-id';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '../container-enums';
+
+export const CONTAINER_REPOSITORY = Symbol('ContainerRepository');
+
+/** Filter for listing containers within an emergency. AND-combined. */
+export interface ListContainersFilter {
+  type?: ContainerType;
+  status?: ContainerStatus;
+  holderType?: ContainerHolderType;
+  holderId?: string;
+  /** Only top-level containers (no parent) — the roots of the trees. */
+  topLevelOnly?: boolean;
+}
+
+export interface ContainerRepository {
+  save(container: Container): Promise<void>;
+  findById(id: ContainerId): Promise<Container | null>;
+  findByEmergency(
+    emergencyId: EmergencyId,
+    filter: ListContainersFilter,
+  ): Promise<Container[]>;
+  /** Direct children of a container (composition is by reference). */
+  findChildren(parentId: ContainerId): Promise<Container[]>;
+  /**
+   * Allocates the next code sequence for a (emergency, type) pair. The domain
+   * formats it into a code (`PAL-0001`); the running count lives in the store.
+   */
+  nextSequence(emergencyId: EmergencyId, type: ContainerType): Promise<number>;
+}

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container-authorization-lookup.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container-authorization-lookup.ts
@@ -1,0 +1,23 @@
+import { eq } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import { containersTable } from './schema';
+import {
+  ContainerAuthorizationFacts,
+  ContainerAuthorizationLookup,
+} from '../../domain/ports/container-authorization-lookup';
+
+export class DrizzleContainerAuthorizationLookup implements ContainerAuthorizationLookup {
+  constructor(private readonly db: Db) {}
+
+  async findAuthorizationFacts(
+    containerId: string,
+  ): Promise<ContainerAuthorizationFacts | null> {
+    const rows = await this.db
+      .select({ emergencyId: containersTable.emergencyId })
+      .from(containersTable)
+      .where(eq(containersTable.id, containerId))
+      .limit(1);
+    if (!rows[0]) return null;
+    return { emergencyId: rows[0].emergencyId };
+  }
+}

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container.repository.int-spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container.repository.int-spec.ts
@@ -1,0 +1,178 @@
+import { createDb, Db } from '../../../../shared/db';
+import { containersTable } from './schema';
+import { DrizzleContainerRepository } from './drizzle-container.repository';
+import { DrizzleContainerAuthorizationLookup } from './drizzle-container-authorization-lookup';
+import { Container } from '../../domain/container';
+import { ContainerId } from '../../domain/container-id';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '../../domain/container-enums';
+import { SupplyLine } from '../../domain/supply-line';
+import { Category } from '../../domain/category';
+import { EmergencyId } from '../../../../shared/domain/emergency-id';
+import type { Pool } from 'pg';
+
+const URL =
+  process.env.DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub';
+const EM = '66666666-6666-4666-8666-666666666666';
+const OTHER_EM = '77777777-7777-4777-8777-777777777777';
+const RESOURCE = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const SHIPMENT = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+function makeContainer(opts?: {
+  emergencyId?: string;
+  code?: string;
+  type?: ContainerType;
+  lines?: SupplyLine[];
+  grossWeightKg?: number | null;
+  holder?: { type: ContainerHolderType; id: string } | null;
+}): Container {
+  return Container.create({
+    id: ContainerId.create(),
+    code: opts?.code ?? 'PAL-0001',
+    type: opts?.type ?? ContainerType.Pallet,
+    emergencyId: EmergencyId.fromString(opts?.emergencyId ?? EM),
+    lines: opts?.lines ?? [],
+    grossWeightKg: opts?.grossWeightKg ?? null,
+    holder: opts?.holder ?? null,
+  });
+}
+
+describe('DrizzleContainerRepository (integration)', () => {
+  let db: Db;
+  let pool: Pool;
+  let repo: DrizzleContainerRepository;
+  let lookup: DrizzleContainerAuthorizationLookup;
+
+  beforeAll(() => {
+    ({ db, pool } = createDb(URL));
+    repo = new DrizzleContainerRepository(db);
+    lookup = new DrizzleContainerAuthorizationLookup(db);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await db.delete(containersTable);
+  });
+
+  it('round-trips a container (jsonb lines, holder, weight) through Postgres', async () => {
+    const c = makeContainer({
+      code: 'CAJ-0001',
+      type: ContainerType.Box,
+      grossWeightKg: 18.5,
+      lines: [
+        SupplyLine.create({
+          name: 'Agua',
+          quantity: 24,
+          unit: 'botellas',
+          category: Category.Water,
+        }),
+      ],
+      holder: { type: ContainerHolderType.Resource, id: RESOURCE },
+    });
+    await repo.save(c);
+
+    const found = await repo.findById(c.id);
+    expect(found).not.toBeNull();
+    expect(found!.code).toBe('CAJ-0001');
+    expect(found!.type).toBe(ContainerType.Box);
+    expect(found!.grossWeightKg).toBe(18.5);
+    expect(found!.lines).toHaveLength(1);
+    expect(found!.lines[0].name).toBe('Agua');
+    expect(found!.holder).toEqual({
+      type: ContainerHolderType.Resource,
+      id: RESOURCE,
+    });
+    expect(found!.status).toBe(ContainerStatus.Open);
+    // typed query builder → real Date, not a string
+    expect(found!.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('persists nesting, sealing and a holder move via upsert', async () => {
+    const pallet = makeContainer({ code: 'PAL-0001' });
+    const box = makeContainer({ code: 'CAJ-0001', type: ContainerType.Box });
+    await repo.save(pallet);
+    await repo.save(box);
+
+    box.setParent(pallet.id);
+    box.seal();
+    box.moveToHolder({ type: ContainerHolderType.Shipment, id: SHIPMENT });
+    await repo.save(box);
+
+    const found = await repo.findById(box.id);
+    expect(found!.parentContainerId?.value).toBe(pallet.id.value);
+    expect(found!.status).toBe(ContainerStatus.Sealed);
+    expect(found!.holder).toEqual({
+      type: ContainerHolderType.Shipment,
+      id: SHIPMENT,
+    });
+
+    const children = await repo.findChildren(pallet.id);
+    expect(children).toHaveLength(1);
+    expect(children[0].id.value).toBe(box.id.value);
+  });
+
+  it('nextSequence counts per (emergency, type)', async () => {
+    const em = EmergencyId.fromString(EM);
+    expect(await repo.nextSequence(em, ContainerType.Pallet)).toBe(1);
+    await repo.save(makeContainer({ code: 'PAL-0001' }));
+    expect(await repo.nextSequence(em, ContainerType.Pallet)).toBe(2);
+    // a different type and a different emergency keep their own count
+    expect(await repo.nextSequence(em, ContainerType.Box)).toBe(1);
+    expect(
+      await repo.nextSequence(
+        EmergencyId.fromString(OTHER_EM),
+        ContainerType.Pallet,
+      ),
+    ).toBe(1);
+  });
+
+  it('findByEmergency filters by type/status/holder/top-level, newest first', async () => {
+    const pallet = makeContainer({
+      code: 'PAL-0001',
+      holder: { type: ContainerHolderType.Shipment, id: SHIPMENT },
+    });
+    await repo.save(pallet);
+    const box = makeContainer({ code: 'CAJ-0001', type: ContainerType.Box });
+    box.setParent(pallet.id);
+    box.seal();
+    await repo.save(box);
+
+    const em = EmergencyId.fromString(EM);
+    expect(await repo.findByEmergency(em, {})).toHaveLength(2);
+    expect(
+      await repo.findByEmergency(em, { type: ContainerType.Box }),
+    ).toHaveLength(1);
+    expect(
+      await repo.findByEmergency(em, { status: ContainerStatus.Sealed }),
+    ).toHaveLength(1);
+    expect(await repo.findByEmergency(em, { topLevelOnly: true })).toHaveLength(
+      1,
+    );
+    const inShipment = await repo.findByEmergency(em, {
+      holderType: ContainerHolderType.Shipment,
+      holderId: SHIPMENT,
+    });
+    expect(inShipment).toHaveLength(1);
+    expect(inShipment[0].id.value).toBe(pallet.id.value);
+  });
+
+  it('authorization lookup resolves the emergency (and null for unknown)', async () => {
+    const c = makeContainer();
+    await repo.save(c);
+    expect(await lookup.findAuthorizationFacts(c.id.value)).toEqual({
+      emergencyId: EM,
+    });
+    expect(
+      await lookup.findAuthorizationFacts(
+        '00000000-0000-4000-8000-000000000000',
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container.repository.int-spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container.repository.int-spec.ts
@@ -1,5 +1,5 @@
 import { createDb, Db } from '../../../../shared/db';
-import { containersTable } from './schema';
+import { containerCodeSequencesTable, containersTable } from './schema';
 import { DrizzleContainerRepository } from './drizzle-container.repository';
 import { DrizzleContainerAuthorizationLookup } from './drizzle-container-authorization-lookup';
 import { Container } from '../../domain/container';
@@ -59,6 +59,7 @@ describe('DrizzleContainerRepository (integration)', () => {
 
   beforeEach(async () => {
     await db.delete(containersTable);
+    await db.delete(containerCodeSequencesTable);
   });
 
   it('round-trips a container (jsonb lines, holder, weight) through Postgres', async () => {
@@ -118,12 +119,12 @@ describe('DrizzleContainerRepository (integration)', () => {
     expect(children[0].id.value).toBe(box.id.value);
   });
 
-  it('nextSequence counts per (emergency, type)', async () => {
+  it('nextSequence allocates a monotonic per-(emergency, type) sequence, never reused', async () => {
     const em = EmergencyId.fromString(EM);
+    // increments on every call, independent of how many rows exist
     expect(await repo.nextSequence(em, ContainerType.Pallet)).toBe(1);
-    await repo.save(makeContainer({ code: 'PAL-0001' }));
     expect(await repo.nextSequence(em, ContainerType.Pallet)).toBe(2);
-    // a different type and a different emergency keep their own count
+    // a different type and a different emergency keep their own sequence
     expect(await repo.nextSequence(em, ContainerType.Box)).toBe(1);
     expect(
       await repo.nextSequence(
@@ -131,6 +132,11 @@ describe('DrizzleContainerRepository (integration)', () => {
         ContainerType.Pallet,
       ),
     ).toBe(1);
+    // deleting containers does NOT free a code for reuse — the sequence is
+    // monotonic, decoupled from the live row count.
+    await repo.save(makeContainer({ code: 'PAL-0003' }));
+    await db.delete(containersTable);
+    expect(await repo.nextSequence(em, ContainerType.Pallet)).toBe(3);
   });
 
   it('findByEmergency filters by type/status/holder/top-level, newest first', async () => {

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container.repository.ts
@@ -1,6 +1,6 @@
-import { and, asc, count, desc, eq, isNull, type SQL } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull, sql, type SQL } from 'drizzle-orm';
 import { Db } from '../../../../shared/db';
-import { containersTable } from './schema';
+import { containerCodeSequencesTable, containersTable } from './schema';
 import {
   ContainerRepository,
   ListContainersFilter,
@@ -121,19 +121,30 @@ export class DrizzleContainerRepository implements ContainerRepository {
     return rows.map((r) => Container.fromSnapshot(rowToSnapshot(r)));
   }
 
+  /**
+   * Atomically allocates the next code sequence for a (emergency, type) pair.
+   * The upsert increments and returns in a single statement, so concurrent
+   * creates never collide and a deleted container never frees its code (the
+   * sequence is monotonic, decoupled from the live row count).
+   */
   async nextSequence(
     emergencyId: EmergencyId,
     type: ContainerType,
   ): Promise<number> {
-    const rows = await this.db
-      .select({ value: count() })
-      .from(containersTable)
-      .where(
-        and(
-          eq(containersTable.emergencyId, emergencyId.value),
-          eq(containersTable.type, type),
-        ),
-      );
-    return (rows[0]?.value ?? 0) + 1;
+    const [row] = await this.db
+      .insert(containerCodeSequencesTable)
+      .values({ emergencyId: emergencyId.value, type, lastValue: 1 })
+      .onConflictDoUpdate({
+        target: [
+          containerCodeSequencesTable.emergencyId,
+          containerCodeSequencesTable.type,
+        ],
+        set: { lastValue: sql`${containerCodeSequencesTable.lastValue} + 1` },
+      })
+      .returning({ value: containerCodeSequencesTable.lastValue });
+    if (!row) {
+      throw new Error('Container code sequence allocation returned no row');
+    }
+    return row.value;
   }
 }

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-container.repository.ts
@@ -1,0 +1,139 @@
+import { and, asc, count, desc, eq, isNull, type SQL } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import { containersTable } from './schema';
+import {
+  ContainerRepository,
+  ListContainersFilter,
+} from '../../domain/ports/container.repository';
+import { Container, ContainerSnapshot } from '../../domain/container';
+import { ContainerId } from '../../domain/container-id';
+import { EmergencyId } from '../../../../shared/domain/emergency-id';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '../../domain/container-enums';
+
+type ContainerRow = typeof containersTable.$inferSelect;
+
+function rowToSnapshot(row: ContainerRow): ContainerSnapshot {
+  return {
+    id: row.id,
+    code: row.code,
+    type: row.type as ContainerType,
+    emergencyId: row.emergencyId,
+    parentContainerId: row.parentContainerId ?? null,
+    lines: row.lines ?? [],
+    grossWeightKg: row.grossWeightKg ?? null,
+    grossVolumeM3: row.grossVolumeM3 ?? null,
+    holderType: (row.holderType as ContainerHolderType | null) ?? null,
+    holderId: row.holderId ?? null,
+    status: row.status as ContainerStatus,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class DrizzleContainerRepository implements ContainerRepository {
+  constructor(private readonly db: Db) {}
+
+  async save(container: Container): Promise<void> {
+    const s = container.toSnapshot();
+    await this.db
+      .insert(containersTable)
+      .values({
+        id: s.id,
+        emergencyId: s.emergencyId,
+        code: s.code,
+        type: s.type,
+        parentContainerId: s.parentContainerId,
+        lines: s.lines,
+        grossWeightKg: s.grossWeightKg,
+        grossVolumeM3: s.grossVolumeM3,
+        holderType: s.holderType,
+        holderId: s.holderId,
+        status: s.status,
+        createdAt: s.createdAt,
+        updatedAt: s.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: containersTable.id,
+        set: {
+          parentContainerId: s.parentContainerId,
+          lines: s.lines,
+          holderType: s.holderType,
+          holderId: s.holderId,
+          status: s.status,
+          updatedAt: s.updatedAt,
+        },
+      });
+  }
+
+  async findById(id: ContainerId): Promise<Container | null> {
+    const rows = await this.db
+      .select()
+      .from(containersTable)
+      .where(eq(containersTable.id, id.value))
+      .limit(1);
+    if (!rows[0]) return null;
+    return Container.fromSnapshot(rowToSnapshot(rows[0]));
+  }
+
+  async findByEmergency(
+    emergencyId: EmergencyId,
+    filter: ListContainersFilter,
+  ): Promise<Container[]> {
+    const conditions: SQL[] = [
+      eq(containersTable.emergencyId, emergencyId.value),
+    ];
+    if (filter.type !== undefined) {
+      conditions.push(eq(containersTable.type, filter.type));
+    }
+    if (filter.status !== undefined) {
+      conditions.push(eq(containersTable.status, filter.status));
+    }
+    if (filter.holderType !== undefined) {
+      conditions.push(eq(containersTable.holderType, filter.holderType));
+    }
+    if (filter.holderId !== undefined) {
+      conditions.push(eq(containersTable.holderId, filter.holderId));
+    }
+    if (filter.topLevelOnly) {
+      conditions.push(isNull(containersTable.parentContainerId));
+    }
+
+    const rows = await this.db
+      .select()
+      .from(containersTable)
+      .where(and(...conditions))
+      .orderBy(desc(containersTable.createdAt));
+
+    return rows.map((r) => Container.fromSnapshot(rowToSnapshot(r)));
+  }
+
+  async findChildren(parentId: ContainerId): Promise<Container[]> {
+    const rows = await this.db
+      .select()
+      .from(containersTable)
+      .where(eq(containersTable.parentContainerId, parentId.value))
+      .orderBy(asc(containersTable.createdAt));
+
+    return rows.map((r) => Container.fromSnapshot(rowToSnapshot(r)));
+  }
+
+  async nextSequence(
+    emergencyId: EmergencyId,
+    type: ContainerType,
+  ): Promise<number> {
+    const rows = await this.db
+      .select({ value: count() })
+      .from(containersTable)
+      .where(
+        and(
+          eq(containersTable.emergencyId, emergencyId.value),
+          eq(containersTable.type, type),
+        ),
+      );
+    return (rows[0]?.value ?? 0) + 1;
+  }
+}

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
@@ -1,4 +1,14 @@
-import { pgTable, text, integer, AnyPgColumn } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  text,
+  integer,
+  uuid,
+  jsonb,
+  doublePrecision,
+  timestamp,
+  AnyPgColumn,
+} from 'drizzle-orm/pg-core';
+import { SupplyLineSnapshot } from '../../domain/supply-line';
 
 export const categoriesTable = pgTable('categories', {
   slug: text('slug').primaryKey(),
@@ -17,4 +27,33 @@ export const categoryAliasesTable = pgTable('category_aliases', {
   categorySlug: text('category_slug')
     .notNull()
     .references(() => categoriesTable.slug),
+});
+
+/**
+ * Trackable packaging units (palet/caja/lote) — #140. Composition is by
+ * reference via the self-FK `parent_container_id` (ON DELETE SET NULL: deleting
+ * a parent un-nests its children). Direct content is the SupplyLine[] jsonb;
+ * the polymorphic holder (resource|shipment, no FK) records where it is now.
+ */
+export const containersTable = pgTable('containers', {
+  id: uuid('id').primaryKey(),
+  emergencyId: uuid('emergency_id').notNull(),
+  // Generated legible code / QR payload (e.g. PAL-0001). Unique per emergency.
+  code: text('code').notNull(),
+  type: text('type').notNull(),
+  parentContainerId: uuid('parent_container_id').references(
+    (): AnyPgColumn => containersTable.id,
+    { onDelete: 'set null' },
+  ),
+  // Loose supply lines held directly in this container (VO from #131).
+  lines: jsonb('lines').$type<SupplyLineSnapshot[]>().notNull(),
+  // Declared gross weight/volume (not yet derived from a catalogue).
+  grossWeightKg: doublePrecision('gross_weight_kg'),
+  grossVolumeM3: doublePrecision('gross_volume_m3'),
+  // Polymorphic holder (no FK): 'resource' | 'shipment'. Null when held by none.
+  holderType: text('holder_type'),
+  holderId: uuid('holder_id'),
+  status: text('status').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
 });

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
@@ -57,3 +57,17 @@ export const containersTable = pgTable('containers', {
   createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
 });
+
+/**
+ * Monotonic per-(emergency, type) allocator for container codes. An atomic
+ * upsert (`INSERT … ON CONFLICT (emergency_id, type) DO UPDATE SET
+ * last_value = last_value + 1 RETURNING last_value`) hands out the next value,
+ * so concurrent creates never mint the same code and a deleted container never
+ * frees its code for reuse — keeping `containers.code` unique per emergency.
+ * The composite primary key (emergency_id, type) lives in migration 0033.
+ */
+export const containerCodeSequencesTable = pgTable('container_code_sequences', {
+  emergencyId: uuid('emergency_id').notNull(),
+  type: text('type').notNull(),
+  lastValue: integer('last_value').notNull(),
+});

--- a/apps/api/src/contexts/supplies/infrastructure/http/container-dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/container-dto.ts
@@ -1,0 +1,138 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsPositive,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '../../domain/container-enums';
+import { SupplyLineDto } from './supply-line.dto';
+
+export class ContainerHolderDto {
+  @ApiProperty({
+    enum: ContainerHolderType,
+    example: ContainerHolderType.Resource,
+  })
+  @IsEnum(ContainerHolderType)
+  type!: ContainerHolderType;
+
+  @ApiProperty({
+    format: 'uuid',
+    description: 'Resource node or shipment id (polymorphic, no FK)',
+  })
+  @IsUUID()
+  id!: string;
+}
+
+export class CreateContainerDto {
+  @ApiProperty({
+    format: 'uuid',
+    description: 'Emergency this container serves',
+  })
+  @IsUUID()
+  emergencyId!: string;
+
+  @ApiProperty({ enum: ContainerType, example: ContainerType.Pallet })
+  @IsEnum(ContainerType)
+  type!: ContainerType;
+
+  @ApiPropertyOptional({
+    type: [SupplyLineDto],
+    description: 'Optional initial loose supply lines',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SupplyLineDto)
+  lines?: SupplyLineDto[];
+
+  @ApiPropertyOptional({
+    example: 120,
+    description: 'Declared gross weight in kg (positive)',
+    type: Number,
+  })
+  @IsOptional()
+  @IsPositive()
+  grossWeightKg?: number;
+
+  @ApiPropertyOptional({
+    example: 1.2,
+    description: 'Declared gross volume in m³ (positive)',
+    type: Number,
+  })
+  @IsOptional()
+  @IsPositive()
+  grossVolumeM3?: number;
+
+  @ApiPropertyOptional({
+    type: ContainerHolderDto,
+    description: 'Optional initial holder (e.g. the hub it is created at)',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ContainerHolderDto)
+  holder?: ContainerHolderDto;
+}
+
+export class NestContainerDto {
+  @ApiPropertyOptional({
+    format: 'uuid',
+    nullable: true,
+    type: String,
+    description: 'New parent container, or null to un-nest (make it top-level)',
+  })
+  @IsOptional()
+  @IsUUID()
+  parentContainerId?: string | null;
+}
+
+export class MoveContainerDto {
+  @ApiPropertyOptional({
+    type: ContainerHolderDto,
+    nullable: true,
+    description: 'New holder (resource ↔ shipment), or null to detach',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ContainerHolderDto)
+  holder?: ContainerHolderDto | null;
+}
+
+export class ListContainersQueryDto {
+  @ApiPropertyOptional({ enum: ContainerType })
+  @IsOptional()
+  @IsEnum(ContainerType)
+  type?: ContainerType;
+
+  @ApiPropertyOptional({ enum: ContainerStatus })
+  @IsOptional()
+  @IsEnum(ContainerStatus)
+  status?: ContainerStatus;
+
+  @ApiPropertyOptional({ enum: ContainerHolderType })
+  @IsOptional()
+  @IsEnum(ContainerHolderType)
+  holderType?: ContainerHolderType;
+
+  @ApiPropertyOptional({ format: 'uuid' })
+  @IsOptional()
+  @IsUUID()
+  holderId?: string;
+
+  @ApiPropertyOptional({
+    type: Boolean,
+    description: 'Only top-level containers (the roots of the trees)',
+  })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  topLevelOnly?: boolean;
+}

--- a/apps/api/src/contexts/supplies/infrastructure/http/container-response.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/container-response.dto.ts
@@ -1,0 +1,84 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '../../domain/container-enums';
+import { SupplyLineResponseDto } from './supply-line.dto';
+
+export class CreateContainerResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({ example: 'PAL-0001', description: 'Generated trackable code' })
+  code!: string;
+}
+
+export class ContainerViewDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({ example: 'PAL-0001' })
+  code!: string;
+
+  @ApiProperty({ enum: ContainerType, example: ContainerType.Pallet })
+  type!: ContainerType;
+
+  @ApiProperty({ format: 'uuid' })
+  emergencyId!: string;
+
+  @ApiPropertyOptional({ format: 'uuid', nullable: true, type: String })
+  parentContainerId!: string | null;
+
+  @ApiProperty({ type: [SupplyLineResponseDto] })
+  lines!: SupplyLineResponseDto[];
+
+  @ApiPropertyOptional({ example: 120, nullable: true, type: Number })
+  grossWeightKg!: number | null;
+
+  @ApiPropertyOptional({ example: 1.2, nullable: true, type: Number })
+  grossVolumeM3!: number | null;
+
+  @ApiPropertyOptional({
+    enum: ContainerHolderType,
+    nullable: true,
+    example: ContainerHolderType.Resource,
+  })
+  holderType!: ContainerHolderType | null;
+
+  @ApiPropertyOptional({ format: 'uuid', nullable: true, type: String })
+  holderId!: string | null;
+
+  @ApiProperty({ enum: ContainerStatus, example: ContainerStatus.Open })
+  status!: ContainerStatus;
+
+  @ApiProperty({ example: '2026-07-01T00:00:00.000Z' })
+  createdAt!: string;
+
+  @ApiProperty({ example: '2026-07-01T00:00:00.000Z' })
+  updatedAt!: string;
+}
+
+export class ContainerTreeViewDto extends ContainerViewDto {
+  @ApiProperty({
+    type: () => [ContainerTreeViewDto],
+    description: 'Direct children (recursive)',
+  })
+  children!: ContainerTreeViewDto[];
+
+  @ApiPropertyOptional({
+    example: 145,
+    nullable: true,
+    type: Number,
+    description: 'Aggregated weight (own + Σ children), null if none declared',
+  })
+  totalWeightKg!: number | null;
+
+  @ApiPropertyOptional({
+    example: 2.5,
+    nullable: true,
+    type: Number,
+    description: 'Aggregated volume (own + Σ children), null if none declared',
+  })
+  totalVolumeM3!: number | null;
+}

--- a/apps/api/src/contexts/supplies/infrastructure/http/containers.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/containers.controller.spec.ts
@@ -1,0 +1,170 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ContainerController } from './containers.controller';
+import { CreateContainerDto } from './container-dto';
+import { CreateContainer } from '../../application/create-container';
+import { AddLineToContainer } from '../../application/add-line-to-container';
+import { RemoveLineFromContainer } from '../../application/remove-line-from-container';
+import { NestContainer } from '../../application/nest-container';
+import { SealContainer } from '../../application/seal-container';
+import { MoveContainer } from '../../application/move-container';
+import { GetContainer } from '../../application/get-container';
+import { ListContainers } from '../../application/list-containers';
+import { MembershipRepository } from '../../../identity/domain/ports/membership.repository';
+import { Role } from '../../../identity/domain/role';
+import { ContainerType } from '../../domain/container-enums';
+
+/**
+ * Controller-level authorization tests (mirror of the shipment controller, #150):
+ * the container write routes carry no scope-resolvable param, so they gate on
+ * coordinator membership of the container's emergency. Pure unit test — no DB.
+ */
+const EM = '44444444-4444-4444-8444-444444444444';
+const CONTAINER = '55555555-5555-4555-8555-555555555555';
+const USER = '11111111-1111-4111-8111-111111111111';
+
+type ReqArg = Parameters<ContainerController['create']>[1];
+
+function req(isAdmin = false): ReqArg {
+  return {
+    user: { id: USER, email: 'coord@example.com', isAdmin },
+  } as unknown as ReqArg;
+}
+
+function createDto(): CreateContainerDto {
+  return { emergencyId: EM, type: ContainerType.Pallet };
+}
+
+function setup() {
+  const createContainer = {
+    execute: jest.fn().mockResolvedValue({ id: CONTAINER, code: 'PAL-0001' }),
+  };
+  const sealContainer = { execute: jest.fn().mockResolvedValue(undefined) };
+  const getContainer = {
+    execute: jest.fn().mockResolvedValue({ id: CONTAINER }),
+  };
+  const noop = { execute: jest.fn() };
+  const containerAuthLookup = { findAuthorizationFacts: jest.fn() };
+  const membershipRepo = { hasRole: jest.fn() };
+
+  const controller = new ContainerController(
+    createContainer as unknown as CreateContainer,
+    noop as unknown as AddLineToContainer,
+    noop as unknown as RemoveLineFromContainer,
+    noop as unknown as NestContainer,
+    sealContainer as unknown as SealContainer,
+    noop as unknown as MoveContainer,
+    getContainer as unknown as GetContainer,
+    noop as unknown as ListContainers,
+    containerAuthLookup,
+    membershipRepo as unknown as MembershipRepository,
+  );
+
+  return {
+    controller,
+    createContainer,
+    sealContainer,
+    getContainer,
+    containerAuthLookup,
+    membershipRepo,
+  };
+}
+
+describe('ContainerController — authorization gating', () => {
+  describe('create', () => {
+    it('403s a non-coordinator and does not create', async () => {
+      const t = setup();
+      t.membershipRepo.hasRole.mockResolvedValue(false);
+      await expect(
+        t.controller.create(createDto(), req()),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(t.createContainer.execute).not.toHaveBeenCalled();
+    });
+
+    it('creates for a coordinator of the emergency', async () => {
+      const t = setup();
+      t.membershipRepo.hasRole.mockResolvedValue(true);
+      const res = await t.controller.create(createDto(), req());
+      expect(res).toEqual({ id: CONTAINER, code: 'PAL-0001' });
+      expect(t.createContainer.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates for a platform admin without checking membership', async () => {
+      const t = setup();
+      await t.controller.create(createDto(), req(true));
+      expect(t.membershipRepo.hasRole).not.toHaveBeenCalled();
+      expect(t.createContainer.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('seal (representative /{id} write)', () => {
+    it('404s when the container does not exist', async () => {
+      const t = setup();
+      t.containerAuthLookup.findAuthorizationFacts.mockResolvedValue(null);
+      await expect(t.controller.seal(CONTAINER, req())).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(t.sealContainer.execute).not.toHaveBeenCalled();
+    });
+
+    it('403s a non-coordinator of the container emergency', async () => {
+      const t = setup();
+      t.containerAuthLookup.findAuthorizationFacts.mockResolvedValue({
+        emergencyId: EM,
+      });
+      t.membershipRepo.hasRole.mockResolvedValue(false);
+      await expect(t.controller.seal(CONTAINER, req())).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      expect(t.sealContainer.execute).not.toHaveBeenCalled();
+    });
+
+    it('seals for a coordinator of the container emergency', async () => {
+      const t = setup();
+      t.containerAuthLookup.findAuthorizationFacts.mockResolvedValue({
+        emergencyId: EM,
+      });
+      t.membershipRepo.hasRole.mockResolvedValue(true);
+      await t.controller.seal(CONTAINER, req());
+      expect(t.sealContainer.execute).toHaveBeenCalledWith({
+        containerId: CONTAINER,
+      });
+    });
+  });
+
+  describe('get (reader gate: coordinator or verifier)', () => {
+    it('404s an unknown container', async () => {
+      const t = setup();
+      t.containerAuthLookup.findAuthorizationFacts.mockResolvedValue(null);
+      await expect(t.controller.get(CONTAINER, req())).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('403s a user who is neither coordinator nor verifier', async () => {
+      const t = setup();
+      t.containerAuthLookup.findAuthorizationFacts.mockResolvedValue({
+        emergencyId: EM,
+      });
+      t.membershipRepo.hasRole.mockResolvedValue(false);
+      await expect(t.controller.get(CONTAINER, req())).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+
+    it('returns the tree for a verifier of the emergency', async () => {
+      const t = setup();
+      t.containerAuthLookup.findAuthorizationFacts.mockResolvedValue({
+        emergencyId: EM,
+      });
+      t.membershipRepo.hasRole.mockImplementation(
+        (_userId: unknown, _em: string, role: Role) =>
+          Promise.resolve(role === Role.Verifier),
+      );
+      const res = await t.controller.get(CONTAINER, req());
+      expect(res).toEqual({ id: CONTAINER });
+      expect(t.getContainer.execute).toHaveBeenCalledWith({
+        containerId: CONTAINER,
+      });
+    });
+  });
+});

--- a/apps/api/src/contexts/supplies/infrastructure/http/containers.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/containers.controller.ts
@@ -1,0 +1,376 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  Inject,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiConflictResponse,
+} from '@nestjs/swagger';
+import { CreateContainer } from '../../application/create-container';
+import { AddLineToContainer } from '../../application/add-line-to-container';
+import { RemoveLineFromContainer } from '../../application/remove-line-from-container';
+import { NestContainer } from '../../application/nest-container';
+import { SealContainer } from '../../application/seal-container';
+import { MoveContainer } from '../../application/move-container';
+import { GetContainer } from '../../application/get-container';
+import { ListContainers } from '../../application/list-containers';
+import {
+  ContainerView,
+  ContainerTreeView,
+} from '../../application/container-view';
+import {
+  CreateContainerDto,
+  ListContainersQueryDto,
+  MoveContainerDto,
+  NestContainerDto,
+} from './container-dto';
+import { SupplyLineDto } from './supply-line.dto';
+import {
+  ContainerTreeViewDto,
+  ContainerViewDto,
+  CreateContainerResponseDto,
+} from './container-response.dto';
+import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
+import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
+import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
+import {
+  CONTAINER_AUTHORIZATION_LOOKUP,
+  type ContainerAuthorizationLookup,
+} from '../../domain/ports/container-authorization-lookup';
+import {
+  MEMBERSHIP_REPOSITORY,
+  type MembershipRepository,
+} from '../../../identity/domain/ports/membership.repository';
+import { UserId } from '../../../identity/domain/user-id';
+import { Role } from '../../../identity/domain/role';
+
+interface AuthenticatedRequest extends Express.Request {
+  user: { id: string; email: string; isAdmin: boolean };
+}
+
+/**
+ * Trackable containers (palet/caja/lote) — #140. Management is gated on
+ * coordinator membership of the container's emergency (mirroring the shipment
+ * controller: the write routes carry no scope-resolvable param, so the global
+ * PermissionGuard would fall back to the platform scope and 403 a legitimate
+ * coordinator). The emergency-scoped list uses the PermissionGuard with
+ * `container:read`.
+ */
+@ApiTags('supplies')
+@Controller()
+export class ContainerController {
+  constructor(
+    private readonly createContainer: CreateContainer,
+    private readonly addLineToContainer: AddLineToContainer,
+    private readonly removeLineFromContainer: RemoveLineFromContainer,
+    private readonly nestContainer: NestContainer,
+    private readonly sealContainer: SealContainer,
+    private readonly moveContainer: MoveContainer,
+    private readonly getContainer: GetContainer,
+    private readonly listContainers: ListContainers,
+    @Inject(CONTAINER_AUTHORIZATION_LOOKUP)
+    private readonly containerAuthLookup: ContainerAuthorizationLookup,
+    @Inject(MEMBERSHIP_REPOSITORY)
+    private readonly membershipRepo: MembershipRepository,
+  ) {}
+
+  /** Coordinator-or-admin gate for managing containers of an emergency. */
+  private async assertEmergencyManager(
+    emergencyId: string,
+    req: AuthenticatedRequest,
+  ): Promise<void> {
+    if (req.user.isAdmin) return;
+    const isCoordinator = await this.membershipRepo.hasRole(
+      UserId.fromString(req.user.id),
+      emergencyId,
+      Role.Coordinator,
+    );
+    if (!isCoordinator) {
+      throw new ForbiddenException(
+        'Only a coordinator of the emergency can manage containers',
+      );
+    }
+  }
+
+  /** Resolves the container's emergency (404 if unknown) and gates management. */
+  private async assertContainerManager(
+    containerId: string,
+    req: AuthenticatedRequest,
+  ): Promise<void> {
+    const facts =
+      await this.containerAuthLookup.findAuthorizationFacts(containerId);
+    if (facts === null) {
+      throw new NotFoundException(`Container ${containerId} not found`);
+    }
+    await this.assertEmergencyManager(facts.emergencyId, req);
+  }
+
+  /** Read gate for a single container: admin, coordinator or verifier. */
+  private async assertContainerReader(
+    containerId: string,
+    req: AuthenticatedRequest,
+  ): Promise<void> {
+    const facts =
+      await this.containerAuthLookup.findAuthorizationFacts(containerId);
+    if (facts === null) {
+      throw new NotFoundException(`Container ${containerId} not found`);
+    }
+    if (req.user.isAdmin) return;
+    const userId = UserId.fromString(req.user.id);
+    const canRead =
+      (await this.membershipRepo.hasRole(
+        userId,
+        facts.emergencyId,
+        Role.Coordinator,
+      )) ||
+      (await this.membershipRepo.hasRole(
+        userId,
+        facts.emergencyId,
+        Role.Verifier,
+      ));
+    if (!canRead) {
+      throw new ForbiddenException(
+        'Only a coordinator or verifier of the emergency can read this container',
+      );
+    }
+  }
+
+  @Post('supplies/containers')
+  @HttpCode(201)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Create a trackable container (palet/caja/lote) (coordinator)',
+  })
+  @ApiCreatedResponse({
+    description: 'Container created (open), with a generated code',
+    type: CreateContainerResponseDto,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid request body' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Not a coordinator of the emergency' })
+  async create(
+    @Body() dto: CreateContainerDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<CreateContainerResponseDto> {
+    await this.assertEmergencyManager(dto.emergencyId, req);
+    return this.createContainer.execute({
+      emergencyId: dto.emergencyId,
+      type: dto.type,
+      lines: (dto.lines ?? []).map((l) => ({
+        name: l.name,
+        quantity: l.quantity,
+        unit: l.unit ?? null,
+        category: l.category,
+        presentation: l.presentation ?? null,
+      })),
+      grossWeightKg: dto.grossWeightKg ?? null,
+      grossVolumeM3: dto.grossVolumeM3 ?? null,
+      holder: dto.holder ? { type: dto.holder.type, id: dto.holder.id } : null,
+    });
+  }
+
+  @Post('supplies/containers/:id/lines')
+  @HttpCode(204)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a supply line to a container (coordinator)' })
+  @ApiParam({ name: 'id', description: 'Container UUID', format: 'uuid' })
+  @ApiNoContentResponse({ description: 'Line added' })
+  @ApiBadRequestResponse({ description: 'Invalid request body' })
+  @ApiNotFoundResponse({ description: 'Container not found' })
+  @ApiConflictResponse({ description: 'Container is sealed (lines immutable)' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Not a coordinator of the emergency' })
+  async addLine(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: SupplyLineDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<void> {
+    await this.assertContainerManager(id, req);
+    await this.addLineToContainer.execute({
+      containerId: id,
+      line: {
+        name: dto.name,
+        quantity: dto.quantity,
+        unit: dto.unit ?? null,
+        category: dto.category,
+        presentation: dto.presentation ?? null,
+      },
+    });
+  }
+
+  @Delete('supplies/containers/:id/lines/:index')
+  @HttpCode(204)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Remove the supply line at an index from a container (coordinator)',
+  })
+  @ApiParam({ name: 'id', description: 'Container UUID', format: 'uuid' })
+  @ApiParam({ name: 'index', description: 'Zero-based line index', example: 0 })
+  @ApiNoContentResponse({ description: 'Line removed' })
+  @ApiNotFoundResponse({ description: 'Container not found' })
+  @ApiConflictResponse({ description: 'Container is sealed (lines immutable)' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Not a coordinator of the emergency' })
+  async removeLine(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('index', ParseIntPipe) index: number,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<void> {
+    await this.assertContainerManager(id, req);
+    await this.removeLineFromContainer.execute({ containerId: id, index });
+  }
+
+  @Post('supplies/containers/:id/nest')
+  @HttpCode(204)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Nest a container under a parent, or un-nest it (coordinator)',
+  })
+  @ApiParam({ name: 'id', description: 'Container UUID', format: 'uuid' })
+  @ApiNoContentResponse({ description: 'Container re-parented' })
+  @ApiBadRequestResponse({ description: 'Invalid request body' })
+  @ApiNotFoundResponse({ description: 'Container or parent not found' })
+  @ApiConflictResponse({
+    description: 'Would create a cycle, or parent is a different emergency',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Not a coordinator of the emergency' })
+  async nest(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: NestContainerDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<void> {
+    await this.assertContainerManager(id, req);
+    await this.nestContainer.execute({
+      containerId: id,
+      parentContainerId: dto.parentContainerId ?? null,
+    });
+  }
+
+  @Post('supplies/containers/:id/seal')
+  @HttpCode(204)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Seal (precintar) a container (coordinator)' })
+  @ApiParam({ name: 'id', description: 'Container UUID', format: 'uuid' })
+  @ApiNoContentResponse({ description: 'Container sealed' })
+  @ApiNotFoundResponse({ description: 'Container not found' })
+  @ApiConflictResponse({ description: 'Container is already sealed' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Not a coordinator of the emergency' })
+  async seal(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<void> {
+    await this.assertContainerManager(id, req);
+    await this.sealContainer.execute({ containerId: id });
+  }
+
+  @Post('supplies/containers/:id/move')
+  @HttpCode(204)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Move a container to a holder (resource ↔ shipment) (coordinator)',
+  })
+  @ApiParam({ name: 'id', description: 'Container UUID', format: 'uuid' })
+  @ApiNoContentResponse({ description: 'Container moved' })
+  @ApiBadRequestResponse({ description: 'Invalid request body' })
+  @ApiNotFoundResponse({ description: 'Container not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Not a coordinator of the emergency' })
+  async move(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: MoveContainerDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<void> {
+    await this.assertContainerManager(id, req);
+    await this.moveContainer.execute({
+      containerId: id,
+      holder: dto.holder ? { type: dto.holder.type, id: dto.holder.id } : null,
+    });
+  }
+
+  @Get('supplies/containers/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Get a container tree with aggregated weight/volume (coordinator/verifier)',
+  })
+  @ApiParam({ name: 'id', description: 'Container UUID', format: 'uuid' })
+  @ApiOkResponse({ description: 'Container tree', type: ContainerTreeViewDto })
+  @ApiNotFoundResponse({ description: 'Container not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({
+    description: 'Not a coordinator/verifier of the emergency',
+  })
+  async get(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<ContainerTreeView> {
+    await this.assertContainerReader(id, req);
+    return this.getContainer.execute({ containerId: id });
+  }
+
+  @Get('emergencies/:emergencyId/supplies/containers')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission('container:read')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'List containers for an emergency (coordinator/verifier)',
+  })
+  @ApiParam({
+    name: 'emergencyId',
+    description: 'Emergency UUID',
+    format: 'uuid',
+  })
+  @ApiOkResponse({ description: 'Containers', type: [ContainerViewDto] })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing container:read permission' })
+  async list(
+    @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
+    @Query() query: ListContainersQueryDto,
+  ): Promise<ContainerView[]> {
+    return this.listContainers.execute({
+      emergencyId,
+      ...(query.type !== undefined ? { type: query.type } : {}),
+      ...(query.status !== undefined ? { status: query.status } : {}),
+      ...(query.holderType !== undefined
+        ? { holderType: query.holderType }
+        : {}),
+      ...(query.holderId !== undefined ? { holderId: query.holderId } : {}),
+      ...(query.topLevelOnly !== undefined
+        ? { topLevelOnly: query.topLevelOnly }
+        : {}),
+    });
+  }
+}

--- a/apps/api/src/contexts/supplies/infrastructure/http/containers.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/containers.controller.ts
@@ -28,6 +28,7 @@ import {
   ApiForbiddenResponse,
   ApiOkResponse,
   ApiConflictResponse,
+  ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
 import { CreateContainer } from '../../application/create-container';
 import { AddLineToContainer } from '../../application/add-line-to-container';
@@ -258,7 +259,7 @@ export class ContainerController {
   @ApiNoContentResponse({ description: 'Container re-parented' })
   @ApiBadRequestResponse({ description: 'Invalid request body' })
   @ApiNotFoundResponse({ description: 'Container or parent not found' })
-  @ApiConflictResponse({
+  @ApiUnprocessableEntityResponse({
     description: 'Would create a cycle, or parent is a different emergency',
   })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
@@ -1,0 +1,61 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { ContainerNotFoundError } from '../../application/container-not-found.error';
+import {
+  ContainerCycleError,
+  ContainerEmergencyMismatchError,
+  ContainerSealedError,
+  ContainerValidationError,
+} from '../../domain/container-errors';
+import { SupplyLineValidationError } from '../../domain/supply-line';
+
+type DomainError =
+  | ContainerNotFoundError
+  | ContainerSealedError
+  | ContainerCycleError
+  | ContainerEmergencyMismatchError
+  | ContainerValidationError
+  | SupplyLineValidationError;
+
+/**
+ * Maps supplies/container domain errors to HTTP codes: not-found → 404; sealed
+ * conflict and cycle/emergency-mismatch invariants → 409; the rest of the
+ * validation errors → 422. Mirrors the per-context filters of resources,
+ * needs, offers and logistics.
+ */
+@Catch(
+  ContainerNotFoundError,
+  ContainerSealedError,
+  ContainerCycleError,
+  ContainerEmergencyMismatchError,
+  ContainerValidationError,
+  SupplyLineValidationError,
+)
+export class SuppliesDomainExceptionFilter implements ExceptionFilter {
+  catch(exception: DomainError, host: ArgumentsHost): void {
+    const response = host.switchToHttp().getResponse<Response>();
+    const statusCode = this.statusFor(exception);
+    response
+      .status(statusCode)
+      .json({ statusCode, message: exception.message });
+  }
+
+  private statusFor(exception: DomainError): HttpStatus {
+    if (exception instanceof ContainerNotFoundError) {
+      return HttpStatus.NOT_FOUND;
+    }
+    if (
+      exception instanceof ContainerSealedError ||
+      exception instanceof ContainerCycleError ||
+      exception instanceof ContainerEmergencyMismatchError
+    ) {
+      return HttpStatus.CONFLICT;
+    }
+    return HttpStatus.UNPROCESSABLE_ENTITY;
+  }
+}

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
@@ -23,10 +23,16 @@ type DomainError =
   | SupplyLineValidationError;
 
 /**
- * Maps supplies/container domain errors to HTTP codes: not-found → 404; sealed
- * conflict and cycle/emergency-mismatch invariants → 409; the rest of the
- * validation errors → 422. Mirrors the per-context filters of resources,
- * needs, offers and logistics.
+ * Maps supplies domain errors to HTTP codes. The supplies context owns the
+ * SupplyLine value object, so its validation error is mapped here (→ 400)
+ * rather than in another context's filter.
+ *
+ * - not-found → 404
+ * - sealed (a state conflict: mutating/re-sealing a precintado container) → 409
+ * - cycle / cross-emergency nest / other container validation → 422
+ *   (matches how the codebase maps "wrong emergency", e.g. offers'
+ *   TargetNeedWrongEmergencyError → 422)
+ * - SupplyLineValidationError (e.g. a whitespace-only line name) → 400
  */
 @Catch(
   ContainerNotFoundError,
@@ -49,12 +55,11 @@ export class SuppliesDomainExceptionFilter implements ExceptionFilter {
     if (exception instanceof ContainerNotFoundError) {
       return HttpStatus.NOT_FOUND;
     }
-    if (
-      exception instanceof ContainerSealedError ||
-      exception instanceof ContainerCycleError ||
-      exception instanceof ContainerEmergencyMismatchError
-    ) {
+    if (exception instanceof ContainerSealedError) {
       return HttpStatus.CONFLICT;
+    }
+    if (exception instanceof SupplyLineValidationError) {
+      return HttpStatus.BAD_REQUEST;
     }
     return HttpStatus.UNPROCESSABLE_ENTITY;
   }

--- a/apps/api/src/contexts/supplies/infrastructure/in-memory-container.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/in-memory-container.repository.ts
@@ -1,0 +1,58 @@
+import {
+  ContainerRepository,
+  ListContainersFilter,
+} from '../domain/ports/container.repository';
+import { Container, ContainerSnapshot } from '../domain/container';
+import { ContainerId } from '../domain/container-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ContainerType } from '../domain/container-enums';
+
+export class InMemoryContainerRepository implements ContainerRepository {
+  private store = new Map<string, ContainerSnapshot>();
+
+  save(container: Container): Promise<void> {
+    this.store.set(container.id.value, container.toSnapshot());
+    return Promise.resolve();
+  }
+
+  findById(id: ContainerId): Promise<Container | null> {
+    const snap = this.store.get(id.value);
+    return Promise.resolve(snap ? Container.fromSnapshot(snap) : null);
+  }
+
+  findByEmergency(
+    emergencyId: EmergencyId,
+    filter: ListContainersFilter,
+  ): Promise<Container[]> {
+    const result = [...this.store.values()]
+      .filter((s) => s.emergencyId === emergencyId.value)
+      .filter((s) => filter.type === undefined || s.type === filter.type)
+      .filter((s) => filter.status === undefined || s.status === filter.status)
+      .filter(
+        (s) =>
+          filter.holderType === undefined || s.holderType === filter.holderType,
+      )
+      .filter(
+        (s) => filter.holderId === undefined || s.holderId === filter.holderId,
+      )
+      .filter((s) => !filter.topLevelOnly || s.parentContainerId === null)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .map((s) => Container.fromSnapshot(s));
+    return Promise.resolve(result);
+  }
+
+  findChildren(parentId: ContainerId): Promise<Container[]> {
+    const result = [...this.store.values()]
+      .filter((s) => s.parentContainerId === parentId.value)
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+      .map((s) => Container.fromSnapshot(s));
+    return Promise.resolve(result);
+  }
+
+  nextSequence(emergencyId: EmergencyId, type: ContainerType): Promise<number> {
+    const count = [...this.store.values()].filter(
+      (s) => s.emergencyId === emergencyId.value && s.type === type,
+    ).length;
+    return Promise.resolve(count + 1);
+  }
+}

--- a/apps/api/src/contexts/supplies/infrastructure/in-memory-container.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/in-memory-container.repository.ts
@@ -9,6 +9,8 @@ import { ContainerType } from '../domain/container-enums';
 
 export class InMemoryContainerRepository implements ContainerRepository {
   private store = new Map<string, ContainerSnapshot>();
+  /** Monotonic per-(emergency, type) code counter; mirrors the DB sequence. */
+  private sequences = new Map<string, number>();
 
   save(container: Container): Promise<void> {
     this.store.set(container.id.value, container.toSnapshot());
@@ -50,9 +52,9 @@ export class InMemoryContainerRepository implements ContainerRepository {
   }
 
   nextSequence(emergencyId: EmergencyId, type: ContainerType): Promise<number> {
-    const count = [...this.store.values()].filter(
-      (s) => s.emergencyId === emergencyId.value && s.type === type,
-    ).length;
-    return Promise.resolve(count + 1);
+    const key = `${emergencyId.value}:${type}`;
+    const next = (this.sequences.get(key) ?? 0) + 1;
+    this.sequences.set(key, next);
+    return Promise.resolve(next);
   }
 }

--- a/apps/api/src/contexts/supplies/supplies.module.ts
+++ b/apps/api/src/contexts/supplies/supplies.module.ts
@@ -5,14 +5,48 @@ import {
   CATEGORY_REPOSITORY,
   CategoryRepository,
 } from './domain/ports/category.repository';
+import {
+  CONTAINER_REPOSITORY,
+  ContainerRepository,
+} from './domain/ports/container.repository';
+import {
+  CONTAINER_AUTHORIZATION_LOOKUP,
+  ContainerAuthorizationLookup,
+} from './domain/ports/container-authorization-lookup';
 import { DrizzleCategoryRepository } from './infrastructure/drizzle/drizzle-category.repository';
+import { DrizzleContainerRepository } from './infrastructure/drizzle/drizzle-container.repository';
+import { DrizzleContainerAuthorizationLookup } from './infrastructure/drizzle/drizzle-container-authorization-lookup';
 import { ListCategories } from './application/list-categories';
+import { CreateContainer } from './application/create-container';
+import { AddLineToContainer } from './application/add-line-to-container';
+import { RemoveLineFromContainer } from './application/remove-line-from-container';
+import { NestContainer } from './application/nest-container';
+import { SealContainer } from './application/seal-container';
+import { MoveContainer } from './application/move-container';
+import { GetContainer } from './application/get-container';
+import { ListContainers } from './application/list-containers';
 import { CategoriesController } from './infrastructure/http/categories.controller';
+import { ContainerController } from './infrastructure/http/containers.controller';
+import { IdentityModule } from '../identity/infrastructure/identity.module';
 
 const categoryRepositoryProvider = {
   provide: CATEGORY_REPOSITORY,
   inject: [DB],
   useFactory: (db: Db): CategoryRepository => new DrizzleCategoryRepository(db),
+};
+
+const containerRepositoryProvider = {
+  provide: CONTAINER_REPOSITORY,
+  inject: [DB],
+  useFactory: (db: Db): ContainerRepository =>
+    new DrizzleContainerRepository(db),
+};
+
+const containerAuthorizationLookupProvider = {
+  provide: CONTAINER_AUTHORIZATION_LOOKUP,
+  inject: [DB],
+  useFactory: (db: Db): ContainerAuthorizationLookup =>
+    new DrizzleContainerAuthorizationLookup(db),
 };
 
 const listCategoriesProvider = {
@@ -22,15 +56,77 @@ const listCategoriesProvider = {
     new ListCategories(repo),
 };
 
+const createContainerProvider = {
+  provide: CreateContainer,
+  inject: [CONTAINER_REPOSITORY],
+  useFactory: (repo: ContainerRepository) => new CreateContainer(repo),
+};
+
+const addLineToContainerProvider = {
+  provide: AddLineToContainer,
+  inject: [CONTAINER_REPOSITORY],
+  useFactory: (repo: ContainerRepository) => new AddLineToContainer(repo),
+};
+
+const removeLineFromContainerProvider = {
+  provide: RemoveLineFromContainer,
+  inject: [CONTAINER_REPOSITORY],
+  useFactory: (repo: ContainerRepository) => new RemoveLineFromContainer(repo),
+};
+
+const nestContainerProvider = {
+  provide: NestContainer,
+  inject: [CONTAINER_REPOSITORY],
+  useFactory: (repo: ContainerRepository) => new NestContainer(repo),
+};
+
+const sealContainerProvider = {
+  provide: SealContainer,
+  inject: [CONTAINER_REPOSITORY],
+  useFactory: (repo: ContainerRepository) => new SealContainer(repo),
+};
+
+const moveContainerProvider = {
+  provide: MoveContainer,
+  inject: [CONTAINER_REPOSITORY],
+  useFactory: (repo: ContainerRepository) => new MoveContainer(repo),
+};
+
+const getContainerProvider = {
+  provide: GetContainer,
+  inject: [CONTAINER_REPOSITORY],
+  useFactory: (repo: ContainerRepository) => new GetContainer(repo),
+};
+
+const listContainersProvider = {
+  provide: ListContainers,
+  inject: [CONTAINER_REPOSITORY],
+  useFactory: (repo: ContainerRepository) => new ListContainers(repo),
+};
+
 /**
  * Supplies — the supplies/insumos domain. Owns the category taxonomy and the
  * supply catalog; provides the SupplyLine value object reused by needs, offers
- * and resources (inventory). Absorbs the former taxonomy context.
+ * and resources (inventory). Hosts the trackable Container aggregate (#140:
+ * palet/caja/lote), upstream of logistics and inventory.
  */
 @Module({
-  imports: [DatabaseModule],
-  controllers: [CategoriesController],
-  providers: [categoryRepositoryProvider, listCategoriesProvider],
-  exports: [CATEGORY_REPOSITORY],
+  imports: [DatabaseModule, IdentityModule],
+  controllers: [CategoriesController, ContainerController],
+  providers: [
+    categoryRepositoryProvider,
+    containerRepositoryProvider,
+    containerAuthorizationLookupProvider,
+    listCategoriesProvider,
+    createContainerProvider,
+    addLineToContainerProvider,
+    removeLineFromContainerProvider,
+    nestContainerProvider,
+    sealContainerProvider,
+    moveContainerProvider,
+    getContainerProvider,
+    listContainersProvider,
+  ],
+  exports: [CATEGORY_REPOSITORY, CONTAINER_REPOSITORY],
 })
 export class SuppliesModule {}

--- a/apps/api/src/shared/configure-http-app.ts
+++ b/apps/api/src/shared/configure-http-app.ts
@@ -4,6 +4,7 @@ import { NeedsDomainExceptionFilter } from '../contexts/needs/infrastructure/htt
 import { ReportExceptionFilter } from '../contexts/reports/infrastructure/http/report-exception.filter';
 import { LogisticsDomainExceptionFilter } from '../contexts/logistics/infrastructure/http/domain-exception.filter';
 import { OffersDomainExceptionFilter } from '../contexts/offers/infrastructure/http/domain-exception.filter';
+import { SuppliesDomainExceptionFilter } from '../contexts/supplies/infrastructure/http/supplies-domain-exception.filter';
 
 /** Pipes and domain exception filters shared by `main.ts` and e2e test apps. */
 export function configureHttpApp(app: INestApplication): void {
@@ -20,5 +21,6 @@ export function configureHttpApp(app: INestApplication): void {
     new ReportExceptionFilter(),
     new LogisticsDomainExceptionFilter(),
     new OffersDomainExceptionFilter(),
+    new SuppliesDomainExceptionFilter(),
   );
 }

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -2062,6 +2062,142 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/supplies/containers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a trackable container (palet/caja/lote) (coordinator) */
+        post: operations["ContainerController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/supplies/containers/{id}/lines": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Add a supply line to a container (coordinator) */
+        post: operations["ContainerController_addLine"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/supplies/containers/{id}/lines/{index}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove the supply line at an index from a container (coordinator) */
+        delete: operations["ContainerController_removeLine"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/supplies/containers/{id}/nest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Nest a container under a parent, or un-nest it (coordinator) */
+        post: operations["ContainerController_nest"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/supplies/containers/{id}/seal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Seal (precintar) a container (coordinator) */
+        post: operations["ContainerController_seal"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/supplies/containers/{id}/move": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Move a container to a holder (resource ↔ shipment) (coordinator) */
+        post: operations["ContainerController_move"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/supplies/containers/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a container tree with aggregated weight/volume (coordinator/verifier) */
+        get: operations["ContainerController_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/emergencies/{emergencyId}/supplies/containers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List containers for an emergency (coordinator/verifier) */
+        get: operations["ContainerController_list"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -4236,6 +4372,148 @@ export interface components {
              * @example 41
              */
             sort: number;
+        };
+        ContainerHolderDto: {
+            /**
+             * @example resource
+             * @enum {string}
+             */
+            type: "resource" | "shipment";
+            /**
+             * Format: uuid
+             * @description Resource node or shipment id (polymorphic, no FK)
+             */
+            id: string;
+        };
+        CreateContainerDto: {
+            /**
+             * Format: uuid
+             * @description Emergency this container serves
+             */
+            emergencyId: string;
+            /**
+             * @example pallet
+             * @enum {string}
+             */
+            type: "pallet" | "box" | "lote";
+            /** @description Optional initial loose supply lines */
+            lines?: components["schemas"]["SupplyLineDto"][];
+            /**
+             * @description Declared gross weight in kg (positive)
+             * @example 120
+             */
+            grossWeightKg?: number;
+            /**
+             * @description Declared gross volume in m³ (positive)
+             * @example 1.2
+             */
+            grossVolumeM3?: number;
+            /** @description Optional initial holder (e.g. the hub it is created at) */
+            holder?: components["schemas"]["ContainerHolderDto"];
+        };
+        CreateContainerResponseDto: {
+            /** Format: uuid */
+            id: string;
+            /**
+             * @description Generated trackable code
+             * @example PAL-0001
+             */
+            code: string;
+        };
+        NestContainerDto: {
+            /**
+             * Format: uuid
+             * @description New parent container, or null to un-nest (make it top-level)
+             */
+            parentContainerId?: string | null;
+        };
+        MoveContainerDto: {
+            /** @description New holder (resource ↔ shipment), or null to detach */
+            holder?: components["schemas"]["ContainerHolderDto"] | null;
+        };
+        ContainerTreeViewDto: {
+            /** Format: uuid */
+            id: string;
+            /** @example PAL-0001 */
+            code: string;
+            /**
+             * @example pallet
+             * @enum {string}
+             */
+            type: "pallet" | "box" | "lote";
+            /** Format: uuid */
+            emergencyId: string;
+            /** Format: uuid */
+            parentContainerId?: string | null;
+            lines: components["schemas"]["SupplyLineResponseDto"][];
+            /** @example 120 */
+            grossWeightKg?: number | null;
+            /** @example 1.2 */
+            grossVolumeM3?: number | null;
+            /**
+             * @example resource
+             * @enum {string|null}
+             */
+            holderType?: "resource" | "shipment" | null;
+            /** Format: uuid */
+            holderId?: string | null;
+            /**
+             * @example open
+             * @enum {string}
+             */
+            status: "open" | "sealed";
+            /** @example 2026-07-01T00:00:00.000Z */
+            createdAt: string;
+            /** @example 2026-07-01T00:00:00.000Z */
+            updatedAt: string;
+            /** @description Direct children (recursive) */
+            children: components["schemas"]["ContainerTreeViewDto"][];
+            /**
+             * @description Aggregated weight (own + Σ children), null if none declared
+             * @example 145
+             */
+            totalWeightKg?: number | null;
+            /**
+             * @description Aggregated volume (own + Σ children), null if none declared
+             * @example 2.5
+             */
+            totalVolumeM3?: number | null;
+        };
+        ContainerViewDto: {
+            /** Format: uuid */
+            id: string;
+            /** @example PAL-0001 */
+            code: string;
+            /**
+             * @example pallet
+             * @enum {string}
+             */
+            type: "pallet" | "box" | "lote";
+            /** Format: uuid */
+            emergencyId: string;
+            /** Format: uuid */
+            parentContainerId?: string | null;
+            lines: components["schemas"]["SupplyLineResponseDto"][];
+            /** @example 120 */
+            grossWeightKg?: number | null;
+            /** @example 1.2 */
+            grossVolumeM3?: number | null;
+            /**
+             * @example resource
+             * @enum {string|null}
+             */
+            holderType?: "resource" | "shipment" | null;
+            /** Format: uuid */
+            holderId?: string | null;
+            /**
+             * @example open
+             * @enum {string}
+             */
+            status: "open" | "sealed";
+            /** @example 2026-07-01T00:00:00.000Z */
+            createdAt: string;
+            /** @example 2026-07-01T00:00:00.000Z */
+            updatedAt: string;
         };
     };
     responses: never;
@@ -9717,6 +9995,412 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["CategoryDto"][];
                 };
+            };
+        };
+    };
+    ContainerController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateContainerDto"];
+            };
+        };
+        responses: {
+            /** @description Container created (open), with a generated code */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateContainerResponseDto"];
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not a coordinator of the emergency */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ContainerController_addLine: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupplyLineDto"];
+            };
+        };
+        responses: {
+            /** @description Line added */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not a coordinator of the emergency */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Container not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Container is sealed (lines immutable) */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ContainerController_removeLine: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container UUID */
+                id: string;
+                /** @description Zero-based line index */
+                index: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Line removed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not a coordinator of the emergency */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Container not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Container is sealed (lines immutable) */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ContainerController_nest: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NestContainerDto"];
+            };
+        };
+        responses: {
+            /** @description Container re-parented */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not a coordinator of the emergency */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Container or parent not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Would create a cycle, or parent is a different emergency */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ContainerController_seal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Container sealed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not a coordinator of the emergency */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Container not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Container is already sealed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ContainerController_move: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MoveContainerDto"];
+            };
+        };
+        responses: {
+            /** @description Container moved */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not a coordinator of the emergency */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Container not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ContainerController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container UUID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Container tree */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerTreeViewDto"];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not a coordinator/verifier of the emergency */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Container not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ContainerController_list: {
+        parameters: {
+            query?: {
+                type?: "pallet" | "box" | "lote";
+                status?: "open" | "sealed";
+                holderType?: "resource" | "shipment";
+                holderId?: string;
+                /** @description Only top-level containers (the roots of the trees) */
+                topLevelOnly?: boolean;
+            };
+            header?: never;
+            path: {
+                /** @description Emergency UUID */
+                emergencyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Containers */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerViewDto"][];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing container:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -10206,7 +10206,7 @@ export interface operations {
                 content?: never;
             };
             /** @description Would create a cycle, or parent is a different emergency */
-            409: {
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Resumen

Implementa el agregado **`Container`** (empaquetado rastreable **palet/caja/lote**) en el contexto **`supplies`** (upstream), reusando `SupplyLine`/`Category` (#131). Es la *keystone* del EPIC de logística #103 y materializa el "Código Único" + "peso de la caja" validados en campo.

Decisiones de la issue, implementadas:
- **Agregado con identidad propia** (no VO embebido): se mueve entre hubs/expediciones y se reutiliza como inventario por lugar.
- **`code` generado** (`PAL-0001`/`CAJ-0001`/`LOT-0001`) por **secuencia + emergencia + tipo**; etiqueta legible / payload QR. Unicidad por `(emergency_id, code)`.
- **Composición recursiva por referencia** (`parentContainerId`): anidar = repuntar el padre; hijos por `parentContainerId`. **Invariante sin ciclos** (directo en el dominio, indirecto en el caso de uso recorriendo el árbol) y **misma emergencia**.
- **Contenido directo** en `SupplyLine[]`; **peso/volumen declarados** con **total agregado** (propio + Σ hijos, `null` si nada lo declara) en `GetContainer`.
- **Holder polimórfico** (`resource ↔ shipment`, sin FK): se mueve sin perder composición.
- **Estado** `open → sealed` (al precintar, las líneas quedan inmutables; posición/holder siguen mutables).

Detalle:
- **Dominio (TDD):** `ContainerId`, enums (type/status/holder), errores, generador de código y agregado `Container`.
- **Casos de uso:** `CreateContainer`, `AddLine`/`RemoveLine`, `Nest`/`Unnest`, `Seal`, `MoveToHolder`, `GetContainer` (árbol + totales), `ListContainers` (filtros por tipo/estado/holder/top-level).
- **Infra:** tabla `containers` (migración `0032`: self-FK `ON DELETE SET NULL`, índices, `UNIQUE(emergency_id, code)`), repo Drizzle (query builder tipado, `count` para la secuencia) + in-memory + `int-spec` contra Postgres real, `ContainerAuthorizationLookup`, DTOs, `ContainerController` y filtro de excepciones (`404/409/422`).
- **HTTP:** `POST /supplies/containers`, `/{id}/lines` (+ `DELETE /{id}/lines/{index}`), `/{id}/nest`, `/{id}/seal`, `/{id}/move`, `GET /supplies/containers/{id}`, `GET /emergencies/{emergencyId}/supplies/containers`.
- **Permisos:** `container:manage` / `container:read` (mirror de `capacity:*`/`shipment:*`); gestión = coordinador / `hub_manager`; verificador solo lectura. La gestión se valida por *membership* del coordinador (las rutas de escritura no llevan param de scope, como en `shipment`); la lista usa `PermissionGuard` con `container:read`.

> Nota: la generación de `code` por conteo + `UNIQUE(emergency_id, code)` es pragmática para el MVP; bajo concurrencia alta una doble creación simultánea podría chocar contra el índice único (no produce duplicados). Aún no se deriva peso/volumen de catálogo (futuro `Supply` master-data de #131).

## Validación

- [x] Pasé el gate que toca para esta zona del repo: `api build` · `eslint --max-warnings=0` · `prettier --check` · `api test` (**178 suites / 1167 tests** verde, incl. el `int-spec` contra Postgres) · `api-client build` · `web build` · `web lint`.
- [x] Verifiqué el comportamiento: flujo de aceptación (crear palet → meter cajas → meter líneas → precintar → leer árbol con peso/volumen agregados) cubierto en `get-container.spec.ts`; el `AppModule` arranca sin errores de DI (vía `gen:openapi`).
- [x] Actualicé migraciones y cliente API: migración `0032_containers.sql` y `packages/api-client/src/schema.ts` regenerado con las 8 rutas nuevas (`pnpm gen:api`).

## Cierre

- Closes #140


---
_Generated by [Claude Code](https://claude.ai/code/session_01VQzvW1PSyHfw35B3XVPr5Z)_