### PR TITLE
feat(supplies): caducidad por línea de insumo (expiresAt)

### DIFF
--- a/apps/api/drizzle/0036_supply_line_expires_at.sql
+++ b/apps/api/drizzle/0036_supply_line_expires_at.sql
@@ -1,0 +1,14 @@
+-- Optional freshness date per supply line, shared by inventory / needs /
+-- donation intakes. Legacy-safe: nullable and backfilled as-is.
+
+ALTER TABLE "resource_items"
+  ADD COLUMN IF NOT EXISTS "expires_at" timestamp with time zone;
+
+ALTER TABLE "need_items"
+  ADD COLUMN IF NOT EXISTS "expires_at" timestamp with time zone;
+
+ALTER TABLE "donation_intake_lines"
+  ADD COLUMN IF NOT EXISTS "expires_at" timestamp with time zone;
+
+ALTER TABLE "offer_items"
+  ADD COLUMN IF NOT EXISTS "expires_at" timestamp with time zone;

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -8616,6 +8616,12 @@
             "type": "string",
             "example": "ampolla",
             "description": "Presentation / route of administration: ampolla, EV (intravenoso), inhalador, pastilla, jarabe… Optional, free-form (#61)."
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date",
+            "example": "2026-07-01",
+            "description": "Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD)."
           }
         },
         "required": [
@@ -10554,6 +10560,13 @@
             "example": "ampolla",
             "nullable": true,
             "description": "Presentation / route of administration (ampolla, EV, inhalador…) — #61."
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date",
+            "nullable": true,
+            "example": "2026-07-01",
+            "description": "Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD)."
           }
         },
         "required": [

--- a/apps/api/src/contexts/needs/application/create-need.ts
+++ b/apps/api/src/contexts/needs/application/create-need.ts
@@ -19,6 +19,7 @@ export interface CreateNeedItemCommand {
   category: Category;
   /** Presentation / route of administration (#61). Optional. */
   presentation?: string | null;
+  expiresAt?: string | null;
 }
 
 export interface CreateNeedLocationCommand {
@@ -73,6 +74,7 @@ export class CreateNeed {
         unit: i.unit,
         category: i.category,
         presentation: i.presentation ?? null,
+        expiresAt: i.expiresAt ?? null,
       }),
     );
 

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.int-spec.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need.repository.int-spec.ts
@@ -162,12 +162,14 @@ describe('DrizzleNeedRepository (integration)', () => {
           unit: 'amp',
           category: Category.Medicines,
           presentation: 'EV/ampolla',
+          expiresAt: '2026-07-01',
         }),
       ],
     });
     await repo.save(need);
     const found = await repo.findById(need.id);
     expect(found!.items[0].presentation).toBe('EV/ampolla');
+    expect(found!.items[0].expiresAt).toBe('2026-07-01');
   });
 
   it('round-trips need with multiple items', async () => {

--- a/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
@@ -128,6 +128,7 @@ export class NeedsController {
         unit: i.unit ?? null,
         category: i.category,
         presentation: i.presentation ?? null,
+        expiresAt: i.expiresAt ?? null,
       })),
       requiredSkill: dto.requiredSkill ?? null,
       skillSpecialty: dto.skillSpecialty ?? null,

--- a/apps/api/src/contexts/offers/application/get-donation-intake-by-id.ts
+++ b/apps/api/src/contexts/offers/application/get-donation-intake-by-id.ts
@@ -11,6 +11,7 @@ export interface DonationIntakeLineView {
   unit: string | null;
   category: Category;
   presentation: string | null;
+  expiresAt: string | null;
 }
 
 export interface DonationIntakeView {
@@ -60,6 +61,7 @@ export class GetDonationIntakeById {
         unit: line.unit,
         category: line.category,
         presentation: line.presentation ?? null,
+        expiresAt: line.expiresAt ?? null,
       })),
       volunteerNotes: snap.volunteerNotes,
       evidenceFileKey: snap.evidenceFileKey,

--- a/apps/api/src/contexts/offers/domain/intake-line.ts
+++ b/apps/api/src/contexts/offers/domain/intake-line.ts
@@ -42,6 +42,7 @@ export class IntakeLine {
         unit: s.unit,
         category: s.category,
         presentation: s.presentation ?? null,
+        expiresAt: s.expiresAt ?? null,
       }),
     );
   }

--- a/apps/api/src/contexts/offers/infrastructure/drizzle/drizzle-donation-intake.repository.int-spec.ts
+++ b/apps/api/src/contexts/offers/infrastructure/drizzle/drizzle-donation-intake.repository.int-spec.ts
@@ -38,6 +38,7 @@ function makeIntake(code: string) {
           quantity: 4,
           unit: 'sacos',
           presentation: null,
+          expiresAt: '2026-07-01',
         },
       },
     ],
