### PR TITLE
feat(supplies): dominio Supply master-data y resolver de sinónimos

### DIFF
--- a/apps/api/src/contexts/supplies/domain/supply-alias.ts
+++ b/apps/api/src/contexts/supplies/domain/supply-alias.ts
@@ -1,0 +1,52 @@
+export interface SupplyAliasProps {
+  alias: string;
+  supplyId: string;
+}
+
+export interface SupplyAliasSnapshot {
+  alias: string;
+  supplyId: string;
+}
+
+export class SupplyAliasValidationError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'SupplyAliasValidationError';
+  }
+}
+
+function normalizeRequiredText(value: string, field: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new SupplyAliasValidationError(`${field} must not be empty`);
+  }
+  return normalized;
+}
+
+export class SupplyAlias {
+  readonly alias: string;
+  readonly supplyId: string;
+
+  private constructor(props: SupplyAliasProps) {
+    this.alias = props.alias;
+    this.supplyId = props.supplyId;
+  }
+
+  static create(props: SupplyAliasProps): SupplyAlias {
+    return new SupplyAlias({
+      alias: normalizeRequiredText(props.alias, 'Supply alias'),
+      supplyId: normalizeRequiredText(props.supplyId, 'Supply alias supplyId'),
+    });
+  }
+
+  static fromSnapshot(s: SupplyAliasSnapshot): SupplyAlias {
+    return new SupplyAlias(s);
+  }
+
+  toSnapshot(): SupplyAliasSnapshot {
+    return {
+      alias: this.alias,
+      supplyId: this.supplyId,
+    };
+  }
+}

--- a/apps/api/src/contexts/supplies/domain/supply-resolver.test.ts
+++ b/apps/api/src/contexts/supplies/domain/supply-resolver.test.ts
@@ -1,0 +1,88 @@
+import { Category } from './category';
+import { Supply } from './supply';
+import { SupplyAlias } from './supply-alias';
+import { SupplyResolver } from './supply-resolver';
+
+describe('SupplyResolver', () => {
+  const water = Supply.create({
+    id: '11111111-1111-4111-8111-111111111111',
+    code: 'INS-0001',
+    name: 'Agua potable',
+    category: Category.Water,
+    defaultUnit: 'litros',
+  });
+  const diapers = Supply.create({
+    id: '22222222-2222-4222-8222-222222222222',
+    code: 'INS-0002',
+    name: 'Panal',
+    category: Category.Other,
+    defaultUnit: 'unidad',
+  });
+
+  it('resuelve por nombre canonico', () => {
+    const resolver = new SupplyResolver([water, diapers]);
+
+    expect(resolver.resolve('  AGUA POTABLE  ')).toBe(water.id);
+  });
+
+  it('resuelve por alias normalizado', () => {
+    const resolver = new SupplyResolver(
+      [water],
+      [
+        SupplyAlias.create({
+          alias: '  Agua embotellada ',
+          supplyId: water.id,
+        }),
+      ],
+    );
+
+    expect(resolver.resolve('agua embotellada')).toBe(water.id);
+  });
+
+  it('resuelve el codigo canonico tambien', () => {
+    const resolver = new SupplyResolver([water]);
+
+    expect(resolver.resolve('ins-0001')).toBe(water.id);
+  });
+
+  it('devuelve null para un termino desconocido', () => {
+    const resolver = new SupplyResolver([water]);
+
+    expect(resolver.resolve('arbol raro')).toBeNull();
+  });
+
+  it('devuelve null cuando una etiqueta es ambigua', () => {
+    const resolver = new SupplyResolver(
+      [water, diapers],
+      [
+        SupplyAlias.create({
+          alias: 'insumo generico',
+          supplyId: water.id,
+        }),
+        SupplyAlias.create({
+          alias: 'insumo generico',
+          supplyId: diapers.id,
+        }),
+      ],
+    );
+
+    expect(resolver.resolve('insumo generico')).toBeNull();
+  });
+
+  it('resolveMany deduplica resultados', () => {
+    const resolver = new SupplyResolver(
+      [water, diapers],
+      [
+        SupplyAlias.create({
+          alias: 'agua',
+          supplyId: water.id,
+        }),
+      ],
+    );
+
+    expect(resolver.resolveMany(['Agua', 'agua', 'Panal', 'xyz'])).toEqual([
+      water.id,
+      diapers.id,
+    ]);
+  });
+});

