### PR TITLE
fix(web): bugs del panel de responsables de punto

### DIFF
--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/actions.ts
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/actions.ts
@@ -102,6 +102,11 @@ export async function grantResourceRoleAction(
     };
   }
 
+  // El <input type="date"> da "YYYY-MM-DD"; lo interpretamos como fin de ese día
+  // (UTC) para que una caducidad de hoy no nazca ya vencida en el backend.
+  const expiresInput = String(formData.get("expiresAt") ?? "").trim();
+  const expiresAt = expiresInput ? `${expiresInput}T23:59:59.999Z` : undefined;
+
   const { error, response } = await api.POST("/grants", {
     body: {
       principalId,
@@ -109,6 +114,7 @@ export async function grantResourceRoleAction(
       scopeType: RESOURCE_SCOPE_TYPE,
       scopeId: resourceId,
       scopeEntityType: RESOURCE_SCOPE_ENTITY_TYPE,
+      ...(expiresAt ? { expiresAt } : {}),
     },
     headers: authHeaders(token),
   });

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
@@ -67,8 +67,8 @@ export default async function RecipientResourcePage({ params }: Props) {
   const td = t.resource_detail;
   const recipientNeeds = needs ?? [];
   const inventoryCategories = resource.inventoryCategories ?? [];
-  const canManagePoint = access?.canCoordinate ?? false;
-  const resourceGrants = canManagePoint
+  const canCoordinate = access?.canCoordinate ?? false;
+  const resourceGrants = canCoordinate
     ? await fetchResourceGrants(resourceId)
     : [];
 
@@ -120,7 +120,7 @@ export default async function RecipientResourcePage({ params }: Props) {
             {t.resource_card.report_cta}
           </Link>
 
-          {canManagePoint && (
+          {canCoordinate && (
             <ResourceGrantsPanel
               slug={slug}
               resourceId={resourceId}

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/resource-grants-panel.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/resource-grants-panel.tsx
@@ -15,6 +15,16 @@ import {
 
 const INITIAL: ActionResult = { status: "idle" };
 
+// Etiquetas de los roles concedibles en un punto. Al añadir roles (voluntarios
+// de entrega/recogida, #208) basta extender este mapa.
+const ROLE_LABELS: Record<string, string> = {
+  point_manager: "Responsable de punto",
+};
+
+function roleLabel(roleId: string): string {
+  return ROLE_LABELS[roleId] ?? roleId;
+}
+
 function formatGrantedAt(locale: string, value: string): string {
   const date = new Date(value);
   return Number.isNaN(date.getTime())
@@ -50,7 +60,7 @@ function ResourceGrantRow({
         <div className="flex flex-col gap-1">
           <p className="font-semibold text-ink">{principalLabel}</p>
           <p className="text-sm text-muted-soft">
-            Responsable de punto · concedido el{" "}
+            {roleLabel(grant.roleId)} · concedido el{" "}
             {formatGrantedAt(locale, grant.grantedAt)}
           </p>
         </div>


### PR DESCRIPTION
@
Arregla los tres bugs detectados en la review de #190 (rol de responsable de punto). Todos en la web, sin cambios de API.

## Cambios
- **#209** — `grantResourceRoleAction` ahora envía `expiresAt` al `POST /grants`. El campo "Caduca (opcional)" se recogía pero se descartaba en silencio. La fecha (`YYYY-MM-DD`) se interpreta como fin de ese día (UTC) para que una caducidad de hoy no nazca ya vencida.
- **#210** — la fila del panel muestra el rol real vía `grant.roleId` (mapa `ROLE_LABELS`, extensible para #208) en vez del texto fijo "Responsable de punto".
- **#212** — `canManagePoint` → `canCoordinate`: el gate es coordinación de la emergencia, no un permiso de punto.

## Validación
- [x] `pnpm --filter @reliefhub/api-client build`
- [x] `pnpm --filter web lint` (solo warning preexistente en `apple-icon.tsx`)
- [x] `pnpm --filter web build`

Closes #209
Closes #210
Closes #212
@