@@ -73,6 +74,7 @@ describe('DrizzleDonationIntakeRepository (integration)', () => {
     expect(found.intakeCode).toBe('ACO-TEST');
     expect(found.lines).toHaveLength(1);
     expect(found.lines[0]?.supplyLine.name).toBe('Harina');
+    expect(found.lines[0]?.supplyLine.expiresAt).toBe('2026-07-01');
   });
 
   it('updates lines on save (replace)', async () => {
@@ -93,6 +95,7 @@ describe('DrizzleDonationIntakeRepository (integration)', () => {
             quantity: 2,
             unit: null,
             presentation: null,
+            expiresAt: '2026-07-02',
           },
         },
         {
@@ -103,6 +106,7 @@ describe('DrizzleDonationIntakeRepository (integration)', () => {
             quantity: 1,
             unit: null,
             presentation: null,
+            expiresAt: null,
           },
         },
       ],
@@ -114,6 +118,7 @@ describe('DrizzleDonationIntakeRepository (integration)', () => {
     if (!found) return;
     expect(found.donorEmail).toBe('pedro@test.com');
     expect(found.lines).toHaveLength(2);
+    expect(found.lines[0]?.supplyLine.expiresAt).toBe('2026-07-02');
   });
 
   it('searches by phone partial and exact code', async () => {

--- a/apps/api/src/contexts/offers/infrastructure/http/donation-intakes.controller.ts
+++ b/apps/api/src/contexts/offers/infrastructure/http/donation-intakes.controller.ts
@@ -81,6 +81,7 @@ function mapItems(items: CreateDonationIntakeDto['items']): SupplyLineProps[] {
     unit: item.unit ?? null,
     category: item.category,
     presentation: item.presentation ?? null,
+    expiresAt: item.expiresAt ?? null,
   }));
 }
 

--- a/apps/api/src/contexts/resources/application/register-resource.ts
+++ b/apps/api/src/contexts/resources/application/register-resource.ts
@@ -39,6 +39,7 @@ export interface RegisterResourceCommand {
     unit?: string | null;
     category: Category;
     presentation?: string | null;
+    expiresAt?: string | null;
   }>;
 }
 
@@ -84,6 +85,7 @@ export class RegisterResource {
           unit: i.unit ?? null,
           category: i.category,
           presentation: i.presentation ?? null,
+          expiresAt: i.expiresAt ?? null,
         }),
       ),
     });

--- a/apps/api/src/contexts/resources/domain/resource.spec.ts
+++ b/apps/api/src/contexts/resources/domain/resource.spec.ts
@@ -78,6 +78,7 @@ describe('Resource', () => {
       unit: 'litros',
       category: Category.Water,
       presentation: null,
+      expiresAt: null,
     });
   });
 

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
@@ -81,6 +81,7 @@ describe('DrizzleResourceRepository (integration)', () => {
           quantity: 200,
           unit: 'litros',
           category: Category.Water,
+          expiresAt: '2026-07-01',
         }),
         SupplyLine.create({
           name: 'Mantas',
@@ -103,6 +104,7 @@ describe('DrizzleResourceRepository (integration)', () => {
           unit: 'litros',
           category: Category.Water,
           presentation: null,
+          expiresAt: '2026-07-01',
         },
         {
           name: 'Mantas',
@@ -110,6 +112,7 @@ describe('DrizzleResourceRepository (integration)', () => {
           unit: null,
           category: Category.Shelter,
           presentation: null,
+          expiresAt: null,
         },
       ]),
     );
@@ -125,6 +128,7 @@ describe('DrizzleResourceRepository (integration)', () => {
           unit: 'kg',
           category: Category.Food,
           presentation: null,
+          expiresAt: null,
         },
       ],
     });
@@ -138,6 +142,7 @@ describe('DrizzleResourceRepository (integration)', () => {
         unit: 'kg',
         category: Category.Food,
         presentation: null,
+        expiresAt: null,
       },
     ]);
   });

--- a/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
@@ -130,6 +130,7 @@ export class ResourcesController {
         unit: i.unit ?? null,
         category: i.category,
         presentation: i.presentation ?? null,
+        expiresAt: i.expiresAt ?? null,
       })),
     });
   }

--- a/apps/api/src/contexts/supplies/domain/supply-line.spec.ts
+++ b/apps/api/src/contexts/supplies/domain/supply-line.spec.ts
@@ -41,6 +41,42 @@ describe('SupplyLine', () => {
     expect(line.presentation).toBe('EV/ampolla');
   });
 