--- a/apps/api/src/contexts/supplies/domain/supply-resolver.ts
+++ b/apps/api/src/contexts/supplies/domain/supply-resolver.ts
@@ -1,0 +1,53 @@
+import { Supply } from './supply';
+import { SupplyAlias } from './supply-alias';
+
+export class SupplyResolver {
+  private readonly index = new Map<string, string | null>();
+
+  constructor(
+    supplies: readonly Supply[],
+    aliases: readonly SupplyAlias[] = [],
+  ) {
+    for (const supply of supplies) {
+      this.addLabel(supply.name, supply.id);
+      this.addLabel(supply.code, supply.id);
+    }
+
+    for (const alias of aliases) {
+      this.addLabel(alias.alias, alias.supplyId);
+    }
+  }
+
+  private normalize(s: string): string {
+    return s
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .trim()
+      .replace(/\s+/g, ' ');
+  }
+
+  private addLabel(label: string, supplyId: string): void {
+    const key = this.normalize(label);
+    const current = this.index.get(key);
+    if (current === undefined) {
+      this.index.set(key, supplyId);
+      return;
+    }
+    if (current !== supplyId) {
+      this.index.set(key, null);
+    }
+  }
+
+  resolve(label: string): string | null {
+    const resolved = this.index.get(this.normalize(label));
+    return resolved ?? null;
+  }
+
+  resolveMany(labels: string[]): string[] {
+    const resolved = labels
+      .map((label) => this.resolve(label))
+      .filter((s): s is string => s !== null);
+    return [...new Set(resolved)];
+  }
+}

--- a/apps/api/src/contexts/supplies/domain/supply.test.ts
+++ b/apps/api/src/contexts/supplies/domain/supply.test.ts
@@ -1,0 +1,81 @@
+import { Category } from './category';
+import { Supply, SupplyValidationError } from './supply';
+
+describe('Supply', () => {
+  it('crea un supply valido y recorta los textos', () => {
+    const supply = Supply.create({
+      id: ' 11111111-1111-4111-8111-111111111111 ',
+      code: ' INS-0001 ',
+      name: '  Agua potable  ',
+      category: Category.Water,
+      defaultUnit: ' litros ',
+      attributes: { presentation: 'botella' },
+    });
+
+    expect(supply.id).toBe('11111111-1111-4111-8111-111111111111');
+    expect(supply.code).toBe('INS-0001');
+    expect(supply.name).toBe('Agua potable');
+    expect(supply.defaultUnit).toBe('litros');
+    expect(supply.attributes).toEqual({ presentation: 'botella' });
+  });
+
+  it.each(['INS-1', 'ins-0001', '0001'])(
+    'rechaza codigos invalidos (%p)',
+    (code) => {
+      expect(() =>
+        Supply.create({
+          id: '11111111-1111-4111-8111-111111111111',
+          code,
+          name: 'Arroz',
+          category: Category.Food,
+          defaultUnit: 'kg',
+        }),
+      ).toThrow(SupplyValidationError);
+    },
+  );
+
+  it('rechaza el nombre vacio', () => {
+    expect(() =>
+      Supply.create({
+        id: '11111111-1111-4111-8111-111111111111',
+        code: 'INS-0002',
+        name: '   ',
+        category: Category.Food,
+        defaultUnit: 'kg',
+      }),
+    ).toThrow(SupplyValidationError);
+  });
+
+  it('acepta variantes y preserva el parent id', () => {
+    const supply = Supply.create({
+      id: '11111111-1111-4111-8111-111111111111',
+      code: 'INS-0003',
+      name: 'Panal talla M',
+      category: Category.Other,
+      defaultUnit: 'unidad',
+      variantOfId: '22222222-2222-4222-8222-222222222222',
+      attributes: { size: 'M' },
+    });
+
+    expect(supply.variantOfId).toBe('22222222-2222-4222-8222-222222222222');
+  });
+
+  it('round-trips through snapshot sin perder datos', () => {
+    const supply = Supply.create({
+      id: '11111111-1111-4111-8111-111111111111',
+      code: 'INS-0004',
+      name: 'Manta',
+      category: Category.Shelter,
+      defaultUnit: 'unidad',
+      attributes: {
+        color: 'gris',
+        packaging: { type: 'folded' },
+      },
+      variantOfId: null,
+    });
+
+    const restored = Supply.fromSnapshot(supply.toSnapshot());
+
+    expect(restored.toSnapshot()).toEqual(supply.toSnapshot());
+  });
+});

