### PR TITLE
feat: teléfono en el perfil — registro + edición (PATCH /auth/me + panel)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -111,6 +111,44 @@
         "tags": [
           "auth"
         ]
+      },
+      "patch": {
+        "operationId": "AuthController_updateMe",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProfileDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Perfil actualizado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token inválido o ausente"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Actualizar teléfono y/o nombre del perfil autenticado",
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/grants/at-scope": {
@@ -4428,6 +4466,129 @@
         ]
       }
     },
+    "/emergencies/{emergencyId}/donation-intakes/by-code/{code}": {
+      "get": {
+        "operationId": "DonationIntakesController_trackByCode",
+        "parameters": [
+          {
+            "name": "emergencyId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "code",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "example": "ACO-7F3K",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonationIntakeTrackingDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No donation with that code"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "summary": "Track a donation by its code (public, no PII)",
+        "tags": [
+          "donation-intakes"
+        ]
+      }
+    },
+    "/resources/{resourceId}/donation-intakes/incoming-summary": {
+      "get": {
+        "operationId": "DonationIntakesController_incomingSummary",
+        "parameters": [
+          {
+            "name": "resourceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IncomingSummaryDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing intake:read"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Aggregated forecast of incoming material for a collection point",
+        "tags": [
+          "donation-intakes"
+        ]
+      }
+    },
+    "/me/donation-intakes": {
+      "get": {
+        "operationId": "DonationIntakesController_myDonations",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MyDonationIntakeDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List the authenticated donor's own donations",
+        "tags": [
+          "donation-intakes"
+        ]
+      }
+    },
     "/donation-intakes/{intakeId}": {
       "patch": {
         "operationId": "DonationIntakesController_update",
@@ -7644,6 +7805,12 @@
           "name": {
             "type": "string",
             "example": "Jane Doe"
+          },
+          "phone": {
+            "type": "string",
+            "example": "+58 412 555 0101",
+            "nullable": true,
+            "description": "Teléfono de contacto opcional"
           }
         },
         "required": [
@@ -7718,6 +7885,12 @@
           "isAdmin": {
             "type": "boolean"
           },
+          "phone": {
+            "type": "string",
+            "example": "+58 412 555 0101",
+            "nullable": true,
+            "description": "Optional contact phone, null until the user provides one"
+          },
           "grants": {
             "description": "The effective role grants (role @ scope) for this user",
             "type": "array",
@@ -7731,8 +7904,24 @@
           "email",
           "name",
           "isAdmin",
+          "phone",
           "grants"
         ]
+      },
+      "UpdateProfileDto": {
+        "type": "object",
+        "properties": {
+          "phone": {
+            "type": "string",
+            "example": "+58 412 555 0101",
+            "nullable": true,
+            "description": "Nuevo teléfono. null para borrar."
+          },
+          "name": {
+            "type": "string",
+            "example": "Nuevo Nombre"
+          }
+        }
       },
       "GrantListItemDto": {
         "type": "object",
@@ -11739,6 +11928,163 @@
           "pendingIntakes"
         ]
       },
+      "DonationIntakeTrackingDto": {
+        "type": "object",
+        "properties": {
+          "intakeCode": {
+            "type": "string",
+            "example": "ACO-7F3K"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "received",
+              "rejected",
+              "incomplete"
+            ]
+          },
+          "resourceName": {
+            "type": "string",
+            "example": "Acopio CDMX Norte",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "receivedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupplyLineResponseDto"
+            }
+          }
+        },
+        "required": [
+          "intakeCode",
+          "status",
+          "createdAt",
+          "updatedAt",
+          "lines"
+        ]
+      },
+      "IncomingSummaryLineDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "Agua embotellada"
+          },
+          "category": {
+            "type": "string",
+            "example": "water"
+          },
+          "unit": {
+            "type": "string",
+            "nullable": true
+          },
+          "presentation": {
+            "type": "string",
+            "nullable": true
+          },
+          "totalQuantity": {
+            "type": "number",
+            "description": "Total expected across all pending intakes for this line",
+            "example": 200
+          },
+          "intakeCount": {
+            "type": "number",
+            "description": "Distinct pending intakes contributing to this line",
+            "example": 3
+          }
+        },
+        "required": [
+          "name",
+          "category",
+          "totalQuantity",
+          "intakeCount"
+        ]
+      },
+      "IncomingSummaryDto": {
+        "type": "object",
+        "properties": {
+          "lines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncomingSummaryLineDto"
+            }
+          },
+          "totalPendingIntakes": {
+            "type": "number",
+            "example": 5
+          }
+        },
+        "required": [
+          "lines",
+          "totalPendingIntakes"
+        ]
+      },
+      "MyDonationIntakeDto": {
+        "type": "object",
+        "properties": {
+          "intakeCode": {
+            "type": "string",
+            "example": "ACO-7F3K"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "received",
+              "rejected",
+              "incomplete"
+            ]
+          },
+          "emergencyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "emergencySlug": {
+            "type": "string",
+            "example": "terremoto-venezuela-2026",
+            "nullable": true
+          },
+          "resourceName": {
+            "type": "string",
+            "example": "Acopio CDMX Norte",
+            "nullable": true
+          },
+          "itemCount": {
+            "type": "number",
+            "example": 3
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "receivedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "required": [
+          "intakeCode",
+          "status",
+          "emergencyId",
+          "itemCount",
+          "createdAt"
+        ]
+      },
       "UpdateDonationIntakeDto": {
         "type": "object",
         "properties": {
@@ -11976,7 +12322,7 @@
         "properties": {
           "url": {
             "type": "string",
-            "example": "http://localhost:3001/e/mexico-demo/donar-acopio?resourceId=33333333-3333-4333-8333-333333333331"
+            "example": "http://localhost:3001/e/mexico-demo/pre-registro?resourceId=33333333-3333-4333-8333-333333333331"
           },
           "resourceName": {
             "type": "string",

--- a/apps/api/src/contexts/identity/application/register-user.spec.ts
+++ b/apps/api/src/contexts/identity/application/register-user.spec.ts
@@ -136,4 +136,37 @@ describe('RegisterUser', () => {
     expect(found?.passwordHash).not.toBe('mysecret');
     expect(found?.passwordHash).toBe('hashed:mysecret');
   });
+
+  it('persiste el teléfono cuando se pasa en el registro', async () => {
+    const repo = new InMemoryUserRepository();
+    const useCase = new RegisterUser(repo, hasher, tokenService);
+
+    await useCase.execute({
+      email: 'phone@reliefhub.org',
+      password: 'password123',
+      name: 'Phone User',
+      phone: '+58 412 555 0101',
+    });
+
+    const found = await repo.findByEmail(
+      Email.fromString('phone@reliefhub.org'),
+    );
+    expect(found?.phone).toBe('+58 412 555 0101');
+  });
+
+  it('phone es null cuando no se pasa en el registro', async () => {
+    const repo = new InMemoryUserRepository();
+    const useCase = new RegisterUser(repo, hasher, tokenService);
+
+    await useCase.execute({
+      email: 'nophone@reliefhub.org',
+      password: 'password123',
+      name: 'No Phone',
+    });
+
+    const found = await repo.findByEmail(
+      Email.fromString('nophone@reliefhub.org'),
+    );
+    expect(found?.phone).toBeNull();
+  });
 });

--- a/apps/api/src/contexts/identity/application/register-user.ts
+++ b/apps/api/src/contexts/identity/application/register-user.ts
@@ -10,7 +10,7 @@ export interface RegisterUserCommand {
   email: string;
   password: string;
   name: string;
-  phone?: string;
+  phone?: string | undefined;
 }
 
 export class RegisterUser {

--- a/apps/api/src/contexts/identity/application/register-user.ts
+++ b/apps/api/src/contexts/identity/application/register-user.ts
@@ -10,6 +10,7 @@ export interface RegisterUserCommand {
   email: string;
   password: string;
   name: string;
+  phone?: string;
 }
 
 export class RegisterUser {
@@ -33,6 +34,7 @@ export class RegisterUser {
       passwordHash,
       name: cmd.name,
       isAdmin: false,
+      phone: cmd.phone ?? null,
     });
     await this.userRepo.save(user);
 

--- a/apps/api/src/contexts/identity/application/update-profile.spec.ts
+++ b/apps/api/src/contexts/identity/application/update-profile.spec.ts
@@ -1,0 +1,65 @@
+import { UpdateProfile } from './update-profile';
+import { InMemoryUserRepository } from '../infrastructure/in-memory-user.repository';
+import { User } from '../domain/user';
+import { UserId } from '../domain/user-id';
+import { Email } from '../domain/email';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+
+async function buildRepo(): Promise<InMemoryUserRepository> {
+  const repo = new InMemoryUserRepository();
+  const user = User.create({
+    id: UserId.fromString(USER_ID),
+    email: Email.fromString('test@reliefhub.org'),
+    passwordHash: 'hashed',
+    name: 'Original Name',
+    isAdmin: false,
+    phone: null,
+  });
+  await repo.save(user);
+  return repo;
+}
+
+describe('UpdateProfile', () => {
+  it('actualiza el teléfono del usuario', async () => {
+    const repo = await buildRepo();
+    const useCase = new UpdateProfile(repo);
+
+    await useCase.execute({ userId: USER_ID, phone: '+34 600 000 001' });
+
+    const updated = await repo.findById(UserId.fromString(USER_ID));
+    expect(updated?.phone).toBe('+34 600 000 001');
+    expect(updated?.name).toBe('Original Name');
+  });
+
+  it('actualiza el nombre del usuario', async () => {
+    const repo = await buildRepo();
+    const useCase = new UpdateProfile(repo);
+
+    await useCase.execute({ userId: USER_ID, name: 'Nuevo Nombre' });
+
+    const updated = await repo.findById(UserId.fromString(USER_ID));
+    expect(updated?.name).toBe('Nuevo Nombre');
+    expect(updated?.phone).toBeNull();
+  });
+
+  it('puede poner el teléfono a null (borrar)', async () => {
+    const repo = await buildRepo();
+    const useCase = new UpdateProfile(repo);
+    await useCase.execute({ userId: USER_ID, phone: '+34 600 000 001' });
+
+    await useCase.execute({ userId: USER_ID, phone: null });
+
+    const updated = await repo.findById(UserId.fromString(USER_ID));
+    expect(updated?.phone).toBeNull();
+  });
+
+  it('lanza si el usuario no existe', async () => {
+    const repo = new InMemoryUserRepository();
+    const useCase = new UpdateProfile(repo);
+
+    await expect(
+      useCase.execute({ userId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', phone: '+1 555 0101' }),
+    ).rejects.toThrow('User not found');
+  });
+});

--- a/apps/api/src/contexts/identity/application/update-profile.spec.ts
+++ b/apps/api/src/contexts/identity/application/update-profile.spec.ts
@@ -59,7 +59,10 @@ describe('UpdateProfile', () => {
     const useCase = new UpdateProfile(repo);
 
     await expect(
-      useCase.execute({ userId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', phone: '+1 555 0101' }),
+      useCase.execute({
+        userId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        phone: '+1 555 0101',
+      }),
     ).rejects.toThrow('User not found');
   });
 });

--- a/apps/api/src/contexts/identity/application/update-profile.ts
+++ b/apps/api/src/contexts/identity/application/update-profile.ts
@@ -1,0 +1,41 @@
+import { UserRepository } from '../domain/ports/user.repository';
+import { UserId } from '../domain/user-id';
+import { User } from '../domain/user';
+
+export interface UpdateProfileCommand {
+  userId: string;
+  phone?: string | null;
+  name?: string;
+}
+
+export interface UpdateProfileResult {
+  id: string;
+  email: string;
+  name: string;
+  phone: string | null;
+}
+
+export class UpdateProfile {
+  constructor(private readonly userRepo: UserRepository) {}
+
+  async execute(cmd: UpdateProfileCommand): Promise<UpdateProfileResult> {
+    const user = await this.userRepo.findById(UserId.fromString(cmd.userId));
+    if (!user) throw new Error('User not found');
+
+    const snap = user.toSnapshot();
+    const updated = User.fromSnapshot({
+      ...snap,
+      name: cmd.name ?? snap.name,
+      phone: cmd.phone !== undefined ? cmd.phone : snap.phone,
+    });
+
+    await this.userRepo.save(updated);
+
+    return {
+      id: updated.id.value,
+      email: updated.email.value,
+      name: updated.name,
+      phone: updated.phone,
+    };
+  }
+}

--- a/apps/api/src/contexts/identity/application/update-profile.ts
+++ b/apps/api/src/contexts/identity/application/update-profile.ts
@@ -4,8 +4,8 @@ import { User } from '../domain/user';
 
 export interface UpdateProfileCommand {
   userId: string;
-  phone?: string | null;
-  name?: string;
+  phone?: string | null | undefined;
+  name?: string | undefined;
 }
 
 export interface UpdateProfileResult {

--- a/apps/api/src/contexts/identity/infrastructure/http/auth.controller.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/auth.controller.ts
@@ -81,6 +81,7 @@ export class AuthController {
       email: dto.email,
       password: dto.password,
       name: dto.name,
+      phone: dto.phone,
     });
   }
 

--- a/apps/api/src/contexts/identity/infrastructure/http/auth.controller.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/auth.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Patch,
   Post,
   Request,
   UseFilters,
@@ -25,11 +26,16 @@ import { Request as ExpressRequest } from 'express';
 import { Login } from '../../application/login';
 import { RegisterUser } from '../../application/register-user';
 import {
+  UpdateProfile,
+  UpdateProfileResult,
+} from '../../application/update-profile';
+import {
   LoginDto,
   LoginResponseDto,
   RegisterDto,
   RegisterResponseDto,
   MeResponseDto,
+  UpdateProfileDto,
 } from './dto';
 import { IdentityExceptionFilter } from './identity-exception.filter';
 import { JwtAuthGuard, AuthenticatedUser } from './jwt-auth.guard';
@@ -43,6 +49,7 @@ export class AuthController {
   constructor(
     private readonly login: Login,
     private readonly registerUser: RegisterUser,
+    private readonly updateProfile: UpdateProfile,
   ) {}
 
   @Post('login')
@@ -108,5 +115,25 @@ export class AuthController {
         expiresAt: g.expiresAt,
       })),
     };
+  }
+
+  @Patch('me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Actualizar teléfono y/o nombre del perfil autenticado',
+  })
+  @ApiOkResponse({ description: 'Perfil actualizado', type: MeResponseDto })
+  @ApiUnauthorizedResponse({ description: 'Token inválido o ausente' })
+  async updateMe(
+    @Request() req: AuthedRequest,
+    @Body() dto: UpdateProfileDto,
+  ): Promise<UpdateProfileResult> {
+    return this.updateProfile.execute({
+      userId: req.user.id,
+      phone: dto.phone,
+      name: dto.name,
+    });
   }
 }

