### PR TITLE
chore(web): ESLint guardarrail anti toLocale* suelto para fechas (#191)

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -27,6 +27,33 @@ const eslintConfig = defineConfig([
       ],
     },
   },
+  // Guardrail (#174): forbid bare `Date` `toLocale*` formatting. It renders in
+  // the browser's LOCAL tz while SSR renders in UTC, so a near-midnight date
+  // mismatches between server and client → React #418 hydration error. Use the
+  // deterministic helper `@/lib/format-date` (formatDate/formatDateTime) or the
+  // `<LocalDate>` atom instead.
+  {
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.property.name=/^toLocale(Date|Time)?String$/]",
+          message:
+            "Usa el helper formatDate/formatDateTime de @/lib/format-date o el atom <LocalDate> (evita el mismatch de hidratación #418).",
+        },
+      ],
+    },
+  },
+  // Allow-list: the single-source date helper (the one place that calls
+  // toLocale* on purpose, pinned to UTC) and the distance badge (a NUMBER/km
+  // format, not a date — `Number.prototype.toLocaleString`).
+  {
+    files: ["**/lib/format-date.ts", "**/components/atoms/distance-badge.tsx"],
+    rules: {
+      "no-restricted-syntax": "off",
+    },
+  },
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
Seguimiento de #174 (React #418 de hidratación por fechas formateadas con `toLocale*` sin `timeZone`).

Añade en `apps/web/eslint.config.mjs` una regla **no-restricted-syntax** que prohíbe `toLocaleDateString`/`toLocaleString`/`toLocaleTimeString` sueltos, con el mensaje que dirige al helper `@/lib/format-date` (formatDate/formatDateTime) o al atom `<LocalDate>`.

**Allow-list** (override por fichero): `lib/format-date.ts` (la única fuente, fija a UTC) y `components/atoms/distance-badge.tsx` (formato de número/km, no fecha).

Verificado: `pnpm --filter web lint` sigue verde (0 errores) y un fichero de prueba con `new Date().toLocaleDateString()` dispara el error → el guardarraíl caza regresiones.

Closes #191