--- a/apps/api/src/contexts/supplies/domain/supply.ts
+++ b/apps/api/src/contexts/supplies/domain/supply.ts
@@ -1,0 +1,123 @@
+import { Category } from './category';
+
+export interface SupplyProps {
+  id: string;
+  code: string;
+  name: string;
+  category: Category;
+  defaultUnit: string | null;
+  attributes?: Record<string, unknown> | null;
+  variantOfId?: string | null;
+}
+
+export interface SupplySnapshot {
+  id: string;
+  code: string;
+  name: string;
+  category: Category;
+  defaultUnit: string | null;
+  attributes: Record<string, unknown>;
+  variantOfId: string | null;
+}
+
+export class SupplyValidationError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'SupplyValidationError';
+  }
+}
+
+function normalizeRequiredText(value: string, field: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new SupplyValidationError(`${field} must not be empty`);
+  }
+  return normalized;
+}
+
+function normalizeOptionalText(
+  value: string | null | undefined,
+  field: string,
+): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new SupplyValidationError(`${field} must not be empty`);
+  }
+  return normalized;
+}
+
+export class Supply {
+  readonly id: string;
+  readonly code: string;
+  readonly name: string;
+  readonly category: Category;
+  readonly defaultUnit: string | null;
+  readonly attributes: Record<string, unknown>;
+  readonly variantOfId: string | null;
+
+  private constructor(props: SupplyProps) {
+    this.id = props.id;
+    this.code = props.code;
+    this.name = props.name;
+    this.category = props.category;
+    this.defaultUnit = props.defaultUnit;
+    this.attributes = { ...(props.attributes ?? {}) };
+    this.variantOfId = props.variantOfId ?? null;
+  }
+
+  static create(props: SupplyProps): Supply {
+    const id = normalizeRequiredText(props.id, 'Supply id');
+    const code = normalizeRequiredText(props.code, 'Supply code');
+    if (!/^INS-\d{4}$/.test(code)) {
+      throw new SupplyValidationError(
+        'Supply code must match the INS-NNNN format',
+      );
+    }
+    const name = normalizeRequiredText(props.name, 'Supply name');
+    const defaultUnit = normalizeOptionalText(
+      props.defaultUnit,
+      'Supply default unit',
+    );
+    const variantOfId = normalizeOptionalText(
+      props.variantOfId,
+      'Supply variantOfId',
+    );
+
+    return new Supply({
+      id,
+      code,
+      name,
+      category: props.category,
+      defaultUnit,
+      attributes: props.attributes ?? {},
+      variantOfId,
+    });
+  }
+
+  static fromSnapshot(s: SupplySnapshot): Supply {
+    return new Supply({
+      id: s.id,
+      code: s.code,
+      name: s.name,
+      category: s.category,
+      defaultUnit: s.defaultUnit,
+      attributes: s.attributes,
+      variantOfId: s.variantOfId,
+    });
+  }
+
+  toSnapshot(): SupplySnapshot {
+    return {
+      id: this.id,
+      code: this.code,
+      name: this.name,
+      category: this.category,
+      defaultUnit: this.defaultUnit,
+      attributes: { ...this.attributes },
+      variantOfId: this.variantOfId,
+    };
+  }
+}


### PR DESCRIPTION
## Resumen
- Añade el dominio `Supply` con código `INS-NNNN`, atributos y variantes.
- Añade `SupplyAlias` y `SupplyResolver` con normalización y detección de ambigüedad.
- Incluye tests de contrato para ambos.

Closes #216
Closes #217

Parte de #228.
