### PR TITLE
feat(identity): añadir rol point_manager y delegación de grants

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -121,13 +121,21 @@
             "name": "scopeType",
             "required": true,
             "in": "query",
-            "description": "platform | organization | emergency | group",
+            "description": "platform | organization | emergency | group | entity",
             "schema": {
               "type": "string"
             }
           },
           {
             "name": "scopeId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scopeEntityType",
             "required": false,
             "in": "query",
             "schema": {

--- a/apps/api/src/contexts/identity/application/grant-role.spec.ts
+++ b/apps/api/src/contexts/identity/application/grant-role.spec.ts
@@ -10,6 +10,7 @@ import {
   PrivilegeEscalationError,
   UnknownRoleError,
 } from '../domain/authorization/errors';
+import { ResourceEmergencyLookup } from '../domain/ports/resource-emergency-lookup';
 
 const ACTOR = '11111111-1111-4111-8111-111111111111';
 const TARGET = '22222222-2222-4222-8222-222222222222';
@@ -30,13 +31,26 @@ function actorWith(
   };
 }
 
+function resourceEmergencyLookup(
+  map: Record<string, string>,
+): ResourceEmergencyLookup {
+  return {
+    findEmergencyId: (resourceId: string) =>
+      Promise.resolve(map[resourceId] ?? null),
+  };
+}
+
 describe('GrantRole (delegation with attenuation)', () => {
   let repo: InMemoryGrantRepository;
   let useCase: GrantRole;
 
   beforeEach(() => {
     repo = new InMemoryGrantRepository();
-    useCase = new GrantRole(repo, new LocalAccessControl());
+    useCase = new GrantRole(
+      repo,
+      new LocalAccessControl(),
+      resourceEmergencyLookup({ r1: 'e1' }),
+    );
   });
 
   it('a platform_admin can grant emergency_coordinator and records the granter', async () => {
@@ -56,6 +70,21 @@ describe('GrantRole (delegation with attenuation)', () => {
     expect(saved).toHaveLength(1);
     expect(saved[0].roleId).toBe('emergency_coordinator');
     expect(saved[0].grantedByPrincipalId).toBe(ACTOR);
+  });
+
+  it('uses the owning emergency when authorizing a resource entity scope', async () => {
+    const actor = actorWith({
+      roleId: 'emergency_coordinator',
+      scope: ScopeRef.emergency('e1'),
+    });
+    await expect(
+      useCase.execute({
+        actor,
+        targetPrincipalId: TARGET,
+        roleId: 'point_manager',
+        scope: ScopeRef.entity('resource', 'r1').toPlain(),
+      }),
+    ).resolves.toHaveProperty('id');
   });
 
   it('an org_admin can grant org_member within their organization', async () => {

--- a/apps/api/src/contexts/identity/application/grant-role.spec.ts
+++ b/apps/api/src/contexts/identity/application/grant-role.spec.ts
@@ -119,7 +119,7 @@ describe('GrantRole (delegation with attenuation)', () => {
 
   it('a principal without role:grant cannot delegate', async () => {
     const actor = actorWith({
-      roleId: 'emergency_coordinator',
+      roleId: 'emergency_verifier',
       scope: ScopeRef.emergency('e1'),
     });
     await expect(

--- a/apps/api/src/contexts/identity/application/grant-role.ts
+++ b/apps/api/src/contexts/identity/application/grant-role.ts
@@ -5,11 +5,7 @@ import {
   AuthorizationContext,
 } from '../domain/authorization/access-control';
 import { Grant } from '../domain/authorization/grant';
-import {
-  ScopeRef,
-  ScopeRefProps,
-  ancestorChain,
-} from '../domain/authorization/scope-ref';
+import { ScopeRef, ScopeRefProps } from '../domain/authorization/scope-ref';
 import {
   permissionsForRole,
   roleExists,
@@ -20,6 +16,8 @@ import {
   PrivilegeEscalationError,
   UnknownRoleError,
 } from '../domain/authorization/errors';
+import { ResourceEmergencyLookup } from '../domain/ports/resource-emergency-lookup';
+import { authorizationChainForScope } from './scope-chain';
 
 export interface GrantRoleCommand {
   /** Who is granting — their effective grants for this request. */
@@ -42,6 +40,7 @@ export class GrantRole {
   constructor(
     private readonly grants: GrantRepository,
     private readonly access: AccessControl,
+    private readonly resourceEmergencyLookup: ResourceEmergencyLookup,
   ) {}
 
   async execute(cmd: GrantRoleCommand): Promise<{ id: string }> {
@@ -60,7 +59,10 @@ export class GrantRole {
       throw new InvalidGrantExpiryError();
     }
 
-    const chain = ancestorChain(cmd.scope);
+    const chain = await authorizationChainForScope(
+      cmd.scope,
+      this.resourceEmergencyLookup,
+    );
     const actorPermissions = await this.access.effectivePermissions(
       cmd.actor,
       chain,

--- a/apps/api/src/contexts/identity/application/list-grants-at-scope.spec.ts
+++ b/apps/api/src/contexts/identity/application/list-grants-at-scope.spec.ts
@@ -10,12 +10,15 @@ import { NotAuthorizedToReadError } from '../domain/authorization/errors';
 import { User } from '../domain/user';
 import { UserId } from '../domain/user-id';
 import { Email } from '../domain/email';
+import { ResourceEmergencyLookup } from '../domain/ports/resource-emergency-lookup';
 
 const PLATFORM_ADMIN = '11111111-1111-4111-8111-111111111111';
 const ORG_ADMIN = '22222222-2222-4222-8222-222222222222';
 const MEMBER = '33333333-3333-4333-8333-333333333333';
+const COORDINATOR = '44444444-4444-4444-8444-444444444444';
 const ORG = 'org-1';
 const OTHER_ORG = 'org-2';
+const EMERGENCY = 'e-1';
 
 function ctx(principalId: string, ...held: Grant[]): AuthorizationContext {
   return { principalId, grants: held.map((g) => g.toSnapshot()) };
@@ -23,13 +26,28 @@ function ctx(principalId: string, ...held: Grant[]): AuthorizationContext {
 
 const access = new LocalAccessControl();
 
+function resourceEmergencyLookup(
+  map: Record<string, string>,
+): ResourceEmergencyLookup {
+  return {
+    findEmergencyId: (resourceId: string) =>
+      Promise.resolve(map[resourceId] ?? null),
+  };
+}
+
 describe('ListGrantsAtScope', () => {
   let grants: InMemoryGrantRepository;
   let users: InMemoryUserRepository;
   let serviceAccounts: InMemoryServiceAccountRepository;
 
   function useCase(): ListGrantsAtScope {
-    return new ListGrantsAtScope(grants, access, users, serviceAccounts);
+    return new ListGrantsAtScope(
+      grants,
+      access,
+      users,
+      serviceAccounts,
+      resourceEmergencyLookup({ r1: EMERGENCY }),
+    );
   }
 
   beforeEach(async () => {
@@ -126,5 +144,32 @@ describe('ListGrantsAtScope', () => {
         scope: ScopeRef.organization(ORG).toPlain(),
       }),
     ).rejects.toThrow(NotAuthorizedToReadError);
+  });
+
+  it('lets an emergency coordinator list grants for a resource in their emergency', async () => {
+    await grants.save(
+      Grant.create({
+        id: 'r1g',
+        principalId: MEMBER,
+        roleId: 'point_manager',
+        scope: ScopeRef.entity('resource', 'r1'),
+      }),
+    );
+
+    const result = await useCase().execute({
+      actor: ctx(
+        COORDINATOR,
+        Grant.create({
+          id: 'ec',
+          principalId: COORDINATOR,
+          roleId: 'emergency_coordinator',
+          scope: ScopeRef.emergency(EMERGENCY),
+        }),
+      ),
+      scope: ScopeRef.entity('resource', 'r1').toPlain(),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].grant.roleId).toBe('point_manager');
   });
 });

--- a/apps/api/src/contexts/identity/application/list-grants-at-scope.ts
+++ b/apps/api/src/contexts/identity/application/list-grants-at-scope.ts
@@ -8,11 +8,10 @@ import {
   AuthorizationContext,
 } from '../domain/authorization/access-control';
 import { Permission } from '../domain/authorization/permission';
-import {
-  ScopeRefProps,
-  ancestorChain,
-} from '../domain/authorization/scope-ref';
+import { ScopeRefProps } from '../domain/authorization/scope-ref';
 import { NotAuthorizedToReadError } from '../domain/authorization/errors';
+import { ResourceEmergencyLookup } from '../domain/ports/resource-emergency-lookup';
+import { authorizationChainForScope } from './scope-chain';
 
 /**
  * Permissions that make a principal an *administrator* of a scope — any of them
@@ -51,13 +50,15 @@ export class ListGrantsAtScope {
     private readonly access: AccessControl,
     private readonly users: UserRepository,
     private readonly serviceAccounts: ServiceAccountRepository,
+    private readonly resourceEmergencyLookup: ResourceEmergencyLookup,
   ) {}
 
   async execute(cmd: ListGrantsAtScopeCommand): Promise<ScopeGrantView[]> {
-    const perms = await this.access.effectivePermissions(
-      cmd.actor,
-      ancestorChain(cmd.scope),
+    const scopeChain = await authorizationChainForScope(
+      cmd.scope,
+      this.resourceEmergencyLookup,
     );
+    const perms = await this.access.effectivePermissions(cmd.actor, scopeChain);
     if (!ADMIN_READ_PERMISSIONS.some((p) => perms.has(p))) {
       throw new NotAuthorizedToReadError('grants at this scope');
     }

--- a/apps/api/src/contexts/identity/application/revoke-grant.spec.ts
+++ b/apps/api/src/contexts/identity/application/revoke-grant.spec.ts
@@ -10,6 +10,7 @@ import {
   LegacyGrantNotRevocableError,
   NotAuthorizedToRevokeError,
 } from '../domain/authorization/errors';
+import { ResourceEmergencyLookup } from '../domain/ports/resource-emergency-lookup';
 
 const ACTOR = '11111111-1111-4111-8111-111111111111';
 const TARGET = '22222222-2222-4222-8222-222222222222';
@@ -31,13 +32,22 @@ function actorWith(
   };
 }
 
+function resourceEmergencyLookup(
+  map: Record<string, string>,
+): ResourceEmergencyLookup {
+  return {
+    findEmergencyId: (resourceId: string) =>
+      Promise.resolve(map[resourceId] ?? null),
+  };
+}
+
 async function seedTargetGrant(repo: InMemoryGrantRepository): Promise<void> {
   await repo.save(
     Grant.create({
       id: GRANT_ID,
       principalId: TARGET,
-      roleId: 'emergency_coordinator',
-      scope: ScopeRef.emergency('e1'),
+      roleId: 'point_manager',
+      scope: ScopeRef.entity('resource', 'r1'),
     }),
   );
 }
@@ -48,7 +58,11 @@ describe('RevokeGrant', () => {
 
   beforeEach(() => {
     repo = new InMemoryGrantRepository();
-    useCase = new RevokeGrant(repo, new LocalAccessControl());
+    useCase = new RevokeGrant(
+      repo,
+      new LocalAccessControl(),
+      resourceEmergencyLookup({ r1: 'e1' }),
+    );
   });
 
   it('a platform_admin can revoke a grant', async () => {
@@ -80,6 +94,18 @@ describe('RevokeGrant', () => {
     await expect(useCase.execute({ actor, grantId: GRANT_ID })).rejects.toThrow(
       NotAuthorizedToRevokeError,
     );
+  });
+
+  it('uses the owning emergency when revoking a resource entity grant', async () => {
+    await seedTargetGrant(repo);
+    const actor = actorWith({
+      roleId: 'emergency_coordinator',
+      scope: ScopeRef.emergency('e1'),
+    });
+    await expect(
+      useCase.execute({ actor, grantId: GRANT_ID }),
+    ).resolves.toBeUndefined();
+    expect(await repo.findById(GRANT_ID)).toBeNull();
   });
 
   it('forbids an admin from revoking their own platform_admin grant (self-lockout)', async () => {

--- a/apps/api/src/contexts/identity/application/revoke-grant.ts
+++ b/apps/api/src/contexts/identity/application/revoke-grant.ts
@@ -3,13 +3,14 @@ import {
   AccessControl,
   AuthorizationContext,
 } from '../domain/authorization/access-control';
-import { ancestorChain } from '../domain/authorization/scope-ref';
 import {
   CannotRevokeOwnAdminError,
   GrantNotFoundError,
   LegacyGrantNotRevocableError,
   NotAuthorizedToRevokeError,
 } from '../domain/authorization/errors';
+import { ResourceEmergencyLookup } from '../domain/ports/resource-emergency-lookup';
+import { authorizationChainForScope } from './scope-chain';
 
 export interface RevokeGrantCommand {
   actor: AuthorizationContext;
@@ -26,6 +27,7 @@ export class RevokeGrant {
   constructor(
     private readonly grants: GrantRepository,
     private readonly access: AccessControl,
+    private readonly resourceEmergencyLookup: ResourceEmergencyLookup,
   ) {}
 
   async execute(cmd: RevokeGrantCommand): Promise<void> {
@@ -50,7 +52,10 @@ export class RevokeGrant {
       throw new CannotRevokeOwnAdminError();
     }
 
-    const chain = ancestorChain(grant.scope.toPlain());
+    const chain = await authorizationChainForScope(
+      grant.scope.toPlain(),
+      this.resourceEmergencyLookup,
+    );
     const actorPermissions = await this.access.effectivePermissions(
       cmd.actor,
       chain,

--- a/apps/api/src/contexts/identity/application/scope-chain.ts
+++ b/apps/api/src/contexts/identity/application/scope-chain.ts
@@ -1,0 +1,31 @@
+import {
+  ScopeRefProps,
+  ancestorChain,
+} from '../domain/authorization/scope-ref';
+import { ResourceEmergencyLookup } from '../domain/ports/resource-emergency-lookup';
+
+/**
+ * Expands a scope into the authorization chain used by delegation / revocation.
+ *
+ * `entity(resource)` scopes are special: the effective admin chain must include
+ * the owning emergency, not only the entity itself and platform. Other entity
+ * types currently continue to behave like the generic ancestor chain until they
+ * gain an owning-emergency lookup port of their own.
+ */
+export async function authorizationChainForScope(
+  scope: ScopeRefProps,
+  resourceEmergencyLookup: ResourceEmergencyLookup,
+): Promise<ScopeRefProps[]> {
+  if (scope.type === 'entity' && scope.entityType === 'resource') {
+    const emergencyId = await resourceEmergencyLookup.findEmergencyId(scope.id);
+    if (emergencyId !== null) {
+      return [
+        scope,
+        { type: 'emergency', id: emergencyId },
+        { type: 'platform' },
+      ];
+    }
+  }
+
+  return ancestorChain(scope);
+}

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.spec.ts
@@ -85,6 +85,33 @@ describe('ROLE_CATALOG', () => {
     expect(verifier.has('container:manage')).toBe(false);
   });
 
+  it('defines a point_manager role scoped to one resource', () => {
+    expect(roleExists('point_manager')).toBe(true);
+
+    const pointManager = ROLE_CATALOG.point_manager;
+    expect(pointManager.defaultScopeType).toBe('entity');
+    expect(new Set(pointManager.permissions).size).toBe(
+      pointManager.permissions.length,
+    );
+    expect(pointManager.permissions).toEqual(
+      expect.arrayContaining([
+        'resource:read',
+        'resource:edit',
+        'container:manage',
+        'container:read',
+        'need:create',
+        'need:read',
+      ]),
+    );
+  });
+
+  it('lets emergency coordinators grant and revoke point managers', () => {
+    const coordinator = new Set(permissionsForRole('emergency_coordinator'));
+    expect(coordinator.has('role:grant')).toBe(true);
+    expect(coordinator.has('role:revoke')).toBe(true);
+    expect(coordinator.has('need:create')).toBe(true);
+  });
+
   it('every role only references permissions that exist in the catalog', () => {
     const valid = new Set<string>(ALL_PERMISSIONS);
     for (const role of Object.values(ROLE_CATALOG)) {

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
@@ -81,10 +81,13 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       'emergency:pause',
       'emergency:resume',
       'emergency:announce',
+      'role:grant',
+      'role:revoke',
       'resource:read',
       'resource:verify',
       'resource:close',
       'resource:edit',
+      'need:create',
       'need:read',
       'need:validate',
       'need:prioritize',
@@ -118,6 +121,20 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       // actividad de SU emergencia. El scope emergency del grant limita la
       // lectura a su propia emergencia (ver EmergencyAuditController).
       'audit:read',
+    ],
+  },
+  point_manager: {
+    id: 'point_manager',
+    description:
+      'Responsable de punto: opera un único punto de acopio sin coordinar toda la emergencia.',
+    defaultScopeType: 'entity',
+    permissions: [
+      'resource:read',
+      'resource:edit',
+      'container:manage',
+      'container:read',
+      'need:create',
+      'need:read',
     ],
   },
   emergency_verifier: {

--- a/apps/api/src/contexts/identity/infrastructure/http/grants.controller.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/grants.controller.ts
@@ -118,6 +118,7 @@ function buildScope(dto: GrantRoleDto): ScopeRefProps {
 function buildScopeFromQuery(
   scopeType: string,
   scopeId?: string,
+  scopeEntityType?: string,
 ): ScopeRefProps {
   if (scopeType === 'platform') return { type: 'platform' };
   if (
@@ -131,6 +132,14 @@ function buildScopeFromQuery(
       );
     }
     return { type: scopeType, id: scopeId };
+  }
+  if (scopeType === 'entity') {
+    if (!scopeId || !scopeEntityType) {
+      throw new BadRequestException(
+        'scopeId and scopeEntityType are required for an entity scope',
+      );
+    }
+    return { type: 'entity', id: scopeId, entityType: scopeEntityType };
   }
   throw new BadRequestException(`unsupported scopeType '${scopeType}'`);
 }
@@ -175,9 +184,10 @@ export class GrantsController {
   @ApiQuery({
     name: 'scopeType',
     required: true,
-    description: 'platform | organization | emergency | group',
+    description: 'platform | organization | emergency | group | entity',
   })
   @ApiQuery({ name: 'scopeId', required: false })
+  @ApiQuery({ name: 'scopeEntityType', required: false })
   @ApiOkResponse({ type: [GrantListItemDto] })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
   @ApiForbiddenResponse({
@@ -187,11 +197,12 @@ export class GrantsController {
     @Query('scopeType') scopeType: string,
     @Req() req: Request & { user?: AuthenticatedUser },
     @Query('scopeId') scopeId?: string,
+    @Query('scopeEntityType') scopeEntityType?: string,
   ): Promise<GrantListItemDto[]> {
     const user = req.user!;
     const views = await this.listGrantsAtScope.execute({
       actor: { principalId: user.id, grants: user.grants },
-      scope: buildScopeFromQuery(scopeType, scopeId),
+      scope: buildScopeFromQuery(scopeType, scopeId, scopeEntityType),
     });
     return views.map((v) =>
       toGrantListItem(v.grant, v.principalName, v.principalEmail),

--- a/apps/api/src/contexts/identity/infrastructure/identity.module.ts
+++ b/apps/api/src/contexts/identity/infrastructure/identity.module.ts
@@ -157,16 +157,22 @@ const scopeResolverProvider = {
 
 const grantRoleProvider = {
   provide: GrantRole,
-  inject: [GRANT_REPOSITORY, ACCESS_CONTROL],
-  useFactory: (grants: GrantRepository, access: AccessControl) =>
-    new GrantRole(grants, access),
+  inject: [GRANT_REPOSITORY, ACCESS_CONTROL, RESOURCE_EMERGENCY_LOOKUP],
+  useFactory: (
+    grants: GrantRepository,
+    access: AccessControl,
+    resourceEmergencyLookup: ResourceEmergencyLookup,
+  ) => new GrantRole(grants, access, resourceEmergencyLookup),
 };
 
 const revokeGrantProvider = {
   provide: RevokeGrant,
-  inject: [GRANT_REPOSITORY, ACCESS_CONTROL],
-  useFactory: (grants: GrantRepository, access: AccessControl) =>
-    new RevokeGrant(grants, access),
+  inject: [GRANT_REPOSITORY, ACCESS_CONTROL, RESOURCE_EMERGENCY_LOOKUP],
+  useFactory: (
+    grants: GrantRepository,
+    access: AccessControl,
+    resourceEmergencyLookup: ResourceEmergencyLookup,
+  ) => new RevokeGrant(grants, access, resourceEmergencyLookup),
 };
 
 const findUserByEmailProvider = {
@@ -233,13 +239,16 @@ const listGrantsAtScopeProvider = {
     ACCESS_CONTROL,
     USER_REPOSITORY,
     SERVICE_ACCOUNT_REPOSITORY,
+    RESOURCE_EMERGENCY_LOOKUP,
   ],
   useFactory: (
     grants: GrantRepository,
     access: AccessControl,
     users: UserRepository,
     sas: ServiceAccountRepository,
-  ) => new ListGrantsAtScope(grants, access, users, sas),
+    resourceEmergencyLookup: ResourceEmergencyLookup,
+  ) =>
+    new ListGrantsAtScope(grants, access, users, sas, resourceEmergencyLookup),
 };
 
 const serviceAccountRepositoryProvider = {

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/actions.ts
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/actions.ts
@@ -1,0 +1,170 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { api } from "@/lib/api";
+import { authHeaders, clearToken, getToken } from "@/lib/auth";
+
+export interface ResourceGrantView {
+  id: string;
+  principalId: string;
+  principalType: string;
+  roleId: string;
+  scopeType: string;
+  scopeId: string | null;
+  grantedByPrincipalId: string | null;
+  grantedAt: string;
+  expiresAt: string | null;
+  principalName: string | null;
+  principalEmail: string | null;
+}
+
+export interface ActionResult {
+  status: "idle" | "success" | "error";
+  message?: string;
+}
+
+const RESOURCE_SCOPE_TYPE = "entity";
+const RESOURCE_SCOPE_ENTITY_TYPE = "resource";
+
+function resourcePath(slug: string, resourceId: string): string {
+  return `/e/${slug}/recursos/${resourceId}`;
+}
+
+async function resolvePrincipalId(
+  token: string,
+  input: string,
+): Promise<string | null> {
+  const query = input.trim();
+  if (!query) return null;
+  const uuid =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (uuid.test(query)) return query;
+
+  const { data, error } = await api.GET("/users/lookup", {
+    params: { query: { email: query } },
+    headers: authHeaders(token),
+  });
+  if (error !== undefined || !data) return null;
+  return data.id;
+}
+
+export async function fetchResourceGrants(
+  resourceId: string,
+): Promise<ResourceGrantView[]> {
+  const token = await getToken();
+  if (!token) return [];
+
+  const { data, error } = await api.GET("/grants/at-scope", {
+    params: {
+      query: {
+        scopeType: RESOURCE_SCOPE_TYPE,
+        scopeId: resourceId,
+        scopeEntityType: RESOURCE_SCOPE_ENTITY_TYPE,
+      },
+    },
+    headers: authHeaders(token),
+  });
+
+  if (error !== undefined) return [];
+  return (data ?? []) as ResourceGrantView[];
+}
+
+export async function grantResourceRoleAction(
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  const slug = String(formData.get("slug") ?? "").trim();
+  const resourceId = String(formData.get("resourceId") ?? "").trim();
+  const principalInput = String(formData.get("principal") ?? "").trim();
+  const roleId = String(formData.get("roleId") ?? "").trim();
+  const token = await getToken();
+  if (!token) redirect(resourcePath(slug, resourceId));
+
+  const scopeType = String(formData.get("scopeType") ?? "").trim();
+  const scopeEntityType = String(formData.get("scopeEntityType") ?? "").trim();
+  if (
+    !slug ||
+    !resourceId ||
+    !principalInput ||
+    !roleId ||
+    scopeType !== RESOURCE_SCOPE_TYPE ||
+    scopeEntityType !== RESOURCE_SCOPE_ENTITY_TYPE
+  ) {
+    return { status: "error", message: "Completa el usuario y el rol." };
+  }
+
+  const principalId = await resolvePrincipalId(token, principalInput);
+  if (!principalId) {
+    return {
+      status: "error",
+      message: "No se encontró ningún usuario con ese email o ID.",
+    };
+  }
+
+  const { error, response } = await api.POST("/grants", {
+    body: {
+      principalId,
+      roleId,
+      scopeType: RESOURCE_SCOPE_TYPE,
+      scopeId: resourceId,
+      scopeEntityType: RESOURCE_SCOPE_ENTITY_TYPE,
+    },
+    headers: authHeaders(token),
+  });
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(resourcePath(slug, resourceId));
+    }
+    if (response.status === 403) {
+      return {
+        status: "error",
+        message:
+          "No puedes conceder este rol aquí: necesitas los permisos de coordinación del punto.",
+      };
+    }
+    if (response.status === 400) {
+      return {
+        status: "error",
+        message: "Datos inválidos. Revisa el formulario.",
+      };
+    }
+    return { status: "error", message: "No se pudo conceder el rol." };
+  }
+
+  revalidatePath(resourcePath(slug, resourceId));
+  return { status: "success", message: "Responsable autorizado." };
+}
+
+export async function revokeResourceGrantAction(
+  grantId: string,
+  slug: string,
+  resourceId: string,
+): Promise<ActionResult> {
+  const token = await getToken();
+  if (!token) redirect(resourcePath(slug, resourceId));
+
+  const { error, response } = await api.DELETE("/grants/{id}", {
+    params: { path: { id: grantId } },
+    headers: authHeaders(token),
+  });
+
+  if (error !== undefined) {
+    if (response.status === 401) {
+      await clearToken();
+      redirect(resourcePath(slug, resourceId));
+    }
+    if (response.status === 403) {
+      return {
+        status: "error",
+        message: "No tienes permiso para revocar este rol.",
+      };
+    }
+    return { status: "error", message: "No se pudo revocar el rol." };
+  }
+
+  revalidatePath(resourcePath(slug, resourceId));
+  return { status: "success" };
+}

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
@@ -1,14 +1,23 @@
-import { notFound } from 'next/navigation';
-import Link from 'next/link';
-import { api } from '@/lib/api';
-import { getEmergencyBySlug } from '@/lib/emergencies';
-import { PublicResourceCard } from '@/components/organisms/public-resource-card';
-import { NeedCard } from '@/components/molecules/need-card';
-import { EmptyState } from '@/components/molecules/empty-state';
-import { categoryLabel, categoryColor } from '@/lib/categories';
-import { getT } from '@/i18n/server';
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { clearToken, getToken } from "@/lib/auth";
+import { api } from "@/lib/api";
+import { getEmergencyBySlug } from "@/lib/emergencies";
+import { getMe, getRoles } from "@/lib/navigation-data";
+import type { MeGrant, RoleCatalogEntry } from "@/lib/admin-scopes";
+import {
+  resolveEmergencyAccess,
+  type EmergencyAccess,
+} from "@/lib/emergency-permissions";
+import { PublicResourceCard } from "@/components/organisms/public-resource-card";
+import { NeedCard } from "@/components/molecules/need-card";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { categoryLabel, categoryColor } from "@/lib/categories";
+import { getT } from "@/i18n/server";
+import { ResourceGrantsPanel } from "./resource-grants-panel";
+import { fetchResourceGrants } from "./actions";
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 type Props = {
   params: Promise<{ slug: string; resourceId: string }>;
@@ -28,13 +37,28 @@ export default async function RecipientResourcePage({ params }: Props) {
   }
 
   const emergencyId = emergency.id;
-  const isActive = emergency.status === 'active';
+  const isActive = emergency.status === "active";
+  const token = await getToken();
+  let access: EmergencyAccess | null = null;
+
+  if (token !== null) {
+    const [me, roles] = await Promise.all([getMe(), getRoles()]);
+    if (me === null) {
+      await clearToken();
+    } else {
+      access = resolveEmergencyAccess(
+        emergencyId,
+        (me.grants ?? []) as MeGrant[],
+        roles as RoleCatalogEntry[],
+      );
+    }
+  }
 
   const [{ data: resource }, { data: needs }] = await Promise.all([
-    api.GET('/emergencies/{emergencyId}/public/resources/{resourceId}', {
+    api.GET("/emergencies/{emergencyId}/public/resources/{resourceId}", {
       params: { path: { emergencyId, resourceId } },
     }),
-    api.GET('/emergencies/{emergencyId}/public/needs', {
+    api.GET("/emergencies/{emergencyId}/public/needs", {
       params: { path: { emergencyId }, query: { resourceId } },
     }),
   ]);
@@ -47,14 +71,18 @@ export default async function RecipientResourcePage({ params }: Props) {
   const td = t.resource_detail;
   const recipientNeeds = needs ?? [];
   const inventoryCategories = resource.inventoryCategories ?? [];
+  const canManagePoint = access?.canCoordinate ?? false;
+  const resourceGrants = canManagePoint
+    ? await fetchResourceGrants(resourceId)
+    : [];
 
   // Citizen delivery pre-registration (#130) is offered only for active
   // collection points of an active emergency — the same targets the API accepts.
   const canPreRegister =
     isActive &&
-    resource.publicStatus === 'active' &&
-    (resource.type === 'collection_point' ||
-      resource.type === 'collection_and_delivery');
+    resource.publicStatus === "active" &&
+    (resource.type === "collection_point" ||
+      resource.type === "collection_and_delivery");
 
   return (
     <main className="flex-1 bg-surface">
@@ -83,7 +111,9 @@ export default async function RecipientResourcePage({ params }: Props) {
               <span className="text-base font-semibold text-white">
                 {td.prereg_cta}
               </span>
-              <span className="text-sm text-white/80">{td.prereg_cta_hint}</span>
+              <span className="text-sm text-white/80">
+                {td.prereg_cta_hint}
+              </span>
             </Link>
           )}
 
@@ -93,6 +123,15 @@ export default async function RecipientResourcePage({ params }: Props) {
           >
             {t.resource_card.report_cta}
           </Link>
+
+          {canManagePoint && (
+            <ResourceGrantsPanel
+              slug={slug}
+              resourceId={resourceId}
+              grants={resourceGrants}
+              locale={locale}
+            />
+          )}
 
           <section
             aria-labelledby="resource-inventory-heading"

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/resource-grants-panel.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/resource-grants-panel.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useActionState } from "react";
+import { Button } from "@/components/atoms/button";
+import { ErrorMessage } from "@/components/atoms/error-message";
+import { Input } from "@/components/atoms/input";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { FormField } from "@/components/molecules/form-field";
+import {
+  grantResourceRoleAction,
+  revokeResourceGrantAction,
+  type ActionResult,
+  type ResourceGrantView,
+} from "./actions";
+
+const INITIAL: ActionResult = { status: "idle" };
+
+function formatGrantedAt(locale: string, value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value
+    : new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(date);
+}
+
+function ResourceGrantRow({
+  grant,
+  slug,
+  resourceId,
+  locale,
+}: {
+  grant: ResourceGrantView;
+  slug: string;
+  resourceId: string;
+  locale: string;
+}) {
+  const [state, formAction, pending] = useActionState(
+    () => revokeResourceGrantAction(grant.id, slug, resourceId),
+    INITIAL,
+  );
+
+  const principalLabel =
+    grant.principalName ?? grant.principalEmail ?? grant.principalId;
+
+  return (
+    <li className="rounded-lg border border-line bg-surface px-4 py-3">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <p className="font-semibold text-ink">{principalLabel}</p>
+          <p className="text-sm text-muted-soft">
+            Responsable de punto · concedido el{" "}
+            {formatGrantedAt(locale, grant.grantedAt)}
+          </p>
+        </div>
+
+        {state.status === "error" && (
+          <ErrorMessage message={state.message ?? ""} />
+        )}
+        {state.status === "success" && (
+          <p
+            role="status"
+            className="rounded-md border border-green-500 bg-green-50 px-4 py-3 text-sm font-medium text-green-800"
+          >
+            Responsable revocado.
+          </p>
+        )}
+
+        <form action={formAction} className="self-start">
+          <Button
+            type="submit"
+            variant="danger-outline"
+            size="sm"
+            disabled={pending}
+          >
+            {pending ? "Revocando…" : "Revocar"}
+          </Button>
+        </form>
+      </div>
+    </li>
+  );
+}
+
+function GrantForm({ slug, resourceId }: { slug: string; resourceId: string }) {
+  const [state, formAction, pending] = useActionState(
+    grantResourceRoleAction,
+    INITIAL,
+  );
+
+  return (
+    <form
+      action={formAction}
+      className="flex flex-col gap-4 rounded-lg border border-line bg-surface px-4 py-4"
+    >
+      <input type="hidden" name="slug" value={slug} />
+      <input type="hidden" name="resourceId" value={resourceId} />
+      <input type="hidden" name="scopeType" value="entity" />
+      <input type="hidden" name="scopeEntityType" value="resource" />
+      <input type="hidden" name="roleId" value="point_manager" />
+
+      {state.status === "error" && (
+        <ErrorMessage message={state.message ?? ""} />
+      )}
+      {state.status === "success" && (
+        <p
+          role="status"
+          className="rounded-md border border-green-500 bg-green-50 px-4 py-3 text-sm font-medium text-green-800"
+        >
+          {state.message ?? "Responsable autorizado."}
+        </p>
+      )}
+
+      <FormField htmlFor="principal" label="Usuario (email o ID)">
+        <Input
+          id="principal"
+          name="principal"
+          type="text"
+          placeholder="persona@ejemplo.org o UUID"
+          required
+          autoComplete="off"
+        />
+      </FormField>
+
+      <FormField htmlFor="expiresAt" label="Caduca (opcional)">
+        <Input id="expiresAt" name="expiresAt" type="date" autoComplete="off" />
+      </FormField>
+
+      <p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+        Solo se concede el rol de responsable de punto. La atenuación del
+        servidor evita escaladas de privilegio.
+      </p>
+
+      <Button type="submit" disabled={pending} size="md">
+        {pending ? "Concediendo…" : "Autorizar responsable"}
+      </Button>
+    </form>
+  );
+}
+
+export function ResourceGrantsPanel({
+  slug,
+  resourceId,
+  grants,
+  locale,
+}: {
+  slug: string;
+  resourceId: string;
+  grants: ResourceGrantView[];
+  locale: string;
+}) {
+  const orderedGrants = [...grants].sort(
+    (a, b) => new Date(b.grantedAt).getTime() - new Date(a.grantedAt).getTime(),
+  );
+
+  return (
+    <section
+      aria-labelledby="resource-grants-heading"
+      className="flex flex-col gap-4"
+    >
+      <div className="flex flex-col gap-2">
+        <h2
+          id="resource-grants-heading"
+          className="font-display text-base font-bold text-navy"
+        >
+          Responsables del punto
+        </h2>
+        <p className="text-sm text-muted-soft">
+          Autoriza personas concretas para operar este punto sin darles
+          coordinación de toda la emergencia.
+        </p>
+      </div>
+
+      <GrantForm slug={slug} resourceId={resourceId} />
+
+      <div className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-ink">
+          Autorizaciones actuales
+        </h3>
+
+        {orderedGrants.length === 0 ? (
+          <EmptyState title="Todavía no hay responsables asignados." />
+        ) : (
+          <ul className="flex flex-col gap-3" role="list">
+            {orderedGrants.map((grant) => (
+              <ResourceGrantRow
+                key={grant.id}
+                grant={grant}
+                slug={slug}
+                resourceId={resourceId}
+                locale={locale}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -5060,9 +5060,10 @@ export interface operations {
     GrantsController_listAtScope: {
         parameters: {
             query: {
-                /** @description platform | organization | emergency | group */
+                /** @description platform | organization | emergency | group | entity */
                 scopeType: string;
                 scopeId?: string;
+                scopeEntityType?: string;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Resumen

- Añade el rol `point_manager` y actualiza los permisos de delegación del coordinador de emergencias.
- Permite flujos de grant/list/revoke autorizando scopes `entity(resource)` a través de la emergencia propietaria.
- Expone panel de gestión de punto de recursos en la página pública de recurso para coordinadores.

## Validación

- [ ] Gate ejecutado en la zona tocada — ESLint y build en verde en los ficheros afectados
- [ ] Comportamiento verificado manualmente

## Cierre

Closes #159