### PR TITLE
feat(web): consola de recepción del operador en el punto de acopio (#129)

### DIFF
--- a/apps/web/src/app/e/[slug]/coordinacion/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/page.tsx
@@ -144,14 +144,18 @@ export default async function CoordinacionPage({ params }: Props) {
 
   return (
     <>
-      {!access.canActOnAnyQueue && !access.canCoordinate && (
-        <EmptyState
-          title={tc.no_actionable_queues_title}
-          description={tc.no_actionable_queues_description}
-        />
-      )}
+      {!access.canActOnAnyQueue &&
+        !access.canCoordinate &&
+        !access.canReadIntakes && (
+          <EmptyState
+            title={tc.no_actionable_queues_title}
+            description={tc.no_actionable_queues_description}
+          />
+        )}
 
-      {(access.canActOnAnyQueue || access.canCoordinate) && (
+      {(access.canActOnAnyQueue ||
+        access.canCoordinate ||
+        access.canReadIntakes) && (
         <section aria-label={tc.hub_sections_label} className="flex flex-col gap-4">
           {resourcesPending !== null && (
             <CoordinationSectionLink
@@ -196,6 +200,13 @@ export default async function CoordinacionPage({ params }: Props) {
               description={tc.hub_shipments_description}
               count={shipmentsActive}
               countAria={tc.hub_shipments_count_aria}
+            />
+          )}
+          {access.canReadIntakes && (
+            <CoordinationSectionLink
+              href={`/e/${slug}/recepcion`}
+              label={t.recepcion.hub_label}
+              description={t.recepcion.hub_description}
             />
           )}
           {access.canCoordinate && (

--- a/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
@@ -1,0 +1,168 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { getMe, getRoles } from '@/lib/navigation-data';
+import {
+  resolveEmergencyAccess,
+  type EmergencyAccess,
+} from '@/lib/emergency-permissions';
+import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
+import { PageHeaderBand } from '@/components/molecules/page-header-band';
+import { getT } from '@/i18n/server';
+import { categoryLabel } from '@/lib/categories';
+import { formatDate } from '@/lib/format-date';
+import { submitReception } from '../actions';
+import { ReceptionActions } from './reception-actions';
+
+export const dynamic = 'force-dynamic';
+
+type Props = {
+  params: Promise<{ slug: string; intakeId: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const { t } = await getT();
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) return { title: 'Emergencia no encontrada · ResponseGrid' };
+  return {
+    title: t.recepcion.meta_title.replace('{emergencyName}', emergency.name),
+  };
+}
+
+export default async function IntakeDetailPage({ params }: Props) {
+  const { slug, intakeId } = await params;
+  const next = `/e/${slug}/recepcion/${intakeId}`;
+
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=${next}`);
+  }
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) {
+    notFound();
+  }
+
+  const headers = authHeaders(token);
+
+  const [me, roles] = await Promise.all([getMe(), getRoles()]);
+  if (me == null) {
+    await clearToken();
+    redirect(`/login?next=${next}`);
+  }
+
+  const access: EmergencyAccess = resolveEmergencyAccess(
+    emergency.id,
+    (me.grants ?? []) as MeGrant[],
+    roles as RoleCatalogEntry[],
+  );
+  if (!access.canReadIntakes) {
+    redirect(`/e/${slug}`);
+  }
+
+  const res = await api.GET('/donation-intakes/{intakeId}', {
+    params: { path: { intakeId } },
+    headers,
+  });
+  if (res.response.status === 401) {
+    await clearToken();
+    redirect(`/login?next=${next}`);
+  }
+  if (res.response.status === 403) {
+    redirect(`/e/${slug}/recepcion`);
+  }
+  const intake = res.data;
+  if (intake == null) {
+    notFound();
+  }
+
+  const { t, locale } = await getT();
+  const tr = t.recepcion;
+
+  const statusLabel =
+    intake.status === 'received'
+      ? tr.status_received
+      : intake.status === 'rejected'
+        ? tr.status_rejected
+        : intake.status === 'incomplete'
+          ? tr.status_incomplete
+          : tr.status_pending;
+
+  const isPending = intake.status === 'pending';
+  const contact = [intake.donorPhone, intake.donorEmail]
+    .filter((v): v is string => typeof v === 'string' && v !== '')
+    .join(' · ');
+
+  const sectionTitle = 'font-display text-base font-bold text-navy';
+
+  return (
+    <main className="flex-1 bg-surface">
+      <div className="mx-auto w-full max-w-md">
+        <PageHeaderBand
+          backHref={`/e/${slug}/recepcion`}
+          backLabel={tr.back_to_list}
+          title={tr.detail_subtitle.replace('{code}', intake.intakeCode)}
+        />
+        <div className="flex flex-col gap-6 px-4 pb-12 pt-6">
+          <span className="w-fit rounded-full bg-surface-alt px-3 py-1 text-sm font-semibold text-ink">
+            {statusLabel}
+          </span>
+
+          <section className="flex flex-col gap-1">
+            <h2 className={sectionTitle}>{tr.donor_heading}</h2>
+            <p className="text-[15px] text-ink">{intake.donorName}</p>
+            <p className="text-sm text-muted">
+              {contact !== '' ? contact : tr.no_contact}
+            </p>
+          </section>
+
+          <section className="flex flex-col gap-3">
+            <h2 className={sectionTitle}>{tr.lines_heading}</h2>
+            <ul className="flex flex-col gap-2" role="list">
+              {intake.lines.map((line) => (
+                <li
+                  key={line.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border-2 border-line bg-white px-4 py-3"
+                >
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate text-[15px] font-semibold text-ink">
+                      {line.name}
+                    </span>
+                    <span className="text-[12.5px] text-muted">
+                      {categoryLabel(line.category, locale)}
+                      {line.presentation != null && line.presentation !== ''
+                        ? ` · ${line.presentation}`
+                        : ''}
+                    </span>
+                  </span>
+                  <span className="shrink-0 text-sm font-semibold text-ink">
+                    {line.quantity}
+                    {line.unit != null && line.unit !== ''
+                      ? ` ${line.unit}`
+                      : ''}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {isPending && access.canReceiveIntakes ? (
+            <ReceptionActions
+              action={submitReception.bind(null, slug, intakeId)}
+              t={tr}
+            />
+          ) : (
+            <p className="rounded-lg border-2 border-line bg-surface-alt px-4 py-3 text-sm text-muted">
+              {intake.status === 'received' && intake.receivedAt != null
+                ? `${tr.received_meta} · ${formatDate(intake.receivedAt, locale)}`
+                : tr.already_processed}
+            </p>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/e/[slug]/recepcion/[intakeId]/reception-actions.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/[intakeId]/reception-actions.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useActionState } from 'react';
+import type { ReceptionActionState } from '../actions';
+import { Button } from '@/components/atoms/button';
+import { Textarea } from '@/components/atoms/textarea';
+import { ErrorMessage } from '@/components/atoms/error-message';
+import { FormField } from '@/components/molecules/form-field';
+import type { Messages } from '@/i18n/messages/es';
+
+const INITIAL: ReceptionActionState = { status: 'idle' };
+
+type BoundAction = (
+  prev: ReceptionActionState,
+  formData: FormData,
+) => Promise<ReceptionActionState>;
+
+interface ReceptionActionsProps {
+  /** `submitReception` bound to (slug, intakeId). */
+  action: BoundAction;
+  t: Messages['recepcion'];
+}
+
+/**
+ * Desk actions on a pending intake: one shared notes box and three submit
+ * buttons whose `intent` (receive / incomplete / reject) the single server
+ * action reads. Rendered only when the intake is pending and the operator
+ * holds `intake:receive`.
+ */
+export function ReceptionActions({ action, t }: ReceptionActionsProps) {
+  const [state, formAction, pending] = useActionState<
+    ReceptionActionState,
+    FormData
+  >(action, INITIAL);
+
+  return (
+    <form action={formAction} className="flex flex-col gap-4">
+      {state.status === 'error' && <ErrorMessage message={state.message} />}
+
+      <FormField htmlFor="volunteerNotes" label={t.notes_label}>
+        <Textarea
+          id="volunteerNotes"
+          name="volunteerNotes"
+          rows={3}
+          placeholder={t.notes_placeholder}
+        />
+      </FormField>
+
+      <div className="flex flex-col gap-2.5">
+        <Button
+          type="submit"
+          name="intent"
+          value="receive"
+          disabled={pending}
+          fullWidth
+        >
+          {pending ? t.receiving : t.receive_button}
+        </Button>
+        <Button
+          type="submit"
+          name="intent"
+          value="incomplete"
+          variant="secondary"
+          disabled={pending}
+          fullWidth
+        >
+          {pending ? t.marking_incomplete : t.incomplete_button}
+        </Button>
+        <Button
+          type="submit"
+          name="intent"
+          value="reject"
+          variant="danger-outline"
+          disabled={pending}
+          fullWidth
+        >
+          {pending ? t.rejecting : t.reject_button}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/e/[slug]/recepcion/actions.ts
+++ b/apps/web/src/app/e/[slug]/recepcion/actions.ts
@@ -1,0 +1,79 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { api } from '@/lib/api';
+import { getToken, authHeaders, clearToken } from '@/lib/auth';
+import { getT } from '@/i18n/server';
+
+export type ReceptionActionState =
+  | { status: 'idle' }
+  | { status: 'error'; message: string };
+
+type Intent = 'receive' | 'reject' | 'incomplete';
+function isIntent(v: unknown): v is Intent {
+  return v === 'receive' || v === 'reject' || v === 'incomplete';
+}
+
+/**
+ * Resolve a pending donation intake at the desk: confirm reception, reject, or
+ * mark incomplete (the verb travels in the `intent` field so a single form with
+ * three buttons shares one notes box). Operator-only — the backend enforces
+ * `intake:receive`. On success we redirect back to the reception list so the
+ * item leaves the pending queue.
+ */
+export async function submitReception(
+  slug: string,
+  intakeId: string,
+  _prev: ReceptionActionState,
+  formData: FormData,
+): Promise<ReceptionActionState> {
+  const token = await getToken();
+  if (!token) redirect(`/login?next=/e/${slug}/recepcion`);
+
+  const { t } = await getT();
+  const tr = t.recepcion;
+
+  const intent = formData.get('intent');
+  if (!isIntent(intent)) {
+    return { status: 'error', message: tr.err_action_failed };
+  }
+
+  const rawNotes = formData.get('volunteerNotes');
+  const volunteerNotes =
+    typeof rawNotes === 'string' && rawNotes.trim() !== ''
+      ? rawNotes.trim()
+      : null;
+
+  // Literal paths (not a computed union) keep the typed client happy.
+  const params = { path: { intakeId } } as const;
+  const result =
+    intent === 'receive'
+      ? await api.POST('/donation-intakes/{intakeId}/receive', {
+          params,
+          headers: authHeaders(token),
+          body: { volunteerNotes },
+        })
+      : intent === 'reject'
+        ? await api.POST('/donation-intakes/{intakeId}/reject', {
+            params,
+            headers: authHeaders(token),
+            body: { volunteerNotes },
+          })
+        : await api.POST('/donation-intakes/{intakeId}/incomplete', {
+            params,
+            headers: authHeaders(token),
+            body: { volunteerNotes },
+          });
+
+  if (result.response.status === 401) {
+    await clearToken();
+    redirect(`/login?next=/e/${slug}/recepcion`);
+  }
+  if (result.response.status === 409) {
+    return { status: 'error', message: tr.err_already_processed };
+  }
+  if (!result.response.ok) {
+    return { status: 'error', message: tr.err_action_failed };
+  }
+  redirect(`/e/${slug}/recepcion`);
+}

--- a/apps/web/src/app/e/[slug]/recepcion/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/page.tsx
@@ -1,0 +1,244 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import Link from 'next/link';
+import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { getMe, getRoles } from '@/lib/navigation-data';
+import {
+  resolveEmergencyAccess,
+  type EmergencyAccess,
+} from '@/lib/emergency-permissions';
+import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
+import { PageHeaderBand } from '@/components/molecules/page-header-band';
+import { EmptyState } from '@/components/molecules/empty-state';
+import { formatDate } from '@/lib/format-date';
+import { getT } from '@/i18n/server';
+
+export const dynamic = 'force-dynamic';
+
+/** Resource types whose pending intakes an operator receives. */
+const COLLECTION_TYPES = new Set(['collection_point', 'collection_and_delivery']);
+
+type Props = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const { t } = await getT();
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) return { title: 'Emergencia no encontrada · ResponseGrid' };
+  return {
+    title: t.recepcion.meta_title.replace('{emergencyName}', emergency.name),
+    description: t.recepcion.meta_description,
+  };
+}
+
+export default async function RecepcionPage({ params, searchParams }: Props) {
+  const { slug } = await params;
+  const sp = await searchParams;
+
+  const token = await getToken();
+  if (token === null) {
+    redirect(`/login?next=/e/${slug}/recepcion`);
+  }
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) {
+    notFound();
+  }
+
+  const emergencyId = emergency.id;
+  const headers = authHeaders(token);
+
+  const [me, roles] = await Promise.all([getMe(), getRoles()]);
+  if (me == null) {
+    await clearToken();
+    redirect(`/login?next=/e/${slug}/recepcion`);
+  }
+
+  const access: EmergencyAccess = resolveEmergencyAccess(
+    emergencyId,
+    (me.grants ?? []) as MeGrant[],
+    roles as RoleCatalogEntry[],
+  );
+  // Reception is for point operators / coordinators holding intake:read.
+  if (!access.canReadIntakes) {
+    redirect(`/e/${slug}`);
+  }
+
+  const { t, locale } = await getT();
+  const tr = t.recepcion;
+
+  const q =
+    typeof sp.q === 'string' ? sp.q.trim().slice(0, 100) : '';
+
+  // The operator's own collection points (to list their pending intakes and
+  // map a target resource id to a human name).
+  const mineRes = await api.GET('/emergencies/{emergencyId}/resources/mine', {
+    params: { path: { emergencyId } },
+    headers,
+  });
+  if (mineRes.response.status === 401) {
+    await clearToken();
+    redirect(`/login?next=/e/${slug}/recepcion`);
+  }
+  const myPoints = (mineRes.data ?? []).filter((r) =>
+    COLLECTION_TYPES.has(r.type),
+  );
+  const pointName = new Map(myPoints.map((p) => [p.id, p.name]));
+
+  // Search mode (by code/email/phone) vs. default pending list at my point(s).
+  const searching = q !== '';
+
+  const searchHits = searching
+    ? await api
+        .GET('/emergencies/{emergencyId}/donation-intakes/search', {
+          params: { path: { emergencyId }, query: { q } },
+          headers,
+        })
+        .then((r) => r.data ?? [])
+    : [];
+
+  const pending = !searching
+    ? (
+        await Promise.all(
+          myPoints.map((p) =>
+            api
+              .GET('/resources/{resourceId}/donation-intakes/pending', {
+                params: { path: { resourceId: p.id } },
+                headers,
+              })
+              .then((r) => r.data ?? []),
+          ),
+        )
+      ).flat()
+    : [];
+
+  const statusLabel = (s: string): string =>
+    s === 'received'
+      ? tr.status_received
+      : s === 'rejected'
+        ? tr.status_rejected
+        : s === 'incomplete'
+          ? tr.status_incomplete
+          : tr.status_pending;
+
+  const rowClass =
+    'flex items-center justify-between gap-3 rounded-lg border-2 border-line bg-white px-4 py-3.5 transition-colors hover:border-navy focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2';
+
+  return (
+    <main className="flex-1 bg-surface">
+      <div className="mx-auto w-full max-w-md">
+        <PageHeaderBand
+          backHref={`/e/${slug}`}
+          backLabel={t.common.back_to_emergency}
+          title={tr.page_title}
+          subtitle={tr.page_subtitle}
+        />
+        <div className="flex flex-col gap-5 px-4 pb-12 pt-6">
+          <Link
+            href={`/e/${slug}/pre-registro`}
+            className="flex items-center justify-center w-full rounded-lg border-2 border-navy bg-white py-3 px-4 text-base font-semibold text-navy transition-colors hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+          >
+            + {tr.new_intake_cta}
+          </Link>
+
+          <form method="get" role="search" className="flex gap-2">
+            <input
+              type="search"
+              name="q"
+              defaultValue={q}
+              placeholder={tr.search_placeholder}
+              aria-label={tr.search_label}
+              className="w-full rounded-lg border-2 border-navy bg-white px-4 py-3 text-base text-ink placeholder:text-muted-soft focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+            />
+            <button
+              type="submit"
+              className="shrink-0 rounded-lg bg-navy px-5 py-3 text-base font-semibold text-white transition-colors hover:bg-navy-700 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+            >
+              {tr.search_button}
+            </button>
+          </form>
+
+          {searching ? (
+            <section className="flex flex-col gap-3">
+              <h2 className="font-display text-base font-bold text-navy">
+                {tr.search_results_heading}
+              </h2>
+              {searchHits.length === 0 ? (
+                <EmptyState title={tr.search_empty} />
+              ) : (
+                <ul className="flex flex-col gap-2.5" role="list">
+                  {searchHits.map((hit) => (
+                    <li key={hit.id}>
+                      <Link
+                        href={`/e/${slug}/recepcion/${hit.id}`}
+                        className={rowClass}
+                      >
+                        <span className="flex min-w-0 flex-col">
+                          <span className="font-display text-base font-bold tracking-wide text-navy">
+                            {hit.intakeCode}
+                          </span>
+                          <span className="truncate text-[13px] text-ink">
+                            {hit.donorName}
+                          </span>
+                          <span className="text-[12px] text-muted">
+                            {tr.item_lines.replace('{n}', String(hit.itemCount))}{' '}
+                            · {statusLabel(hit.status)}
+                          </span>
+                        </span>
+                        <span className="shrink-0 text-sm font-semibold text-navy">
+                          {tr.item_select} →
+                        </span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          ) : (
+            <section className="flex flex-col gap-3">
+              <h2 className="font-display text-base font-bold text-navy">
+                {tr.pending_heading}
+              </h2>
+              {myPoints.length === 0 ? (
+                <EmptyState title={tr.no_points_note} />
+              ) : pending.length === 0 ? (
+                <EmptyState title={tr.pending_empty} />
+              ) : (
+                <ul className="flex flex-col gap-2.5" role="list">
+                  {pending.map((it) => (
+                    <li key={it.id}>
+                      <Link
+                        href={`/e/${slug}/recepcion/${it.id}`}
+                        className={rowClass}
+                      >
+                        <span className="flex min-w-0 flex-col">
+                          <span className="font-display text-base font-bold tracking-wide text-navy">
+                            {it.intakeCode}
+                          </span>
+                          <span className="truncate text-[12.5px] text-muted">
+                            {pointName.get(it.targetResourceId) ?? tr.point_label}{' '}
+                            ·{' '}
+                            {tr.item_lines.replace('{n}', String(it.itemCount))} ·{' '}
+                            {formatDate(it.createdAt, locale)}
+                          </span>
+                        </span>
+                        <span className="shrink-0 text-sm font-semibold text-navy">
+                          {tr.item_select} →
+                        </span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -623,6 +623,69 @@ export const en = {
     err_too_many: 'Too many attempts. Please wait a moment and try again.',
   },
 
+  // ── Operator reception console (#129) ─────────────────────────────────────
+  recepcion: {
+    meta_title: 'Donation reception — {emergencyName} · ResponseGrid',
+    meta_description:
+      'Collection-point console: find the pre-registration and confirm the delivery.',
+    page_title: 'Donation reception',
+    page_subtitle:
+      'Find the pre-registration by code, email or phone and confirm it at the desk.',
+
+    // Entry from the coordination hub
+    hub_label: 'Donation reception',
+    hub_description: 'Confirm pre-registered deliveries at the desk',
+
+    no_points_note:
+      'You don’t manage any collection point in this emergency, but you can search a delivery by its code.',
+
+    // Search
+    search_label: 'Search delivery',
+    search_placeholder: 'Code (ACO-…), email or phone',
+    search_button: 'Search',
+    search_results_heading: 'Results',
+    search_empty: 'No deliveries match your search.',
+
+    // Pending
+    pending_heading: 'Pending deliveries at your point',
+    pending_empty: 'No pending deliveries right now.',
+    new_intake_cta: 'Register a new delivery',
+
+    // List item
+    item_lines: '{n} lines',
+    item_select: 'View / receive',
+    point_label: 'Point',
+
+    // Statuses
+    status_pending: 'Pending',
+    status_received: 'Received',
+    status_rejected: 'Rejected',
+    status_incomplete: 'Incomplete',
+
+    // Detail
+    back_to_list: 'Back to reception',
+    detail_subtitle: 'Delivery {code}',
+    donor_heading: 'Donor',
+    contact_heading: 'Contact',
+    lines_heading: 'Declared supplies',
+    no_contact: 'No contact',
+    received_meta: 'Received',
+    already_processed: 'This delivery has already been processed.',
+
+    // Actions
+    notes_label: 'Notes (optional)',
+    notes_placeholder: 'Reception remarks…',
+    receive_button: 'Confirm reception',
+    receiving: 'Confirming…',
+    reject_button: 'Reject',
+    rejecting: 'Rejecting…',
+    incomplete_button: 'Mark incomplete',
+    marking_incomplete: 'Saving…',
+
+    err_action_failed: 'Couldn’t complete the action. Please try again.',
+    err_already_processed: 'The delivery had already been processed.',
+  },
+
   // ── Offer transport (#105) ────────────────────────────────────────────────
   ofrecerTransporte: {
     page_title: 'I can offer transport',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -651,6 +651,69 @@ export const es = {
     err_too_many: 'Demasiados intentos. Espera un momento y vuelve a probar.',
   },
 
+  // ── Consola de recepción del operador (#129) ──────────────────────────────
+  recepcion: {
+    meta_title: 'Recepción de donaciones — {emergencyName} · ResponseGrid',
+    meta_description:
+      'Consola del punto de acopio: localiza el pre-registro y confirma la entrega.',
+    page_title: 'Recepción de donaciones',
+    page_subtitle:
+      'Localiza el pre-registro por código, correo o teléfono y confírmalo en el mostrador.',
+
+    // Entrada desde el hub de coordinación
+    hub_label: 'Recepción de donaciones',
+    hub_description: 'Confirma las entregas pre-registradas en el mostrador',
+
+    no_points_note:
+      'No gestionas ningún punto de recogida en esta emergencia, pero puedes buscar una entrega por su código.',
+
+    // Buscador
+    search_label: 'Buscar entrega',
+    search_placeholder: 'Código (ACO-…), correo o teléfono',
+    search_button: 'Buscar',
+    search_results_heading: 'Resultados',
+    search_empty: 'No hay entregas que coincidan con la búsqueda.',
+
+    // Pendientes
+    pending_heading: 'Entregas pendientes en tu punto',
+    pending_empty: 'No hay entregas pendientes ahora mismo.',
+    new_intake_cta: 'Registrar una entrega nueva',
+
+    // Item de lista
+    item_lines: '{n} líneas',
+    item_select: 'Ver / recibir',
+    point_label: 'Punto',
+
+    // Estados
+    status_pending: 'Pendiente',
+    status_received: 'Recibida',
+    status_rejected: 'Rechazada',
+    status_incomplete: 'Incompleta',
+
+    // Detalle
+    back_to_list: 'Volver a recepción',
+    detail_subtitle: 'Entrega {code}',
+    donor_heading: 'Donante',
+    contact_heading: 'Contacto',
+    lines_heading: 'Material declarado',
+    no_contact: 'Sin contacto',
+    received_meta: 'Recibida',
+    already_processed: 'Esta entrega ya ha sido procesada.',
+
+    // Acciones
+    notes_label: 'Notas (opcional)',
+    notes_placeholder: 'Observaciones de la recepción…',
+    receive_button: 'Confirmar recepción',
+    receiving: 'Confirmando…',
+    reject_button: 'Rechazar',
+    rejecting: 'Rechazando…',
+    incomplete_button: 'Marcar incompleta',
+    marking_incomplete: 'Guardando…',
+
+    err_action_failed: 'No se pudo completar la acción. Inténtalo de nuevo.',
+    err_already_processed: 'La entrega ya había sido procesada.',
+  },
+
   // ── Ofrecer transporte (#105) ─────────────────────────────────────────────
   ofrecerTransporte: {
     page_title: 'Ofrezco transporte',

--- a/apps/web/src/lib/emergency-permissions.test.ts
+++ b/apps/web/src/lib/emergency-permissions.test.ts
@@ -30,6 +30,8 @@ const ROLES = [
   { id: 'platform_viewer', permissions: ['org:read'] },
   // A citizen — only the implicit self perms, never coordination.
   { id: 'volunteer', permissions: ['task:read'] },
+  // A collection-point operator — handles donation reception only.
+  { id: 'point_operator', permissions: ['intake:read', 'intake:receive'] },
 ];
 
 const E1 = '11111111-1111-4111-8111-111111111111';
@@ -126,4 +128,25 @@ test('canCoordinateAtPlatform: unknown roleId contributes nothing', () => {
 
 test('canCoordinateAtPlatform: no grants → false', () => {
   assert.equal(canCoordinateAtPlatform([], ROLES), false);
+});
+
+test('resolveEmergencyAccess: intake flags reflect intake:read / intake:receive', () => {
+  const operator = resolveEmergencyAccess(
+    E1,
+    [{ roleId: 'point_operator', scopeType: 'emergency', scopeId: E1 }],
+    ROLES,
+  );
+  assert.equal(operator.canReadIntakes, true);
+  assert.equal(operator.canReceiveIntakes, true);
+  // An intake-only operator is not a coordinator queue actor.
+  assert.equal(operator.canActOnAnyQueue, false);
+
+  // A coordinator without intake perms gets no intake access.
+  const coordinator = resolveEmergencyAccess(
+    E1,
+    [{ roleId: 'emergency_coordinator', scopeType: 'emergency', scopeId: E1 }],
+    ROLES,
+  );
+  assert.equal(coordinator.canReadIntakes, false);
+  assert.equal(coordinator.canReceiveIntakes, false);
 });

--- a/apps/web/src/lib/emergency-permissions.ts
+++ b/apps/web/src/lib/emergency-permissions.ts
@@ -33,6 +33,10 @@ export interface EmergencyAccess {
    * do not — the log is coordinator-only.
    */
   canViewAudit: boolean;
+  /** Can read this emergency's donation intakes (search / list / detail). */
+  canReadIntakes: boolean;
+  /** Can confirm / reject / mark-incomplete reception of donation intakes. */
+  canReceiveIntakes: boolean;
 }
 
 /** Permissions that mean "this person runs coordinator-only surfaces". */
@@ -77,6 +81,8 @@ export function resolveEmergencyAccess(
   const canCoordinateLogistics = permissions.has('shipment:read');
   const canCoordinate = COORDINATOR_PERMISSIONS.some((p) => permissions.has(p));
   const canViewAudit = permissions.has('audit:read');
+  const canReadIntakes = permissions.has('intake:read');
+  const canReceiveIntakes = permissions.has('intake:receive');
 
   return {
     roleIds,
@@ -88,6 +94,8 @@ export function resolveEmergencyAccess(
     canCoordinate,
     canActOnAnyQueue: canValidateNeeds || canVerifyResources || canMatchOffers,
     canViewAudit,
+    canReadIntakes,
+    canReceiveIntakes,
   };
 }
 


### PR DESCRIPTION
## Resumen

La **cara web de la recepción en el mostrador** (parte de la EPIC #126; UI de #128/#129), sobre los endpoints de `donation-intakes` que ya estaban en `main`. Cierra la mitad operativa del flujo: el donante pre-registra (#130, ya en prod) y ahora el **operador del punto** lo localiza y lo confirma.

Incluye:

- **`/e/[slug]/recepcion`** (permiso `intake:read`): buscador de pre-registros por **código / correo / teléfono** (`GET …/donation-intakes/search`) y, por defecto, las **entregas pendientes** de los puntos que gestiona el operador (`resources/mine` → `GET /resources/{id}/donation-intakes/pending`). Entrada desde el hub de coordinación.
- **`/e/[slug]/recepcion/[intakeId]`**: donante, contacto y material declarado; si está **pendiente** y el operador tiene `intake:receive`, un único formulario con notas y tres acciones — **confirmar recepción / marcar incompleta / rechazar** (`POST …/{receive|incomplete|reject}`).
- **Alta de entrega in-situ** reutilizando el flujo de pre-registro (`/pre-registro`) para donantes que llegan sin pre-registro.
- Flags **`canReadIntakes` / `canReceiveIntakes`** en `emergency-permissions` (+ test). i18n **ES/EN**.

> **Pendiente de #129 (no incluido aquí):** el **consumidor del evento que incremente `resource_items`** (stock en tiempo real) y el **ajuste de líneas recibidas vs. declaradas**. Es backend y va en el siguiente PR. También queda señalada la reconciliación de **#187** (la API de #183 genera QR hacia `/donar-acopio`, ruta que no existe; mi `/pre-registro` hace ese trabajo).

## Validación

- [x] Pasé el gate que toca para esta zona del repo — **web**: `test` (39 ✓), `lint`, `build` en verde. (No toca `apps/api`.)
- [ ] Verifiqué el comportamiento manualmente — pendiente; a validar en el preview de Vercel con un usuario con grant de `intake:*`.
- [x] Actualicé docs, migraciones o cliente API si correspondía — sin cambios de API/cliente (solo consume endpoints existentes).

## Cierre

- Parte de #126 · UI de #128/#129 (no cierra #129: falta su backend de inventario).