+  it('keeps the expiresAt date when provided', () => {
+    const line = SupplyLine.create({
+      name: 'Yogur',
+      quantity: 12,
+      unit: 'unidades',
+      category: Category.Food,
+      expiresAt: '2026-07-01',
+    });
+
+    expect(line.expiresAt).toBe('2026-07-01');
+  });
+
+  it('throws when expiresAt is not a YYYY-MM-DD date', () => {
+    expect(() =>
+      SupplyLine.create({
+        name: 'Yogur',
+        quantity: 12,
+        unit: 'unidades',
+        category: Category.Food,
+        expiresAt: '2026-07-01T12:00:00Z',
+      }),
+    ).toThrow(SupplyLineValidationError);
+  });
+
+  it('throws when expiresAt is not a real calendar date', () => {
+    expect(() =>
+      SupplyLine.create({
+        name: 'Yogur',
+        quantity: 12,
+        unit: 'unidades',
+        category: Category.Food,
+        expiresAt: '2026-02-30',
+      }),
+    ).toThrow(SupplyLineValidationError);
+  });
+
   it('throws when the name is empty', () => {
     expect(() =>
       SupplyLine.create({
@@ -66,13 +102,14 @@ describe('SupplyLine', () => {
     },
   );
 
-  it('round-trips through a snapshot (including presentation)', () => {
+  it('round-trips through a snapshot (including presentation and expiresAt)', () => {
     const line = SupplyLine.create({
       name: 'Budesonida',
       quantity: 5,
       unit: null,
       category: Category.Medicines,
       presentation: 'inhalador',
+      expiresAt: '2026-07-01',
     });
 
     const restored = SupplyLine.fromSnapshot(line.toSnapshot());

--- a/apps/api/src/contexts/supplies/domain/supply-line.ts
+++ b/apps/api/src/contexts/supplies/domain/supply-line.ts
@@ -14,7 +14,8 @@ import { Category } from './category';
  * that needs/offers/resources depend on — so categories and per-line parameters
  * stay consistent everywhere. `presentation` (route of administration:
  * ampolla/EV/inhalador…) is the integrated per-line parameter for the health
- * vertical (#61); it is optional and free-form.
+ * vertical (#61); it is optional and free-form. `expiresAt` is the optional
+ * per-line freshness date used by inventory and donation intake.
  *
  * For now a SupplyLine carries the supply's name inline (free text). It is
  * designed to later reference a catalog `Supply` by id (master data) without
@@ -26,6 +27,7 @@ export interface SupplyLineProps {
   unit: string | null;
   category: Category;
   presentation?: string | null;
+  expiresAt?: string | null;
 }
 
 export interface SupplyLineSnapshot {
@@ -35,6 +37,26 @@ export interface SupplyLineSnapshot {
   category: Category;
   /** Optional (legacy-safe) presentation / route of administration (#61). */
   presentation?: string | null;
+  /** Optional freshness date for the line, kept as an ISO date string. */
+  expiresAt?: string | null;
+}
+
+function normalizeDateOnly(value?: string | null): string | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const errorMessage = 'SupplyLine expiresAt must be a valid YYYY-MM-DD date';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    throw new SupplyLineValidationError(errorMessage);
+  }
+  const parsed = new Date(`${trimmed}T00:00:00.000Z`);
+  if (
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== trimmed
+  ) {
+    throw new SupplyLineValidationError(errorMessage);
+  }
+  return trimmed;
 }
 
 export class SupplyLineValidationError extends Error {
@@ -50,6 +72,7 @@ export class SupplyLine {
   readonly unit: string | null;
   readonly category: Category;
   readonly presentation: string | null;
+  readonly expiresAt: string | null;
 
   private constructor(props: SupplyLineProps) {
     this.name = props.name;
@@ -57,6 +80,7 @@ export class SupplyLine {
     this.unit = props.unit;
     this.category = props.category;
     this.presentation = props.presentation ?? null;
+    this.expiresAt = normalizeDateOnly(props.expiresAt);
   }
 
   static create(props: SupplyLineProps): SupplyLine {
@@ -74,6 +98,7 @@ export class SupplyLine {
       unit: props.unit ?? null,
       category: props.category,
       presentation: props.presentation ?? null,
+      expiresAt: normalizeDateOnly(props.expiresAt),
     });
   }
 
@@ -88,6 +113,7 @@ export class SupplyLine {
       unit: this.unit,
       category: this.category,
       presentation: this.presentation,
+      expiresAt: this.expiresAt,
     };
   }
 }

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/supply-line-columns.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/supply-line-columns.ts
@@ -1,12 +1,13 @@
-import { text, integer } from 'drizzle-orm/pg-core';
+import { integer, text, timestamp } from 'drizzle-orm/pg-core';
 import { Category } from '../../domain/category';
 import { SupplyLineSnapshot } from '../../domain/supply-line';
 
 /**
  * The shared Drizzle columns of a supply line — the canonical material line of
- * the platform: `name + quantity + unit + category + presentation`. Spread into
- * every `*_items` child table (`need_items`, `resource_items`, `offer_items`,
- * `donation_intake_lines`) so the column set can never drift across contexts.
+ * the platform: name + quantity + unit + category + presentation + expiresAt.
+ * Spread into every `*_items` child table (`need_items`, `resource_items`,
+ * `offer_items`, `donation_intake_lines`) so the column set can never drift
+ * across contexts.
  *
  * A factory (not a shared constant) so each table gets its own fresh column
  * builders.
@@ -18,6 +19,7 @@ export function supplyLineColumns() {
     unit: text('unit'),
     category: text('category').notNull(),
     presentation: text('presentation'),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
   };
 }
 
@@ -28,6 +30,16 @@ export interface SupplyLineRow {
   unit: string | null;
   category: string;
   presentation: string | null;
+  expiresAt: Date | null;
+}
+
+function supplyLineDateToDb(value: string | null | undefined): Date | null {
+  if (value == null || value === '') return null;
+  return new Date(`${value}T00:00:00.000Z`);
+}
+
+function supplyLineDateFromDb(value: Date | null | undefined): string | null {
+  return value ? value.toISOString().slice(0, 10) : null;
 }
 
 /** Map a persisted row to the canonical {@link SupplyLineSnapshot}. */
@@ -40,6 +52,7 @@ export function rowToSupplyLineSnapshot(
     unit: row.unit ?? null,
     category: row.category as Category,
     presentation: row.presentation ?? null,
+    expiresAt: supplyLineDateFromDb(row.expiresAt),
   };
 }
 
@@ -51,5 +64,6 @@ export function supplyLineToColumns(line: SupplyLineSnapshot): SupplyLineRow {
     unit: line.unit,
     category: line.category,
     presentation: line.presentation ?? null,
+    expiresAt: supplyLineDateToDb(line.expiresAt),
   };
 }

--- a/apps/api/src/contexts/supplies/infrastructure/http/supply-line.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supply-line.dto.ts
@@ -5,13 +5,15 @@ import {
   IsOptional,
   IsPositive,
   IsString,
+  Matches,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Category } from '../../domain/category';
 
 /**
  * SupplyLineDto — the single request shape for a line of aid material
- * (a {@link SupplyLine}): name + quantity + unit + category + presentation.
+ * (a {@link SupplyLine}): name + quantity + unit + category + presentation +
+ * optional expiresAt freshness date.
  * Shared by every context that accepts supply lines (needs, resources
  * inventory) so the contract stays identical.
  */
@@ -46,6 +48,16 @@ export class SupplyLineDto {
   @IsOptional()
   @IsString()
   presentation?: string;
+
+  @ApiPropertyOptional({
+    example: '2026-07-01',
+    format: 'date',
+    description:
+      'Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD).',
+  })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  expiresAt?: string;
 }
 
 /**
@@ -72,4 +84,14 @@ export class SupplyLineResponseDto {
       'Presentation / route of administration (ampolla, EV, inhalador…) — #61.',
   })
   presentation!: string | null;
+
+  @ApiPropertyOptional({
+    example: '2026-07-01',
+    nullable: true,
+    type: String,
+    format: 'date',
+    description:
+      'Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD).',
+  })
+  expiresAt?: string | null;
 }

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -263,7 +263,13 @@ for (const p of items) {
     },
     "locationSensitivity": "approximate",
     "items": [
-      { "name": "Agua", "quantity": 100, "unit": "litros", "category": "water" }
+      {
+        "name": "Agua",
+        "quantity": 100,
+        "unit": "litros",
+        "category": "water",
+        "expiresAt": "2026-07-01"
+      }
     ],
     "createdAt": "2026-06-27T09:00:00.000Z",
     "expiresAt": "2026-06-29T09:00:00.000Z",

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -3,11 +3,13 @@ import { notFound } from 'next/navigation';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getToken } from '@/lib/auth';
+import { type ResourceViewDto } from '@/lib/group-by-country';
 import { OfficialHeaderBand } from '@/components/organisms/official-header-band';
 import { ResourceList } from '@/components/organisms/resource-list';
 import { EmergencyMapWrapper } from '@/components/organisms/emergency-map-wrapper';
 import { NeedsFilter } from '@/components/molecules/needs-filter';
 import { MetricCard } from '@/components/molecules/metric-card';
+import { Card } from '@/components/atoms/card';
 import { StatusBanner } from '@/components/molecules/status-banner';
 import { AnnouncementCard } from '@/components/molecules/announcement-card';
 import { HelpActionRow } from '@/components/molecules/help-action-row';
@@ -49,7 +51,6 @@ const VALID_PRIORITIES = ['low', 'medium', 'high', 'urgent'] as const;
 
 type NeedCategory = typeof VALID_CATEGORIES[number];
 type Priority = typeof VALID_PRIORITIES[number];
-
 export default async function EmergencyPage({ params, searchParams }: Props) {
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
@@ -100,19 +101,15 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
     }),
   ]);
 
-  const activeResources = resourcesPage?.items ?? [];
+  const activeResources = (resourcesPage?.items ?? []) as ResourceViewDto[];
   const resourcesTotal = resourcesPage?.total ?? 0;
-  // Facets: the schema types byCategory/byCountry as Record<string, never> due
-  // to OpenAPI's additionalProperties representation, but at runtime they are
-  // Record<string, number>. We cast here and default to empty objects.
   const facetsByCategory = (facets?.byCategory ?? {}) as Record<string, number>;
   const facetsByCountry = (facets?.byCountry ?? {}) as Record<string, number>;
   const validatedNeeds = needs ?? [];
+  const officialContacts = activeResources
+    .filter((resource: ResourceViewDto) => resource.verificationLevel === 'official' && resource.contact != null)
+    .slice(0, 3);
 
-  // Build map points from the SSR-fetched resources (page 1) and needs (all)
-  // that have valid coordinates. EmergencyMapWrapper re-fetches ALL resource
-  // points client-side and merges them with these needs, so the map is never
-  // limited to the first page even though the list paginates.
   const mapPoints: MapPoint[] = [
     ...activeResources
       .filter((r) => r.location.latitude !== 0 && r.location.longitude !== 0)
@@ -142,12 +139,11 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
   ];
 
   const te = t.emergency;
-  const dontList = emergency.dontBringList.length > 0 ? emergency.dontBringList : te.dont_bring_items;
+  const dontList: string[] =
+    emergency.dontBringList.length > 0 ? emergency.dontBringList : te.dont_bring_items;
   const sectionTitle = 'font-display text-base font-bold text-navy';
   const announcement = typeof emergency.announcement === 'string' ? emergency.announcement : null;
 
-  // The explorer opens on whichever list the citizen is most likely acting on:
-  // if they arrived with a needs filter applied, start on the needs tab.
   const initialTab: 'points' | 'needs' =
     category !== undefined || priority !== undefined ? 'needs' : 'points';
 
@@ -206,18 +202,12 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
         te={te}
       />
 
-      {/* Aviso de estado (sólo en pausa/cerrada) — ancho completo, prominente */}
       {!isActive && (
         <div className="px-4 pt-4 lg:px-8">
           <StatusBanner status={emergency.status} t={t.status_banner} />
         </div>
       )}
 
-      {/*
-        Layout dashboard: en escritorio el mapa es protagonista — columna izquierda
-        fija (sticky, alto de viewport) — y el panel de acciones/listas hace scroll
-        a la derecha. En móvil el mapa es un "hero" arriba y el panel va debajo.
-      */}
       <div className="lg:flex lg:items-start">
         <section
           aria-labelledby="map-heading"
@@ -247,6 +237,91 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
               updatedAt={emergency.updatedAt}
               t={t.announcement}
             />
+          )}
+
+          <section aria-labelledby="quick-access-heading" className="flex flex-col gap-3">
+            <h2 id="quick-access-heading" className={sectionTitle}>
+              {te.quick_access_heading}
+            </h2>
+            <div className="grid gap-2.5 lg:grid-cols-3">
+              <Card as="div" className="flex flex-col gap-3 p-4">
+                <div>
+                  <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-accent">
+                    {te.quick_access_card_label}
+                  </p>
+                  <h3 className="mt-1 text-[15px] font-bold text-ink">
+                    {te.actions_heading}
+                  </h3>
+                  <p className="mt-1 text-xs text-muted">{te.quick_access_help_intro}</p>
+                </div>
+                <HelpActionRow
+                  href="#actions-heading"
+                  icon="🧭"
+                  title={te.quick_access_help_cta}
+                />
+              </Card>
+
+              <Card as="div" className="flex flex-col gap-3 p-4">
+                <div>
+                  <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-accent">
+                    {te.quick_access_card_label}
+                  </p>
+                  <h3 className="mt-1 text-[15px] font-bold text-ink">
+                    {te.explore_heading}
+                  </h3>
+                  <p className="mt-1 text-xs text-muted">{te.quick_access_where_intro}</p>
+                </div>
+                <HelpActionRow
+                  href="#explore-heading"
+                  icon="📍"
+                  title={te.quick_access_where_cta}
+                />
+              </Card>
+
+              <Card as="div" className="flex flex-col gap-3 p-4">
+                <div>
+                  <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-accent">
+                    {te.quick_access_card_label}
+                  </p>
+                  <h3 className="mt-1 text-[15px] font-bold text-ink">
+                    {te.quick_access_call_heading}
+                  </h3>
+                  <p className="mt-1 text-xs text-muted">{te.quick_access_call_intro}</p>
+                </div>
+
+                {officialContacts.length > 0 ? (
+                  <ul className="flex flex-col gap-2" role="list">
+                    {officialContacts.map((resource) => (
+                      <li key={resource.id} className="rounded-[13px] border border-line bg-surface-alt px-3 py-2">
+                        <p className="text-xs font-semibold text-navy">{resource.name}</p>
+                        <p className="text-[12.5px] text-muted">
+                          {t.resource_card.meta_contact_official} {resource.contact}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs italic text-muted-soft">
+                    {te.quick_access_no_official_contact}
+                  </p>
+                )}
+              </Card>
+            </div>
+          </section>
+
+          {metrics !== undefined && (
+            <section aria-labelledby="metrics-heading" className="flex flex-col gap-2.5">
+              <div>
+                <h2 id="metrics-heading" className={sectionTitle}>{te.metrics_heading}</h2>
+                <p className="mt-0.5 text-[12.5px] text-muted">{te.metrics_caption}</p>
+              </div>
+              <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+                <MetricCard value={metrics.needs.open} label={te.metric_tile_open} tone="navy" />
+                <MetricCard value={metrics.resources.active} label={te.metric_tile_points} tone="navy" />
+                <MetricCard value={metrics.needs.closed} label={te.metric_tile_covered} tone="success" />
+                <MetricCard value={metrics.resources.pending} label={te.metric_tile_queue} tone="accent" />
+              </div>
+            </section>
           )}
 
           <section aria-labelledby="actions-heading" className="flex flex-col gap-3">
@@ -292,25 +367,6 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
             )}
           </section>
 
-          {/* Métricas (fila de KPIs) — cifras GLOBALES del operativo, distintas
-              de lo realmente visible en el mapa (que se muestra en las pestañas). */}
-          {metrics !== undefined && (
-            <section aria-labelledby="metrics-heading" className="flex flex-col gap-2.5">
-              <div>
-                <h2 id="metrics-heading" className={sectionTitle}>{te.metrics_heading}</h2>
-                <p className="mt-0.5 text-[12.5px] text-muted">{te.metrics_caption}</p>
-              </div>
-              <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
-                <MetricCard value={metrics.needs.open} label={te.metric_tile_open} tone="navy" />
-                <MetricCard value={metrics.resources.active} label={te.metric_tile_points} tone="navy" />
-                <MetricCard value={metrics.needs.closed} label={te.metric_tile_covered} tone="success" />
-                <MetricCard value={metrics.resources.pending} label={te.metric_tile_queue} tone="accent" />
-              </div>
-            </section>
-          )}
-
-          {/* Explorador segmentado: Puntos | Necesidades — lo que se ve en el
-              mapa (una lista a la vez). Sus contadores reflejan lo visible. */}
           <section aria-labelledby="explore-heading" className="flex flex-col gap-3">
             <h2 id="explore-heading" className={sectionTitle}>{te.explore_heading}</h2>
             <EmergencyExplorer
@@ -325,7 +381,6 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
             />
           </section>
 
-          {/* Qué NO hacer ahora — colapsable para no robar protagonismo */}
           <details className="group rounded-card border border-line bg-surface-alt px-4 py-3.5 open:pb-4">
             <summary className="flex cursor-pointer list-none items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
               <span className="flex flex-col">

--- a/apps/web/src/app/e/[slug]/registrar/inventory-field.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/inventory-field.tsx
@@ -13,6 +13,7 @@ interface Item {
   quantity: number;
   unit: string;
   category: string;
+  expiresAt: string;
 }
 
 let nextId = 1;
@@ -24,6 +25,7 @@ function makeItem(): Item {
     quantity: 1,
     unit: '',
     category: MATERIAL_CATEGORIES[0],
+    expiresAt: '',
   };
 }
 
@@ -32,6 +34,10 @@ function makeItem(): Item {
  * registrar form (`Messages['registrar']`) and the citizen pre-registration
  * form (`Messages['prereg']['lines']`), so the same editor serves both surfaces
  * without coupling to one feature's message namespace.
+ *
+ * `item_expiry_label` and `item_expiry_opt` are optional — when omitted the
+ * expiry date row is hidden, so pre-registration forms that don't declare expiry
+ * still type-check without adding the keys to their message namespace.
  */
 export interface InventoryFieldLabels {
   inventory_heading: string;
@@ -48,6 +54,8 @@ export interface InventoryFieldLabels {
   item_unit_opt: string;
   item_unit_placeholder: string;
   item_category_label: string;
+  item_expiry_label?: string;
+  item_expiry_opt?: string;
 }
 
 interface InventoryFieldProps {
@@ -88,6 +96,8 @@ export function InventoryField({
     unitOpt: t.item_unit_opt,
     unitPlaceholder: t.item_unit_placeholder,
     categoryLabel: t.item_category_label,
+    expiryLabel: t.item_expiry_label,
+    expiryOpt: t.item_expiry_opt,
   };
 
   // Serialize only rows that have a name — empty rows are ignored so the field
@@ -95,11 +105,12 @@ export function InventoryField({
   const serialized = JSON.stringify(
     items
       .filter((i) => i.name.trim() !== '')
-      .map(({ name, quantity, unit, category }) => ({
+      .map(({ name, quantity, unit, category, expiresAt }) => ({
         name: name.trim(),
         quantity,
         ...(unit.trim() !== '' ? { unit: unit.trim() } : {}),
         category,
+        ...(expiresAt !== '' ? { expiresAt } : {}),
       })),
   );
 
@@ -129,7 +140,7 @@ export function InventoryField({
         <button
           type="button"
           onClick={addItem}
-          className="shrink-0 text-sm font-semibold text-ink underline underline-offset-2 hover:text-muted focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 rounded"
+          className="shrink-0 rounded text-sm font-semibold text-ink underline underline-offset-2 hover:text-muted focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
         >
           {t.inventory_add}
         </button>
@@ -158,6 +169,7 @@ export function InventoryField({
         ))
       )}
 
+      {/* Hidden input carries serialized items to the server action */}
       <input type="hidden" name="items" value={serialized} />
     </div>
   );

--- a/apps/web/src/components/molecules/need-card.tsx
+++ b/apps/web/src/components/molecules/need-card.tsx
@@ -46,6 +46,11 @@ export function NeedCard({ need, te, slug, active, locale }: NeedCardProps) {
           {item.presentation}
         </p>
       )}
+      {item?.expiresAt != null && (
+        <p className="text-[12.5px] text-muted">
+          {item.expiresAt}
+        </p>
+      )}
       {approximate && <PrivacyLocationNotice text={te.privacy_approximate_location} />}
       {active && (
         <Link

--- a/apps/web/src/components/molecules/supply-line-row-fields.tsx
+++ b/apps/web/src/components/molecules/supply-line-row-fields.tsx
@@ -7,6 +7,7 @@ export interface SupplyLineRowValue {
   quantity: number;
   unit: string;
   category: string;
+  expiresAt?: string;
 }
 
 /** Per-row label strings (built from each form's i18n; same keys everywhere). */
@@ -23,6 +24,8 @@ export interface SupplyLineRowLabels {
   unitOpt: string;
   unitPlaceholder: string;
   categoryLabel: string;
+  expiryLabel?: string;
+  expiryOpt?: string;
 }
 
 interface SupplyLineRowFieldsProps {
@@ -80,6 +83,7 @@ export function SupplyLineRowFields({
         )}
       </div>
 
+      {/* Nombre del insumo */}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor={`${idPrefix}-name-${rowId}`}
@@ -99,6 +103,7 @@ export function SupplyLineRowFields({
       </div>
 
       <div className="grid grid-cols-2 gap-3">
+        {/* Cantidad */}
         <div className="flex flex-col gap-1.5">
           <label
             htmlFor={`${idPrefix}-qty-${rowId}`}
@@ -122,6 +127,7 @@ export function SupplyLineRowFields({
           />
         </div>
 
+        {/* Unidad */}
         <div className="flex flex-col gap-1.5">
           <label
             htmlFor={`${idPrefix}-unit-${rowId}`}
@@ -141,6 +147,28 @@ export function SupplyLineRowFields({
         </div>
       </div>
 
+      {labels.expiryLabel != null && labels.expiryOpt != null && (
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor={`${idPrefix}-exp-${rowId}`}
+            className="text-sm font-medium text-ink-soft"
+          >
+            {labels.expiryLabel}{' '}
+            <span className="text-muted-soft font-normal">
+              {labels.expiryOpt}
+            </span>
+          </label>
+          <input
+            id={`${idPrefix}-exp-${rowId}`}
+            type="date"
+            value={value.expiresAt ?? ''}
+            onChange={(e) => onChange({ expiresAt: e.target.value })}
+            className="w-full rounded-lg border-2 border-navy bg-white px-4 py-3 text-base text-ink focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2"
+          />
+        </div>
+      )}
+
+      {/* Categoría */}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor={`${idPrefix}-cat-${rowId}`}

--- a/apps/web/src/components/organisms/need-detail.tsx
+++ b/apps/web/src/components/organisms/need-detail.tsx
@@ -225,6 +225,9 @@ export function NeedDetail({
                   {item.presentation != null && item.presentation !== ''
                     ? ` · ${item.presentation}`
                     : ''}
+                  {item.expiresAt != null && item.expiresAt !== ''
+                    ? ` · ${item.expiresAt}`
+                    : ''}
                 </span>
               </li>
             ))}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -175,6 +175,16 @@ export const en = {
     actions_paused:
       'Resource and request registration is paused. Check the available information and come back later.',
 
+    quick_access_heading: 'Quick access',
+    quick_access_card_label: 'At a glance',
+    quick_access_help_intro: 'Go straight to the action area if you want to help right now.',
+    quick_access_help_cta: 'See how to help',
+    quick_access_where_intro: 'Jump to the verified points that are already active.',
+    quick_access_where_cta: 'See where to go',
+    quick_access_call_heading: 'Who to call',
+    quick_access_call_intro: 'Official contacts from verified points appear here first.',
+    quick_access_no_official_contact: 'No verified official contacts are published yet.',
+
     points_heading: 'Active points',
     points_empty_title: 'No active points yet.',
     points_empty_description:
@@ -438,6 +448,8 @@ export const en = {
     item_unit_label: 'Unit',
     item_unit_opt: '(opt.)',
     item_unit_placeholder: 'boxes, liters…',
+    item_expiry_label: 'Expires',
+    item_expiry_opt: '(optional)',
     item_category_label: 'Category',
 
     // server-action messages
@@ -1171,7 +1183,7 @@ export const en = {
     n_privacy:
       'Privacy: some needs expose approximate coordinates (locationSensitivity: "approximate") so as not to reveal a requester’s home. Do not try to de-obfuscate them; treat them as indicative.',
     n_fields:
-      'Each need includes id, title, description, location, locationSensitivity, priority, items (with name, quantity, unit and category), status, createdAt, expiresAt and lastVerifiedAt.',
+      'Each need includes id, title, description, location, locationSensitivity, priority, items (with name, quantity, unit, category and optional expiresAt), status, createdAt, expiresAt and lastVerifiedAt.',
 
     // States & categories
     enums_heading: 'States & categories',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -179,6 +179,16 @@ export const es = {
     actions_paused:
       'El alta de recursos y peticiones está en pausa. Consulta la información disponible y vuelve más tarde.',
 
+    quick_access_heading: 'Acceso rápido',
+    quick_access_card_label: 'Resumen',
+    quick_access_help_intro: 'Ve directo a la zona de acciones si quieres ayudar ahora mismo.',
+    quick_access_help_cta: 'Ver cómo ayudar',
+    quick_access_where_intro: 'Salta a los puntos verificados que ya están activos.',
+    quick_access_where_cta: 'Ver dónde ir',
+    quick_access_call_heading: 'A quién llamar',
+    quick_access_call_intro: 'Aquí aparecen primero los contactos oficiales de puntos verificados.',
+    quick_access_no_official_contact: 'Aún no hay contactos oficiales verificados publicados.',
+
     // Active points
     points_heading: 'Puntos activos',
     points_empty_title: 'Aún no hay puntos activos.',
@@ -458,6 +468,8 @@ export const es = {
     item_unit_label: 'Unidad',
     item_unit_opt: '(opt.)',
     item_unit_placeholder: 'cajas, litros…',
+    item_expiry_label: 'Caduca',
+    item_expiry_opt: '(opcional)',
     item_category_label: 'Categoría',
 
     // server-action messages

--- a/apps/web/src/lib/supply-lines.ts
+++ b/apps/web/src/lib/supply-lines.ts
@@ -31,7 +31,10 @@ export function parseSupplyLines(
   const items: SupplyLineDto[] = [];
   for (const entry of parsed) {
     if (typeof entry !== 'object' || entry === null) return null;
-    const { name, quantity, unit, category } = entry as Record<string, unknown>;
+    const { name, quantity, unit, category, expiresAt } = entry as Record<
+      string,
+      unknown
+    >;
     if (typeof name !== 'string' || name.trim() === '') return null;
     if (
       typeof quantity !== 'number' ||
@@ -43,12 +46,22 @@ export function parseSupplyLines(
     if (typeof category !== 'string' || !opts.isValidCategory(category)) {
       return null;
     }
+    if (
+      expiresAt !== undefined &&
+      expiresAt !== null &&
+      (typeof expiresAt !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(expiresAt))
+    ) {
+      return null;
+    }
     items.push({
       name: name.trim(),
       quantity,
       category: category as SupplyLineDto['category'],
       ...(typeof unit === 'string' && unit.trim() !== ''
         ? { unit: unit.trim() }
+        : {}),
+      ...(typeof expiresAt === 'string' && expiresAt !== ''
+        ? { expiresAt }
         : {}),
     });
   }

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -2698,6 +2698,11 @@ export interface components {
              * @example ampolla
              */
             presentation?: string;
+            /**
+             * @description Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD).
+             * @example 2026-07-01
+             */
+            expiresAt?: string;
         };
         RegisterResourceDto: {
             /**
@@ -3636,6 +3641,11 @@ export interface components {
              * @example ampolla
              */
             presentation?: string | null;
+            /**
+             * @description Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD).
+             * @example 2026-07-01
+             */
+            expiresAt?: string | null;
         };
         NeedViewDto: {
             /**


### PR DESCRIPTION
@
Reemplazo limpio de #181, reaplicado sobre `main` actual.

## Qué hace
- `SupplyLine` gana `expiresAt` opcional (caducidad por línea de insumo), integrado en API, persistencia, esquema OpenAPI/cliente y formularios web (inventario de recursos, necesidades, líneas de recogida).

## Diferencia clave con #181 — migración renumerada
La migración va como **`0036_supply_line_expires_at.sql`**, no `0032`. El `0032` colisionaba con migraciones **ya aplicadas en producción** (`0032_offer_inventory`, etc.); renombrar esas habría hecho que el deploy las re-ejecutara y reventara (`migrate.sh` rastrea por nombre de fichero). Aquí solo se introduce una migración **nueva** con número libre, que es seguro.

## Validación
- [x] `pnpm --filter api build` / `eslint` / `prettier`
- [x] `pnpm --filter @reliefhub/api-client build`
- [x] `pnpm --filter web lint` / `build`
- [x] Merge de los cambios de #181 sobre `main` sin conflictos; generados (`openapi.json`/`schema.ts`) consistentes (validado por los builds tsc)

## Cierre
- Closes #164

Sustituye a #181 (se cerrará apuntando aquí).
@