### PR TITLE
feat(api): la recepción de donaciones suma al inventario del punto (#129)

### DIFF
--- a/apps/api/src/contexts/resources/application/receive-donation-into-inventory.spec.ts
+++ b/apps/api/src/contexts/resources/application/receive-donation-into-inventory.spec.ts
@@ -1,0 +1,87 @@
+import { ReceiveDonationIntoInventory } from './receive-donation-into-inventory';
+import { InMemoryResourceRepository } from '../infrastructure/in-memory-resource.repository';
+import { Resource } from '../domain/resource';
+import { SupplyLine } from '../../supplies/domain/supply-line';
+import { Category } from '../../supplies/domain/category';
+import { ResourceId } from '../domain/resource-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ResourceType, ResourceStage } from '../domain/resource-enums';
+import { Location } from '../../../shared/domain/location';
+
+const EMG = '11111111-1111-4111-8111-111111111111';
+
+const buildResource = (id: ResourceId, items: SupplyLine[] = []): Resource =>
+  Resource.register({
+    id,
+    emergencyId: EmergencyId.fromString(EMG),
+    type: ResourceType.Warehouse,
+    stage: ResourceStage.Origin,
+    name: 'Acopio',
+    location: Location.create({ address: 'X', latitude: 1, longitude: 2 }),
+    ownerUserId: 'u1',
+    items,
+  });
+
+describe('ReceiveDonationIntoInventory', () => {
+  it('merges received lines into the target inventory and persists', async () => {
+    const repo = new InMemoryResourceRepository();
+    const id = ResourceId.create();
+    await repo.save(
+      buildResource(id, [
+        SupplyLine.create({
+          name: 'Agua',
+          quantity: 10,
+          unit: 'l',
+          category: Category.Water,
+        }),
+      ]),
+    );
+
+    const useCase = new ReceiveDonationIntoInventory(repo);
+    const result = await useCase.execute({
+      targetResourceId: id.value,
+      lines: [
+        {
+          name: 'Agua',
+          quantity: 5,
+          unit: 'l',
+          category: Category.Water,
+          presentation: null,
+        },
+        {
+          name: 'Arroz',
+          quantity: 3,
+          unit: 'kg',
+          category: Category.Food,
+          presentation: null,
+        },
+      ],
+    });
+
+    expect(result).toBe('applied');
+    const updated = await repo.findById(id);
+    const byName = new Map(updated!.items.map((i) => [i.name, i.quantity]));
+    expect(byName.get('Agua')).toBe(15);
+    expect(byName.get('Arroz')).toBe(3);
+  });
+
+  it('returns resource_not_found when the target does not exist (no throw)', async () => {
+    const repo = new InMemoryResourceRepository();
+    const useCase = new ReceiveDonationIntoInventory(repo);
+
+    const result = await useCase.execute({
+      targetResourceId: ResourceId.create().value,
+      lines: [
+        {
+          name: 'Agua',
+          quantity: 1,
+          unit: null,
+          category: Category.Water,
+          presentation: null,
+        },
+      ],
+    });
+
+    expect(result).toBe('resource_not_found');
+  });
+});

--- a/apps/api/src/contexts/resources/application/receive-donation-into-inventory.ts
+++ b/apps/api/src/contexts/resources/application/receive-donation-into-inventory.ts
@@ -1,0 +1,42 @@
+import { ResourceId } from '../domain/resource-id';
+import { ResourceRepository } from '../domain/ports/resource.repository';
+import {
+  SupplyLine,
+  SupplyLineSnapshot,
+} from '../../supplies/domain/supply-line';
+
+export interface ReceiveDonationIntoInventoryCommand {
+  targetResourceId: string;
+  lines: SupplyLineSnapshot[];
+}
+
+export type ReceiveDonationResult = 'applied' | 'resource_not_found';
+
+/**
+ * Apply a confirmed donation's lines to the target collection point's declared
+ * inventory (#129), so the point's stock reflects what has actually arrived.
+ * Consumed off the `donation_intake.received` event.
+ *
+ * Idempotency: the underlying queue is at-least-once, so a redelivery after a
+ * successful commit would re-add the lines. Acceptable for now — a transactional
+ * dedup ledger is future work tied to the entries/traceability issues (#9/#12);
+ * the repository save is atomic, so a *failed* attempt never partially applies.
+ */
+export class ReceiveDonationIntoInventory {
+  constructor(private readonly repo: ResourceRepository) {}
+
+  async execute(
+    cmd: ReceiveDonationIntoInventoryCommand,
+  ): Promise<ReceiveDonationResult> {
+    const resource = await this.repo.findById(
+      ResourceId.fromString(cmd.targetResourceId),
+    );
+    if (!resource) return 'resource_not_found';
+
+    resource.receiveInventory(
+      cmd.lines.map((line) => SupplyLine.fromSnapshot(line)),
+    );
+    await this.repo.save(resource);
+    return 'applied';
+  }
+}

--- a/apps/api/src/contexts/resources/domain/resource-receive-inventory.spec.ts
+++ b/apps/api/src/contexts/resources/domain/resource-receive-inventory.spec.ts
@@ -1,0 +1,84 @@
+import { Resource } from './resource';
+import { SupplyLine } from '../../supplies/domain/supply-line';
+import { Category } from '../../supplies/domain/category';
+import { ResourceId } from './resource-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ResourceType, ResourceStage } from './resource-enums';
+import { Location } from '../../../shared/domain/location';
+
+const make = (items: SupplyLine[] = []): Resource =>
+  Resource.register({
+    id: ResourceId.create(),
+    emergencyId: EmergencyId.fromString('11111111-1111-4111-8111-111111111111'),
+    type: ResourceType.Warehouse,
+    stage: ResourceStage.Origin,
+    name: 'Acopio Centro',
+    location: Location.create({ address: 'X', latitude: 1, longitude: 2 }),
+    ownerUserId: 'user-1',
+    items,
+  });
+
+const line = (
+  name: string,
+  quantity: number,
+  unit: string | null = null,
+  category: Category = Category.Water,
+  presentation: string | null = null,
+): SupplyLine =>
+  SupplyLine.create({ name, quantity, unit, category, presentation });
+
+describe('Resource.receiveInventory', () => {
+  it('sums quantities of lines with the same name + category + unit', () => {
+    const r = make([line('Agua', 10, 'l')]);
+    r.receiveInventory([line('Agua', 5, 'l')]);
+    expect(r.items).toHaveLength(1);
+    expect(r.items[0].toSnapshot()).toMatchObject({
+      name: 'Agua',
+      quantity: 15,
+      unit: 'l',
+    });
+  });
+
+  it('appends genuinely new lines, keeping existing ones first', () => {
+    const r = make([line('Agua', 10, 'l')]);
+    r.receiveInventory([line('Arroz', 3, 'kg', Category.Food)]);
+    expect(r.items.map((i) => i.name)).toEqual(['Agua', 'Arroz']);
+  });
+
+  it('keeps lines distinct when unit or category differ', () => {
+    const r = make([line('Agua', 10, 'l')]);
+    r.receiveInventory([
+      line('Agua', 4, 'cajas'), // different unit
+      line('Agua', 2, 'l', Category.Other), // different category
+    ]);
+    expect(r.items).toHaveLength(3);
+  });
+
+  it('merges medical lines only when the presentation matches', () => {
+    const r = make([line('Suero', 5, null, Category.MedicalSupplies, 'EV')]);
+    r.receiveInventory([
+      line('Suero', 3, null, Category.MedicalSupplies, 'EV'), // merges → 8
+      line('Suero', 7, null, Category.MedicalSupplies, 'ampolla'), // distinct
+    ]);
+    expect(r.items).toHaveLength(2);
+    expect(r.items.find((i) => i.presentation === 'EV')?.quantity).toBe(8);
+    expect(r.items.find((i) => i.presentation === 'ampolla')?.quantity).toBe(7);
+  });
+
+  it('is a no-op for an empty list', () => {
+    const r = make([line('Agua', 10, 'l')]);
+    r.receiveInventory([]);
+    expect(r.items).toHaveLength(1);
+    expect(r.items[0].quantity).toBe(10);
+  });
+
+  it('adds to an empty inventory', () => {
+    const r = make();
+    r.receiveInventory([line('Mantas', 20, 'unidades', Category.Shelter)]);
+    expect(r.items).toHaveLength(1);
+    expect(r.items[0].toSnapshot()).toMatchObject({
+      name: 'Mantas',
+      quantity: 20,
+    });
+  });
+});

--- a/apps/api/src/contexts/resources/domain/resource.ts
+++ b/apps/api/src/contexts/resources/domain/resource.ts
@@ -124,7 +124,7 @@ export class Resource {
     public readonly provenance: Provenance | null,
     public readonly isFinalRecipient: boolean,
     public readonly recipientType: string | null,
-    public readonly items: SupplyLine[],
+    private _items: SupplyLine[],
     private _disputed: boolean,
     private _disputedAt: Date | null,
   ) {}
@@ -226,6 +226,10 @@ export class Resource {
   get disputedAt(): Date | null {
     return this._disputedAt;
   }
+  /** Declared inventory the place holds for delivery (#28, #129). */
+  get items(): SupplyLine[] {
+    return this._items;
+  }
 
   verify(level: VerificationLevel, coordinatorId: string): void {
     if (level === VerificationLevel.Unverified) {
@@ -304,6 +308,37 @@ export class Resource {
       this._schedule =
         props.schedule === null ? null : props.schedule.trim() || null;
     }
+  }
+
+  /**
+   * Merge confirmed donation lines into the declared inventory: lines with the
+   * same identity (name + category + unit + presentation) sum their quantities;
+   * genuinely new lines are appended. Drives real-time stock when a
+   * pre-registered donation is received at the point (#129). Order is stable:
+   * existing lines keep their position (with updated quantity), new lines are
+   * appended in arrival order.
+   */
+  receiveInventory(lines: SupplyLine[]): void {
+    if (lines.length === 0) return;
+    const keyOf = (l: SupplyLine): string =>
+      JSON.stringify([l.name, l.category, l.unit, l.presentation]);
+    const byKey = new Map<string, SupplyLine>();
+    for (const item of this._items) byKey.set(keyOf(item), item);
+    for (const incoming of lines) {
+      const k = keyOf(incoming);
+      const current = byKey.get(k);
+      byKey.set(
+        k,
+        SupplyLine.create({
+          name: incoming.name,
+          quantity: (current?.quantity ?? 0) + incoming.quantity,
+          unit: incoming.unit,
+          category: incoming.category,
+          presentation: incoming.presentation,
+        }),
+      );
+    }
+    this._items = [...byKey.values()];
   }
 
   /**

--- a/apps/api/src/contexts/resources/infrastructure/donation-events.worker.ts
+++ b/apps/api/src/contexts/resources/infrastructure/donation-events.worker.ts
@@ -1,0 +1,92 @@
+import { Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Worker, Job } from 'bullmq';
+import IORedis from 'ioredis';
+import { ReceiveDonationIntoInventory } from '../application/receive-donation-into-inventory';
+import { SupplyLineSnapshot } from '../../supplies/domain/supply-line';
+
+interface DomainEventJobData {
+  name: string;
+  occurredOn: string;
+  aggregateId: string;
+  payload: Record<string, unknown>;
+}
+
+const DONATION_RECEIVED = 'donation_intake.received';
+
+/**
+ * Consumes the shared `domain-events` queue and, for `donation_intake.received`,
+ * applies the received lines to the target point's inventory (#129) — the first
+ * domain-event consumer in the codebase.
+ *
+ * Limitation: a single BullMQ worker on the shared queue is a *competing*
+ * consumer — it also acks (no-ops) every other event on the queue. That is fine
+ * while this is the only consumer; a second consumer for a different event will
+ * need per-event queues or a fan-out. Fail-open: an error fails only that job
+ * (jobs are published with the BullMQ default of one attempt, so a malformed or
+ * doomed event is dropped rather than retried forever).
+ */
+export class DonationEventsWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(DonationEventsWorker.name);
+  private worker: Worker<DomainEventJobData> | null = null;
+  private connection: IORedis | null = null;
+
+  constructor(private readonly receive: ReceiveDonationIntoInventory) {}
+
+  onModuleInit(): void {
+    const url = process.env.REDIS_URL;
+    if (!url) throw new Error('REDIS_URL is required');
+    // BullMQ workers need a dedicated connection with blocking commands enabled.
+    this.connection = new IORedis(url, { maxRetriesPerRequest: null });
+    this.worker = new Worker<DomainEventJobData>(
+      'domain-events',
+      (job: Job<DomainEventJobData>) => this.handle(job),
+      { connection: this.connection },
+    );
+    this.worker.on('failed', (job, err) => {
+      this.logger.error(
+        `domain-events job ${job?.id ?? '?'} (${job?.name ?? '?'}) failed: ${err.message}`,
+      );
+    });
+  }
+
+  private async handle(job: Job<DomainEventJobData>): Promise<void> {
+    if (job.data.name !== DONATION_RECEIVED) return;
+
+    const payload = job.data.payload as {
+      targetResourceId?: unknown;
+      lines?: unknown;
+    };
+    if (
+      typeof payload.targetResourceId !== 'string' ||
+      !Array.isArray(payload.lines)
+    ) {
+      this.logger.warn(
+        `Skipping malformed ${DONATION_RECEIVED} payload (job ${job.id ?? '?'})`,
+      );
+      return;
+    }
+
+    const result = await this.receive.execute({
+      targetResourceId: payload.targetResourceId,
+      lines: payload.lines as SupplyLineSnapshot[],
+    });
+    if (result === 'resource_not_found') {
+      this.logger.warn(
+        `${DONATION_RECEIVED}: target resource ${payload.targetResourceId} not found; inventory not updated`,
+      );
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    try {
+      await this.worker?.close();
+    } catch {
+      // ignore — let teardown proceed
+    }
+    try {
+      await this.connection?.quit();
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/apps/api/src/contexts/resources/infrastructure/resources.module.ts
+++ b/apps/api/src/contexts/resources/infrastructure/resources.module.ts
@@ -22,6 +22,8 @@ import { PublishResource } from '../application/publish-resource';
 import { EditResource } from '../application/edit-resource';
 import { DiscardResource } from '../application/discard-resource';
 import { UpdateResourcePublicStatus } from '../application/update-resource-public-status';
+import { ReceiveDonationIntoInventory } from '../application/receive-donation-into-inventory';
+import { DonationEventsWorker } from './donation-events.worker';
 import {
   RESOURCE_REPOSITORY,
   ResourceRepository,
@@ -284,6 +286,22 @@ const getResourceAdminDetailProvider = {
   ) => new GetResourceAdminDetail(repo, validityRepo),
 };
 
+// Donation reception → inventory (#129): apply received intake lines to the
+// target point's stock, consumed off the `donation_intake.received` event.
+const receiveDonationIntoInventoryProvider = {
+  provide: ReceiveDonationIntoInventory,
+  inject: [RESOURCE_REPOSITORY],
+  useFactory: (repo: ResourceRepository) =>
+    new ReceiveDonationIntoInventory(repo),
+};
+
+const donationEventsWorkerProvider = {
+  provide: DonationEventsWorker,
+  inject: [ReceiveDonationIntoInventory],
+  useFactory: (receive: ReceiveDonationIntoInventory) =>
+    new DonationEventsWorker(receive),
+};
+
 @Module({
   imports: [DatabaseModule, IdentityModule, NotificationsModule],
   controllers: [
@@ -322,6 +340,8 @@ const getResourceAdminDetailProvider = {
     getResourceValidityReportsProvider,
     listResourcesAdminProvider,
     getResourceAdminDetailProvider,
+    receiveDonationIntoInventoryProvider,
+    donationEventsWorkerProvider,
   ],
 })
 export class ResourcesModule implements OnModuleDestroy {


### PR DESCRIPTION
## Resumen

Cierra el **motor del stock en tiempo real** (req de campo): cuando el operador confirma una entrega en el mostrador (#194), su evento `donation_intake.received` (que ya cargaba `targetResourceId` + líneas) ahora **se consume** y suma esas líneas al `resource_items` del punto destino.

- **`Resource.receiveInventory(lines)`** (dominio): fusiona por identidad de línea **(nombre + categoría + unidad + presentación)** sumando cantidades; las líneas nuevas se añaden (orden estable: las existentes mantienen su posición). `items` pasa de `public readonly` a `_items` con getter.
- **`ReceiveDonationIntoInventory`** (application, framework-free): carga el punto, fusiona y persiste; si el recurso no existe → no-op sin lanzar. Tests con `InMemoryResourceRepository`.
- **`DonationEventsWorker`** (infra): **primer consumidor de eventos de dominio del codebase** — worker BullMQ sobre la cola compartida `domain-events` que procesa `donation_intake.received`.

> **Limitación documentada:** un único worker sobre la cola compartida es un *consumidor competitivo* (también ackea/no-opea el resto de eventos). Está bien mientras sea el único consumidor; un segundo consumidor para otro evento necesitará colas por evento o un fan-out. La cola es *at-least-once*: una redelivery tras commit re-sumaría líneas — el dedup *exactly-once* (ligado al libro de entradas/trazabilidad #9/#12) queda como trabajo aparte.

Sin migración (`resource_items` existe desde `0028`) ni cambios de contrato API/cliente.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — **api**: `build` (nest/tsc), `eslint --max-warnings=0`, `prettier --check` en verde. (Los tests `jest` requieren Postgres/Redis del `global-setup`, no disponibles en el entorno de esta sesión; son unitarios — dominio + use-case con repo in-memory — y los ejecuta CI.)
- [ ] Verifiqué el comportamiento manualmente — pendiente; a validar end-to-end (pre-registro → recepción → inventario del punto) en preview/prod con Redis.
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica (sin migración ni cambios de API).

## Cierre

- Avanza #129 (no lo cierra: faltan el ajuste de líneas recibidas vs. declaradas y el dedup transaccional). Parte de la EPIC #126 / #1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpvuMeZyxhQzwkghqZo3Ut)_