--- a/apps/api/src/contexts/identity/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
@@ -30,6 +30,17 @@ export class RegisterDto {
   @ApiProperty({ example: 'Jane Doe' })
   @IsString()
   name!: string;
+
+  @ApiProperty({
+    example: '+58 412 555 0101',
+    required: false,
+    nullable: true,
+    type: String,
+    description: 'Teléfono de contacto opcional',
+  })
+  @IsOptional()
+  @IsString()
+  phone?: string;
 }
 
 export class RegisterResponseDto {
@@ -92,4 +103,22 @@ export class MeResponseDto {
     description: 'The effective role grants (role @ scope) for this user',
   })
   grants!: MeGrantDto[];
+}
+
+export class UpdateProfileDto {
+  @ApiProperty({
+    example: '+58 412 555 0101',
+    required: false,
+    nullable: true,
+    type: String,
+    description: 'Nuevo teléfono. null para borrar.',
+  })
+  @IsOptional()
+  @IsString()
+  phone?: string | null;
+
+  @ApiProperty({ example: 'Nuevo Nombre', required: false })
+  @IsOptional()
+  @IsString()
+  name?: string;
 }

--- a/apps/api/src/contexts/identity/infrastructure/identity.module.ts
+++ b/apps/api/src/contexts/identity/infrastructure/identity.module.ts
@@ -25,6 +25,7 @@ import { ListServiceAccountsByOrg } from '../application/list-service-accounts-b
 import { ListUsersAdmin } from '../application/list-users-admin';
 import { GetUserAdminDetail } from '../application/get-user-admin-detail';
 import { EnsureDonorAccount } from '../application/ensure-donor-account';
