### PR TITLE
Clean Code en todo el frontend (menos comentarios, código autodescriptivo)

### DIFF
--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -3,10 +3,6 @@
 import { redirect } from 'next/navigation';
 import { clearToken } from '@/lib/auth';
 
-/**
- * Global logout server action. Clears the auth cookie and returns to /login.
- * Shared by the app shell's AccountMenu and any page-level logout control.
- */
 export async function logoutAction(): Promise<void> {
   await clearToken();
   redirect('/login');

--- a/apps/web/src/app/auth/complete/page.tsx
+++ b/apps/web/src/app/auth/complete/page.tsx
@@ -35,7 +35,6 @@ export default function AuthCompletePage() {
       return;
     }
 
-    // Call the Server Action — it sets the cookie and redirects to `next` (or /).
     void completeOAuthAction(token, next ?? undefined);
   }, []);
 

--- a/apps/web/src/app/docs/code-block.tsx
+++ b/apps/web/src/app/docs/code-block.tsx
@@ -1,10 +1,6 @@
 'use client';
 
 /**
- * CodeBlock — presentational code/JSON/curl sample for the developer docs page
- * (/docs). Dark navy surface so samples stand out from the warm page, with an
- * optional language label and a copy-to-clipboard button.
- *
  * Client component (clipboard + local "copied" state). Per the project i18n
  * pattern, the translated button labels are passed in as plain-string props
  * from the Server Component that renders it — no dictionary is read here.

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -340,7 +340,6 @@ for (const p of items) {
         <SiteHeaderBand />
 
         <div className="px-5 pb-16 pt-8 lg:px-8 lg:pt-10">
-          {/* Hero */}
           <header className="grid items-center gap-8 lg:grid-cols-2 lg:gap-12">
             <div>
               <p className="font-display text-xs font-bold uppercase tracking-[0.14em] text-accent">
