### PR TITLE
test(api): guard contra números de migración duplicados nuevos

### DIFF
--- a/apps/api/src/shared/drizzle-migration-numbering.spec.ts
+++ b/apps/api/src/shared/drizzle-migration-numbering.spec.ts
@@ -1,0 +1,42 @@
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Números de secuencia que YA tienen migraciones duplicadas en `main`, fruto de
+ * PRs paralelas mergeadas a la vez. Son inocuos (tanto `deploy/migrate.sh` como
+ * el global-setup aplican por NOMBRE DE FICHERO completo, no por número) y están
+ * aplicados en producción: son historia congelada y NO se renombran —renombrar
+ * una migración aplicada haría que el deploy la re-ejecute y rompa prod.
+ *
+ * Este guard solo evita la PROLIFERACIÓN: cualquier número duplicado NUEVO fuera
+ * de esta lista es un error de la PR; usa el siguiente número libre (mira el
+ * directorio) en vez de reutilizar uno.
+ */
+const GRANDFATHERED_DUPLICATE_PREFIXES = new Set([
+  '0005',
+  '0023',
+  '0028',
+  '0029',
+  '0032',
+  '0034',
+]);
+
+describe('numeración de migraciones drizzle', () => {
+  it('no introduce números de migración duplicados nuevos', () => {
+    const dir = resolve(__dirname, '../../drizzle');
+    const byPrefix = new Map<string, string[]>();
+    for (const file of readdirSync(dir).filter((f) => f.endsWith('.sql'))) {
+      const prefix = file.slice(0, 4);
+      byPrefix.set(prefix, [...(byPrefix.get(prefix) ?? []), file]);
+    }
+
+    const offending = [...byPrefix.entries()]
+      .filter(
+        ([prefix, files]) =>
+          files.length > 1 && !GRANDFATHERED_DUPLICATE_PREFIXES.has(prefix),
+      )
+      .map(([prefix, files]) => `${prefix}: ${files.join(', ')}`);
+
+    expect(offending).toEqual([]);
+  });
+});


### PR DESCRIPTION
@
## Qué hace
Añade un test que falla si una PR introduce una migración con un número de secuencia **ya usado**, salvo los prefijos ya duplicados en `main` (heredados de PRs paralelas: `0005, 0023, 0028, 0029, 0032, 0034`).

## Por qué
Los duplicados existentes son **inocuos** (`migrate.sh` y el global-setup aplican por nombre de fichero completo, no por número) y están aplicados en producción → historia congelada, no se renombran. Este guard solo evita la **proliferación** de duplicados nuevos, empujando a usar el siguiente número libre.

Contexto: surgió al revisar #215, que intentaba "arreglar" la colisión renombrando migraciones ya aplicadas — lo que habría roto el deploy (re-ejecución por nombre de fichero). La regla correcta es prevenir hacia delante, nunca renombrar lo aplicado.

## Validación
- [x] Lógica verificada contra el directorio real (`offending: []`)
- [x] `eslint` / `prettier`

## Cierre
- Closes #211
@