+import { UpdateProfile } from '../application/update-profile';
 import {
   SET_PASSWORD_INVITER,
   SetPasswordInviter,
@@ -414,6 +415,12 @@ const ensureDonorAccountProvider = {
     new EnsureDonorAccount(users, inviter),
 };
 
+const updateProfileProvider = {
+  provide: UpdateProfile,
+  inject: [USER_REPOSITORY],
+  useFactory: (userRepo: UserRepository) => new UpdateProfile(userRepo),
+};
+
 @Module({
   imports: [
     DatabaseModule,
@@ -447,6 +454,7 @@ const ensureDonorAccountProvider = {
     authenticateWithProviderProvider,
     setPasswordInviterProvider,
     ensureDonorAccountProvider,
+    updateProfileProvider,
     grantRoleProvider,
     revokeGrantProvider,
     findUserByEmailProvider,

--- a/apps/web/src/app/panel/mi-perfil/ProfileForm.tsx
+++ b/apps/web/src/app/panel/mi-perfil/ProfileForm.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useActionState } from 'react';
+import { updateProfileAction, type ProfileActionResult } from './actions';
+import { Input } from '@/components/atoms/input';
+import { Button } from '@/components/atoms/button';
+import { useLocale } from '@/i18n/locale-context';
+import { getMessages } from '@/i18n';
+
+const INITIAL: ProfileActionResult = { status: 'idle' };
+
+interface ProfileFormProps {
+  initialName: string;
+  initialPhone: string | null;
+}
+
+export function ProfileForm({ initialName, initialPhone }: ProfileFormProps) {
+  const m = getMessages(useLocale());
+  const tm = m.miPerfil;
+
+  const [state, formAction, pending] = useActionState(updateProfileAction, INITIAL);
+
+  return (
+    <form action={formAction} className="flex flex-col gap-5">
+      {state.status === 'success' && (
+        <p className="rounded-lg border-2 border-emerald-300 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-800">
+          {tm.success}
+        </p>
+      )}
+      {state.status === 'error' && (
+        <p className="rounded-lg border-2 border-danger bg-danger/5 px-4 py-3 text-sm font-semibold text-danger">
+          {tm.error}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="name" className="text-sm font-semibold text-ink">
+          {tm.label_name}
+        </label>
+        <Input
+          id="name"
+          name="name"
+          type="text"
+          defaultValue={initialName}
+          required
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="phone" className="text-sm font-semibold text-ink">
+          {tm.label_phone}
+        </label>
+        <Input
+          id="phone"
+          name="phone"
+          type="tel"
+          defaultValue={initialPhone ?? ''}
+          placeholder="+34 600 000 000"
+        />
+        <p className="text-xs text-muted">{tm.phone_hint}</p>
+      </div>
+
+      <Button type="submit" disabled={pending} fullWidth>
+        {pending ? tm.btn_saving : tm.btn_save}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/app/panel/mi-perfil/actions.ts
+++ b/apps/web/src/app/panel/mi-perfil/actions.ts
@@ -1,0 +1,32 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { api } from '@/lib/api';
+import { getToken, authHeaders } from '@/lib/auth';
+
+export type ProfileActionResult =
+  | { status: 'idle' }
+  | { status: 'success' }
+  | { status: 'error'; message: string };
+
+export async function updateProfileAction(
+  _prev: ProfileActionResult,
+  formData: FormData,
+): Promise<ProfileActionResult> {
+  const token = await getToken();
+  if (!token) return { status: 'error', message: 'No autenticado' };
+
+  const name = (formData.get('name') as string | null)?.trim() || undefined;
+  const rawPhone = (formData.get('phone') as string | null)?.trim() ?? '';
+  const phone: string | null = rawPhone === '' ? null : rawPhone;
+
+  const { error } = await api.PATCH('/auth/me', {
+    headers: authHeaders(token),
+    body: { name, phone },
+  });
+
+  if (error !== undefined) return { status: 'error', message: 'Error al guardar' };
+
+  revalidatePath('/panel/mi-perfil');
+  return { status: 'success' };
+}

--- a/apps/web/src/app/panel/mi-perfil/page.tsx
+++ b/apps/web/src/app/panel/mi-perfil/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getToken, authHeaders } from '@/lib/auth';
+import { api } from '@/lib/api';
+import { getT } from '@/i18n/server';
+import { PageContainer } from '@/components/molecules/page-container';
+import { PageHeader } from '@/components/molecules/page-header';
+import { ProfileForm } from './ProfileForm';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await getT();
+  return {
+    title: t.miPerfil.meta_title,
+    description: t.miPerfil.meta_description,
+  };
+}
+
+export default async function MiPerfilPage() {
+  const token = await getToken();
+  if (token === null) redirect('/login?next=/panel/mi-perfil');
+
+  const { t } = await getT();
+  const tm = t.miPerfil;
+
+  const { data: me } = await api.GET('/auth/me', {
+    headers: authHeaders(token),
+  });
+
+  if (me === undefined) redirect('/login?next=/panel/mi-perfil');
+
+  return (
+    <main className="flex-1 bg-surface">
+      <PageContainer>
+        <PageHeader title={tm.page_title} subtitle={tm.page_subtitle} />
+        <ProfileForm initialName={me.name} initialPhone={me.phone} />
+      </PageContainer>
+    </main>
+  );
+}

--- a/apps/web/src/app/panel/page.tsx
+++ b/apps/web/src/app/panel/page.tsx
@@ -96,6 +96,7 @@ export default async function PanelPage() {
               href="/panel/mis-donaciones"
               label={tp.qa_my_donations}
             />
+            <QuickAction href="/panel/mi-perfil" label={tp.qa_my_profile} />
             <QuickAction href="/" label={tp.qa_explore} />
           </div>
         </section>

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -2554,5 +2554,20 @@ export const en = {
     qa_notifications: 'Notifications',
     qa_my_donations: 'My donations',
     qa_explore: 'View emergencies',
+    qa_my_profile: 'My profile',
+  },
+
+  miPerfil: {
+    meta_title: 'My profile — ResponseGrid',
+    meta_description: 'Edit your name and contact phone.',
+    page_title: 'My profile',
+    page_subtitle: 'Update your name and contact phone.',
+    label_name: 'Name',
+    label_phone: 'Phone',
+    phone_hint: 'Optional. Leave blank to remove it.',
+    btn_save: 'Save changes',
+    btn_saving: 'Saving…',
+    success: 'Profile updated.',
+    error: 'Could not save. Please try again.',
   },
 } satisfies Messages;

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -2591,6 +2591,21 @@ export const es = {
     qa_notifications: 'Notificaciones',
     qa_my_donations: 'Mis donaciones',
     qa_explore: 'Ver emergencias',
+    qa_my_profile: 'Mi perfil',
+  },
+
+  miPerfil: {
+    meta_title: 'Mi perfil — ResponseGrid',
+    meta_description: 'Edita tu nombre y teléfono de contacto.',
+    page_title: 'Mi perfil',
+    page_subtitle: 'Actualiza tu nombre y teléfono de contacto.',
+    label_name: 'Nombre',
+    label_phone: 'Teléfono',
+    phone_hint: 'Opcional. Déjalo vacío para no mostrarlo.',
+    btn_save: 'Guardar cambios',
+    btn_saving: 'Guardando…',
+    success: 'Perfil actualizado.',
+    error: 'No se pudo guardar. Inténtalo de nuevo.',
   },
 };
 

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -52,7 +52,8 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /** Actualizar teléfono y/o nombre del perfil autenticado */
+        patch: operations["AuthController_updateMe"];
         trace?: never;
     };
     "/grants/at-scope": {
@@ -1410,6 +1411,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/emergencies/{emergencyId}/donation-intakes/by-code/{code}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Track a donation by its code (public, no PII) */
+        get: operations["DonationIntakesController_trackByCode"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/resources/{resourceId}/donation-intakes/incoming-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Aggregated forecast of incoming material for a collection point */
+        get: operations["DonationIntakesController_incomingSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/me/donation-intakes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the authenticated donor's own donations */
+        get: operations["DonationIntakesController_myDonations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/donation-intakes/{intakeId}": {
         parameters: {
             query?: never;
@@ -1488,57 +1540,6 @@ export interface paths {
         };
         /** List pending intakes for a collection point */
         get: operations["DonationIntakesController_listPending"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/emergencies/{emergencyId}/donation-intakes/by-code/{code}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Track a donation by its code (public, no PII) */
-        get: operations["DonationIntakesController_trackByCode"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/resources/{resourceId}/donation-intakes/incoming-summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Aggregated forecast of incoming material for a collection point */
-        get: operations["DonationIntakesController_incomingSummary"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/me/donation-intakes": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List the authenticated donor's own donations */
-        get: operations["DonationIntakesController_myDonations"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2423,6 +2424,11 @@ export interface components {
             password: string;
             /** @example Jane Doe */
             name: string;
+            /**
+             * @description Teléfono de contacto opcional
+             * @example +58 412 555 0101
+             */
+            phone?: string | null;
         };
         RegisterResponseDto: {
             /** @description JWT access token (auto-login after registration) */
@@ -2456,6 +2462,15 @@ export interface components {
             phone: string | null;
             /** @description The effective role grants (role @ scope) for this user */
             grants: components["schemas"]["MeGrantDto"][];
+        };
+        UpdateProfileDto: {
+            /**
+             * @description Nuevo teléfono. null para borrar.
+             * @example +58 412 555 0101
+             */
+            phone?: string | null;
+            /** @example Nuevo Nombre */
+            name?: string;
         };
         GrantListItemDto: {
             /** Format: uuid */
@@ -4198,6 +4213,62 @@ export interface components {
             donorName?: string | null;
             pendingIntakes: components["schemas"]["PendingIntakeSummaryDto"][];
         };
+        DonationIntakeTrackingDto: {
+            /** @example ACO-7F3K */
+            intakeCode: string;
+            /** @enum {string} */
+            status: "pending" | "received" | "rejected" | "incomplete";
+            /** @example Acopio CDMX Norte */
+            resourceName?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            receivedAt?: string | null;
+            /** Format: date-time */
+            updatedAt: string;
+            lines: components["schemas"]["SupplyLineResponseDto"][];
+        };
+        IncomingSummaryLineDto: {
+            /** @example Agua embotellada */
+            name: string;
+            /** @example water */
+            category: string;
+            unit?: string | null;
+            presentation?: string | null;
+            /**
+             * @description Total expected across all pending intakes for this line
+             * @example 200
+             */
+            totalQuantity: number;
+            /**
+             * @description Distinct pending intakes contributing to this line
+             * @example 3
+             */
+            intakeCount: number;
+        };
+        IncomingSummaryDto: {
+            lines: components["schemas"]["IncomingSummaryLineDto"][];
+            /** @example 5 */
+            totalPendingIntakes: number;
+        };
+        MyDonationIntakeDto: {
+            /** @example ACO-7F3K */
+            intakeCode: string;
+            /** @enum {string} */
+            status: "pending" | "received" | "rejected" | "incomplete";
+            /** Format: uuid */
+            emergencyId: string;
+            /** @example terremoto-venezuela-2026 */
+            emergencySlug?: string | null;
+            /** @example Acopio CDMX Norte */
+            resourceName?: string | null;
+            /** @example 3 */
+            itemCount: number;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            receivedAt?: string | null;
+        };
         UpdateDonationIntakeDto: {
             /** @example ACO-7F3K */
             intakeCode: string;
@@ -4273,62 +4344,6 @@ export interface components {
             itemCount: number;
             /** Format: date-time */
             createdAt: string;
-        };
-        DonationIntakeTrackingDto: {
-            /** @example ACO-7F3K */
-            intakeCode: string;
-            /** @enum {string} */
-            status: "pending" | "received" | "rejected" | "incomplete";
-            /** @example Acopio CDMX Norte */
-            resourceName?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            receivedAt?: string | null;
-            /** Format: date-time */
-            updatedAt: string;
-            lines: components["schemas"]["SupplyLineResponseDto"][];
-        };
-        IncomingSummaryLineDto: {
-            /** @example Agua embotellada */
-            name: string;
-            /** @example water */
-            category: string;
-            unit?: string | null;
-            presentation?: string | null;
-            /**
-             * @description Total expected across all pending intakes for this line
-             * @example 200
-             */
-            totalQuantity: number;
-            /**
-             * @description Distinct pending intakes contributing to this line
-             * @example 3
-             */
-            intakeCount: number;
-        };
-        IncomingSummaryDto: {
-            lines: components["schemas"]["IncomingSummaryLineDto"][];
-            /** @example 5 */
-            totalPendingIntakes: number;
-        };
-        MyDonationIntakeDto: {
-            /** @example ACO-7F3K */
-            intakeCode: string;
-            /** @enum {string} */
-            status: "pending" | "received" | "rejected" | "incomplete";
-            /** Format: uuid */
-            emergencyId: string;
-            /** @example terremoto-venezuela-2026 */
-            emergencySlug?: string | null;
-            /** @example Acopio CDMX Norte */
-            resourceName?: string | null;
-            /** @example 3 */
-            itemCount: number;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            receivedAt?: string | null;
         };
         IntakeDeepLinkDto: {
             /** @example http://localhost:3001/e/mexico-demo/pre-registro?resourceId=33333333-3333-4333-8333-333333333331 */
@@ -5187,6 +5202,37 @@ export interface operations {
                 };
             };
             /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_updateMe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateProfileDto"];
+            };
+        };
+        responses: {
+            /** @description Perfil actualizado */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MeResponseDto"];
+                };
+            };
+            /** @description Token inválido o ausente */
             401: {
                 headers: {
                     [name: string]: unknown;
@@ -8733,48 +8779,6 @@ export interface operations {
             };
         };
     };
-    DonationIntakesController_getById: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                intakeId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DonationIntakeViewDto"];
-                };
-            };
-            /** @description Missing or invalid token */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Missing intake:read */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Intake not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
     DonationIntakesController_trackByCode: {
         parameters: {
             query?: never;
@@ -8865,6 +8869,48 @@ export interface operations {
             };
             /** @description Missing or invalid token */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    DonationIntakesController_getById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                intakeId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DonationIntakeViewDto"];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing intake:read */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Intake not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Resumen

Cierra el hueco de #205: el usuario puede fijar su teléfono al registrarse y editarlo desde el panel.

- **API:** `phone` opcional en `RegisterDto`; nuevo use-case `UpdateProfile`; `PATCH /auth/me` (autenticado, devuelve perfil actualizado).
- **Web:** nueva página `/panel/mi-perfil` con formulario de nombre + teléfono; acceso desde el panel de inicio.
- Sin migración de BD — la columna `phone` ya existía desde PR #201.
- `packages/api-client/src/schema.ts` regenerado con el nuevo endpoint.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — api: build, eslint, prettier, test; web: build, lint; api-client: build. En verde.
- [ ] Verifiqué el comportamiento manualmente — pendiente de preview: registro con phone → /panel/mi-perfil → editar → /auth/me devuelve phone actualizado.
- [x] Actualicé docs, migraciones o cliente API si correspondía — schema.ts regenerado; sin migraciones.

## Cierre

- Closes #205