@@ -392,7 +391,6 @@ for (const p of items) {
             </aside>
 
             <div className="flex min-w-0 flex-col gap-12">
-              {/* Overview */}
               <Section id="intro" title={d.intro_heading}>
                 <Lead>{d.intro_p1}</Lead>
                 <Lead>{d.intro_p2}</Lead>
@@ -421,7 +419,6 @@ for (const p of items) {
                 </dl>
               </Section>
 
-              {/* Concepts */}
               <Section id="concepts" title={d.concepts_heading}>
                 <Lead>{d.concepts_intro}</Lead>
                 <div className="grid gap-3 sm:grid-cols-2">
@@ -432,7 +429,6 @@ for (const p of items) {
                 </div>
               </Section>
 
-              {/* Authentication */}
               <Section id="auth" title={d.auth_heading}>
                 <Lead>{d.auth_intro}</Lead>
                 <div className="grid gap-3 sm:grid-cols-2">
@@ -443,7 +439,6 @@ for (const p of items) {
                 <Callout tone="warn">{d.auth_note}</Callout>
               </Section>
 
-              {/* Quickstart */}
               <Section id="quickstart" title={d.qs_heading}>
                 <Lead>{d.qs_intro}</Lead>
                 <ol className="ml-4 list-decimal space-y-1.5 text-[14.5px] leading-[1.6] text-ink-soft marker:font-bold marker:text-accent">
@@ -456,7 +451,6 @@ for (const p of items) {
                 <Callout>{d.qs_note}</Callout>
               </Section>
 
-              {/* List emergencies */}
               <Section id="emergencies" title={d.e_heading}>
                 <Endpoint method="GET" path="/emergencies" />
                 <Lead>{d.e_intro}</Lead>
@@ -505,7 +499,6 @@ for (const p of items) {
                 <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={facetsJson} lang="JSON" />
               </Section>
 
-              {/* Needs (read) */}
               <Section id="needs" title={d.n_heading}>
                 <Endpoint method="GET" path="/emergencies/{emergencyId}/public/needs" />
                 <Lead>{d.n_intro}</Lead>
@@ -515,7 +508,6 @@ for (const p of items) {
                 <Callout tone="warn">{d.n_privacy}</Callout>
               </Section>
 
-              {/* States & categories */}
               <Section id="enums" title={d.enums_heading}>
                 <Lead>{d.enums_intro}</Lead>
 
@@ -584,7 +576,6 @@ for (const p of items) {
                 <Chips items={['low', 'medium', 'high', 'urgent']} />
               </Section>
 
-              {/* Contribute data (writes) */}
               <Section id="write" title={d.w_heading}>
                 <Lead>{d.w_intro}</Lead>
                 <Callout tone="warn">{d.w_moderation_note}</Callout>
@@ -609,7 +600,6 @@ for (const p of items) {
                 <CodeBlock copyLabel={d.copy} copiedLabel={d.copied} code={curlCreateResource} lang="cURL" />
               </Section>
 
-              {/* Best practices */}
               <Section id="practices" title={d.bp_heading}>
                 <div className="grid gap-3 sm:grid-cols-2">
                   <Card title={d.bp_cache_t}>{d.bp_cache_b}</Card>
@@ -620,7 +610,6 @@ for (const p of items) {
                 </div>
               </Section>
 
-              {/* License & attribution */}
               <Section id="license" title={d.license_heading}>
                 <Lead>{d.license_intro}</Lead>
                 <div className="grid gap-3 sm:grid-cols-2">
@@ -640,7 +629,6 @@ for (const p of items) {
                 </a>
               </Section>
 
-              {/* Reference & links */}
               <Section id="links" title={d.links_heading}>
                 <div className="flex flex-col gap-3">
                   <a
@@ -671,7 +659,6 @@ for (const p of items) {
                 </div>
               </Section>
 
-              {/* CTA */}
               <section className="rounded-card border border-line bg-surface-alt px-6 py-8 text-center">
                 <h2 className="font-display text-xl font-bold text-navy">{d.cta_heading}</h2>
                 <p className="mx-auto mt-2 max-w-md text-[14.5px] leading-[1.55] text-muted">{d.cta_body}</p>

--- a/apps/web/src/app/e/[slug]/coordinacion/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/actions.ts
@@ -40,9 +40,6 @@ export interface EditReportInput {
   priority?: ReportPriority;
 }
 
-/**
- * Matches an open offer to a need (coordinator only).
- */
 export async function matchOffer(
   offerId: string,
   needId: string,
@@ -82,9 +79,6 @@ export async function matchOffer(
   return { status: 'success' };
 }
 
-/**
- * Marks a matched offer as fulfilled (coordinator only).
- */
 export async function fulfillOffer(
   offerId: string,
   slug: string,
@@ -119,9 +113,6 @@ export async function fulfillOffer(
   return { status: 'success' };
 }
 
-/**
- * Cancels an offer (coordinator only in this context).
- */
 export async function cancelOffer(
   offerId: string,
   slug: string,
@@ -161,13 +152,6 @@ export type ActionResult =
   | { status: 'success' }
   | { status: 'error'; message: string };
 
-/**
- * Verifies a resource and immediately publishes it.
- * The verification level is derived server-side by the backend — no level
- * is sent in the request body.
- * The token is read server-side from the httpOnly cookie — never exposed to
- * the client.
- */
 export async function verifyAndPublish(
   resourceId: string,
   slug: string,
@@ -232,9 +216,6 @@ export async function verifyAndPublish(
   return { status: 'success' };
 }
 
-/**
- * Validates a pending need (moves it to "validated" state so it appears publicly).
- */
 export async function validateNeed(
   needId: string,
   slug: string,
@@ -305,16 +286,12 @@ export async function renewNeed(
   return { status: 'success' };
 }
 
-/**
- * Clears the auth cookie and redirects to the login page.
- */
 export async function logout(): Promise<never> {
   await clearToken();
   redirect('/login');
 }
 
 /**
- * Pauses intake for the given emergency (coordinator only).
  * Returns an ActionResult — does not redirect, so the coordinator stays on
  * the page and sees the outcome.
  */
@@ -353,9 +330,6 @@ export async function pauseEmergency(
   return { status: 'success' };
 }
 
-/**
- * Resumes intake for a paused emergency (coordinator only).
- */
 export async function resumeEmergency(
   emergencyId: string,
   slug: string,
@@ -752,9 +726,6 @@ export async function discardReport(
   return { status: 'success' };
 }
 
-/**
- * Updates the official announcement for an emergency (coordinator only).
- */
 export async function publishAnnouncement(
   emergencyId: string,
   slug: string,

--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
@@ -15,15 +15,13 @@ export type ActionResult =
 type ShipmentItemInput = components['schemas']['SupplyLineDto'];
 type CapacityView = components['schemas']['CapacityViewDto'];
 
-/** Result of fetching ranked capacity suggestions for a shipment (#107). */
 export type SuggestionsResult =
   | { status: 'success'; capacities: CapacityView[] }
   | { status: 'error'; message: string };
 
 /**
- * Creates a shipment / expedición for the given emergency (coordinator).
  * `emergencyId` is bound server-side in the page so it is never trusted from
- * the client form. Origin/destination are resource ids picked from a select.
+ * the client form.
  */
 export async function createShipment(
   emergencyId: string,
@@ -179,9 +177,6 @@ export async function getCapacitySuggestions(
   return { status: 'success', capacities: data };
 }
 
-/**
- * Marks an assigned shipment as in transit (assigned carrier or coordinator).
- */
 export async function markInTransit(
   shipmentId: string,
   slug: string,
@@ -227,9 +222,6 @@ export async function markInTransit(
   return { status: 'success' };
 }
 
-/**
- * Confirms a shipment delivery (assigned carrier or coordinator).
- */
 export async function confirmDelivery(
   shipmentId: string,
   slug: string,
@@ -273,9 +265,6 @@ export async function confirmDelivery(
   return { status: 'success' };
 }
 
-/**
- * Cancels a planned/assigned shipment (coordinator).
- */
 export async function cancelShipment(
   shipmentId: string,
   slug: string,

--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/create-shipment.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/create-shipment.tsx
@@ -15,7 +15,6 @@ import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
 import { MATERIAL_CATEGORIES, categoryLabel } from '@/lib/categories';
 
-/** A resource option for the origin/destination selects. */
 export interface ResourceOption {
   id: string;
   name: string;
@@ -45,12 +44,6 @@ interface CreateShipmentProps {
 }
 
 /**
- * "Crear expedición" — a button that opens a drawer with a minimal create form:
- * origin/destination selects (from the emergency's resources), repeatable cargo
- * lines (the canonical SupplyLine: insumo + cantidad + unidad + categoría) and a
- * free-text manifiesto. On success the drawer closes and the route refreshes so
- * the new shipment appears.
- *
  * The loose lines use the shared material model (#141); loading trackable
  * containers (#140) onto a shipment is a separate flow, not part of this form.
  */
@@ -221,7 +214,6 @@ export function CreateShipment({
               </Select>
             </FormField>
 
-            {/* Repeatable cargo lines (canonical SupplyLine) */}
             <fieldset className="flex flex-col gap-3">
               <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
                 {tc.ship_items_legend} <span aria-hidden="true">*</span>

--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/page.tsx
@@ -38,7 +38,6 @@ const VALID_CAP_STATUSES: CapacityStatus[] = [
   'withdrawn',
 ];
 
-// Resources usable as shipment origin/destination — collection/warehouse nodes.
 const RESOURCE_PAGE_SIZE = 100;
 
 type Props = {
@@ -99,7 +98,6 @@ export default async function CoordinacionExpedicionesPage({
 
   const canCreate = access.permissions.has('shipment:create');
 
-  // --- Parse filter params ----------------------------------------------
   const rawStatus =
     typeof resolvedSearchParams.status === 'string'
       ? resolvedSearchParams.status
@@ -134,7 +132,6 @@ export default async function CoordinacionExpedicionesPage({
     }
   };
 
-  // --- Fetch shipments + capacities + resources (for names/selects) -----
   const [shipments, capacities, resourcesPage] = await Promise.all([
     api
       .GET('/emergencies/{emergencyId}/logistics/shipments', {
@@ -164,7 +161,7 @@ export default async function CoordinacionExpedicionesPage({
         await onUnauthorized(r.response.status);
         return r.data ?? [];
       }),
-    // ponytail: origen/destino se eligen de un <select> poblado con la lista
+    // origen/destino se eligen de un <select> poblado con la lista
     // pública de recursos (sin map-resource-picker). Tomamos la primera página
     // (límite 100); paginación de recursos en el selector queda fuera de v1.
     api
@@ -181,7 +178,6 @@ export default async function CoordinacionExpedicionesPage({
   for (const r of resourcesPage) resourceNames[r.id] = r.name;
   const resourceOptions = resourcesPage.map((r) => ({ id: r.id, name: r.name }));
 
-  // Available capacities the coordinator can assign from a shipment drawer.
   const assignableCapacities = capacities.filter((c) => c.status === 'available');
 
   const isShipmentsFiltered = status !== undefined;
@@ -224,7 +220,6 @@ export default async function CoordinacionExpedicionesPage({
         />
       </div>
 
-      {/* ── Capacidades disponibles (read-only, #105) ──────────────────── */}
       <div className="flex flex-col gap-5 border-t border-line pt-6">
         <h2 className="text-xl font-bold text-ink">{tc.cap_heading}</h2>
         <p className="text-sm text-muted">{tc.cap_subtitle}</p>

--- a/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
@@ -15,7 +15,6 @@ import { CoordinationTabs } from '@/components/organisms/coordination-tabs';
 import { Badge } from '@/components/atoms/badge';
 import type { Messages } from '@/i18n/messages/es';
 
-/** Friendly per-role label, falling back to the catalog description. */
 function roleLabel(
   roleId: string,
   tc: Messages['coord'],
@@ -35,13 +34,6 @@ function roleLabel(
   }
 }
 
-/**
- * Coordination shell: dashboard chrome + emergency context banner, plus the
- * panel container, integrated header (title · emergency name · role badges) and
- * the permission-aware sub-nav ({@link CoordinationTabs}). Every coordination
- * page renders only its own sections inside this frame — the header and tabs no
- * longer live in each page.
- */
 export default async function CoordinacionLayout({
   children,
   params,

--- a/apps/web/src/app/e/[slug]/coordinacion/ofertas/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/ofertas/page.tsx
@@ -78,7 +78,6 @@ export default async function CoordinacionOfertasPage({
     redirect(`/e/${slug}/coordinacion`);
   }
 
-  // --- Parse filter params ----------------------------------------------
   const rawCategory =
     typeof resolvedSearchParams.category === 'string' ? resolvedSearchParams.category : undefined;
   const rawStatus =
@@ -102,7 +101,6 @@ export default async function CoordinacionOfertasPage({
     }
   };
 
-  // --- Fetch the offers queue + validated needs (match targets) ---------
   const [offersQueue, validatedNeeds] = await Promise.all([
     api
       .GET('/emergencies/{emergencyId}/offers/queue', {

--- a/apps/web/src/app/e/[slug]/coordinacion/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/page.tsx
@@ -14,7 +14,6 @@ import { CoordinationSectionLink } from '@/components/molecules/coordination-sec
 import { EmptyState } from '@/components/molecules/empty-state';
 import { getT } from '@/i18n/server';
 
-// Always fetch live data — never serve a stale cached page.
 export const dynamic = 'force-dynamic';
 
 type Props = {
@@ -35,7 +34,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function CoordinacionPage({ params }: Props) {
   const { slug } = await params;
 
-  // --- Auth + emergency (frame is rendered by the layout) ---------------
   const token = await getToken();
   if (token === null) {
     redirect(`/login?next=/e/${slug}/coordinacion`);
@@ -71,7 +69,6 @@ export default async function CoordinacionPage({ params }: Props) {
     }
   };
 
-  // --- Pending counters for each actionable section ---------------------
   // Resources: ask for one row only — we just need the `total`.
   const [
     resourcesPending,
@@ -121,7 +118,6 @@ export default async function CoordinacionPage({ params }: Props) {
           })
           .then(async (r) => {
             await onUnauthorized(r.response.status);
-            // Count only the in-flight shipments (not delivered/cancelled).
             return (r.data ?? []).filter(
               (s) => s.status !== 'delivered' && s.status !== 'cancelled',
             ).length;

--- a/apps/web/src/app/e/[slug]/coordinacion/personnel-actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/personnel-actions.ts
@@ -11,10 +11,6 @@ export type PersonnelActionResult =
   | { status: 'success'; taskId: string }
   | { status: 'error'; message: string };
 
-/**
- * Crea una tarea a partir de una need de personal y opcionalmente asigna
- * voluntarios. Solo coordinadores.
- */
 export async function createTaskFromNeed(
   needId: string,
   slug: string,

--- a/apps/web/src/app/e/[slug]/coordinacion/peticiones/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/peticiones/page.tsx
@@ -79,7 +79,6 @@ export default async function CoordinacionPeticionesPage({
     redirect(`/e/${slug}/coordinacion`);
   }
 
-  // --- Parse filter / search params -------------------------------------
   const rawCategory =
     typeof resolvedSearchParams.category === 'string' ? resolvedSearchParams.category : undefined;
   const rawPriority =
@@ -106,7 +105,6 @@ export default async function CoordinacionPeticionesPage({
     }
   };
 
-  // --- Fetch the validation queue + (coordinator) the expired list ------
   const [needsQueue, expiredNeeds] = await Promise.all([
     api
       .GET('/emergencies/{emergencyId}/needs/queue', {

--- a/apps/web/src/app/e/[slug]/coordinacion/recursos/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/recursos/page.tsx
@@ -86,7 +86,6 @@ export default async function CoordinacionRecursosPage({
     redirect(`/e/${slug}/coordinacion`);
   }
 
-  // --- Parse search / filter / page params ------------------------------
   const rawQ =
     typeof resolvedSearchParams.q === 'string' ? resolvedSearchParams.q.trim() : '';
   const q = rawQ.slice(0, 100);
@@ -106,7 +105,6 @@ export default async function CoordinacionRecursosPage({
   const { t } = await getT();
   const tc = t.coord;
 
-  // --- Fetch the paged verification queue -------------------------------
   const result = await api.GET('/emergencies/{emergencyId}/coordination/queue', {
     params: {
       path: { emergencyId },

--- a/apps/web/src/app/e/[slug]/coordinacion/reportes/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/reportes/page.tsx
@@ -39,13 +39,11 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
-  // --- Auth guard ---
   const token = await getToken();
   if (token === null) {
     redirect(`/login?next=/e/${slug}/coordinacion/reportes`);
   }
 
-  // --- Emergency resolution ---
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {
     notFound();
@@ -54,7 +52,6 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
   const emergencyId = emergency.id;
   const headers = authHeaders(token);
 
-  // --- Parse and validate filter params ---
   const rawStatus = typeof resolvedSearchParams.status === 'string' ? resolvedSearchParams.status : undefined;
   const rawPriority = typeof resolvedSearchParams.priority === 'string' ? resolvedSearchParams.priority : undefined;
   const rawResourceId = typeof resolvedSearchParams.resourceId === 'string' ? resolvedSearchParams.resourceId : undefined;
@@ -74,7 +71,6 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
     ? rawResourceId.trim()
     : undefined;
 
-  // --- Fetch reports ---
   // Use the body openapi-fetch already parsed (`data`); calling response.json()
   // a second time throws "Body has already been read".
   let reports: FieldReport[] = [];
@@ -133,14 +129,12 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
 
   return (
     <>
-      {/* ── FILTROS ─────────────────────────────────────────────────── */}
       <section aria-labelledby="filters-heading" className="flex flex-col gap-3">
         <h2 id="filters-heading" className="text-sm font-semibold text-ink uppercase tracking-wide">
           {tc.reports_filter_heading}
         </h2>
 
         <div className="flex flex-wrap gap-2">
-          {/* Status filter */}
           <div className="flex gap-1">
             <Link
               href={baseUrl}
@@ -169,7 +163,6 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
             ))}
           </div>
 
-          {/* Priority filter */}
           <div className="flex gap-1">
             {VALID_PRIORITIES.map((p) => (
               <Link
@@ -188,7 +181,6 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
           </div>
         </div>
 
-        {/* Clear filters */}
         {(statusFilter !== undefined || priorityFilter !== undefined) && (
           <Link
             href={baseUrl}
@@ -201,7 +193,6 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
 
       <hr className="border-line" />
 
-      {/* ── LISTA DE PARTES ─────────────────────────────────────────── */}
       <section aria-labelledby="reports-heading" className="flex flex-col gap-4">
         <h2 id="reports-heading" className="text-xl font-bold text-ink">
           {tc.reports_received_heading}

--- a/apps/web/src/app/e/[slug]/coordinacion/voluntarios/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/voluntarios/actions.ts
@@ -11,9 +11,6 @@ export type ActionResult =
   | { status: 'success' }
   | { status: 'error'; message: string };
 
-/**
- * Update the status of a volunteer (coordinator only).
- */
 export async function updateVolunteerStatus(
   volunteerId: string,
   status: 'available' | 'assigned' | 'inactive',
@@ -50,9 +47,6 @@ export async function updateVolunteerStatus(
   return { status: 'success' };
 }
 
-/**
- * Create a new task for an emergency (coordinator only).
- */
 export async function createTask(
   emergencyId: string,
   slug: string,
@@ -84,7 +78,6 @@ export async function createTask(
 
   const skillValue = VALID_SKILLS.includes(requiredSkill as Skill) ? (requiredSkill as Skill) : undefined;
 
-  // Build optional location only when all three fields are present
   let location: { address: string; latitude: number; longitude: number } | undefined;
   if (address !== '' && latitudeRaw !== '' && longitudeRaw !== '') {
     const latitude = parseFloat(latitudeRaw);
@@ -120,9 +113,6 @@ export async function createTask(
   return { status: 'success' };
 }
 
-/**
- * Assign a volunteer to a task (coordinator only).
- */
 export async function assignVolunteer(
   taskId: string,
   volunteerId: string,
@@ -162,9 +152,6 @@ export async function assignVolunteer(
   return { status: 'success' };
 }
 
-/**
- * Unassign a volunteer from a task (coordinator only).
- */
 export async function unassignVolunteer(
   taskId: string,
   volunteerId: string,
@@ -204,9 +191,6 @@ export async function unassignVolunteer(
   return { status: 'success' };
 }
 
-/**
- * Mark a task as completed (coordinator only).
- */
 export async function completeTask(
   taskId: string,
   slug: string,
@@ -241,9 +225,6 @@ export async function completeTask(
   return { status: 'success' };
 }
 
-/**
- * Cancel a task (coordinator only).
- */
 export async function cancelTask(
   taskId: string,
   slug: string,

--- a/apps/web/src/app/e/[slug]/coordinacion/voluntarios/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/voluntarios/page.tsx
@@ -11,7 +11,6 @@ import { EmptyState } from '@/components/molecules/empty-state';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
 
-// Always fetch live data — never serve a stale cached page.
 export const dynamic = 'force-dynamic';
 
 type VolunteerStatus = components['schemas']['VolunteerViewDto']['status'];
@@ -39,13 +38,11 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
-  // --- Auth guard ---
   const token = await getToken();
   if (token === null) {
     redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
   }
 
-  // --- Emergency resolution ---
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {
     notFound();
@@ -54,7 +51,6 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
   const emergencyId = emergency.id;
   const headers = authHeaders(token);
 
-  // --- Parse roster filter params ---
   const VALID_SKILLS: VolunteerSkill[] = ['driving', 'medical', 'logistics', 'cooking', 'languages', 'admin', 'general'];
   const VALID_AVAILABILITIES: VolunteerAvailability[] = ['immediate', 'this_week', 'flexible'];
   const VALID_VEHICLES: VolunteerVehicle[] = ['none', 'car', 'van', 'truck'];
@@ -70,7 +66,6 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
   const vehicleFilter = VALID_VEHICLES.includes(rawVehicle as VolunteerVehicle) ? rawVehicle as VolunteerVehicle : undefined;
   const statusFilter = VALID_STATUSES.includes(rawStatus as VolunteerStatus) ? rawStatus as VolunteerStatus : undefined;
 
-  // --- Fetch roster and tasks in parallel ---
   const [rosterResult, tasksResult] = await Promise.all([
     api.GET('/emergencies/{emergencyId}/volunteers', {
       params: {
@@ -90,13 +85,11 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
     }),
   ]);
 
-  // Handle 401 — token expired
   if (rosterResult.response.status === 401 || tasksResult.response.status === 401) {
     await clearToken();
     redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
   }
 
-  // Handle 403 — not a coordinator for this emergency
   if (rosterResult.response.status === 403 || tasksResult.response.status === 403) {
     redirect(`/e/${slug}/coordinacion`);
   }
@@ -116,7 +109,6 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
 
   return (
     <>
-      {/* ── ROSTER DE VOLUNTARIOS ────────────────────────────────── */}
       <section aria-labelledby="roster-heading" className="flex flex-col gap-4">
         <h2 id="roster-heading" className="text-xl font-bold text-ink">
           {tc.roster_heading}
@@ -142,16 +134,13 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
 
       <hr className="border-line" />
 
-      {/* ── TAREAS ───────────────────────────────────────────────── */}
       <section aria-labelledby="tasks-heading" className="flex flex-col gap-6">
         <h2 id="tasks-heading" className="text-xl font-bold text-ink">
           {tc.tasks_heading}
         </h2>
 
-        {/* Create task form */}
         <CreateTaskForm emergencyId={emergencyId} slug={slug} />
 
-        {/* Task list */}
         {tasks.length === 0 ? (
           <EmptyState
             title={tc.tasks_empty_title}

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/donar-form.tsx
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/donar-form.tsx
@@ -23,9 +23,7 @@ type BoundAction = (prev: OfferState, formData: FormData) => Promise<OfferState>
 interface DonarFormProps {
   action: BoundAction;
   slug: string;
-  /** The need title if this is a directed offer, undefined otherwise. */
   targetNeedTitle?: string;
-  /** The need id if this is a directed offer, undefined otherwise. */
   targetNeedId?: string;
   locationPicker: ReactNode;
   orgSelector: ReactNode;
@@ -70,7 +68,6 @@ export function DonarForm({
   };
   const { clearDraft, wasRestored } = useFormDraft(draftKey, draftValues, draftSetters);
 
-  // Clear draft on successful submit
   useEffect(() => {
     if (state.status === 'success') clearDraft();
   }, [state.status, clearDraft]);
@@ -100,7 +97,6 @@ export function DonarForm({
         <ErrorMessage message={state.message ?? t.error_fallback} />
       )}
 
-      {/* Directed offer indicator */}
       {targetNeedTitle !== undefined && targetNeedId !== undefined && (
         <>
           <div
@@ -114,7 +110,6 @@ export function DonarForm({
         </>
       )}
 
-      {/* Categoría */}
       <FormField
         htmlFor="category"
         label={<>{t.category_label} <span aria-hidden="true">*</span></>}
@@ -137,7 +132,6 @@ export function DonarForm({
         </Select>
       </FormField>
 
-      {/* Descripción */}
       <FormField
         htmlFor="description"
         label={<>{t.description_label} <span aria-hidden="true">*</span></>}
@@ -154,7 +148,6 @@ export function DonarForm({
         />
       </FormField>
 
-      {/* Cantidad + Unidad */}
       <div className="flex gap-3">
         <div className="flex-1">
           <FormField
@@ -196,7 +189,6 @@ export function DonarForm({
         </div>
       </div>
 
-      {/* Ubicación */}
       <FormField
         htmlFor="location-search"
         label={<>{t.location_label} <span aria-hidden="true">*</span></>}
@@ -205,10 +197,8 @@ export function DonarForm({
         {locationPicker}
       </FormField>
 
-      {/* Organización */}
       {orgSelector}
 
-      {/* Notas */}
       <FormField
         htmlFor="notes"
         label={
@@ -228,7 +218,6 @@ export function DonarForm({
         />
       </FormField>
 
-      {/* Submit */}
       <Button type="submit" disabled={pending} fullWidth>
         {pending ? t.submitting : t.submit}
       </Button>

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
@@ -46,13 +46,11 @@ export default async function DonarPage({ params, searchParams }: Props) {
     notFound();
   }
 
-  // Resolve optional ?needId= query param
   const rawNeedId =
     typeof resolvedSearchParams.needId === 'string'
       ? resolvedSearchParams.needId.trim()
       : undefined;
 
-  // If a needId is provided, try to resolve the need title from the public list
   let targetNeedTitle: string | undefined;
   if (rawNeedId !== undefined && rawNeedId !== '') {
     const { data: needs } = await api.GET(

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
@@ -15,10 +15,6 @@ export type CheckActionResult =
   | { status: 'success' }
   | { status: 'error'; message: string };
 
-/**
- * Fetch the authenticated user's volunteer profile for the given emergency.
- * Returns null when not registered (404) or on network error.
- */
 export async function fetchMyVolunteerProfile(
   emergencyId: string,
   slug: string,
@@ -48,9 +44,6 @@ export async function fetchMyVolunteerProfile(
   return data;
 }
 
-/**
- * Fetch tasks assigned to the authenticated volunteer for the given emergency.
- */
 export async function fetchMyTasks(
   emergencyId: string,
   slug: string,
@@ -76,9 +69,6 @@ export async function fetchMyTasks(
   return data ?? [];
 }
 
-/**
- * Check in a volunteer to a task.
- */
 export async function checkInTask(
   taskId: string,
   volunteerId: string,
@@ -114,9 +104,6 @@ export async function checkInTask(
   return { status: 'success' };
 }
 
-/**
- * Check out a volunteer from a task.
- */
 export async function checkOutTask(
   taskId: string,
   volunteerId: string,

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
@@ -61,19 +61,16 @@ export default async function MiVoluntariadoPage({ params }: Props) {
     inactive: ta.vol_status_inactive,
   };
 
-  // --- Auth guard -----------------------------------------------------------
   const token = await getToken();
   if (token === null) {
     redirect(`/login?next=/e/${slug}/mi-voluntariado`);
   }
 
-  // --- Emergency resolution -------------------------------------------------
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {
     notFound();
   }
 
-  // --- Fetch data in parallel -----------------------------------------------
   const [profile, myTasks] = await Promise.all([
     fetchMyVolunteerProfile(emergency.id, slug),
     fetchMyTasks(emergency.id, slug),
@@ -90,7 +87,6 @@ export default async function MiVoluntariadoPage({ params }: Props) {
         />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
 
-        {/* ── PERFIL ────────────────────────────────────────────────── */}
         <section aria-labelledby="profile-heading" className="flex flex-col gap-4">
           <h2 id="profile-heading" className="text-xl font-bold text-ink">
             {ta.profile_heading}
@@ -139,7 +135,6 @@ export default async function MiVoluntariadoPage({ params }: Props) {
                 </span>
               </div>
 
-              {/* Skills */}
               {profile.skills.length > 0 && (
                 <div className="flex flex-col gap-2">
                   <p className="text-xs font-semibold text-muted uppercase tracking-wide">
@@ -155,7 +150,6 @@ export default async function MiVoluntariadoPage({ params }: Props) {
                 </div>
               )}
 
-              {/* Meta */}
               <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted border-t border-line pt-3">
                 <span>
                   {ta.availability_label}{' '}
@@ -181,7 +175,6 @@ export default async function MiVoluntariadoPage({ params }: Props) {
           )}
         </section>
 
-        {/* ── MIS TAREAS ────────────────────────────────────────────── */}
         {profile !== null && (
           <section aria-labelledby="tasks-heading" className="flex flex-col gap-4">
             <h2 id="tasks-heading" className="text-xl font-bold text-ink">

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/task-card.tsx
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/task-card.tsx
@@ -71,7 +71,6 @@ export function TaskCard({ task, volunteerId, slug }: TaskCardProps) {
       aria-label={ta.task_card_aria.replace('{name}', task.title)}
       className="flex flex-col gap-4 rounded-lg border-2 border-navy bg-white p-5"
     >
-      {/* Header */}
       <div className="flex flex-col gap-1">
         <div className="flex flex-wrap items-center gap-2">
           <h3 className="text-lg font-bold text-ink leading-tight flex-1">
@@ -88,7 +87,6 @@ export function TaskCard({ task, volunteerId, slug }: TaskCardProps) {
         )}
       </div>
 
-      {/* Metadata */}
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
         <span>
           {ta.task_status_label}{' '}
@@ -112,19 +110,16 @@ export function TaskCard({ task, volunteerId, slug }: TaskCardProps) {
         )}
       </div>
 
-      {/* Errors */}
       {errorMessage !== null && (
         <ErrorMessage message={errorMessage} />
       )}
 
-      {/* Success feedback */}
       {(checkInState.status === 'success' || checkOutState.status === 'success') && (
         <p role="alert" aria-live="polite" className="text-xs text-success font-medium">
           {ta.updated_success}
         </p>
       )}
 
-      {/* Check-in / Check-out buttons */}
       {myStatus === 'assigned' && (
         <form action={checkInAction}>
           <Button

--- a/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
@@ -31,7 +31,6 @@ export default async function MisExpedicionesPage({ params }: Props) {
   const { t } = await getT();
   const ta = t.account;
 
-  // --- Auth guard -----------------------------------------------------------
   const token = await getToken();
   if (token === null) {
     redirect(`/login?next=/e/${slug}/mis-expediciones`);
@@ -45,7 +44,6 @@ export default async function MisExpedicionesPage({ params }: Props) {
   const emergencyId = emergency.id;
   const headers = authHeaders(token);
 
-  // --- Fetch my shipments + resource names in parallel ----------------------
   const [shipments, resourcesPage] = await Promise.all([
     api
       .GET('/logistics/shipments/mine', {

--- a/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
+++ b/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
@@ -14,9 +14,6 @@ export type ActionResult =
   | { status: 'success' }
   | { status: 'error'; message: string };
 
-/**
- * Fetch resources owned by the authenticated user for a given emergency.
- */
 export async function fetchMyResources(
   emergencyId: string,
   slug: string,
@@ -46,10 +43,6 @@ export async function fetchMyResources(
   return data;
 }
 
-/**
- * Update the publicStatus of a resource the authenticated user owns.
- * Calls POST /resources/{resourceId}/status (owner or coordinator).
- */
 export async function updateResourceStatus(
   resourceId: string,
   status: PublicStatus,

--- a/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
@@ -47,19 +47,16 @@ export default async function MisPuntosPage({ params }: Props) {
     destination: ta.stage_destination,
   };
 
-  // --- Auth guard -----------------------------------------------------------
   const token = await getToken();
   if (token === null) {
     redirect(`/login?next=/e/${slug}/mis-puntos`);
   }
 
-  // --- Emergency resolution -------------------------------------------------
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {
     notFound();
   }
 
-  // --- Fetch my resources ---------------------------------------------------
   const myResources = await fetchMyResources(emergency.id, slug);
 
   return (
@@ -73,7 +70,6 @@ export default async function MisPuntosPage({ params }: Props) {
         />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
 
-        {/* ── LISTA DE PUNTOS ───────────────────────────────────────── */}
         <section aria-labelledby="my-points-heading" className="flex flex-col gap-4">
           <h2 id="my-points-heading" className="sr-only">
             {ta.points_list_heading}

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
@@ -19,7 +19,7 @@ function isMode(value: unknown): value is CapacityMode {
   return VALID_MODES.includes(value as CapacityMode);
 }
 
-// ponytail: restricciones libres v1 — lista cerrada de checkboxes en la UI; el
+// restricciones libres v1 — lista cerrada de checkboxes en la UI; el
 // API acepta string[] arbitrario, así que sólo dejamos pasar las tres conocidas.
 const VALID_CONSTRAINTS = ['refrigerated', 'hazmat', 'fragile'] as const;
 
@@ -116,7 +116,7 @@ export async function submitCapacity(
     headers: authHeaders(token),
     body: {
       emergencyId,
-      // ponytail: el proveedor es siempre el ciudadano autenticado (volunteer);
+      // el proveedor es siempre el ciudadano autenticado (volunteer);
       // sin selector de proveedor ni org-as-provider en esta pantalla (#105).
       provider: { type: 'volunteer', id: providerId },
       mode: rawMode,
@@ -124,7 +124,7 @@ export async function submitCapacity(
         ...(weightKg !== undefined ? { weightKg } : {}),
         ...(volumeM3 !== undefined ? { volumeM3 } : {}),
       },
-      // ponytail: área libre v1; corredor por coords/resource-picking diferido —
+      // área libre v1; corredor por coords/resource-picking diferido —
       // el matching #107 admite áreas (rankea más abajo).
       coverage: { kind: 'area', area: coverageArea },
       ...(window !== undefined ? { window } : {}),

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/ofrecer-transporte-form.tsx
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/ofrecer-transporte-form.tsx
@@ -97,7 +97,6 @@ export function OfrecerTransporteForm({
 
       <p className="text-sm text-muted">{t.intro}</p>
 
-      {/* Modo de transporte — segmentado (radios) */}
       <fieldset className="flex flex-col gap-2">
         <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
           {t.mode_label} <span aria-hidden="true">*</span>
@@ -129,7 +128,6 @@ export function OfrecerTransporteForm({
         </div>
       </fieldset>
 
-      {/* Capacidad — peso y/o volumen */}
       <fieldset className="flex flex-col gap-2">
         <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
           {t.capacity_legend} <span aria-hidden="true">*</span>
@@ -169,7 +167,6 @@ export function OfrecerTransporteForm({
         </div>
       </fieldset>
 
-      {/* Cobertura — área/ruta libre */}
       <FormField
         htmlFor="coverageArea"
         label={<>{t.coverage_label} <span aria-hidden="true">*</span></>}
@@ -185,7 +182,6 @@ export function OfrecerTransporteForm({
         />
       </FormField>
 
-      {/* Ventana de disponibilidad (opcional) */}
       <fieldset className="flex flex-col gap-2">
         <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
           {t.window_legend}{' '}
@@ -209,7 +205,6 @@ export function OfrecerTransporteForm({
         </div>
       </fieldset>
 
-      {/* Restricciones (opcional) */}
       <fieldset className="flex flex-col gap-2">
         <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
           {t.constraints_legend}{' '}
@@ -232,7 +227,6 @@ export function OfrecerTransporteForm({
         </div>
       </fieldset>
 
-      {/* Notas (opcional) */}
       <FormField
         htmlFor="notes"
         label={

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -158,7 +158,6 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
     { color: 'bg-red-500', label: te.map_legend_need },
   ];
 
-  // ── Slots handed to the segmented explorer ──────────────────────────────────
   const pointsSlot = (
     <ResourceList
       emergencyId={emergencyId}
@@ -220,7 +219,6 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
         a la derecha. En móvil el mapa es un "hero" arriba y el panel va debajo.
       */}
       <div className="lg:flex lg:items-start">
-        {/* ── Mapa: hero en móvil, panel fijo en escritorio ──────────────────── */}
         <section
           aria-labelledby="map-heading"
           className="relative lg:sticky lg:top-0 lg:h-screen lg:w-[58%] lg:shrink-0"
@@ -232,7 +230,6 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
             slug={slug}
             containerClassName="h-[44vh] min-h-[300px] max-h-[480px] border-y border-line lg:h-full lg:min-h-0 lg:max-h-none lg:border-y-0 lg:border-r"
           />
-          {/* Leyenda flotante sobre el mapa */}
           <div className="pointer-events-none absolute bottom-3 left-3 z-[500] flex max-w-[calc(100%-1.5rem)] flex-wrap items-center gap-x-3 gap-y-1 rounded-xl border border-line bg-white/95 px-3 py-2 text-[11px] font-medium text-muted shadow-md backdrop-blur-sm">
             {legendItems.map((item) => (
               <span key={item.label} className="flex items-center gap-1.5">
@@ -243,9 +240,7 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
           </div>
         </section>
 
-        {/* ── Panel: acciones, métricas, listas ──────────────────────────────── */}
         <div className="flex min-w-0 flex-1 flex-col gap-6 px-4 pb-12 pt-5 lg:mx-auto lg:max-w-3xl lg:px-8 lg:pt-7">
-          {/* Comunicado oficial (sólo si existe) */}
           {announcement !== null && (
             <AnnouncementCard
               announcement={announcement}
@@ -254,7 +249,6 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
             />
           )}
 
-          {/* ¿Cómo quieres colaborar? — acción primaria, arriba del todo */}
           <section aria-labelledby="actions-heading" className="flex flex-col gap-3">
             <h2 id="actions-heading" className={sectionTitle}>{te.actions_heading}</h2>
             {isActive ? (

--- a/apps/web/src/app/e/[slug]/peticion/items-field.tsx
+++ b/apps/web/src/app/e/[slug]/peticion/items-field.tsx
@@ -32,7 +32,6 @@ export function ItemsField({ t }: ItemsFieldProps) {
   const [items, setItems] = useState<Item[]>([makeItem()]);
   const locale = useLocale();
 
-  // Show personnel fields when at least one item is in the medical_personnel category
   const hasPersonnelCategory = items.some(
     (item) => item.category === 'medical_personnel',
   );
@@ -50,7 +49,6 @@ export function ItemsField({ t }: ItemsFieldProps) {
     categoryLabel: t.item_category_label,
   };
 
-  // Serialize to hidden input on every change
   const serialized = JSON.stringify(
     items.map(({ name, quantity, unit, category }) => ({
       name,
@@ -107,10 +105,8 @@ export function ItemsField({ t }: ItemsFieldProps) {
         />
       ))}
 
-      {/* Hidden input carries serialized items to the server action */}
       <input type="hidden" name="items" value={serialized} />
 
-      {/* Personnel detail fields — visible when at least one item is medical_personnel */}
       {hasPersonnelCategory && <PersonnelNeedFields />}
     </div>
   );

--- a/apps/web/src/app/e/[slug]/peticion/peticion-form.tsx
+++ b/apps/web/src/app/e/[slug]/peticion/peticion-form.tsx
@@ -58,7 +58,6 @@ export function PeticionForm({
     draftSetters,
   );
 
-  // Clear draft on successful submit
   useEffect(() => {
     if (state.status === 'success') clearDraft();
   }, [state.status, clearDraft]);
@@ -93,7 +92,6 @@ export function PeticionForm({
       {/* Organización — primer campo: en nombre de quién se hace la petición */}
       {orgSelector}
 
-      {/* Título */}
       <FormField
         htmlFor="title"
         label={<>{t.title_label} <span aria-hidden="true">*</span></>}
@@ -110,7 +108,6 @@ export function PeticionForm({
         />
       </FormField>
 
-      {/* Descripción */}
       <FormField
         htmlFor="description"
         label={
@@ -130,7 +127,6 @@ export function PeticionForm({
         />
       </FormField>
 
-      {/* Prioridad */}
       <FormField
         htmlFor="priority"
         label={<>{t.priority_label} <span aria-hidden="true">*</span></>}
@@ -153,7 +149,6 @@ export function PeticionForm({
         </Select>
       </FormField>
 
-      {/* Ubicación */}
       <FormField
         htmlFor="location-search"
         label={<>{t.location_label} <span aria-hidden="true">*</span></>}
@@ -162,10 +157,8 @@ export function PeticionForm({
         {locationPicker}
       </FormField>
 
-      {/* Artículos */}
       {itemsField}
 
-      {/* Submit */}
       <Button type="submit" disabled={pending} fullWidth>
         {pending ? t.submitting : t.submit}
       </Button>

--- a/apps/web/src/app/e/[slug]/pre-registro/actions.ts
+++ b/apps/web/src/app/e/[slug]/pre-registro/actions.ts
@@ -5,7 +5,6 @@ import { getT } from '@/i18n/server';
 import { MATERIAL_CATEGORIES } from '@/lib/categories';
 import { parseSupplyLines } from '@/lib/supply-lines';
 
-/** Narrow a free string to a known material category slug (single source). */
 function isMaterialCategory(v: string): boolean {
   return (MATERIAL_CATEGORIES as readonly string[]).includes(v);
 }

--- a/apps/web/src/app/e/[slug]/pre-registro/pre-registro-form.tsx
+++ b/apps/web/src/app/e/[slug]/pre-registro/pre-registro-form.tsx
@@ -87,7 +87,6 @@ export function PreRegistroForm({
         <ErrorMessage message={state.message ?? t.err_submit_failed} />
       )}
 
-      {/* Tu nombre */}
       <FormField
         htmlFor="donorName"
         label={
@@ -108,7 +107,6 @@ export function PreRegistroForm({
         />
       </FormField>
 
-      {/* Contacto (al menos uno) */}
       <fieldset className="flex flex-col gap-4 rounded-lg border-2 border-line p-4">
         <legend className="px-1 text-sm font-semibold uppercase tracking-wide text-ink">
           {t.contact_heading}
@@ -142,10 +140,8 @@ export function PreRegistroForm({
         </FormField>
       </fieldset>
 
-      {/* Qué vas a llevar (líneas de material) */}
       <InventoryField t={t.lines} locale={locale} startWithOneRow />
 
-      {/* Submit */}
       <Button type="submit" disabled={pending} fullWidth>
         {pending ? t.submitting : t.submit}
       </Button>

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
@@ -14,10 +14,6 @@ type Props = {
   params: Promise<{ slug: string; resourceId: string }>;
 };
 
-/**
- * Public detail page for a single resource / final recipient: its ficha plus
- * the list of needs linked to it (1‑a‑N, via ?resourceId=). EPIC #59.
- */
 export default async function RecipientResourcePage({ params }: Props) {
   const { slug, resourceId } = await params;
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/report-validez-form.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/report-validez-form.tsx
@@ -77,7 +77,6 @@ export function ReportValidezForm({
         <ErrorMessage message={state.message ?? t.error_fallback} />
       )}
 
-      {/* Motivo */}
       <FormField
         htmlFor="reason"
         label={
@@ -104,7 +103,6 @@ export function ReportValidezForm({
         </Select>
       </FormField>
 
-      {/* Nota (opcional) */}
       <FormField htmlFor="note" label={t.note_label}>
         <Textarea
           id="note"
@@ -114,7 +112,6 @@ export function ReportValidezForm({
         />
       </FormField>
 
-      {/* Fotos (opcional) */}
       <PhotoUploader onUrlsChange={handlePhotoUrlsChange} />
 
       <Button type="submit" disabled={pending} fullWidth>

--- a/apps/web/src/app/e/[slug]/registrar/actions.ts
+++ b/apps/web/src/app/e/[slug]/registrar/actions.ts
@@ -11,7 +11,6 @@ import { getT } from '@/i18n/server';
 type ResourceType = components['schemas']['RegisterResourceDto']['type'];
 type Stage = components['schemas']['RegisterResourceDto']['stage'];
 
-/** Narrow a free string to a known material category slug (single source). */
 function isMaterialCategory(v: string): boolean {
   return (MATERIAL_CATEGORIES as readonly string[]).includes(v);
 }

--- a/apps/web/src/app/e/[slug]/registrar/inventory-field.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/inventory-field.tsx
@@ -158,7 +158,6 @@ export function InventoryField({
         ))
       )}
 
-      {/* Hidden input carries serialized items to the server action */}
       <input type="hidden" name="items" value={serialized} />
     </div>
   );

--- a/apps/web/src/app/e/[slug]/registrar/registrar-form.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/registrar-form.tsx
@@ -60,7 +60,6 @@ export function RegistrarForm({
     draftSetters,
   );
 
-  // Clear draft on successful submit
   useEffect(() => {
     if (state.status === 'success') clearDraft();
   }, [state.status, clearDraft]);
@@ -101,7 +100,6 @@ export function RegistrarForm({
         <ErrorMessage message={state.message ?? t.error_fallback} />
       )}
 
-      {/* Tipo de recurso */}
       <FormField
         htmlFor="type"
         label={<>{t.type_label} <span aria-hidden="true">*</span></>}
@@ -124,7 +122,6 @@ export function RegistrarForm({
         </Select>
       </FormField>
 
-      {/* Etapa */}
       <FormField
         htmlFor="stage"
         label={<>{t.stage_label} <span aria-hidden="true">*</span></>}
@@ -147,7 +144,6 @@ export function RegistrarForm({
         </Select>
       </FormField>
 
-      {/* Nombre */}
       <FormField
         htmlFor="name"
         label={<>{t.name_label} <span aria-hidden="true">*</span></>}
@@ -164,7 +160,6 @@ export function RegistrarForm({
         />
       </FormField>
 
-      {/* Descripción */}
       <FormField
         htmlFor="description"
         label={
@@ -184,7 +179,6 @@ export function RegistrarForm({
         />
       </FormField>
 
-      {/* Ubicación */}
       <FormField
         htmlFor="location-search"
         label={<>{t.location_label} <span aria-hidden="true">*</span></>}
@@ -193,13 +187,10 @@ export function RegistrarForm({
         {locationPicker}
       </FormField>
 
-      {/* Organización */}
       {orgSelector}
 
-      {/* Inventario / material disponible (opcional) */}
       <InventoryField t={t} locale={locale} />
 
-      {/* Submit */}
       <Button type="submit" disabled={pending} fullWidth>
         {pending ? t.submitting : t.submit}
       </Button>

--- a/apps/web/src/app/e/[slug]/reportar/report-form.tsx
+++ b/apps/web/src/app/e/[slug]/reportar/report-form.tsx
@@ -58,7 +58,6 @@ export function ReportForm({
     draftSetters,
   );
 
-  // Clear draft on successful submit
   useEffect(() => {
     if (state.status === 'success') clearDraft();
   }, [state.status, clearDraft]);
@@ -108,7 +107,6 @@ export function ReportForm({
         <ErrorMessage message={state.message ?? t.error_fallback} />
       )}
 
-      {/* Tipo */}
       <FormField
         htmlFor="type"
         label={<>{t.type_label} <span aria-hidden="true">*</span></>}
@@ -127,7 +125,6 @@ export function ReportForm({
         </Select>
       </FormField>
 
-      {/* Prioridad */}
       <FormField
         htmlFor="priority"
         label={<>{t.priority_label} <span aria-hidden="true">*</span></>}
@@ -146,7 +143,6 @@ export function ReportForm({
         </Select>
       </FormField>
 
-      {/* Nota */}
       <FormField
         htmlFor="note"
         label={<>{t.note_label} <span aria-hidden="true">*</span></>}
@@ -162,7 +158,6 @@ export function ReportForm({
         />
       </FormField>
 
-      {/* Punto relacionado */}
       {myResources.length > 0 && (
         <FormField
           htmlFor="resourceId"
@@ -187,10 +182,8 @@ export function ReportForm({
         <input type="hidden" name="resourceId" value={prefilledResourceId} />
       )}
 
-      {/* Fotos */}
       <PhotoUploader onUrlsChange={handlePhotoUrlsChange} />
 
-      {/* Submit */}
       <Button type="submit" disabled={pending} fullWidth>
         {pending ? t.submitting : t.submit}
       </Button>

--- a/apps/web/src/app/e/[slug]/voluntario/voluntario-form.tsx
+++ b/apps/web/src/app/e/[slug]/voluntario/voluntario-form.tsx
@@ -61,7 +61,6 @@ export function VoluntarioForm({ action, slug, existingProfile, t, backToEmergen
     { debounce: existingProfile !== null ? 999999 : 600 },
   );
 
-  // Clear draft on successful submit
   useEffect(() => {
     if (state.status === 'success') clearDraft();
   }, [state.status, clearDraft]);
@@ -146,7 +145,6 @@ export function VoluntarioForm({ action, slug, existingProfile, t, backToEmergen
         <ErrorMessage message={state.message} />
       )}
 
-      {/* Nombre */}
       <FormField
         htmlFor="name"
         label={<>{t.name_label} <span aria-hidden="true">*</span></>}
@@ -163,7 +161,6 @@ export function VoluntarioForm({ action, slug, existingProfile, t, backToEmergen
         />
       </FormField>
 
-      {/* Contacto */}
       <FormField
         htmlFor="contact"
         label={<>{t.contact_label} <span aria-hidden="true">*</span></>}
@@ -180,7 +177,6 @@ export function VoluntarioForm({ action, slug, existingProfile, t, backToEmergen
         />
       </FormField>
 
-      {/* Municipio */}
       <FormField
         htmlFor="municipality"
         label={<>{t.municipality_label} <span aria-hidden="true">*</span></>}
@@ -197,7 +193,6 @@ export function VoluntarioForm({ action, slug, existingProfile, t, backToEmergen
         />
       </FormField>
 
-      {/* Habilidades */}
       <fieldset className="flex flex-col gap-3">
         <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
           {t.skills_legend}
@@ -230,7 +225,6 @@ export function VoluntarioForm({ action, slug, existingProfile, t, backToEmergen
         </div>
       </fieldset>
 
-      {/* Disponibilidad */}
       <FormField
         htmlFor="availability"
         label={<>{t.availability_label} <span aria-hidden="true">*</span></>}
@@ -253,7 +247,6 @@ export function VoluntarioForm({ action, slug, existingProfile, t, backToEmergen
         </Select>
       </FormField>
 
-      {/* Vehículo */}
       <FormField
         htmlFor="vehicle"
         label={<>{t.vehicle_label} <span aria-hidden="true">*</span></>}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,7 +6,6 @@ import { GlobalFooter } from '@/components/organisms/global-footer';
 import { getT } from '@/i18n/server';
 import { LocaleProvider } from '@/i18n/locale-context';
 
-// Display face (headings, metrics, wordmark) and body face — self-hosted by next/font.
 const archivo = Archivo({
   subsets: ['latin'],
   weight: ['500', '600', '700', '800'],

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -44,7 +44,6 @@ export default async function LoginPage({ searchParams }: Props) {
               </div>
             )}
 
-            {/* Login form */}
             <LoginForm next={next} t={t.login} />
           </Card>
         </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -26,7 +26,6 @@ export default async function HomePage() {
   const { t } = await getT();
   const { data: emergencies } = await api.GET('/emergencies');
 
-  // Fetch notification unread count and admin status when authenticated.
   const token = await getToken();
   let notificationUnreadCount = 0;
   let isAdmin = false;

--- a/apps/web/src/app/panel/administracion/acreditaciones/actions.ts
+++ b/apps/web/src/app/panel/administracion/acreditaciones/actions.ts
@@ -25,7 +25,6 @@ export interface AccreditationDto {
   grantedAt: string;
 }
 
-/** Fetch all accreditations, optionally filtered by org or emergency. */
 export async function fetchAccreditations(
   organizationId?: string,
   emergencyId?: string,
@@ -46,7 +45,6 @@ export async function fetchAccreditations(
   return (data ?? []) as unknown as AccreditationDto[];
 }
 
-/** Grant an accreditation (POST /accreditations). */
 export async function grantAccreditationAction(
   _prev: AccreditationActionResult,
   formData: FormData,
@@ -100,7 +98,6 @@ export async function grantAccreditationAction(
   return { status: 'success' };
 }
 
-/** Revoke an accreditation (DELETE /accreditations/{id}). */
 export async function revokeAccreditationAction(
   id: string,
 ): Promise<AccreditationActionResult> {

--- a/apps/web/src/app/panel/administracion/acreditaciones/grant-form.tsx
+++ b/apps/web/src/app/panel/administracion/acreditaciones/grant-form.tsx
@@ -47,7 +47,6 @@ export function GrantAccreditationForm() {
         />
       </FormField>
 
-      {/* Scope radio group */}
       <fieldset className="flex flex-col gap-2">
         <legend className="text-sm font-semibold text-ink uppercase tracking-wide">
           {ta.acc_f_scope_legend}

--- a/apps/web/src/app/panel/administracion/acreditaciones/page.tsx
+++ b/apps/web/src/app/panel/administracion/acreditaciones/page.tsx
@@ -22,13 +22,11 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function AcreditacionesPage() {
-  // ── Auth guard ──────────────────────────────────────────────────────────
   const token = await getToken();
   if (!token) {
     redirect('/login?next=/panel/administracion/acreditaciones');
   }
 
-  // ── Admin check via GET /auth/me ────────────────────────────────────────
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
@@ -41,7 +39,6 @@ export default async function AcreditacionesPage() {
     redirect('/');
   }
 
-  // ── Fetch existing accreditations ────────────────────────────────────────
   const accreditations = await fetchAccreditations();
 
   const { t, locale } = await getT();
@@ -61,7 +58,6 @@ export default async function AcreditacionesPage() {
           </Link>
         </p>
 
-        {/* ── LISTADO DE ACREDITACIONES ────────────────────────────────── */}
         <section aria-labelledby="list-heading" className="flex flex-col gap-4">
           <h2 id="list-heading" className="text-xl font-bold text-ink">
             {ta.acc_list_heading.replace('{count}', String(accreditations.length))}
@@ -116,7 +112,6 @@ export default async function AcreditacionesPage() {
 
         <hr className="border-line" />
 
-        {/* ── CONCEDER ACREDITACIÓN ────────────────────────────────────── */}
         <section aria-labelledby="grant-heading" className="flex flex-col gap-4">
           <h2 id="grant-heading" className="text-xl font-bold text-ink">
             {ta.acc_grant_heading}

--- a/apps/web/src/app/panel/administracion/ambito/[scopeType]/[id]/actions.ts
+++ b/apps/web/src/app/panel/administracion/ambito/[scopeType]/[id]/actions.ts
@@ -63,7 +63,6 @@ export async function fetchRoles(): Promise<RoleView[]> {
   return (data ?? []) as RoleView[];
 }
 
-/** Grants made at a scope (who holds a role here), enriched with name/email. */
 export async function fetchScopeGrants(
   scopeType: ScopeType,
   scopeId: string,
@@ -98,7 +97,6 @@ async function resolvePrincipalId(
   return data.id;
 }
 
-/** Grant a catalog role (by email or id) within this scope. */
 export async function grantRoleAction(
   _prev: ActionResult,
   formData: FormData,
@@ -177,8 +175,7 @@ export async function revokeGrantAction(
   return { status: 'success' };
 }
 
-// ── Service accounts (organization scope only) ──────────────────────────────
-
+// Service accounts exist only at organization scope.
 export async function fetchOrgServiceAccounts(
   orgId: string,
 ): Promise<ServiceAccountView[]> {

--- a/apps/web/src/app/panel/administracion/ambito/[scopeType]/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/ambito/[scopeType]/[id]/page.tsx
@@ -76,7 +76,6 @@ export default async function ScopeAdminPage({ params }: PageProps) {
       />
       <p className="font-mono text-xs text-muted break-all">{scopeId}</p>
 
-      {/* ── MIEMBROS / ROLES ─────────────────────────────────────────────── */}
       <section aria-labelledby="members-heading" className="flex flex-col gap-4">
         <h2 id="members-heading" className="text-xl font-bold text-ink">
           Roles concedidos ({grants.length})
@@ -131,7 +130,6 @@ export default async function ScopeAdminPage({ params }: PageProps) {
 
       <hr className="border-line" />
 
-      {/* ── CONCEDER ROL ─────────────────────────────────────────────────── */}
       <section aria-labelledby="grant-heading" className="flex flex-col gap-4">
         <h2 id="grant-heading" className="text-xl font-bold text-ink">
           Asignar un rol
@@ -139,7 +137,6 @@ export default async function ScopeAdminPage({ params }: PageProps) {
         <GrantRoleForm scopeType={scopeType} scopeId={scopeId} roles={roles} />
       </section>
 
-      {/* ── CUENTAS DE SERVICIO (solo organización) ──────────────────────── */}
       {serviceAccounts !== null && (
         <>
           <hr className="border-line" />

--- a/apps/web/src/app/panel/administracion/auditoria/audit-filter.tsx
+++ b/apps/web/src/app/panel/administracion/auditoria/audit-filter.tsx
@@ -7,12 +7,8 @@ import { getMessages } from '@/i18n';
 const selectClass =
   'rounded-lg border-2 border-line bg-white px-3 py-1.5 text-sm text-ink focus:border-navy focus:outline-none';
 
-/**
- * AuditFilter — client component that drives `entityType` and
- * `emergencyId` searchParams filters for the audit log page.
- * Uses router.replace so the Server Component page re-renders with
- * updated params without a full navigation.
- */
+// Uses router.replace so the Server Component page re-renders with updated
+// params without a full navigation.
 export function AuditFilter() {
   const ta = getMessages(useLocale()).admin;
   const router = useRouter();

--- a/apps/web/src/app/panel/administracion/auditoria/page.tsx
+++ b/apps/web/src/app/panel/administracion/auditoria/page.tsx
@@ -31,13 +31,11 @@ interface PageProps {
 const PAGE_LIMIT = 50;
 
 export default async function AuditoriaPage({ searchParams }: PageProps) {
-  // ── Auth guard ──────────────────────────────────────────────────────────
   const token = await getToken();
   if (!token) {
     redirect('/login?next=/panel/administracion/auditoria');
   }
 
-  // ── Admin check via GET /auth/me ────────────────────────────────────────
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
@@ -50,13 +48,11 @@ export default async function AuditoriaPage({ searchParams }: PageProps) {
     redirect('/');
   }
 
-  // ── Resolve searchParams ─────────────────────────────────────────────────
   const params = await searchParams;
   const entityType = params.entityType ?? '';
   const emergencyId = params.emergencyId ?? '';
   const offset = Number(params.offset ?? '0');
 
-  // ── Fetch audit entries ──────────────────────────────────────────────────
   const { entries, total } = await fetchAuditEntries({
     ...(entityType ? { entityType } : {}),
     ...(emergencyId ? { emergencyId } : {}),
@@ -93,12 +89,10 @@ export default async function AuditoriaPage({ searchParams }: PageProps) {
           </p>
         )}
 
-        {/* ── FILTROS ─────────────────────────────────────────────────── */}
         <section aria-label={ta.audit_filters_aria}>
           <AuditFilter />
         </section>
 
-        {/* ── LISTADO ─────────────────────────────────────────────────── */}
         <section aria-labelledby="audit-heading" className="flex flex-col gap-4">
           <h2 id="audit-heading" className="text-xl font-bold text-ink">
             {ta.audit_recent_heading}
@@ -115,14 +109,12 @@ export default async function AuditoriaPage({ searchParams }: PageProps) {
             />
           ) : (
             <>
-              {/* ── Mobile: stacked cards ──────────────────────────────── */}
               <ul className="flex flex-col gap-3 md:hidden" role="list">
                 {entries.map((entry) => (
                   <AuditEntryCard key={entry.id} entry={entry} />
                 ))}
               </ul>
 
-              {/* ── Desktop: table ─────────────────────────────────────── */}
               <div className="hidden md:block overflow-x-auto rounded-lg border-2 border-navy">
                 <table className="w-full text-left border-collapse">
                   <thead>
@@ -155,7 +147,6 @@ export default async function AuditoriaPage({ searchParams }: PageProps) {
                 </table>
               </div>
 
-              {/* ── Pagination ─────────────────────────────────────────── */}
               {(hasPrev || hasNext) && (
                 <nav
                   aria-label={ta.audit_pagination_aria}

--- a/apps/web/src/app/panel/administracion/centros/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/centros/[id]/page.tsx
@@ -31,7 +31,6 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function CentroDetailPage({ params }: Props) {
   const { id } = await params;
 
-  // ── Auth guard ──────────────────────────────────────────────────────────
   const token = await getToken();
   if (!token) redirect(`/login?next=/panel/administracion/centros/${id}`);
 
@@ -72,7 +71,6 @@ export default async function CentroDetailPage({ params }: Props) {
         backLabel={ta.centros_detail_back}
       />
       <div className="flex flex-col gap-8">
-        {/* ── Resumen ─────────────────────────────────────────────────── */}
           <section className="flex flex-col gap-3 rounded-lg border border-line bg-white p-4">
             <div className="flex flex-wrap items-center gap-2">
               <span
@@ -177,7 +175,6 @@ export default async function CentroDetailPage({ params }: Props) {
             </dl>
           </section>
 
-          {/* ── Inventario declarado ────────────────────────────────────── */}
           <section
             aria-labelledby="inventory-heading"
             className="flex flex-col gap-3"
@@ -212,7 +209,6 @@ export default async function CentroDetailPage({ params }: Props) {
             )}
           </section>
 
-          {/* ── Reportes de validez ─────────────────────────────────────── */}
           <section
             aria-labelledby="reports-heading"
             className="flex flex-col gap-3"

--- a/apps/web/src/app/panel/administracion/centros/actions.ts
+++ b/apps/web/src/app/panel/administracion/centros/actions.ts
@@ -11,12 +11,8 @@ export type ResourceAdminDetail =
   components['schemas']['ResourceAdminDetailDto'];
 export type ValidityReport = components['schemas']['ValidityReportDto'];
 
-/**
- * Fetch the admin global list of ALL resources (GET /resources) — every
- * emergency, status and verification level. On 401 the session is cleared and
- * the user is redirected to login. Mirrors the users/organizations admin fetch
- * (#175/#176).
- */
+// Unlike the public listing, returns resources of every status and
+// verification level (admin-only view).
 export async function fetchAdminResources(): Promise<ResourceAdminListItem[]> {
   const token = await getToken();
   if (!token) redirect('/login?next=/panel/administracion/centros');
@@ -39,10 +35,7 @@ export async function fetchAdminResources(): Promise<ResourceAdminListItem[]> {
   return (data?.items ?? []) as ResourceAdminListItem[];
 }
 
-/**
- * Fetch one resource's admin detail (GET /resources/:id), of ANY status.
- * Returns null on 404 so the page can render a not-found state.
- */
+// Returns null on 404 so the page can render a not-found state.
 export async function fetchAdminResourceDetail(
   id: string,
 ): Promise<ResourceAdminDetail | null> {

--- a/apps/web/src/app/panel/administracion/centros/centro-presentation.ts
+++ b/apps/web/src/app/panel/administracion/centros/centro-presentation.ts
@@ -1,9 +1,3 @@
-/**
- * Pure presentation helpers for the admin centers/resources pages: maps backend
- * enum values (resource type, public status, verification level, report status)
- * to localized labels and to badge styling. Safe to import from Server or Client
- * Components.
- */
 import type { Messages } from '@/i18n/messages/es';
 
 type AdminMessages = Messages['admin'];
@@ -23,7 +17,6 @@ export function resourceTypeLabel(type: string, ta: AdminMessages): string {
   return key ? ta[key] : type;
 }
 
-/** Resource types in display order, for the filter dropdown. */
 export const RESOURCE_TYPES: ReadonlyArray<string> = [
   'collection_point',
   'delivery_point',
@@ -47,7 +40,6 @@ export function statusLabel(status: string, ta: AdminMessages): string {
   return key ? ta[key] : status;
 }
 
-/** Public statuses in display order, for the filter dropdown. */
 export const PUBLIC_STATUSES: ReadonlyArray<string> = [
   'active',
   'saturated',
@@ -88,7 +80,6 @@ export function verificationLabel(level: string, ta: AdminMessages): string {
   return key ? ta[key] : level;
 }
 
-/** Maps a verification level to a shared Badge variant. */
 export function verificationBadgeVariant(
   level: string,
 ): 'verification-official' | 'verification-verified' | 'offer-cancelled' | 'unverified' {

--- a/apps/web/src/app/panel/administracion/centros/centros-list.tsx
+++ b/apps/web/src/app/panel/administracion/centros/centros-list.tsx
@@ -32,7 +32,6 @@ export function CentrosList({ resources, ta }: CentrosListProps) {
   const [status, setStatus] = useState('');
   const [emergency, setEmergency] = useState('');
 
-  // Emergency options derived from the data (id → name), sorted by name.
   const emergencies = useMemo(() => {
     const byId = new Map<string, string>();
     for (const r of resources) {
@@ -78,7 +77,6 @@ export function CentrosList({ resources, ta }: CentrosListProps) {
 
   return (
     <div className="flex flex-col gap-4">
-      {/* ── Search ──────────────────────────────────────────────────────── */}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor="centro-search"
@@ -98,7 +96,6 @@ export function CentrosList({ resources, ta }: CentrosListProps) {
         />
       </div>
 
-      {/* ── Filters (mobile-first: stack, then 3-up) ────────────────────── */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         <div className="flex flex-col gap-1.5">
           <label

--- a/apps/web/src/app/panel/administracion/centros/page.tsx
+++ b/apps/web/src/app/panel/administracion/centros/page.tsx
@@ -18,13 +18,11 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function CentrosPage() {
-  // ── Auth guard ──────────────────────────────────────────────────────────
   const token = await getToken();
   if (!token) {
     redirect('/login?next=/panel/administracion/centros');
   }
 
-  // ── Admin check via GET /auth/me ────────────────────────────────────────
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });

--- a/apps/web/src/app/panel/administracion/layout.tsx
+++ b/apps/web/src/app/panel/administracion/layout.tsx
@@ -1,10 +1,3 @@
-/**
- * Administration shell. Sits inside the dashboard chrome (panel/layout.tsx →
- * DashboardLayout) and frames every admin tool with a single wide container and
- * the permission-aware AdminTabs sub-nav. Each tool page owns its own PageHeader
- * (title + optional back link/actions) and renders its section(s) below —
- * mirroring the coordination area.
- */
 import type { ReactNode } from 'react';
 import { getMe } from '@/lib/navigation-data';
 import { PageContainer } from '@/components/molecules/page-container';

--- a/apps/web/src/app/panel/administracion/organizaciones/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/organizaciones/[id]/page.tsx
@@ -30,7 +30,6 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function OrganizacionDetailPage({ params }: Props) {
   const { id } = await params;
 
-  // ── Auth guard ──────────────────────────────────────────────────────────
   const token = await getToken();
   if (!token) redirect(`/login?next=/panel/administracion/organizaciones/${id}`);
 
@@ -68,7 +67,6 @@ export default async function OrganizacionDetailPage({ params }: Props) {
         backLabel={ta.orgs_detail_back}
       />
       <div className="flex flex-col gap-8">
-        {/* ── Resumen ─────────────────────────────────────────────────── */}
         <Card className="flex flex-col gap-3 border-navy p-4">
           <div className="flex flex-wrap items-center gap-2">
             <Badge variant={accreditationBadgeVariant(org.accreditationStatus)}>
@@ -124,7 +122,6 @@ export default async function OrganizacionDetailPage({ params }: Props) {
           </dl>
         </Card>
 
-        {/* ── Miembros ────────────────────────────────────────────────── */}
         <section
           aria-labelledby="members-heading"
           className="flex flex-col gap-3"
@@ -167,7 +164,6 @@ export default async function OrganizacionDetailPage({ params }: Props) {
           )}
         </section>
 
-        {/* ── Cuentas de servicio / API keys ──────────────────────────── */}
         <section
           aria-labelledby="accounts-heading"
           className="flex flex-col gap-3"
@@ -206,7 +202,6 @@ export default async function OrganizacionDetailPage({ params }: Props) {
           )}
         </section>
 
-        {/* ── Acreditaciones ──────────────────────────────────────────── */}
         <section
           aria-labelledby="accreditations-heading"
           className="flex flex-col gap-3"
@@ -251,7 +246,6 @@ export default async function OrganizacionDetailPage({ params }: Props) {
           )}
         </section>
 
-        {/* ── Emergencias en las que participa ────────────────────────── */}
         <section
           aria-labelledby="emergencies-heading"
           className="flex flex-col gap-3"

--- a/apps/web/src/app/panel/administracion/organizaciones/actions.ts
+++ b/apps/web/src/app/panel/administracion/organizaciones/actions.ts
@@ -57,10 +57,6 @@ export interface OrganizationDetail {
   emergencyIds: string[];
 }
 
-/**
- * Fetch the admin global list of organizations (GET /organizations/admin).
- * On 401 the session is cleared and the user is redirected to login.
- */
 export async function fetchOrganizations(): Promise<OrganizationListItem[]> {
   const token = await getToken();
   if (!token) redirect('/login?next=/panel/administracion/organizaciones');
@@ -80,10 +76,7 @@ export async function fetchOrganizations(): Promise<OrganizationListItem[]> {
   return (data ?? []) as OrganizationListItem[];
 }
 
-/**
- * Fetch one organization's admin detail (GET /organizations/:id).
- * Returns null on 404 so the page can render a not-found state.
- */
+// Returns null on 404 so the page can render a not-found state.
 export async function fetchOrganizationDetail(
   id: string,
 ): Promise<OrganizationDetail | null> {

--- a/apps/web/src/app/panel/administracion/organizaciones/org-presentation.ts
+++ b/apps/web/src/app/panel/administracion/organizaciones/org-presentation.ts
@@ -1,8 +1,3 @@
-/**
- * Pure presentation helpers for the admin organizations pages: maps backend
- * enum values to localized labels and to the shared Badge variants. Safe to
- * import from Server or Client Components.
- */
 import type { Messages } from '@/i18n/messages/es';
 import type { AccreditationStatus } from './actions';
 
@@ -35,7 +30,6 @@ export function accreditationLabel(
   return ta[ACCR_KEYS[status]];
 }
 
-/** Maps accreditation status to a shared Badge variant. */
 export function accreditationBadgeVariant(
   status: AccreditationStatus,
 ): 'verification-official' | 'verification-verified' | 'unverified' {

--- a/apps/web/src/app/panel/administracion/organizaciones/page.tsx
+++ b/apps/web/src/app/panel/administracion/organizaciones/page.tsx
@@ -18,13 +18,11 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function OrganizacionesPage() {
-  // ── Auth guard ──────────────────────────────────────────────────────────
   const token = await getToken();
   if (!token) {
     redirect('/login?next=/panel/administracion/organizaciones');
   }
 
-  // ── Admin check via GET /auth/me ────────────────────────────────────────
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });

--- a/apps/web/src/app/panel/administracion/permisos/page.tsx
+++ b/apps/web/src/app/panel/administracion/permisos/page.tsx
@@ -47,7 +47,6 @@ export default async function PermisosPage({ searchParams }: Props) {
         subtitle="Concede y revoca roles a usuarios y cuentas de servicio. Solo administradores."
       />
 
-      {/* ── Look up a principal's grants ───────────────────────────────── */}
       <section className="flex flex-col gap-4">
         <h2 className="text-xl font-bold text-ink">
           Consultar roles de un principal
@@ -118,7 +117,6 @@ export default async function PermisosPage({ searchParams }: Props) {
 
       <hr className="border-line" />
 
-      {/* ── Grant a role ───────────────────────────────────────────────── */}
       <section className="flex flex-col gap-4">
         <h2 className="text-xl font-bold text-ink">Conceder un rol</h2>
         <p className="text-xs text-amber-700 bg-amber-50 border border-amber-300 rounded px-3 py-2">
@@ -130,7 +128,6 @@ export default async function PermisosPage({ searchParams }: Props) {
 
       <hr className="border-line" />
 
-      {/* ── Role catalog reference ─────────────────────────────────────── */}
       <section className="flex flex-col gap-4">
         <h2 className="text-xl font-bold text-ink">
           Catálogo de roles ({roles.length})

--- a/apps/web/src/app/panel/administracion/plantillas/actions.ts
+++ b/apps/web/src/app/panel/administracion/plantillas/actions.ts
@@ -14,8 +14,6 @@ export type TemplateActionResult =
 
 export type TemplateViewDto = components['schemas']['TemplateViewDto'];
 
-// ── List ────────────────────────────────────────────────────────────────────
-
 export async function fetchTemplates(): Promise<TemplateViewDto[]> {
   const token = await getToken();
   if (!token) return [];
@@ -28,8 +26,6 @@ export async function fetchTemplates(): Promise<TemplateViewDto[]> {
 
   return data ?? [];
 }
-
-// ── Create ──────────────────────────────────────────────────────────────────
 
 export async function createTemplateAction(
   _prev: TemplateActionResult,
@@ -90,8 +86,6 @@ export async function createTemplateAction(
   return { status: 'success', message: t.templates.ok_created };
 }
 
-// ── Delete ──────────────────────────────────────────────────────────────────
-
 export async function deleteTemplateAction(id: string): Promise<TemplateActionResult> {
   const token = await getToken();
   if (!token) {
@@ -122,8 +116,6 @@ export async function deleteTemplateAction(id: string): Promise<TemplateActionRe
   revalidatePath('/panel/administracion/plantillas');
   return { status: 'success' };
 }
-
-// ── Create from template ────────────────────────────────────────────────────
 
 export type CreateFromTemplateResult =
   | { status: 'idle' }

--- a/apps/web/src/app/panel/administracion/plantillas/page.tsx
+++ b/apps/web/src/app/panel/administracion/plantillas/page.tsx
@@ -22,13 +22,11 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function TemplatesPage() {
-  // ── Auth guard ──────────────────────────────────────────────────────────
   const token = await getToken();
   if (!token) {
     redirect('/login?next=/panel/administracion/plantillas');
   }
 
-  // ── Admin check via GET /auth/me ────────────────────────────────────────
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
@@ -41,7 +39,6 @@ export default async function TemplatesPage() {
     redirect('/');
   }
 
-  // ── Fetch templates ──────────────────────────────────────────────────────
   const templates = await fetchTemplates();
 
   const { t } = await getT();
@@ -50,7 +47,6 @@ export default async function TemplatesPage() {
     <>
       <PageHeader title={t.templates.title} subtitle={t.templates.subtitle} />
 
-      {/* ── LISTADO ─────────────────────────────────────────────────── */}
         <section aria-labelledby="list-heading" className="flex flex-col gap-4">
           <h2 id="list-heading" className="text-xl font-bold text-ink">
             {t.templates.list_heading.replace('{count}', String(templates.length))}
@@ -80,7 +76,6 @@ export default async function TemplatesPage() {
 
         <hr className="border-line" />
 
-        {/* ── CREAR PLANTILLA ─────────────────────────────────────────── */}
         <section aria-labelledby="create-template-heading" className="flex flex-col gap-4">
           <h2 id="create-template-heading" className="text-xl font-bold text-ink">
             {t.templates.new_heading}
@@ -90,7 +85,6 @@ export default async function TemplatesPage() {
 
         <hr className="border-line" />
 
-        {/* ── CREAR EMERGENCIA DESDE PLANTILLA ────────────────────────── */}
         <section aria-labelledby="create-emergency-heading" className="flex flex-col gap-4">
           <h2 id="create-emergency-heading" className="text-xl font-bold text-ink">
             {t.templates.create_from_heading}

--- a/apps/web/src/app/panel/administracion/usuarios/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/usuarios/[id]/page.tsx
@@ -24,7 +24,6 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function UsuarioDetailPage({ params }: Props) {
   const { id } = await params;
 
-  // ── Auth guard ──────────────────────────────────────────────────────────
   const token = await getToken();
   if (!token) redirect(`/login?next=/panel/administracion/usuarios/${id}`);
 
@@ -62,7 +61,6 @@ export default async function UsuarioDetailPage({ params }: Props) {
         backLabel={ta.users_detail_back}
       />
       <div className="flex flex-col gap-8">
-        {/* ── Resumen ─────────────────────────────────────────────────── */}
         <Card className="flex flex-col gap-3 border-navy p-4">
           {user.isAdmin && (
             <div className="flex flex-wrap items-center gap-2">
@@ -105,7 +103,6 @@ export default async function UsuarioDetailPage({ params }: Props) {
           </dl>
         </Card>
 
-        {/* ── Roles / grants por ámbito ───────────────────────────────── */}
         <section aria-labelledby="grants-heading" className="flex flex-col gap-3">
           <h2 id="grants-heading" className="text-lg font-bold text-ink">
             {ta.users_detail_grants_heading.replace(
@@ -159,7 +156,6 @@ export default async function UsuarioDetailPage({ params }: Props) {
           )}
         </section>
 
-        {/* ── Organizaciones ──────────────────────────────────────────── */}
         <section aria-labelledby="orgs-heading" className="flex flex-col gap-3">
           <h2 id="orgs-heading" className="text-lg font-bold text-ink">
             {ta.users_detail_orgs_heading.replace(
@@ -194,7 +190,6 @@ export default async function UsuarioDetailPage({ params }: Props) {
           )}
         </section>
 
-        {/* ── Actividad reciente ──────────────────────────────────────── */}
         <section
           aria-labelledby="activity-heading"
           className="flex flex-col gap-3"

--- a/apps/web/src/app/panel/administracion/usuarios/actions.ts
+++ b/apps/web/src/app/panel/administracion/usuarios/actions.ts
@@ -56,10 +56,6 @@ export interface UserDetail {
   activity: UserActivity[];
 }
 
-/**
- * Fetch the admin global list of users (GET /users). On 401 the session is
- * cleared and the user is redirected to login.
- */
 export async function fetchUsers(): Promise<UserListItem[]> {
   const token = await getToken();
   if (!token) redirect('/login?next=/panel/administracion/usuarios');
@@ -79,10 +75,7 @@ export async function fetchUsers(): Promise<UserListItem[]> {
   return (data ?? []) as UserListItem[];
 }
 
-/**
- * Fetch one user's admin detail (GET /users/:id). Returns null on 404 so the
- * page can render a not-found state.
- */
+// Returns null on 404 so the page can render a not-found state.
 export async function fetchUserDetail(id: string): Promise<UserDetail | null> {
   const token = await getToken();
   if (!token) redirect(`/login?next=/panel/administracion/usuarios/${id}`);

--- a/apps/web/src/app/panel/administracion/usuarios/page.tsx
+++ b/apps/web/src/app/panel/administracion/usuarios/page.tsx
@@ -18,13 +18,11 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function UsuariosPage() {
-  // ── Auth guard ──────────────────────────────────────────────────────────
   const token = await getToken();
   if (!token) {
     redirect('/login?next=/panel/administracion/usuarios');
   }
 
-  // ── Admin check via GET /auth/me ────────────────────────────────────────
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });

--- a/apps/web/src/app/panel/administracion/usuarios/user-presentation.ts
+++ b/apps/web/src/app/panel/administracion/usuarios/user-presentation.ts
@@ -1,8 +1,3 @@
-/**
- * Pure presentation helpers for the admin users pages: maps backend enum values
- * to localized labels and to shared Badge variants. Safe to import from Server
- * or Client Components.
- */
 import type { Messages } from '@/i18n/messages/es';
 import type { UserGrant } from './actions';
 
@@ -34,7 +29,6 @@ export function grantScopeLabel(grant: UserGrant, ta: AdminMessages): string {
   return scopeTypeLabel(grant.scopeType, ta);
 }
 
-/** True when a grant has an expiry that is already in the past. */
 export function isExpired(grant: UserGrant, now: Date = new Date()): boolean {
   return grant.expiresAt !== null && new Date(grant.expiresAt) <= now;
 }

--- a/apps/web/src/app/panel/grupos/[id]/page.tsx
+++ b/apps/web/src/app/panel/grupos/[id]/page.tsx
@@ -68,7 +68,6 @@ export default async function GroupDetailPage({ params }: Props) {
           }
         />
 
-        {/* ── Manager view ─────────────────────────────────────────────── */}
         {isManager ? (
           <>
             <section className="flex flex-col gap-4">
@@ -117,7 +116,6 @@ export default async function GroupDetailPage({ params }: Props) {
             </section>
           </>
         ) : (
-          /* ── Member / visitor view ──────────────────────────────────── */
           <section className="flex flex-col gap-4">
             {myMembership ? (
               myMembership.membershipStatus === 'approved' ? (

--- a/apps/web/src/app/panel/grupos/actions.ts
+++ b/apps/web/src/app/panel/grupos/actions.ts
@@ -44,7 +44,6 @@ export async function fetchMyGroups(): Promise<MyGroup[]> {
   return (data ?? []) as MyGroup[];
 }
 
-/** A group's basic info, or null if not found. */
 export async function fetchGroup(groupId: string): Promise<GroupInfo | null> {
   const token = await getToken();
   if (!token) return null;

--- a/apps/web/src/app/panel/grupos/page.tsx
+++ b/apps/web/src/app/panel/grupos/page.tsx
@@ -34,7 +34,6 @@ export default async function GruposPage() {
     redirect('/login?next=/panel/grupos');
   }
 
-  // Can the user create groups? True if any of their roles confers group:create.
   const roleMap = new Map((roles ?? []).map((r) => [r.id, r]));
   const canCreate =
     me.isAdmin ||

--- a/apps/web/src/app/panel/mis-permisos/page.tsx
+++ b/apps/web/src/app/panel/mis-permisos/page.tsx
@@ -41,7 +41,6 @@ export default async function MisPermisosPage() {
           subtitle="Tus roles, dónde aplican y qué te permiten hacer."
         />
 
-        {/* Identity */}
         <section className="flex flex-col gap-2 rounded-lg border border-line p-4">
           <div className="flex items-center gap-3">
             <span className="text-lg font-bold text-ink">{me.name}</span>
@@ -55,7 +54,6 @@ export default async function MisPermisosPage() {
           <span className="text-xs text-muted break-all">ID: {me.id}</span>
         </section>
 
-        {/* Grants */}
         <section aria-labelledby="grants-heading" className="flex flex-col gap-4">
           <h2 id="grants-heading" className="text-xl font-bold text-ink">
             Mis roles ({grants.length})

--- a/apps/web/src/app/panel/notificaciones/actions.ts
+++ b/apps/web/src/app/panel/notificaciones/actions.ts
@@ -46,9 +46,6 @@ export async function markNotificationReadAction(
   return { status: 'success' };
 }
 
-/**
- * Mark all notifications for the authenticated user as read.
- */
 export async function markAllNotificationsReadAction(): Promise<NotificationActionResult> {
   const token = await getToken();
   if (!token) {

--- a/apps/web/src/app/panel/notificaciones/mark-all-read-button.tsx
+++ b/apps/web/src/app/panel/notificaciones/mark-all-read-button.tsx
@@ -10,10 +10,6 @@ interface MarkAllReadButtonProps {
   hasUnread: boolean;
 }
 
-/**
- * MarkAllReadButton — client component that calls the markAllNotificationsRead
- * server action and shows a pending state while the request is in-flight.
- */
 export function MarkAllReadButton({ hasUnread }: MarkAllReadButtonProps) {
   const tn = getMessages(useLocale()).notificaciones;
   const [isPending, startTransition] = useTransition();

--- a/apps/web/src/app/panel/notificaciones/page.tsx
+++ b/apps/web/src/app/panel/notificaciones/page.tsx
@@ -9,7 +9,6 @@ import { PageHeader } from '@/components/molecules/page-header';
 import { MarkAllReadButton } from './mark-all-read-button';
 import { getT } from '@/i18n/server';
 
-// Always reflect the latest notifications state.
 export const dynamic = 'force-dynamic';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -43,7 +42,6 @@ export default async function NotificacionesPage() {
           title={hasUnread ? tn.title_unread.replace('{count}', String(unreadCount)) : tn.title}
         />
 
-        {/* ── LISTA DE NOTIFICACIONES ───────────────────────────────── */}
         <section aria-labelledby="notifications-heading" className="flex flex-col gap-4">
           <h2 id="notifications-heading" className="sr-only">
             {tn.heading_sr}

--- a/apps/web/src/app/panel/organizaciones/[id]/add-member-form.tsx
+++ b/apps/web/src/app/panel/organizaciones/[id]/add-member-form.tsx
@@ -28,7 +28,6 @@ export function AddMemberForm({ orgId }: AddMemberFormProps) {
         <ErrorMessage message={state.message ?? td.add_error} />
       )}
 
-      {/* Success */}
       {state.status === 'success' && (
         <p
           role="status"

--- a/apps/web/src/app/panel/organizaciones/[id]/page.tsx
+++ b/apps/web/src/app/panel/organizaciones/[id]/page.tsx
@@ -28,19 +28,16 @@ export default async function OrganizationDetailPage({ params }: Props) {
     redirect(`/login?next=/panel/organizaciones/${id}`);
   }
 
-  // Fetch current user id to determine ownership
   const { data: me } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
 
-  // Fetch my orgs to show org name
   const { data: myOrgs } = await api.GET('/organizations/mine', {
     headers: authHeaders(token),
   });
 
   const org = myOrgs?.find((o) => o.id === id);
 
-  // Fetch members
   const { data: members, error: membersError } = await api.GET(
     '/organizations/{id}/members',
     {
@@ -72,7 +69,6 @@ export default async function OrganizationDetailPage({ params }: Props) {
           subtitle={org ? `${org.type} · ${org.verificationLevel}` : undefined}
         />
 
-        {/* Members list */}
         <section aria-labelledby="members-heading" className="flex flex-col gap-4">
           <h2 id="members-heading" className="text-xl font-bold text-ink">
             {td.members_heading} ({memberList.length})
@@ -103,7 +99,6 @@ export default async function OrganizationDetailPage({ params }: Props) {
           </ul>
         </section>
 
-        {/* Add member form */}
         <section aria-labelledby="add-member-heading" className="flex flex-col gap-4">
           <h2 id="add-member-heading" className="text-xl font-bold text-ink">
             {td.add_heading}

--- a/apps/web/src/app/panel/organizaciones/create-org-form.tsx
+++ b/apps/web/src/app/panel/organizaciones/create-org-form.tsx
@@ -34,7 +34,6 @@ export function CreateOrgForm() {
         <ErrorMessage message={state.message ?? to.form_error} />
       )}
 
-      {/* Name */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="org-name" className="text-sm font-semibold text-ink">
           {to.f_name} <span aria-hidden="true">*</span>
@@ -42,7 +41,6 @@ export function CreateOrgForm() {
         <Input id="org-name" name="name" type="text" required placeholder={to.f_name_ph} />
       </div>
 
-      {/* Type */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="org-type" className="text-sm font-semibold text-ink">
           {to.f_type} <span aria-hidden="true">*</span>
@@ -55,7 +53,6 @@ export function CreateOrgForm() {
         </Select>
       </div>
 
-      {/* Tax ID */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="org-taxid" className="text-sm font-semibold text-ink">
           {to.f_taxid}
@@ -64,7 +61,6 @@ export function CreateOrgForm() {
         <Input id="org-taxid" name="taxId" type="text" placeholder="ES-12345678" />
       </div>
 
-      {/* Contact email */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="org-email" className="text-sm font-semibold text-ink">
           {to.f_email} <span aria-hidden="true">*</span>
@@ -72,7 +68,6 @@ export function CreateOrgForm() {
         <Input id="org-email" name="contactEmail" type="email" required placeholder={to.f_email_ph} />
       </div>
 
-      {/* Contact phone */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="org-phone" className="text-sm font-semibold text-ink">
           {to.f_phone} <span aria-hidden="true">*</span>

--- a/apps/web/src/app/panel/organizaciones/page.tsx
+++ b/apps/web/src/app/panel/organizaciones/page.tsx
@@ -38,7 +38,6 @@ export default async function OrganizacionesPage() {
       <PageContainer>
         <PageHeader title={to.title} subtitle={to.subtitle} />
 
-        {/* Org list */}
         <section aria-labelledby="orgs-heading" className="flex flex-col gap-4">
           <h2 id="orgs-heading" className="text-xl font-bold text-ink">
             {to.list_heading} ({myOrgs.length})
@@ -65,7 +64,6 @@ export default async function OrganizacionesPage() {
           )}
         </section>
 
-        {/* Create org form */}
         <section aria-labelledby="create-org-heading" className="flex flex-col gap-4">
           <h2 id="create-org-heading" className="text-xl font-bold text-ink">
             {to.create_heading}

--- a/apps/web/src/app/panel/page.tsx
+++ b/apps/web/src/app/panel/page.tsx
@@ -75,7 +75,6 @@ export default async function PanelPage() {
       <PageContainer>
         <PageHeader title={tp.title} subtitle={tp.subtitle} />
 
-        {/* Quick actions */}
         <section aria-labelledby="qa-heading" className={sectionGap}>
           <SectionHeading id="qa-heading" size="sm">
             {tp.quick_actions_heading}
@@ -97,7 +96,6 @@ export default async function PanelPage() {
           </div>
         </section>
 
-        {/* My emergencies */}
         <section aria-labelledby="emg-heading" className={sectionGap}>
           <SectionHeading id="emg-heading" size="sm">
             {tp.emergencies_heading}
@@ -169,7 +167,6 @@ export default async function PanelPage() {
           </section>
         )}
 
-        {/* My groups */}
         <section aria-labelledby="grp-heading" className={sectionGap}>
           <SectionHeading id="grp-heading" size="sm">
             {tp.groups_heading}
@@ -204,7 +201,6 @@ export default async function PanelPage() {
           )}
         </section>
 
-        {/* My organizations */}
         <section aria-labelledby="org-heading" className={sectionGap}>
           <SectionHeading id="org-heading" size="sm">
             {tp.orgs_heading}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -27,7 +27,6 @@ export default async function SignupPage({ searchParams }: Props) {
         <PageHeaderBand title={t.signup.title} subtitle={t.signup.subtitle} />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
           <Card className="p-5 lg:p-7">
-            {/* Signup form */}
             <SignupForm next={next} t={t.signup} />
           </Card>
         </div>

--- a/apps/web/src/components/atoms/badge.tsx
+++ b/apps/web/src/components/atoms/badge.tsx
@@ -42,7 +42,6 @@ const VARIANT_CLASSES: Record<BadgeVariant, string> = {
     'inline-flex items-center rounded-full border border-success bg-success-soft px-2.5 py-0.5 text-xs font-semibold text-success',
   'offer-cancelled':
     'inline-flex items-center rounded-full border border-line bg-surface-alt px-2.5 py-0.5 text-xs font-semibold text-muted',
-  // Need-priority pills (Banda oficial brand)
   'priority-urgent':
     'inline-flex items-center rounded-full bg-danger-soft px-2 py-0.5 text-[10.5px] font-extrabold uppercase tracking-[0.05em] text-danger',
   'priority-high':

--- a/apps/web/src/components/atoms/brand-mark.tsx
+++ b/apps/web/src/components/atoms/brand-mark.tsx
@@ -1,15 +1,5 @@
-/**
- * BrandMark — the ResponseGrid logo glyph.
- *
- * Based on the Global Emergency civil-protection emblem (orange disc + a
- * white-bordered navy triangle) with a ResponseGrid twist: glowing nodes at the
- * triangle's three vertices, evoking a connected grid of response points.
- *
- * Pure multicolour SVG so it reads on both navy bands and light surfaces. Also
- * rendered by next/og (Satori) for the favicon, apple-icon and PWA icons.
- */
+// Also rendered by next/og (Satori) for the favicon, apple-icon and PWA icons.
 interface BrandMarkProps {
-  /** Square side length in px. */
   size?: number;
   className?: string;
   /** When set, the glyph is exposed to assistive tech with this label. */

--- a/apps/web/src/components/atoms/card.tsx
+++ b/apps/web/src/components/atoms/card.tsx
@@ -1,15 +1,10 @@
 import type { ElementType, HTMLAttributes, ReactNode } from 'react';
 
 interface CardProps extends HTMLAttributes<HTMLElement> {
-  /** Element to render (div by default; e.g. 'article', 'aside', 'section'). */
   as?: ElementType;
   children?: ReactNode;
 }
 
-/**
- * Card — the brand surface primitive: warm 1px border, card radius, white fill.
- * Compose padding/layout via `className`; pick the element via `as`.
- */
 export function Card({ as: As = 'div', className = '', children, ...props }: CardProps) {
   return (
     <As className={`rounded-card border border-line bg-white ${className}`.trim()} {...props}>

--- a/apps/web/src/components/atoms/consent-checkbox.tsx
+++ b/apps/web/src/components/atoms/consent-checkbox.tsx
@@ -4,17 +4,11 @@ import type { InputHTMLAttributes } from 'react';
 
 interface ConsentCheckboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
-  /** Legal text shown next to the checkbox. */
   label: string;
   id: string;
   name: string;
 }
 
-/**
- * ConsentCheckbox — Blocking checkbox with legal text.
- * Renders a styled checkbox with accessible label. Form submission is
- * blocked unless this is checked (required attribute + form validation).
- */
 export function ConsentCheckbox({
   label,
   id,

--- a/apps/web/src/components/atoms/disputed-badge.tsx
+++ b/apps/web/src/components/atoms/disputed-badge.tsx
@@ -1,15 +1,14 @@
 import { Badge } from '@/components/atoms/badge';
 
 interface DisputedBadgeProps {
-  /** Visible + accessible label, e.g. "En verificación". */
   label: string;
   className?: string;
 }
 
 /**
- * DisputedBadge — warning pill shown on a point that several citizens reported
- * as invalid (closed / moved / …). The point stays visible; this signals
- * "in review" without asserting it is closed (a coordinator confirms first).
+ * Warning pill shown on a point that several citizens reported as invalid
+ * (closed / moved / …). The point stays visible; this signals "in review"
+ * without asserting it is closed (a coordinator confirms first).
  */
 export function DisputedBadge({ label, className }: DisputedBadgeProps) {
   // The visible label is the accessible name; the emoji is decorative. No

--- a/apps/web/src/components/atoms/distance-badge.tsx
+++ b/apps/web/src/components/atoms/distance-badge.tsx
@@ -3,16 +3,10 @@ import type { Locale } from '@/i18n';
 interface DistanceBadgeProps {
   distanceMeters: number;
   locale: Locale;
-  /** i18n prefix word, defaults to "a" */
   label?: string;
 }
 
-/**
- * DistanceBadge — shows a human-friendly distance from the citizen's queried location.
- *
- * - <1000 m → "a 850 m"
- * - ≥1000 m → "a 2,3 km" (es) / "a 2.3 km" (en)
- */
+// <1000 m → "a 850 m"; ≥1000 m → "a 2,3 km" (es) / "a 2.3 km" (en).
 export function DistanceBadge({ distanceMeters, locale, label = 'a' }: DistanceBadgeProps) {
   let text: string;
 

--- a/apps/web/src/components/atoms/draft-restored-banner.tsx
+++ b/apps/web/src/components/atoms/draft-restored-banner.tsx
@@ -1,9 +1,5 @@
 'use client';
 
-/**
- * Discrete notice shown when a form draft has been restored from localStorage.
- * Atom — no interactivity; purely informational.
- */
 export function DraftRestoredBanner() {
   return (
     <div

--- a/apps/web/src/components/atoms/error-message.tsx
+++ b/apps/web/src/components/atoms/error-message.tsx
@@ -2,10 +2,6 @@ interface ErrorMessageProps {
   message: string;
 }
 
-/**
- * Inline form error banner — aria-live assertive, role alert.
- * Used in all forms that wire a Server Action with useActionState.
- */
 export function ErrorMessage({ message }: ErrorMessageProps) {
   return (
     <p

--- a/apps/web/src/components/atoms/freshness-indicator.tsx
+++ b/apps/web/src/components/atoms/freshness-indicator.tsx
@@ -1,15 +1,9 @@
 'use client';
 
 /**
- * FreshnessIndicator — shows an amber "verify before acting" badge when a need
- * is considered stale but not yet expired.
- *
- * Staleness criteria (either condition triggers the badge):
- *   • lastVerifiedAt is more than 6 hours ago, OR
- *   • expiresAt is less than 2 hours away
- *
- * Expired needs are excluded from public listings by the backend, so this
- * component only needs to handle the stale-but-active case.
+ * Stale = lastVerifiedAt more than 6 hours ago, OR expiresAt less than 2 hours
+ * away. Expired needs are excluded from public listings by the backend, so this
+ * only needs to handle the stale-but-active case.
  */
 
 import { useLocale } from '@/i18n/locale-context';

--- a/apps/web/src/components/atoms/illustrations.tsx
+++ b/apps/web/src/components/atoms/illustrations.tsx
@@ -1,12 +1,4 @@
-/**
- * Brand illustrations — self-authored, decorative inline SVGs for the static
- * content pages. Vector (crisp at any size), themed with the design-system
- * palette, and lightweight (no external assets). Marked aria-hidden: the page
- * copy carries the meaning. Each accepts a className for sizing.
- *
- * Palette: navy #112b4a · navy-700 #13315c · accent #e8740e · surface-alt
- * #f4f1ec · line #e7e2da.
- */
+// Decorative inline SVGs: aria-hidden because the page copy carries the meaning.
 interface IllustrationProps {
   className?: string;
 }

--- a/apps/web/src/components/atoms/input.tsx
+++ b/apps/web/src/components/atoms/input.tsx
@@ -6,9 +6,7 @@ const INPUT_BASE =
   'w-full rounded-lg border border-line bg-white py-3 text-base text-ink placeholder:text-muted-soft focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
-  /** Extra class names merged on top of the base style. */
   className?: string;
-  /** Optional leading icon rendered inside the field (e.g. a search glyph). */
   icon?: ReactNode;
 }
 

--- a/apps/web/src/components/atoms/local-date.tsx
+++ b/apps/web/src/components/atoms/local-date.tsx
@@ -33,17 +33,13 @@ import {
 } from '@/lib/format-date';
 
 interface LocalDateProps {
-  /** ISO 8601 timestamp string. */
   iso: string;
-  /** Include the time component (date + 24h time). Default: date only. */
   withTime?: boolean;
   /**
-   * Custom `Intl.DateTimeFormatOptions` for sites with a bespoke format. When
-   * set it takes precedence over `withTime`; any `timeZone` is ignored for the
-   * post-hydration local render. Omit for the standard date / date+time presets.
+   * When set it takes precedence over `withTime`; any `timeZone` is ignored for
+   * the post-hydration local render.
    */
   opts?: Intl.DateTimeFormatOptions;
-  /** Optional CSS classes forwarded to the <time> element. */
   className?: string;
 }
 

--- a/apps/web/src/components/atoms/nav-item.tsx
+++ b/apps/web/src/components/atoms/nav-item.tsx
@@ -1,10 +1,7 @@
 'use client';
 
-/**
- * NavItem — a single sidebar/drawer link with active-route highlighting.
- * Labels arrive pre-resolved (the server shell resolves i18n + dynamic names),
- * so this atom only needs the current path. Styled for the navy sidebar.
- */
+// Labels arrive pre-resolved (the server shell resolves i18n + dynamic names),
+// so this atom only needs the current path.
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 

--- a/apps/web/src/components/atoms/priority-badge.tsx
+++ b/apps/web/src/components/atoms/priority-badge.tsx
@@ -1,17 +1,10 @@
-/**
- * PriorityBadge — coloured pill for a validated need's priority.
- * Mirrors the VerificationBadge / StatusLight pattern: maps a domain value to a
- * Badge variant and renders a caller-localised label.
- */
 import { Badge } from '@/components/atoms/badge';
 
 export type Priority = 'low' | 'medium' | 'high' | 'urgent';
 
 interface PriorityBadgeProps {
   priority: Priority;
-  /** Localised label, e.g. te.priority_urgent. */
   label: string;
-  /** aria prefix, e.g. te.needs_priority_label. */
   ariaPrefix?: string;
   className?: string;
 }

--- a/apps/web/src/components/atoms/privacy-location-notice.tsx
+++ b/apps/web/src/components/atoms/privacy-location-notice.tsx
@@ -1,12 +1,4 @@
-/**
- * PrivacyLocationNotice — Atom (F09 · Privacidad de ubicación)
- *
- * Renders a discrete notice when a need has approximate coordinates.
- * Only shows when `locationSensitivity === 'approximate'`.
- */
-
 interface PrivacyLocationNoticeProps {
-  /** Translated message text from i18n. */
   text: string;
 }
 

--- a/apps/web/src/components/atoms/privacy-note.tsx
+++ b/apps/web/src/components/atoms/privacy-note.tsx
@@ -1,7 +1,3 @@
-/**
- * PrivacyNote — Prominent callout reminding users that data is private
- * and only accessible to authorised emergency personnel.
- */
 export function PrivacyNote() {
   return (
     <div

--- a/apps/web/src/components/atoms/recipient-type-badge.tsx
+++ b/apps/web/src/components/atoms/recipient-type-badge.tsx
@@ -1,14 +1,6 @@
-/**
- * RecipientTypeBadge — pill shown on a resource that is a "final recipient"
- * of aid (#60), displaying its localised recipient type. Colour comes from
- * `lib/recipient-types`; degrades gracefully for unknown/custom types.
- */
 interface RecipientTypeBadgeProps {
-  /** Localised type label, e.g. "Hospital" (or the raw slug if unknown). */
   label: string;
-  /** Tailwind colour classes from recipientTypeColor(). */
   colorClass: string;
-  /** Full aria label, e.g. "Destinatario final: Hospital". */
   ariaLabel: string;
 }
 

--- a/apps/web/src/components/atoms/relative-time.tsx
+++ b/apps/web/src/components/atoms/relative-time.tsx
@@ -1,24 +1,11 @@
 'use client';
 
-/**
- * RelativeTime — hydration-safe "last updated" display.
- *
- * Thin wrapper over {@link LocalDate} (issue #174): it renders an absolute
- * "DD MMM, HH:MM" timestamp (e.g. "26 jun, 14:32") deterministically in UTC for
- * SSR / first paint, then swaps to the user's local zone after mount — so there
- * is no server/client hydration mismatch. The machine-readable ISO string is
- * preserved in the `<time dateTime>` attribute by `LocalDate`.
- *
- * Kept as a named component so existing call sites (`isoString` prop) are
- * unchanged.
- */
-
+// Kept as a named component so existing call sites (`isoString` prop) are
+// unchanged.
 import { LocalDate } from '@/components/atoms/local-date';
 
 interface RelativeTimeProps {
-  /** ISO 8601 timestamp string */
   isoString: string;
-  /** Optional CSS classes */
   className?: string;
 }
 

--- a/apps/web/src/components/atoms/section-heading.tsx
+++ b/apps/web/src/components/atoms/section-heading.tsx
@@ -16,10 +16,6 @@ interface SectionHeadingProps {
   className?: string;
 }
 
-/**
- * SectionHeading — the Archivo / navy / bold section title used across the app.
- * Keeps heading typography consistent and themeable from one place.
- */
 export function SectionHeading({
   children,
   as: As = 'h2',

--- a/apps/web/src/components/atoms/skill-tag.tsx
+++ b/apps/web/src/components/atoms/skill-tag.tsx
@@ -21,10 +21,6 @@ interface SkillTagProps {
   skill: string;
 }
 
-/**
- * Pastilla de skill de voluntario. Acepta cualquier string del enum VolunteerSkill.
- * Si el valor no es reconocido se muestra tal cual.
- */
 export function SkillTag({ skill }: SkillTagProps) {
   const label = SKILL_LABELS[skill as SkillValue] ?? skill;
   return (

--- a/apps/web/src/components/atoms/status-code-badge.tsx
+++ b/apps/web/src/components/atoms/status-code-badge.tsx
@@ -2,10 +2,6 @@ interface StatusCodeBadgeProps {
   code: number;
 }
 
-/**
- * StatusCodeBadge — coloured pill for HTTP status codes.
- * Green  for 2xx, amber for 3xx, red for 4xx/5xx.
- */
 export function StatusCodeBadge({ code }: StatusCodeBadgeProps) {
   let classes: string;
 

--- a/apps/web/src/components/atoms/status-light.tsx
+++ b/apps/web/src/components/atoms/status-light.tsx
@@ -26,13 +26,7 @@ const LABEL_KEY: Record<PublicStatus, keyof Messages['status_light']> = {
   hidden: 'hidden',
 };
 
-/**
- * StatusLight — compact operational-state indicator for a resource point.
- *
- * Renders as an inline flex row (dot + label) so it composes naturally
- * inside flex containers. Accessible via aria-label on the wrapper.
- * `t` is optional — falls back to Spanish when omitted (used in coordinator pages).
- */
+// `t` is optional — falls back to Spanish when omitted (used in coordinator pages).
 export function StatusLight({
   status,
   t = es.status_light,

--- a/apps/web/src/components/atoms/verification-badge.tsx
+++ b/apps/web/src/components/atoms/verification-badge.tsx
@@ -38,13 +38,7 @@ const LABEL_KEY: Record<VerificationLevel, keyof Messages['verification_badge']>
   rejected: 'rejected',
 };
 
-/**
- * VerificationBadge — visual indicator for resource trust level.
- *
- * Renders as a <span> so it can be used inline inside flex rows.
- * Accessible: aria-label describes both the type and value.
- * `t` is optional — falls back to Spanish when omitted (used in coordinator pages).
- */
+// `t` is optional — falls back to Spanish when omitted (used in coordinator pages).
 export function VerificationBadge({
   level,
   t = es.verification_badge,

--- a/apps/web/src/components/molecules/account-menu.tsx
+++ b/apps/web/src/components/molecules/account-menu.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-/**
- * AccountMenu — user chip + language switch + logout, pinned to the bottom of
- * the app shell. Rendered on the navy sidebar (and inside the mobile drawer).
- * Receives the principal as plain props; labels are pre-resolved by the shell.
- */
 import { logoutAction } from '@/app/actions';
 import { LanguageSwitcher } from '@/components/molecules/language-switcher';
 

--- a/apps/web/src/components/molecules/account-nav.tsx
+++ b/apps/web/src/components/molecules/account-nav.tsx
@@ -1,8 +1,3 @@
-/**
- * AccountNav — secondary account/coordination links for the home page.
- * Previously lived inside the home footer; now an in-page nav so the page keeps
- * a single (global) footer. Admin links surface only for admins.
- */
 import Link from 'next/link';
 import type { Messages } from '@/i18n/messages/es';
 

--- a/apps/web/src/components/molecules/announcement-card.tsx
+++ b/apps/web/src/components/molecules/announcement-card.tsx
@@ -1,9 +1,3 @@
-/**
- * AnnouncementCard — official coordinator communiqué (Banda oficial look).
- * Renders just the last-updated line when there is no announcement.
- * `t` is optional — falls back to Spanish when omitted.
- */
-
 import { Card } from '@/components/atoms/card';
 import { RelativeTime } from '@/components/atoms/relative-time';
 import type { Messages } from '@/i18n/messages/es';

--- a/apps/web/src/components/molecules/capacities-filter.tsx
+++ b/apps/web/src/components/molecules/capacities-filter.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-/**
- * Lean mode + status filter for the read-only "Capacidades disponibles" panel.
- * Drives the `capMode` and `capStatus` search params; the expediciones page
- * applies them to the fetched capacities. Mirrors {@link OffersFilter}.
- */
 import type { ChangeEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Select } from '@/components/atoms/select';

--- a/apps/web/src/components/molecules/coordination-section-link.tsx
+++ b/apps/web/src/components/molecules/coordination-section-link.tsx
@@ -1,10 +1,5 @@
 import Link from 'next/link';
 
-/**
- * Hub entry for one coordination section: a full-width tap target with the
- * section name, an optional pending-count pill and a trailing arrow. Used by the
- * coordination landing to route into each section (Recursos, Peticiones…).
- */
 interface CoordinationSectionLinkProps {
   href: string;
   label: string;

--- a/apps/web/src/components/molecules/create-org-modal.tsx
+++ b/apps/web/src/components/molecules/create-org-modal.tsx
@@ -1,16 +1,8 @@
 'use client';
 
-/**
- * CreateOrgModal — inline organization creation in a modal.
- *
- * Lets a user create an organization without leaving the form they are filling
- * in (petición/registrar/donar). On success it calls `onCreated` with the new
- * org so the caller can select it immediately.
- *
- * Inputs are controlled (no nested `<form>` submission to the parent form); the
- * server action is invoked directly. The surrounding `Modal` portals this out
- * of the parent form's DOM, so the `<form>` here is safe.
- */
+// Inputs are controlled (no nested `<form>` submission to the parent form); the
+// server action is invoked directly. The surrounding `Modal` portals this out
+// of the parent form's DOM, so the `<form>` here is safe.
 import { useState, type FormEvent } from 'react';
 import { Modal } from '@/components/molecules/modal';
 import { Input } from '@/components/atoms/input';
@@ -110,7 +102,6 @@ export function CreateOrgModal({ open, onClose, onCreated }: CreateOrgModalProps
       <form onSubmit={handleSubmit} className="flex flex-col gap-5" noValidate>
         {error !== null && <ErrorMessage message={error} />}
 
-        {/* Name */}
         <div className="flex flex-col gap-1.5">
           <label htmlFor="modal-org-name" className="text-sm font-semibold text-ink">
             {to.f_name} <span aria-hidden="true">*</span>
@@ -126,7 +117,6 @@ export function CreateOrgModal({ open, onClose, onCreated }: CreateOrgModalProps
           />
         </div>
 
-        {/* Type */}
         <div className="flex flex-col gap-1.5">
           <label htmlFor="modal-org-type" className="text-sm font-semibold text-ink">
             {to.f_type} <span aria-hidden="true">*</span>
@@ -149,7 +139,6 @@ export function CreateOrgModal({ open, onClose, onCreated }: CreateOrgModalProps
           </Select>
         </div>
 
-        {/* Tax ID */}
         <div className="flex flex-col gap-1.5">
           <label htmlFor="modal-org-taxid" className="text-sm font-semibold text-ink">
             {to.f_taxid}
@@ -165,7 +154,6 @@ export function CreateOrgModal({ open, onClose, onCreated }: CreateOrgModalProps
           />
         </div>
 
-        {/* Contact email */}
         <div className="flex flex-col gap-1.5">
           <label htmlFor="modal-org-email" className="text-sm font-semibold text-ink">
             {to.f_email} <span aria-hidden="true">*</span>
@@ -181,7 +169,6 @@ export function CreateOrgModal({ open, onClose, onCreated }: CreateOrgModalProps
           />
         </div>
 
-        {/* Contact phone */}
         <div className="flex flex-col gap-1.5">
           <label htmlFor="modal-org-phone" className="text-sm font-semibold text-ink">
             {to.f_phone} <span aria-hidden="true">*</span>
@@ -197,7 +184,6 @@ export function CreateOrgModal({ open, onClose, onCreated }: CreateOrgModalProps
           />
         </div>
 
-        {/* Actions */}
         <div className="flex gap-3 pt-1">
           <Button
             type="button"

--- a/apps/web/src/components/molecules/detail-field.tsx
+++ b/apps/web/src/components/molecules/detail-field.tsx
@@ -6,11 +6,6 @@ interface DetailFieldProps {
   value?: ReactNode;
 }
 
-/**
- * DetailField — a single labelled row inside a detail drawer body.
- * Renders nothing when the value is empty, so callers can pass optional DTO
- * fields directly without guarding each one.
- */
 export function DetailField({ label, value }: DetailFieldProps) {
   if (value == null || value === '') return null;
   return (
@@ -28,7 +23,6 @@ interface DetailSectionProps {
   children: ReactNode;
 }
 
-/** A titled group of {@link DetailField}s. */
 export function DetailSection({ title, children }: DetailSectionProps) {
   return (
     <section className="border-t border-line first:border-t-0">

--- a/apps/web/src/components/molecules/emergency-context-banner.tsx
+++ b/apps/web/src/components/molecules/emergency-context-banner.tsx
@@ -1,8 +1,3 @@
-/**
- * EmergencyContextBanner — a slim strip shown above coordination content so the
- * operator always knows which emergency they're in and can step back out to its
- * public landing. Server component (presentational).
- */
 import Link from 'next/link';
 
 interface EmergencyContextBannerProps {

--- a/apps/web/src/components/molecules/emergency-header-menu.tsx
+++ b/apps/web/src/components/molecules/emergency-header-menu.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-/**
- * EmergencyHeaderMenu — the "options" menu for the emergency landing header.
- * A thin wrapper over the shared {@link HeaderMenu} with the emergency-specific
- * labels and links.
- */
 import { HeaderMenu } from '@/components/molecules/header-menu';
 import type { Messages } from '@/i18n/messages/es';
 

--- a/apps/web/src/components/molecules/emergency-quick-links.tsx
+++ b/apps/web/src/components/molecules/emergency-quick-links.tsx
@@ -1,10 +1,3 @@
-/**
- * EmergencyQuickLinks — in-page quick access for the emergency landing.
- *
- * Was previously a second <footer>; now a plain nav section so the page keeps a
- * single (global) footer. Surfaces authenticated self-service links and the
- * coordination entry, and points the trust line at the public verify guide.
- */
 import Link from 'next/link';
 import type { Messages } from '@/i18n/messages/es';
 

--- a/apps/web/src/components/molecules/empty-state.tsx
+++ b/apps/web/src/components/molecules/empty-state.tsx
@@ -3,11 +3,6 @@ interface EmptyStateProps {
   description?: string;
 }
 
-/**
- * EmptyState — dashed-border placeholder used when a list has no items.
- * Matches the `rounded-lg border-2 border-dashed border-line px-6 py-10 text-center`
- * pattern that appears in the emergency list, needs list, resources list, etc.
- */
 export function EmptyState({ title, description }: EmptyStateProps) {
   return (
     <div className="rounded-lg border-2 border-dashed border-line px-6 py-10 text-center">

--- a/apps/web/src/components/molecules/filter-field.tsx
+++ b/apps/web/src/components/molecules/filter-field.tsx
@@ -1,10 +1,5 @@
 import type { ReactNode } from 'react';
 
-/**
- * FilterField — a labelled form control for the filter bars. Keeps every field
- * (selects, search) visually identical: full width, label above, consistent
- * spacing. Wrapping in <label> means the caption also focuses the control.
- */
 interface FilterFieldProps {
   label: string;
   children: ReactNode;

--- a/apps/web/src/components/molecules/form-field.tsx
+++ b/apps/web/src/components/molecules/form-field.tsx
@@ -13,12 +13,6 @@ interface FormFieldProps {
   labelAs?: 'label' | 'p';
 }
 
-/**
- * FormField — Label + control + optional error message.
- *
- * Encapsulates the `flex flex-col gap-2` wrapper + label style that repeats
- * in every form field across the app.
- */
 export function FormField({
   htmlFor,
   label,

--- a/apps/web/src/components/molecules/form-success-screen.tsx
+++ b/apps/web/src/components/molecules/form-success-screen.tsx
@@ -2,26 +2,11 @@
 
 import Link from 'next/link';
 
-/**
- * FormSuccessScreen — molecule.
- *
- * Renders the success state that appears after a form is submitted
- * successfully. Shared by peticion, registrar, donar and reportar forms.
- *
- * The primary link uses hard navigation (window.location.href) so the
- * form page re-mounts and all controlled state is reset.
- */
-
 interface FormSuccessScreenProps {
-  /** Main message displayed in the success card. */
   message: string;
-  /** href for the primary "submit another" call-to-action. */
   primaryHref: string;
-  /** Label for the primary call-to-action button. */
   primaryLabel: string;
-  /** href for the secondary "back to emergency" link. */
   secondaryHref: string;
-  /** Label for the secondary link. */
   secondaryLabel: string;
 }
 
@@ -45,6 +30,7 @@ export function FormSuccessScreen({
         <Link
           href={primaryHref}
           className="flex items-center justify-center w-full py-4 px-6 text-base font-semibold text-white bg-navy rounded-lg hover:bg-navy-700 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors"
+          // Hard navigation so the form page re-mounts and all controlled state resets.
           onClick={() => {
             window.location.href = primaryHref;
           }}

--- a/apps/web/src/components/molecules/header-menu.tsx
+++ b/apps/web/src/components/molecules/header-menu.tsx
@@ -1,12 +1,5 @@
 'use client';
 
-/**
- * HeaderMenu — a compact "options" dropdown for the header band. Collapses the
- * language switch and a few site links behind a single button so the navy band
- * stays small on mobile. Renders a white dropdown anchored to the button; closes
- * on outside click or Escape. Shared by the public site header and the emergency
- * header (each passes its own labels + links).
- */
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { LanguageSwitcher } from '@/components/molecules/language-switcher';
@@ -17,9 +10,7 @@ export interface HeaderMenuLink {
 }
 
 interface HeaderMenuProps {
-  /** Accessible label for the trigger button. */
   ariaLabel: string;
-  /** Heading shown above the language switch. */
   languageLabel: string;
   links: HeaderMenuLink[];
 }
@@ -78,14 +69,14 @@ export function HeaderMenu({ ariaLabel, languageLabel, links }: HeaderMenuProps)
             <LanguageSwitcher tone="light" />
           </div>
           {links.length > 0 && <div className="my-1 border-t border-line" />}
-          {links.map((l) => (
+          {links.map((link) => (
             <Link
-              key={l.href}
-              href={l.href}
+              key={link.href}
+              href={link.href}
               role="menuitem"
               className="block rounded-lg px-2 py-2 text-sm font-medium text-ink-soft transition-colors hover:bg-surface focus:bg-surface focus:outline-none"
             >
-              {l.label}
+              {link.label}
             </Link>
           ))}
         </div>

--- a/apps/web/src/components/molecules/help-action-row.tsx
+++ b/apps/web/src/components/molecules/help-action-row.tsx
@@ -1,7 +1,3 @@
-/**
- * HelpActionRow — a single "¿Cómo quieres ayudar?" action: icon, title, optional
- * subtitle and a trailing arrow. Linked. Variants set the visual weight.
- */
 import Link from 'next/link';
 
 type Variant = 'primary' | 'default' | 'danger';

--- a/apps/web/src/components/molecules/how-it-works-step.tsx
+++ b/apps/web/src/components/molecules/how-it-works-step.tsx
@@ -1,6 +1,3 @@
-/**
- * HowItWorksStep — a numbered step in the Home "Cómo funciona" section.
- */
 interface HowItWorksStepProps {
   index: number;
   title: string;

--- a/apps/web/src/components/molecules/intake-receipt.tsx
+++ b/apps/web/src/components/molecules/intake-receipt.tsx
@@ -4,8 +4,6 @@ import Link from 'next/link';
 import { QRCodeSVG } from 'qrcode.react';
 
 /**
- * IntakeReceipt — molecule.
- *
  * The donor's proof of a delivery pre-registration (#130): the short, human
  * code plus a QR encoding it, shown after a successful pre-registration so the
  * person can present it at the collection-point desk. The desk operator finds

--- a/apps/web/src/components/molecules/language-switcher.tsx
+++ b/apps/web/src/components/molecules/language-switcher.tsx
@@ -1,15 +1,5 @@
 'use client';
 
-/**
- * LanguageSwitcher — molecule component.
- *
- * Sets the `rh_locale` cookie and reloads the current page to apply the new locale.
- * Uses a pair of <button> elements (not a <select>) for clarity and accessibility.
- * Classified as a molecule: it composes multiple button atoms with cookie/locale logic.
- *
- * `tone="dark"` renders for placement on the navy header band.
- */
-
 import { useLocale } from '@/i18n/locale-context';
 import { LOCALE_COOKIE } from '@/i18n/index';
 import type { Locale } from '@/i18n/index';

--- a/apps/web/src/components/molecules/metric-card.tsx
+++ b/apps/web/src/components/molecules/metric-card.tsx
@@ -15,10 +15,6 @@ const TONE_CLASS: Record<Tone, string> = {
   accent: 'text-accent',
 };
 
-/**
- * MetricCard — a single metric tile (big figure + label) for the emergency
- * summary grid. Branded "Banda oficial" look: warm card, Archivo figure.
- */
 export function MetricCard({ value, label, tone = 'navy' }: MetricCardProps) {
   return (
     <Card className="px-3.5 py-3">

--- a/apps/web/src/components/molecules/modal.tsx
+++ b/apps/web/src/components/molecules/modal.tsx
@@ -53,7 +53,6 @@ export function Modal({ open, onClose, title, children, closeLabel, ariaLabel }:
       aria-modal="true"
       aria-label={ariaLabel ?? title}
     >
-      {/* Backdrop */}
       <button
         type="button"
         aria-label={closeLabel}
@@ -61,9 +60,7 @@ export function Modal({ open, onClose, title, children, closeLabel, ariaLabel }:
         className="absolute inset-0 bg-black/50"
       />
 
-      {/* Panel: bottom sheet on mobile, centered card on desktop */}
       <div className="relative z-10 flex max-h-[92vh] w-full flex-col overflow-hidden rounded-t-2xl bg-white shadow-xl sm:m-4 sm:max-w-md sm:rounded-2xl">
-        {/* Header */}
         <div className="flex items-start justify-between gap-3 border-b border-line px-5 py-4">
           <h2 className="text-lg font-bold leading-tight text-ink break-words">{title}</h2>
           <button
@@ -88,7 +85,6 @@ export function Modal({ open, onClose, title, children, closeLabel, ariaLabel }:
           </button>
         </div>
 
-        {/* Scrollable body */}
         <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
       </div>
     </div>,

--- a/apps/web/src/components/molecules/nav-drawer.tsx
+++ b/apps/web/src/components/molecules/nav-drawer.tsx
@@ -1,12 +1,7 @@
 'use client';
 
-/**
- * NavDrawer — the mobile top bar (brand + hamburger) and the slide-in drawer it
- * toggles. The nav content, brand and account block are passed in pre-rendered
- * by the server shell (the same nodes the desktop sidebar uses). The drawer
- * closes on Escape, backdrop click, the close button, and on any click inside
- * the nav (which covers link taps). Hidden at lg+.
- */
+// The nav content, brand and account block are passed in pre-rendered by the
+// server shell (the same nodes the desktop sidebar uses).
 import { useState, useEffect, type ReactNode } from 'react';
 
 interface NavDrawerProps {
@@ -40,7 +35,6 @@ export function NavDrawer({
 
   return (
     <div className="lg:hidden">
-      {/* Top bar */}
       <div className="flex items-center justify-between bg-navy px-4 py-3 text-white">
         {brand}
         <button
@@ -58,7 +52,6 @@ export function NavDrawer({
         </button>
       </div>
 
-      {/* Backdrop + sliding panel */}
       {open ? (
         <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-label={navAriaLabel}>
           <button

--- a/apps/web/src/components/molecules/nav-group.tsx
+++ b/apps/web/src/components/molecules/nav-group.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-/**
- * NavGroup — an optional heading + a list of NavItems, for the app shell.
- */
 import { NavItem, type ResolvedNavItem } from '@/components/atoms/nav-item';
 
 export interface ResolvedNavGroup {

--- a/apps/web/src/components/molecules/need-card.tsx
+++ b/apps/web/src/components/molecules/need-card.tsx
@@ -1,7 +1,3 @@
-/**
- * NeedCard — a validated need (Banda oficial look): priority pill + freshness on
- * top, title, the headline item, optional privacy notice and an offer CTA.
- */
 import Link from 'next/link';
 import type { components } from '@reliefhub/api-client';
 import { Card } from '@/components/atoms/card';

--- a/apps/web/src/components/molecules/notification-item.tsx
+++ b/apps/web/src/components/molecules/notification-item.tsx
@@ -15,15 +15,6 @@ export interface NotificationItemProps {
   link: string | null;
 }
 
-/**
- * NotificationItem — molecule displaying a single in-app notification.
- *
- * - Unread notifications have a blue dot indicator and bold message text.
- * - If the notification has a `link`, the item wraps its content in a Next.js
- *   Link and marks itself read on click.
- * - When `link` is null, clicking "Marcar leída" fires the server action
- *   directly via a form button.
- */
 export function NotificationItem({
   id,
   message,
@@ -65,7 +56,6 @@ export function NotificationItem({
       }`}
       aria-label={read ? `${tn.item_read_aria}: ${message}` : `${tn.item_unread_aria}: ${message}`}
     >
-      {/* Unread indicator dot */}
       <span
         className={`mt-1.5 h-2 w-2 flex-shrink-0 rounded-full ${
           read ? 'bg-transparent' : 'bg-info-dot'

--- a/apps/web/src/components/molecules/offers-filter.tsx
+++ b/apps/web/src/components/molecules/offers-filter.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-/**
- * Category + status filter for the coordination Offers queue. Drives the
- * `category` and `status` search params; the page applies them to the fetched
- * offers. Mirrors {@link NeedsFilter}'s URL-sync approach.
- */
 import type { ChangeEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Select } from '@/components/atoms/select';

--- a/apps/web/src/components/molecules/org-selector-field.tsx
+++ b/apps/web/src/components/molecules/org-selector-field.tsx
@@ -1,13 +1,5 @@
 'use client';
 
-/**
- * OrgSelectorField — client part of the OrgSelector.
- *
- * Renders the "on whose behalf?" `<select name="organizationId">` plus a
- * "create organization" trigger that opens a modal. A freshly created org is
- * appended to the list and auto-selected, so it is submitted with the parent
- * form. The list is seeded server-side via `initialOrgs`.
- */
 import { useState } from 'react';
 import { getMessages } from '@/i18n';
 import { useLocale } from '@/i18n/locale-context';

--- a/apps/web/src/components/molecules/org-selector.tsx
+++ b/apps/web/src/components/molecules/org-selector.tsx
@@ -3,20 +3,9 @@ import { authHeaders, getToken } from '@/lib/auth';
 import { OrgSelectorField } from './org-selector-field';
 
 /**
- * OrgSelector — Server Component.
- *
- * Fetches the organizations the authenticated user belongs to and hands them to
- * the interactive {@link OrgSelectorField}, which renders:
- *   - "as an individual" (empty value, always first)
- *   - One <option> per organization
- *   - A "create organization" trigger that opens a modal; the new org is
- *     appended and auto-selected.
- *
- * If the user is unauthenticated or has no organizations, only the
- * "as an individual" option is shown — the component never throws.
- *
- * Include inside a <form> and the selected organizationId will be submitted
- * with the rest of the form fields.
+ * Unauthenticated or no organizations → only the "as an individual" option is
+ * shown; the component never throws. Include inside a <form> and the selected
+ * organizationId is submitted with the rest of the form fields.
  */
 export async function OrgSelector() {
   const token = await getToken();

--- a/apps/web/src/components/molecules/page-container.tsx
+++ b/apps/web/src/components/molecules/page-container.tsx
@@ -1,28 +1,13 @@
 import type { ReactNode } from 'react';
 
-/**
- * The single canonical page width. Every page — public, auth, dashboard, admin —
- * centers its content at this width with the same gutters, so the whole app
- * shares ONE layout. Exported so the few standalone pages that place a flush
- * header band above their body can reuse the exact same width string.
- */
+// One shared width for every page, so the whole app lines up.
 export const PAGE_WIDTH_CLASS = 'mx-auto w-full max-w-3xl';
 
 interface PageContainerProps {
   children: ReactNode;
-  /** Extra classes appended to the inner container. */
   className?: string;
 }
 
-/**
- * PageContainer — the one page body wrapper used across the app. Mobile-first:
- * full-bleed with comfortable gutters on phones, capped + centered at the
- * standard width on larger screens, with the app's standard vertical rhythm
- * (gap-8). There are no width variants on purpose: a single width keeps every
- * page identical.
- *
- * Server component — no 'use client'.
- */
 export function PageContainer({ children, className = '' }: PageContainerProps) {
   return (
     <div

--- a/apps/web/src/components/molecules/page-header-band.tsx
+++ b/apps/web/src/components/molecules/page-header-band.tsx
@@ -1,8 +1,3 @@
-/**
- * PageHeaderBand — reusable navy band for secondary/inner pages: brand + ES/EN
- * (via HeaderBandShell), an optional back link, and an optional title/subtitle.
- * Pair it with a `bg-surface` page wrapper for the full "Banda oficial" look.
- */
 import Link from 'next/link';
 import { HeaderBandShell } from '@/components/molecules/header-band-shell';
 

--- a/apps/web/src/components/molecules/page-header.tsx
+++ b/apps/web/src/components/molecules/page-header.tsx
@@ -4,24 +4,12 @@ import Link from 'next/link';
 interface PageHeaderProps {
   title: string;
   subtitle?: string;
-  /** Optional back link, rendered above the title. */
   backHref?: string;
   backLabel?: string;
-  /** Right-aligned action slot (buttons, etc.). */
   actions?: ReactNode;
-  /** Below the title — role badges, status chips, etc. */
   badges?: ReactNode;
 }
 
-/**
- * PageHeader — the standard in-shell page header: a navy display title, an
- * optional subtitle and back link, plus a right-aligned actions slot and an
- * optional badges row. Used across the dashboard/panel areas; the navy
- * HeaderBandShell is reserved for standalone public pages. Replaces the ad-hoc
- * inline `<header>` blocks that each page used to define.
- *
- * Server component — no 'use client'.
- */
 export function PageHeader({
   title,
   subtitle,

--- a/apps/web/src/components/molecules/pagination.tsx
+++ b/apps/web/src/components/molecules/pagination.tsx
@@ -1,11 +1,7 @@
 import Link from 'next/link';
 
-/**
- * Server-rendered pager. Prev/next links preserve the current filter params
- * (e.g. `q`, `type`) and only set `page` when it is > 1, keeping page-1 URLs
- * clean. Renders a summary line ("Página X de Y · N resultados") and hides the
- * prev/next controls when there is a single page.
- */
+// Prev/next links preserve the current filter params and only set `page` when
+// it is > 1, keeping page-1 URLs clean.
 interface PaginationProps {
   page: number;
   limit: number;

--- a/apps/web/src/components/molecules/personnel-need-fields.tsx
+++ b/apps/web/src/components/molecules/personnel-need-fields.tsx
@@ -45,7 +45,6 @@ export function PersonnelNeedFields() {
         {tc.personnel_fields_heading}
       </p>
 
-      {/* Habilidad requerida */}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor="personnel-skill"
@@ -70,7 +69,6 @@ export function PersonnelNeedFields() {
         </select>
       </div>
 
-      {/* Especialidad (texto libre) */}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor="personnel-specialty"
@@ -90,7 +88,6 @@ export function PersonnelNeedFields() {
         />
       </div>
 
-      {/* Personas necesarias */}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor="personnel-count"

--- a/apps/web/src/components/molecules/photo-uploader.tsx
+++ b/apps/web/src/components/molecules/photo-uploader.tsx
@@ -138,7 +138,6 @@ export function PhotoUploader({ onUrlsChange }: PhotoUploaderProps) {
           const formData = new FormData();
           formData.append('file', blob, file.name);
 
-          // POST to the Next.js proxy which reads the httpOnly cookie server-side
           const res = await fetch('/api/upload', {
             method: 'POST',
             body: formData,

--- a/apps/web/src/components/molecules/resource-filter-bar.tsx
+++ b/apps/web/src/components/molecules/resource-filter-bar.tsx
@@ -1,22 +1,5 @@
 'use client';
 
-/**
- * ResourceFilterBar — molecule for filtering the resource list.
- *
- * Provides:
- *  - Category <select> populated from facets.byCategory (with counts).
- *  - Country <select> populated from facets.byCountry (with counts).
- *  - Text search input (client-side, does not trigger re-fetch).
- *  - Active-filter chips with "×" dismiss buttons.
- *
- * Every control is a full-width field of identical height (Select / Input atoms
- * wrapped in FilterField) so the whole bar reads as one tidy form.
- *
- * Filter changes for category/country bubble up via callbacks so the parent
- * can reset the list and re-fetch page 1 with the new params.
- * Search text bubbles up via onSearchChange for client-side filtering.
- */
-
 import type { Messages } from '@/i18n/messages/es';
 import type { Locale } from '@/i18n';
 import { categoryLabel } from '@/lib/categories';

--- a/apps/web/src/components/molecules/resource-type-filter.tsx
+++ b/apps/web/src/components/molecules/resource-type-filter.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-/**
- * Single-select filter for the resource verification queue: narrows the queue
- * by resource type via the `type` search param. Pairs with {@link SearchBox}
- * and pagination on the coordination Recursos page. Resets `page` on change.
- */
 import type { ChangeEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Select } from '@/components/atoms/select';

--- a/apps/web/src/components/molecules/search-box.tsx
+++ b/apps/web/src/components/molecules/search-box.tsx
@@ -1,11 +1,5 @@
 'use client';
 
-/**
- * URL-synced search box. Writes the trimmed query into a search param (default
- * `q`) with a short debounce so typing doesn't fire a navigation per keystroke,
- * and resets `page` to 1 whenever the query changes. Reads its labels from the
- * active locale so it stays framework-i18n-consistent without prop drilling.
- */
 import { useState, useEffect, useRef, type ChangeEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Input } from '@/components/atoms/input';

--- a/apps/web/src/components/molecules/shipments-filter.tsx
+++ b/apps/web/src/components/molecules/shipments-filter.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-/**
- * Status filter for the coordination Expediciones list. Drives the `status`
- * search param; the page passes it to the shipments endpoint. Mirrors
- * {@link OffersFilter}'s URL-sync approach.
- */
 import type { ChangeEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Select } from '@/components/atoms/select';

--- a/apps/web/src/components/molecules/social-login-buttons.tsx
+++ b/apps/web/src/components/molecules/social-login-buttons.tsx
@@ -25,7 +25,6 @@ export function SocialLoginButtons({ next }: SocialLoginButtonsProps) {
         <div className="flex-1 h-px bg-line" />
       </div>
 
-      {/* Google */}
       <a
         href={`${API_URL}/auth/google${nextQuery}`}
         className="flex items-center justify-center gap-3 w-full rounded-lg border border-line bg-white px-4 py-2.5 text-sm font-medium text-ink-soft hover:bg-surface transition-colors"
@@ -51,7 +50,6 @@ export function SocialLoginButtons({ next }: SocialLoginButtonsProps) {
         {t.continue_with.replace('{provider}', 'Google')}
       </a>
 
-      {/* Facebook */}
       <a
         href={`${API_URL}/auth/facebook${nextQuery}`}
         className="flex items-center justify-center gap-3 w-full rounded-lg border border-line bg-white px-4 py-2.5 text-sm font-medium text-ink-soft hover:bg-surface transition-colors"

--- a/apps/web/src/components/molecules/status-banner.tsx
+++ b/apps/web/src/components/molecules/status-banner.tsx
@@ -1,9 +1,3 @@
-/**
- * StatusBanner — prominent banner shown when an emergency is paused or closed.
- * Renders nothing when status is 'active'.
- * `t` is optional — falls back to Spanish when omitted.
- */
-
 import type { Messages } from '@/i18n/messages/es';
 import { es } from '@/i18n/messages/es';
 

--- a/apps/web/src/components/molecules/supply-line-row-fields.tsx
+++ b/apps/web/src/components/molecules/supply-line-row-fields.tsx
@@ -80,7 +80,6 @@ export function SupplyLineRowFields({
         )}
       </div>
 
-      {/* Nombre del insumo */}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor={`${idPrefix}-name-${rowId}`}
@@ -100,7 +99,6 @@ export function SupplyLineRowFields({
       </div>
 
       <div className="grid grid-cols-2 gap-3">
-        {/* Cantidad */}
         <div className="flex flex-col gap-1.5">
           <label
             htmlFor={`${idPrefix}-qty-${rowId}`}
@@ -124,7 +122,6 @@ export function SupplyLineRowFields({
           />
         </div>
 
-        {/* Unidad */}
         <div className="flex flex-col gap-1.5">
           <label
             htmlFor={`${idPrefix}-unit-${rowId}`}
@@ -144,7 +141,6 @@ export function SupplyLineRowFields({
         </div>
       </div>
 
-      {/* Categoría */}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor={`${idPrefix}-cat-${rowId}`}

--- a/apps/web/src/components/molecules/template-card.tsx
+++ b/apps/web/src/components/molecules/template-card.tsx
@@ -10,10 +10,6 @@ interface TemplateCardProps {
   actions?: ReactNode;
 }
 
-/**
- * TemplateCard — displays a summary of an emergency template.
- * Actions slot accepts delete/edit controls (optional). Server component.
- */
 export async function TemplateCard({
   name,
   description,

--- a/apps/web/src/components/molecules/trust-levels-card.tsx
+++ b/apps/web/src/components/molecules/trust-levels-card.tsx
@@ -1,7 +1,3 @@
-/**
- * TrustLevelsCard — "La confianza es el producto": explains each verification
- * level next to the very badge users will see across the platform.
- */
 import { Card } from '@/components/atoms/card';
 import { SectionHeading } from '@/components/atoms/section-heading';
 import { VerificationBadge, type VerificationLevel } from '@/components/atoms/verification-badge';

--- a/apps/web/src/components/molecules/volunteer-card.tsx
+++ b/apps/web/src/components/molecules/volunteer-card.tsx
@@ -82,7 +82,6 @@ export function VolunteerCard({ volunteer, slug }: VolunteerCardProps) {
       aria-label={tc.volunteer_card_label.replace('{name}', volunteer.name)}
       className="flex flex-col gap-3 rounded-lg border-2 border-line bg-white p-4"
     >
-      {/* Header */}
       <div className="flex items-start justify-between gap-3 flex-wrap">
         <div className="flex flex-col gap-0.5">
           <h3 className="text-base font-bold text-ink leading-tight">{volunteer.name}</h3>
@@ -93,7 +92,6 @@ export function VolunteerCard({ volunteer, slug }: VolunteerCardProps) {
         </span>
       </div>
 
-      {/* Skills */}
       {volunteer.skills.length > 0 && (
         <div className="flex flex-wrap gap-1.5" aria-label={tc.volunteer_skills_label}>
           {volunteer.skills.map((skill) => (
@@ -104,7 +102,6 @@ export function VolunteerCard({ volunteer, slug }: VolunteerCardProps) {
         </div>
       )}
 
-      {/* Meta row */}
       <div className="flex flex-wrap gap-3 text-xs text-muted">
         <span>
           <span className="font-medium">{tc.volunteer_availability_label}:</span>{' '}
@@ -117,10 +114,8 @@ export function VolunteerCard({ volunteer, slug }: VolunteerCardProps) {
         </span>
       </div>
 
-      {/* Error */}
       {state.status === 'error' && <ErrorMessage message={state.message} />}
 
-      {/* Status change form */}
       <form action={formAction} className="flex items-center gap-2 flex-wrap">
         <label htmlFor={`status-${volunteer.id}`} className="text-xs font-semibold text-ink-soft uppercase tracking-wide">
           {tc.volunteer_change_status_label}:

--- a/apps/web/src/components/molecules/volunteer-suggestion-card.tsx
+++ b/apps/web/src/components/molecules/volunteer-suggestion-card.tsx
@@ -35,7 +35,6 @@ export function VolunteerSuggestionCard({
           : 'border-line bg-white hover:border-line'
       }`}
     >
-      {/* Header */}
       <div className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-0.5">
           <h4 className="text-base font-bold text-ink leading-tight">
@@ -55,7 +54,6 @@ export function VolunteerSuggestionCard({
           </div>
         </div>
 
-        {/* Toggle button */}
         <button
           type="button"
           onClick={() => onToggle(volunteer.volunteerId)}
@@ -75,7 +73,6 @@ export function VolunteerSuggestionCard({
         </button>
       </div>
 
-      {/* Skills */}
       {volunteer.skills.length > 0 && (
         <div className="flex flex-wrap gap-1.5" aria-label={tc.volunteer_skills_label}>
           {volunteer.skills.map((skill) => (

--- a/apps/web/src/components/organisms/admin-tabs.tsx
+++ b/apps/web/src/components/organisms/admin-tabs.tsx
@@ -1,24 +1,17 @@
 'use client';
 
-/**
- * Sub-navigation for the administration area (`/panel/administracion`). Platform
- * admins get the global management tools; scope-only admins (org/group/emergency)
- * see just the hub, so the tab bar is hidden for them. Delegates rendering to the
- * shared {@link SectionTabs}.
- */
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
 import { SectionTabs, type SectionTab } from '@/components/organisms/section-tabs';
 
 interface AdminTabsProps {
-  /** Platform admins get the global tools; scope admins see only the hub. */
   isPlatformAdmin: boolean;
 }
 
 export function AdminTabs({ isPlatformAdmin }: AdminTabsProps) {
   const tn = getMessages(useLocale()).nav;
 
-  // Scope-only admins have no global tools to navigate — the hub stands alone.
+  // Scope-only admins reach just the hub — no global tools to tab between.
   if (!isPlatformAdmin) return null;
 
   const base = '/panel/administracion';

--- a/apps/web/src/components/organisms/app-shell.tsx
+++ b/apps/web/src/components/organisms/app-shell.tsx
@@ -1,9 +1,3 @@
-/**
- * AppShell — the responsive dashboard chrome for authenticated/role areas.
- * Persistent navy sidebar at lg+, a hamburger drawer below that. Server
- * component: it only lays out and renders the client nav/drawer/account
- * islands, receiving an already-resolved nav model (plain strings) as props.
- */
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { BrandLogo } from '@/components/molecules/brand-logo';
@@ -57,7 +51,6 @@ export function AppShell({
 
   return (
     <div className="flex flex-1 flex-col lg:flex-row">
-      {/* Desktop sidebar */}
       <aside className="hidden bg-navy lg:sticky lg:top-0 lg:flex lg:h-screen lg:w-64 lg:shrink-0 lg:flex-col">
         <div className="px-4 py-4">{brand}</div>
         <nav aria-label={chrome.navAria} className="flex-1 overflow-y-auto px-2">
@@ -66,7 +59,6 @@ export function AppShell({
         <div className="pb-4">{account}</div>
       </aside>
 
-      {/* Mobile top bar + slide-in drawer */}
       <NavDrawer
         brand={brand}
         account={account}
@@ -77,7 +69,6 @@ export function AppShell({
         {navGroups}
       </NavDrawer>
 
-      {/* Content column */}
       <div className="flex min-w-0 flex-1 flex-col">
         {emergencyContext}
         {children}

--- a/apps/web/src/components/organisms/capacities-panel.tsx
+++ b/apps/web/src/components/organisms/capacities-panel.tsx
@@ -25,12 +25,8 @@ interface CapacitiesPanelProps {
   emptyDescription: string;
 }
 
-/**
- * Read-only "Capacidades disponibles" panel (#105's coordinator-visible view):
- * each capacity card shows mode, capacity (peso/volumen), coverage area, window
- * and status. No actions — coordination assigns capacities from the shipment
- * detail drawer, not here.
- */
+// No actions here — coordination assigns capacities from the shipment detail
+// drawer, not this read-only panel.
 export function CapacitiesPanel({
   capacities,
   tc,

--- a/apps/web/src/components/organisms/content-page.tsx
+++ b/apps/web/src/components/organisms/content-page.tsx
@@ -1,9 +1,3 @@
-/**
- * ContentPage — shared chrome for the static content/marketing pages
- * (/sobre, /como-funciona, /transparencia, /verificar). Renders the branded
- * header band, a hero (overline + H1 + lead + illustration) and a closing CTA.
- * The global footer comes from the root layout. Server component.
- */
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { SiteHeaderBand } from '@/components/organisms/site-header-band';
@@ -32,7 +26,6 @@ export function ContentPage({ overline, h1, lead, illustration, children, cta }:
         <SiteHeaderBand />
 
         <article className="px-5 pb-16 pt-8 lg:px-8 lg:pt-10">
-          {/* Hero */}
           <header className="grid items-center gap-8 lg:grid-cols-2 lg:gap-12">
             <div>
               <p className="font-display text-xs font-bold uppercase tracking-[0.14em] text-accent">{overline}</p>
@@ -44,10 +37,8 @@ export function ContentPage({ overline, h1, lead, illustration, children, cta }:
             <div aria-hidden="true">{illustration}</div>
           </header>
 
-          {/* Sections */}
           <div className="mt-12 flex flex-col gap-10 lg:mt-16">{children}</div>
 
-          {/* CTA */}
           <section className="mt-12 rounded-card border border-line bg-surface-alt px-6 py-8 text-center lg:mt-16">
             <h2 className="font-display text-xl font-bold text-navy">{cta.heading}</h2>
             <p className="mx-auto mt-2 max-w-md text-[14.5px] leading-[1.55] text-muted">{cta.body}</p>
@@ -80,7 +71,6 @@ interface ContentSectionProps {
   children: ReactNode;
 }
 
-/** A titled prose block. */
 export function ContentSection({ heading, children }: ContentSectionProps) {
   return (
     <section className="max-w-2xl">

--- a/apps/web/src/components/organisms/coordination-tabs.tsx
+++ b/apps/web/src/components/organisms/coordination-tabs.tsx
@@ -1,12 +1,5 @@
 'use client';
 
-/**
- * Sub-navigation for the coordination area. Renders one tab per section the
- * principal can act on (permission-gated by the flags the server resolves with
- * {@link resolveEmergencyAccess}). Builds the tab list and delegates rendering
- * to the shared {@link SectionTabs} (mobile-scroll / desktop-wrap pills with an
- * active state derived from the path).
- */
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
 import { SectionTabs, type SectionTab } from '@/components/organisms/section-tabs';
@@ -51,8 +44,7 @@ export function CoordinationTabs({ slug, access }: CoordinationTabsProps) {
     tabs.push({ href: `${base}/actividad`, label: tc.tab_activity });
   }
 
-  // A lone "overview" tab means the user has no actionable section — the hub
-  // already conveys that, so the sub-nav adds nothing.
+  // A lone overview tab adds nothing the hub doesn't already show.
   if (tabs.length <= 1) return null;
 
   return <SectionTabs tabs={tabs} ariaLabel={tc.tabs_aria} />;

--- a/apps/web/src/components/organisms/create-task-form.tsx
+++ b/apps/web/src/components/organisms/create-task-form.tsx
@@ -39,7 +39,6 @@ export function CreateTaskForm({ emergencyId, slug }: CreateTaskFormProps) {
     async (_prev, formData) => {
       const result = await createTask(emergencyId, slug, formData);
       if (result.status === 'success') {
-        // Reset the form on success
         formRef.current?.reset();
       }
       return result;
@@ -105,7 +104,6 @@ export function CreateTaskForm({ emergencyId, slug }: CreateTaskFormProps) {
         </select>
       </FormField>
 
-      {/* Optional location */}
       <fieldset className="flex flex-col gap-3 rounded-lg border border-line p-4">
         <legend className="px-1 text-xs font-semibold text-ink-soft uppercase tracking-wide">
           {tc.task_location_legend}

--- a/apps/web/src/components/organisms/detail-drawer.tsx
+++ b/apps/web/src/components/organisms/detail-drawer.tsx
@@ -67,7 +67,6 @@ export function DetailDrawer({
       aria-modal="true"
       aria-label={ariaLabel ?? title}
     >
-      {/* Backdrop */}
       <button
         type="button"
         aria-label={tc.drawer_close}
@@ -75,7 +74,6 @@ export function DetailDrawer({
         className="absolute inset-0 bg-black/50"
       />
 
-      {/* Panel: bottom sheet on mobile, right panel on desktop */}
       <div
         className={[
           'absolute bg-white shadow-xl',
@@ -85,7 +83,6 @@ export function DetailDrawer({
           'sm:inset-y-0 sm:right-0 sm:left-auto sm:max-h-none sm:w-[30rem] sm:max-w-full sm:rounded-t-none',
         ].join(' ')}
       >
-        {/* Header (sticky) */}
         <div className="flex items-start justify-between gap-3 border-b border-line px-5 py-4">
           <div className="flex min-w-0 flex-col gap-2">
             <h2 className="text-lg font-bold leading-tight text-ink break-words">
@@ -119,10 +116,8 @@ export function DetailDrawer({
           </button>
         </div>
 
-        {/* Scrollable body */}
         <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
 
-        {/* Sticky footer (actions) */}
         {footer != null && (
           <div className="sticky bottom-0 border-t border-line bg-white px-5 py-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
             {footer}

--- a/apps/web/src/components/organisms/disputed-queue.tsx
+++ b/apps/web/src/components/organisms/disputed-queue.tsx
@@ -24,11 +24,7 @@ type ValidityReport = components['schemas']['ValidityReportDto'];
 const INPUT_CLASS =
   'w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink focus:border-navy focus:outline-none';
 
-/**
- * Coordination queue of resources flagged "disputed" by citizens. Each card
- * shows the reason breakdown and lets a coordinator confirm closure, mark the
- * point invalid or dismiss the reports — each requiring a reason (audit trail).
- */
+// Each resolution requires a reason, recorded in the audit trail.
 export function DisputedQueue({
   items,
   slug,

--- a/apps/web/src/components/organisms/emergency-controls.tsx
+++ b/apps/web/src/components/organisms/emergency-controls.tsx
@@ -17,7 +17,6 @@ interface EmergencyControlsProps {
   emergencyId: string;
   slug: string;
   status: 'active' | 'paused' | 'closed';
-  /** Current announcement text, used to pre-fill the textarea */
   currentAnnouncement: string | null;
 }
 

--- a/apps/web/src/components/organisms/emergency-directory-card.tsx
+++ b/apps/web/src/components/organisms/emergency-directory-card.tsx
@@ -1,8 +1,3 @@
-/**
- * EmergencyDirectoryCard — one active emergency in the public Home directory.
- * Status pill + freshness, name (H3), region, optional announcement excerpt and
- * an "enter the operation" affordance. The whole card links to /e/[slug].
- */
 import Link from 'next/link';
 import type { components } from '@reliefhub/api-client';
 import { RelativeTime } from '@/components/atoms/relative-time';

--- a/apps/web/src/components/organisms/emergency-explorer.tsx
+++ b/apps/web/src/components/organisms/emergency-explorer.tsx
@@ -1,15 +1,8 @@
 'use client';
 
-/**
- * EmergencyExplorer — segmented control that swaps between the "Puntos activos"
- * and "Necesidades validadas" lists so the landing shows ONE list at a time
- * instead of stacking every list vertically.
- *
- * Both lists are passed in as slots (already-configured client components) and
- * kept mounted: the inactive one is hidden with the `hidden` attribute so its
- * internal state (pagination, "near me", filters) survives a tab switch with no
- * refetch.
- */
+// Both lists stay mounted; the inactive one is hidden with the `hidden`
+// attribute so its internal state (pagination, "near me", filters) survives a
+// tab switch with no refetch.
 
 import { useId, useState, type ReactNode } from 'react';
 
@@ -22,9 +15,7 @@ interface EmergencyExplorerProps {
   needsCount: number;
   pointsSlot: ReactNode;
   needsSlot: ReactNode;
-  /** Which tab is selected on first render. */
   initialTab?: Tab;
-  /** Accessible label for the whole tablist. */
   ariaLabel: string;
 }
 

--- a/apps/web/src/components/organisms/emergency-map.tsx
+++ b/apps/web/src/components/organisms/emergency-map.tsx
@@ -341,7 +341,6 @@ export default function EmergencyMap({
         <ClusteredMarkersLayer points={points} slug={slug} />
       </MapContainer>
 
-      {/* Empty-state overlay rendered on top of the map */}
       {points.length === 0 && (
         <div className="absolute inset-0 flex items-center justify-center bg-white/80 z-[1000] pointer-events-none">
           <p className="text-sm font-medium text-muted">

--- a/apps/web/src/components/organisms/expired-need-card.tsx
+++ b/apps/web/src/components/organisms/expired-need-card.tsx
@@ -47,7 +47,6 @@ export function ExpiredNeedCard({ need, slug }: ExpiredNeedCardProps) {
       aria-label={tc.expired_card_label.replace('{title}', need.title)}
       className="flex flex-col gap-4 rounded-lg border-2 border-line bg-surface p-5 opacity-75"
     >
-      {/* Header */}
       <div className="flex flex-col gap-1">
         <h2 className="text-xl font-bold text-ink-soft leading-tight break-words">
           {need.title}
@@ -72,12 +71,10 @@ export function ExpiredNeedCard({ need, slug }: ExpiredNeedCardProps) {
         </div>
       </div>
 
-      {/* Error message */}
       {state.status === 'error' && (
         <ErrorMessage message={state.message ?? tc.error_unknown} />
       )}
 
-      {/* Renew form */}
       <form action={formAction}>
         <Button type="submit" disabled={pending} fullWidth>
           {pending ? tc.expired_renewing : tc.expired_renew}

--- a/apps/web/src/components/organisms/global-footer.tsx
+++ b/apps/web/src/components/organisms/global-footer.tsx
@@ -1,11 +1,3 @@
-/**
- * GlobalFooter — the real, site-wide footer. Rendered once in the root layout
- * so every page closes with a consistent footer anchored to the bottom of the
- * viewport (the sticky-footer pattern: each page <main> is flex-1).
- *
- * Carries the Global Emergency attribution, site navigation, resource pages and
- * the shared legal links (privacy / terms on the org site).
- */
 import Link from 'next/link';
 import { BrandLogo } from '@/components/molecules/brand-logo';
 import { LanguageSwitcher } from '@/components/molecules/language-switcher';
@@ -41,7 +33,6 @@ export function GlobalFooter({ tf }: GlobalFooterProps) {
     <footer aria-label={tf.aria_label} className="mt-auto bg-navy text-white">
       <div className="mx-auto w-full max-w-6xl px-5 py-10 lg:px-8 lg:py-12">
         <div className="grid grid-cols-2 gap-8 sm:grid-cols-2 lg:grid-cols-4">
-          {/* Brand + attribution */}
           <div className="col-span-2 lg:col-span-1">
             <BrandLogo size={26} wordmarkClassName="text-base text-white" />
             <p className="mt-3 max-w-xs text-sm leading-relaxed text-white/70">{tf.tagline}</p>
@@ -58,7 +49,6 @@ export function GlobalFooter({ tf }: GlobalFooterProps) {
             </p>
           </div>
 
-          {/* Navigation */}
           <nav aria-label={tf.nav_heading} className="flex flex-col gap-2.5">
             <h2 className={colHeading}>{tf.nav_heading}</h2>
             {nav.map((l) => (
@@ -68,7 +58,6 @@ export function GlobalFooter({ tf }: GlobalFooterProps) {
             ))}
           </nav>
 
-          {/* Resources */}
           <nav aria-label={tf.resources_heading} className="flex flex-col gap-2.5">
             <h2 className={colHeading}>{tf.resources_heading}</h2>
             {resources.map((l) => (
@@ -78,7 +67,6 @@ export function GlobalFooter({ tf }: GlobalFooterProps) {
             ))}
           </nav>
 
-          {/* Legal */}
           <nav aria-label={tf.legal_heading} className="flex flex-col gap-2.5">
             <h2 className={colHeading}>{tf.legal_heading}</h2>
             <a href={GLOBAL_EMERGENCY.privacy} target="_blank" rel="noopener noreferrer" className={linkClass}>
@@ -90,7 +78,6 @@ export function GlobalFooter({ tf }: GlobalFooterProps) {
           </nav>
         </div>
 
-        {/* Bottom bar */}
         <div className="mt-10 flex flex-col items-start gap-4 border-t border-white/15 pt-6 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-xs text-white/60">
             {tf.copyright.replace('{year}', String(year))} · {tf.built_by}

--- a/apps/web/src/components/organisms/location-picker.tsx
+++ b/apps/web/src/components/organisms/location-picker.tsx
@@ -39,7 +39,6 @@ export function LocationPicker({ defaultValue }: LocationPickerProps) {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Debounced geocode fetch
   const fetchResults = useCallback(async (q: string) => {
     if (q.length < 3) {
       setResults([]);
@@ -64,7 +63,6 @@ export function LocationPicker({ defaultValue }: LocationPickerProps) {
 
   const handleInputChange = (value: string) => {
     setQuery(value);
-    // Clear previous selection when typing
     setSelected(null);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
@@ -79,7 +77,6 @@ export function LocationPicker({ defaultValue }: LocationPickerProps) {
     setResults([]);
   };
 
-  // Close dropdown when clicking outside
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (
@@ -93,7 +90,6 @@ export function LocationPicker({ defaultValue }: LocationPickerProps) {
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -102,7 +98,6 @@ export function LocationPicker({ defaultValue }: LocationPickerProps) {
 
   return (
     <div className="flex flex-col gap-3" ref={containerRef}>
-      {/* Search input */}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor="location-search"
@@ -135,7 +130,6 @@ export function LocationPicker({ defaultValue }: LocationPickerProps) {
           )}
         </div>
 
-        {/* Dropdown results */}
         {isOpen && results.length > 0 && (
           <ul
             id="location-results"
@@ -175,7 +169,6 @@ export function LocationPicker({ defaultValue }: LocationPickerProps) {
         value={selected?.longitude ?? ''}
       />
 
-      {/* Mini map — rendered only when a location is selected */}
       {selected !== null && (
         <div aria-label={t.map_showing.replace('{address}', selected.address)}>
           <LeafletMap

--- a/apps/web/src/components/organisms/login-form.tsx
+++ b/apps/web/src/components/organisms/login-form.tsx
@@ -31,7 +31,6 @@ export function LoginForm({ next, t }: LoginFormProps) {
           <ErrorMessage message={state.message ?? t.error_fallback} />
         )}
 
-        {/* Email */}
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="email">{t.email_label}</Label>
           <Input
@@ -44,7 +43,6 @@ export function LoginForm({ next, t }: LoginFormProps) {
           />
         </div>
 
-        {/* Password */}
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="password">{t.password_label}</Label>
           <Input

--- a/apps/web/src/components/organisms/needs-list.tsx
+++ b/apps/web/src/components/organisms/needs-list.tsx
@@ -1,14 +1,6 @@
 'use client';
 
 /**
- * NeedsList — public list of validated needs with an optional "near me" mode.
- *
- * By default it renders the `initialItems` fetched server-side (already
- * filtered by category/priority via the URL). When the citizen activates the
- * NearbyButton, their ephemeral location is sent to the needs/nearby endpoint
- * and the list is replaced by the nearest validated needs, each annotated with
- * a DistanceBadge. Clearing returns to the default (filtered) list.
- *
  * Location privacy: the coordinates never leave the browser except as the
  * query of a single API call, and the distances shown for needs flagged as
  * "approximate" are derived server-side from the jittered point (see

--- a/apps/web/src/components/organisms/official-header-band.tsx
+++ b/apps/web/src/components/organisms/official-header-band.tsx
@@ -1,8 +1,3 @@
-/**
- * OfficialHeaderBand — the navy "Banda oficial" header for an emergency landing.
- * Accent overline, emergency name (H1), and an operational-status pill with the
- * last-updated time. Built on the shared HeaderBandShell.
- */
 import { HeaderBandShell } from '@/components/molecules/header-band-shell';
 import { HeaderAccountEntry } from '@/components/molecules/header-account-entry';
 import { EmergencyHeaderMenu } from '@/components/molecules/emergency-header-menu';

--- a/apps/web/src/components/organisms/personnel-need-panel.tsx
+++ b/apps/web/src/components/organisms/personnel-need-panel.tsx
@@ -95,7 +95,6 @@ export function PersonnelNeedPanel({
       aria-label={tc.personnel_panel_label.replace('{title}', need.title)}
       className="flex flex-col gap-4 rounded-lg border-2 border-info-line bg-info-soft p-4"
     >
-      {/* Need summary */}
       <div className="flex flex-col gap-1">
         <p className="text-xs font-semibold text-info uppercase tracking-wide">
           {tc.personnel_need_heading}
@@ -113,7 +112,6 @@ export function PersonnelNeedPanel({
         </div>
       </div>
 
-      {/* Volunteer suggestions */}
       <div className="flex flex-col gap-2">
         <p className="text-sm font-semibold text-ink">
           {tc.personnel_suggestions_heading}
@@ -139,10 +137,8 @@ export function PersonnelNeedPanel({
         )}
       </div>
 
-      {/* Error */}
       {error !== null && <ErrorMessage message={error} />}
 
-      {/* Create task button */}
       <button
         type="button"
         onClick={handleCreateTask}

--- a/apps/web/src/components/organisms/public-resource-card.tsx
+++ b/apps/web/src/components/organisms/public-resource-card.tsx
@@ -26,14 +26,6 @@ interface PublicResourceCardProps {
   slug?: string;
 }
 
-/**
- * PublicResourceCard — a verified logistics point (Banda oficial look):
- * trust + operational pills on top, name, then "type · stage · city, country".
- *
- * Carries the rich data layer: accepts chips (via `lib/categories`), a meta row
- * (contact / schedule / manager / source) and a freshness indicator. Every
- * extra field is null-guarded so the card degrades gracefully.
- */
 export function PublicResourceCard({
   resource,
   t,
@@ -78,7 +70,6 @@ export function PublicResourceCard({
       aria-label={t.aria_label.replace('{name}', resource.name)}
       className="flex flex-col gap-1.5 p-4"
     >
-      {/* ── Trust + operational pills ───────────────────────────────────── */}
       <div className="flex flex-wrap items-center gap-2">
         <VerificationBadge level={resource.verificationLevel} t={tVerification} />
         <StatusLight status={resource.publicStatus} t={tStatusLight} />
@@ -100,7 +91,6 @@ export function PublicResourceCard({
         )}
       </div>
 
-      {/* ── Name ────────────────────────────────────────────────────────── */}
       <h3 className="text-[15px] font-bold leading-tight text-ink">
         {slug != null ? (
           <Link
@@ -114,10 +104,8 @@ export function PublicResourceCard({
         )}
       </h3>
 
-      {/* ── Subtitle: type · stage · city, country ──────────────────────── */}
       <p className="text-[12.5px] text-muted">{subtitle}</p>
 
-      {/* ── Accepts chips ───────────────────────────────────────────────── */}
       {(resource.accepts ?? []).length > 0 && (
         <div className="mt-0.5 flex flex-wrap gap-1" role="list" aria-label={t.accepts_label}>
           {(resource.accepts ?? []).map((slug) => (
@@ -132,7 +120,6 @@ export function PublicResourceCard({
         </div>
       )}
 
-      {/* ── Meta row: contact / schedule / manager ──────────────────────── */}
       {/* sourceName is intentionally NOT rendered — ResponseGrid is the
           source of truth; external provenance is internal metadata only. */}
       {(resource.contact != null ||
@@ -164,14 +151,12 @@ export function PublicResourceCard({
         </dl>
       )}
 
-      {/* ── Sin contacto oficial (#64) ──────────────────────────────────── */}
       {resource.contact == null && (
         <p className="text-xs italic text-muted-soft">
           {t.no_official_contact}
         </p>
       )}
 
-      {/* ── Freshness indicator ─────────────────────────────────────────── */}
       {resource.externalUpdatedAt != null && (
         <FreshnessIndicator lastVerifiedAt={resource.externalUpdatedAt} />
       )}

--- a/apps/web/src/components/organisms/report-card.tsx
+++ b/apps/web/src/components/organisms/report-card.tsx
@@ -130,7 +130,6 @@ export function ReportCard({ report, slug }: ReportCardProps) {
       aria-label={tc.report_card_label.replace('{type}', TYPE_LABELS[report.type] ?? report.type)}
       className="flex flex-col gap-4 rounded-lg border-2 border-navy bg-white p-5"
     >
-      {/* Header row */}
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-sm font-bold text-ink">
           {TYPE_LABELS[report.type] ?? report.type}
@@ -142,12 +141,10 @@ export function ReportCard({ report, slug }: ReportCardProps) {
         <span className={statusClass}>{statusLabel}</span>
       </div>
 
-      {/* Note */}
       <p className="text-sm text-ink leading-relaxed whitespace-pre-wrap">
         {report.note}
       </p>
 
-      {/* Photo thumbnails */}
       {report.photoUrls != null && report.photoUrls.length > 0 && (
         <ul className="flex flex-wrap gap-2" aria-label={tc.report_photos_label}>
           {report.photoUrls.filter((u) => u !== '').map((urlOrKey) => {
@@ -179,7 +176,6 @@ export function ReportCard({ report, slug }: ReportCardProps) {
         </ul>
       )}
 
-      {/* Meta info */}
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
         {report.resourceName != null && (
           <span>{tc.report_point_label}: {report.resourceName}</span>
@@ -192,7 +188,6 @@ export function ReportCard({ report, slug }: ReportCardProps) {
         )}
       </div>
 
-      {/* Review action */}
       {!isReviewed && (
         <form action={reviewFormAction}>
           {reviewState.status === 'error' && (

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -1,22 +1,5 @@
 'use client';
 
-/**
- * ResourceList — paginated "load more" list of public resources.
- *
- * Starts with the `initialItems` fetched server-side (page 1).
- * Each "Cargar más" click fetches the next page from the client using the
- * typed API client and appends results (no full page reload).
- *
- * Supports:
- *  - Category + country filter props: re-fetches page 1 and resets
- *    accumulated items whenever they change.
- *  - Server-side full-text search via `q` query param (debounced ~300 ms).
- *  - Geographic grouping: Venezuela first, diaspora/others after.
- *  - Nearby mode: citizen geolocates and sees nearest points, ordered by
- *    distance. Filter bar, load-more and geographic grouping are hidden in
- *    this mode.
- */
-
 import { useState, useTransition, useEffect, useMemo, useRef } from 'react';
 import { createResponseGridClient } from '@reliefhub/api-client';
 import type { components } from '@reliefhub/api-client';
@@ -230,7 +213,6 @@ export function ResourceList({
   if (nearbyItems !== null) {
     return (
       <div className="flex flex-col gap-4">
-        {/* NearbyButton in active state (shows "Volver a la lista") */}
         <NearbyButton
           tNearby={tNearby}
           onLocate={handleNearbyLocate}
@@ -239,15 +221,12 @@ export function ResourceList({
           active
         />
 
-        {/* Summary */}
         <p className="text-xs text-muted">
           {tNearby.showing_nearby.replace('{n}', String(nearbyItems.length))}
         </p>
 
-        {/* Privacy notice */}
         <PrivacyLocationNotice text={tNearby.privacy_note} />
 
-        {/* Nearby items list */}
         <ul className="flex flex-col gap-3" role="list">
           {nearbyItems.map((item) => (
             <li key={item.id}>
@@ -276,7 +255,6 @@ export function ResourceList({
   if (items.length === 0 && !isPending) {
     return (
       <div className="flex flex-col gap-4">
-        {/* NearbyButton above filter bar */}
         <NearbyButton
           tNearby={tNearby}
           onLocate={handleNearbyLocate}
@@ -285,7 +263,6 @@ export function ResourceList({
           active={nearbyItems !== null}
         />
 
-        {/* Geo error alert */}
         {geoError && (
           <p role="alert" className="rounded-card border border-warning bg-warning-soft px-3 py-2 text-xs text-warning">
             {tNearby.geo_error}
@@ -320,7 +297,6 @@ export function ResourceList({
 
   return (
     <div className="flex flex-col gap-4">
-      {/* ── NearbyButton above filter bar ───────────────────────────────── */}
       <NearbyButton
         tNearby={tNearby}
         onLocate={handleNearbyLocate}
@@ -329,7 +305,6 @@ export function ResourceList({
         active={nearbyItems !== null}
       />
 
-      {/* ── Geo error alert ──────────────────────────────────────────────── */}
       {geoError && nearbyItems === null && (
         <p role="alert" className="rounded-card border border-warning bg-warning-soft px-3 py-2 text-xs text-warning">
           {tNearby.geo_error}
@@ -345,7 +320,6 @@ export function ResourceList({
         </p>
       )}
 
-      {/* ── Filter bar ──────────────────────────────────────────────────── */}
       <ResourceFilterBar
         byCategory={facetsByCategory}
         byCountry={facetsByCountry}
@@ -359,7 +333,6 @@ export function ResourceList({
         locale={locale}
       />
 
-      {/* ── Summary line ────────────────────────────────────────────────── */}
       <p className="text-xs text-muted">
         {isSearching
           ? tList.search_results.replace('{n}', String(total))
@@ -372,7 +345,6 @@ export function ResourceList({
         <EmptyState title={tEmpty.title} description={tEmpty.description} />
       ) : (
         <div className="flex flex-col gap-6">
-          {/* Venezuela group */}
           {venezuela.length > 0 && (
             <section aria-labelledby="group-ve-heading">
               <h3
@@ -398,7 +370,6 @@ export function ResourceList({
             </section>
           )}
 
-          {/* Diaspora group */}
           {diaspora.length > 0 && (
             <section aria-labelledby="group-diaspora-heading">
               <h3
@@ -424,7 +395,6 @@ export function ResourceList({
             </section>
           )}
 
-          {/* Other group (no country) */}
           {other.length > 0 && (
             <section aria-labelledby="group-other-heading">
               <h3
@@ -452,7 +422,6 @@ export function ResourceList({
         </div>
       )}
 
-      {/* ── Load more / errors ──────────────────────────────────────────── */}
       {loadMoreError && (
         <p role="alert" className="text-center text-sm text-danger">
           <button

--- a/apps/web/src/components/organisms/section-tabs.tsx
+++ b/apps/web/src/components/organisms/section-tabs.tsx
@@ -1,19 +1,11 @@
 'use client';
 
-/**
- * SectionTabs — reusable pill sub-navigation. Mobile-first: a horizontally
- * scrollable row of pills that wraps to multiple lines on wider screens. The
- * active tab is derived from the current path and exposed via
- * `aria-current="page"`. Shared by the coordination and administration areas
- * (each builds its own permission-gated tab list and renders this).
- */
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 export interface SectionTab {
   href: string;
   label: string;
-  /** Active-match strategy: exact path vs path prefix (default: prefix). */
   exact?: boolean;
 }
 

--- a/apps/web/src/components/organisms/shipment-detail.tsx
+++ b/apps/web/src/components/organisms/shipment-detail.tsx
@@ -106,7 +106,7 @@ export function ShipmentDetail({
 
   const [suggestions, setSuggestions] = useState<CapacityViewDto[] | null>(null);
   const [suggestionsError, setSuggestionsError] = useState<string | null>(null);
-  // ponytail: sugerencias primero, select manual tras un toggle.
+  // sugerencias primero, select manual tras un toggle.
   const [showAllManual, setShowAllManual] = useState(false);
   const [assigningId, setAssigningId] = useState<string | null>(null);
   const [, startAssign] = useTransition();

--- a/apps/web/src/components/organisms/shipments-list.tsx
+++ b/apps/web/src/components/organisms/shipments-list.tsx
@@ -1,16 +1,9 @@
 'use client';
 
-/**
- * Clickable shipments / expediciones list. Each row is a full-surface tap
- * target (≥44px, no hover-only affordances) that opens the mobile-first
- * {@link ShipmentDetail} drawer with the shipment's full detail + the lifecycle
- * actions allowed in its current status.
- *
- * Unlike the offers/needs queues, a shipment is NOT removed when acted on — its
- * lifecycle has several steps (planned → assigned → in_transit → delivered), so
- * after a successful transition we close the drawer and refresh the route (the
- * server action has already revalidated) to reflect the new status server-side.
- */
+// Unlike the offers/needs queues, a shipment is NOT removed when acted on — its
+// lifecycle has several steps (planned → assigned → in_transit → delivered), so
+// after a successful transition we close the drawer and refresh the route (the
+// server action has already revalidated) to reflect the new status server-side.
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { components } from '@reliefhub/api-client';

--- a/apps/web/src/components/organisms/signup-form.tsx
+++ b/apps/web/src/components/organisms/signup-form.tsx
@@ -31,7 +31,6 @@ export function SignupForm({ next, t }: SignupFormProps) {
           <ErrorMessage message={state.message ?? t.error_fallback} />
         )}
 
-        {/* Name */}
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="name">{t.name_label}</Label>
           <Input
@@ -44,7 +43,6 @@ export function SignupForm({ next, t }: SignupFormProps) {
           />
         </div>
 
-        {/* Email */}
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="email">{t.email_label}</Label>
           <Input
@@ -57,7 +55,6 @@ export function SignupForm({ next, t }: SignupFormProps) {
           />
         </div>
 
-        {/* Password */}
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="password">
             {t.password_label}{' '}

--- a/apps/web/src/components/organisms/site-header-band.tsx
+++ b/apps/web/src/components/organisms/site-header-band.tsx
@@ -1,10 +1,3 @@
-/**
- * SiteHeaderBand — brand navy band for the public Home + content pages. Signed-in
- * viewers get a "Mi panel" bridge into their role-aware dashboard (the nav
- * sidebar/drawer only lives inside the dashboard sections); everyone gets an
- * options menu (language + key site links) so the header is consistent with the
- * emergency header and useful on mobile.
- */
 import { getT } from '@/i18n/server';
 import { HeaderBandShell } from '@/components/molecules/header-band-shell';
 import { HeaderAccountEntry } from '@/components/molecules/header-account-entry';
@@ -12,7 +5,7 @@ import { HeaderMenu } from '@/components/molecules/header-menu';
 
 export async function SiteHeaderBand() {
   const { t } = await getT();
-  const f = t.common.footer;
+  const footer = t.common.footer;
 
   return (
     <HeaderBandShell
@@ -23,10 +16,10 @@ export async function SiteHeaderBand() {
           ariaLabel={t.common.menu_aria}
           languageLabel={t.common.language}
           links={[
-            { href: '/como-funciona', label: f.resources_how },
-            { href: '/verificar', label: f.resources_verify },
-            { href: '/sobre', label: f.resources_about },
-            { href: '/transparencia', label: f.resources_transparency },
+            { href: '/como-funciona', label: footer.resources_how },
+            { href: '/verificar', label: footer.resources_verify },
+            { href: '/sobre', label: footer.resources_about },
+            { href: '/transparencia', label: footer.resources_transparency },
           ]}
         />
       }

--- a/apps/web/src/components/organisms/task-card.tsx
+++ b/apps/web/src/components/organisms/task-card.tsx
@@ -96,9 +96,7 @@ export function TaskCard({ task, availableVolunteers, slug }: TaskCardProps) {
 
   const isTerminal = task.status === 'completed' || task.status === 'cancelled';
 
-  // Volunteers already assigned to this task (by id)
   const assignedIds = new Set(task.assignments.map((a) => a.volunteerId));
-  // Volunteers not yet assigned
   const unassignedAvailable = availableVolunteers.filter((v) => !assignedIds.has(v.id));
 
   return (
@@ -106,7 +104,6 @@ export function TaskCard({ task, availableVolunteers, slug }: TaskCardProps) {
       aria-label={tc.task_card_label.replace('{title}', task.title)}
       className="flex flex-col gap-4 rounded-lg border-2 border-navy bg-white p-5"
     >
-      {/* Header */}
       <div className="flex items-start justify-between gap-3 flex-wrap">
         <div className="flex flex-col gap-1 flex-1 min-w-0">
           <h3 className="text-base font-bold text-ink leading-tight break-words">{task.title}</h3>
@@ -117,7 +114,6 @@ export function TaskCard({ task, availableVolunteers, slug }: TaskCardProps) {
         </span>
       </div>
 
-      {/* Meta */}
       <div className="flex flex-wrap gap-3 text-xs text-muted">
         {task.requiredSkill != null && (
           <span>
@@ -133,7 +129,6 @@ export function TaskCard({ task, availableVolunteers, slug }: TaskCardProps) {
         )}
       </div>
 
-      {/* Assignments */}
       {task.assignments.length > 0 && (
         <div className="flex flex-col gap-2">
           <p className="text-xs font-semibold text-ink-soft uppercase tracking-wide">
@@ -169,13 +164,10 @@ export function TaskCard({ task, availableVolunteers, slug }: TaskCardProps) {
         </div>
       )}
 
-      {/* Error */}
       {errorMessage !== undefined && <ErrorMessage message={errorMessage} />}
 
-      {/* Actions — only for non-terminal tasks */}
       {!isTerminal && (
         <div className="flex flex-col gap-3">
-          {/* Assign volunteer */}
           {unassignedAvailable.length > 0 && (
             <form action={assignFormAction} className="flex flex-col gap-2">
               <select
@@ -206,7 +198,6 @@ export function TaskCard({ task, availableVolunteers, slug }: TaskCardProps) {
             </form>
           )}
 
-          {/* Complete / Cancel */}
           <div className="flex gap-2 flex-wrap">
             <form action={completeFormAction} className="flex-1">
               <Button
@@ -235,8 +226,6 @@ export function TaskCard({ task, availableVolunteers, slug }: TaskCardProps) {
     </article>
   );
 }
-
-// ---------- sub-component ----------
 
 interface UnassignButtonProps {
   taskId: string;

--- a/apps/web/src/components/organisms/validation-actions.tsx
+++ b/apps/web/src/components/organisms/validation-actions.tsx
@@ -7,7 +7,6 @@ import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
 import type { ActionResult } from '@/app/e/[slug]/coordinacion/actions';
 
-/** A field a coordinator can edit while validating. */
 export type EditField =
   | {
       key: string;

--- a/apps/web/src/lib/admin-scopes.ts
+++ b/apps/web/src/lib/admin-scopes.ts
@@ -1,13 +1,3 @@
-/**
- * Derives, from a principal's effective grants and the role catalog, the set of
- * scopes they can ADMINISTER and what they can do in each. Pure and
- * framework-free so it works in Server and Client Components and is unit-tested.
- *
- * This is the heart of the role-aware admin hub: instead of special-casing each
- * role, we read the permissions each grant confers and group management
- * capabilities by scope (docs/features/13 §3, §5).
- */
-
 /** Permissions that make a principal an administrator of a scope. */
 export const MANAGEMENT_PERMISSIONS = [
   'role:grant',

--- a/apps/web/src/lib/dashboard-layout.tsx
+++ b/apps/web/src/lib/dashboard-layout.tsx
@@ -1,9 +1,3 @@
-/**
- * DashboardLayout — shared server layout for authenticated/role areas. Loads the
- * nav context (cached), redirects anonymous users to /login, builds + resolves
- * the role-aware menu and renders the AppShell around the page. Section layouts
- * delegate to this; the coordinación layout passes an emergencyContext banner.
- */
 import type { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
 import { getT } from '@/i18n/server';

--- a/apps/web/src/lib/global-emergency.ts
+++ b/apps/web/src/lib/global-emergency.ts
@@ -9,10 +9,7 @@
  * @see https://globalemergency.online
  */
 export const GLOBAL_EMERGENCY = {
-  /** Umbrella organisation site. */
   site: 'https://globalemergency.online',
-  /** Shared privacy policy — "Política de privacidad". */
   privacy: 'https://globalemergency.online/privacidad',
-  /** Shared terms & conditions — "Términos y condiciones". */
   terms: 'https://globalemergency.online/terminos',
 } as const;


### PR DESCRIPTION
## Resumen

Pasada de Clean Code sobre **todo el frontend** (`apps/web`) para sentar buen precedente: código autodescriptivo en lugar de comentarios que repiten lo que ya dice el código.

Dos commits:
1. **Primitivos de layout compartidos** — quita el JSDoc verboso de `PageContainer`, `PageHeader`, `SectionTabs`, `AdminTabs`, `CoordinationTabs`, `HeaderMenu`, `SiteHeaderBand`, etc.; renombra locales poco descriptivos (`l`→`link`, `f`→`footer`).
2. **Frontend completo** — 168 ficheros (atoms, molecules, organisms, lib, y páginas de panel/administración/coordinación/públicas): elimina divisores decorativos (`{/* ── Sección ── */}`), etiquetas de sección, banners de "auth guard" y doc por-campo evidente. También quita el prefijo suelto `ponytail:` de varios comentarios.

Conserva **siempre** los comentarios que explican un *porqué* no evidente, gotchas, reglas de negocio y directivas de tooling (`eslint-disable`, `@ts-*`). Solo comentarios (+ algún rename local seguro): sin cambios de lógica, JSX, clases, imports, exports ni atajos i18n. **~177 ficheros, ~1000 líneas de comentario menos.**

Backend (`apps/api`) queda fuera a propósito: sus comentarios de dominio (DDD) suelen ser intencionados; si lo quieres, lo hago en una PR aparte.

## Validación

- [x] Pasé el gate que toca — `pnpm --filter web build` (Next + type-check) y `pnpm --filter web lint` en verde.
- [x] Verifiqué que es seguro — diff comprobado: solo se eliminan comentarios; ninguna directiva `'use client'`/`'use server'` ni línea de código eliminada.
- [x] Sin cambios de API/DTO ni docs (no aplica).

## Cierre

Sin issue asociada (mejora de calidad de código sobre #196).