### PR TITLE
fix(resources): ventana de frescura para reportes de validez

### DIFF
--- a/apps/api/src/contexts/resources/application/get-disputed-resources.ts
+++ b/apps/api/src/contexts/resources/application/get-disputed-resources.ts
@@ -2,6 +2,7 @@ import { ResourceRepository } from '../domain/ports/resource.repository';
 import { ResourceValidityReportRepository } from '../domain/ports/resource-validity-report.repository';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
 import { ResourceView, toResourceView } from './resource-view';
+import { FRESHNESS_WINDOW_DAYS } from './report-resource-validity';
 
 export interface DisputedResourceView {
   resource: ResourceView;
@@ -17,7 +18,7 @@ export interface GetDisputedResourcesQuery {
   emergencyId: string;
 }
 
-/** Coordination queue: resources flagged `disputed`, with a reason breakdown. */
+/** Coordination queue: resources with enough fresh open reports, plus reasons. */
 export class GetDisputedResources {
   constructor(
     private readonly resources: ResourceRepository,
@@ -25,28 +26,36 @@ export class GetDisputedResources {
   ) {}
 
   async execute(q: GetDisputedResourcesQuery): Promise<DisputedResourceView[]> {
-    const disputed = await this.resources.findDisputedByEmergency(
+    const visible = await this.resources.findVisibleByEmergency(
       EmergencyId.fromString(q.emergencyId),
     );
+    const cutoff = new Date(
+      Date.now() - FRESHNESS_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+    );
 
-    // Each disputed resource needs its own open-report breakdown; fetch them
-    // concurrently (Promise.all preserves the queue order from the repository).
-    return Promise.all(
-      disputed.map(async (resource) => {
+    const disputed = await Promise.all(
+      visible.map(async (resource) => {
         const open = await this.reports.findOpenByResource(resource.id.value);
+        const fresh = open.filter((r) => r.createdAt >= cutoff);
+        if (fresh.length === 0) return null;
+
         const byReason: Record<string, number> = {};
         let last: Date | null = null;
-        for (const r of open) {
+        for (const r of fresh) {
           byReason[r.reason] = (byReason[r.reason] ?? 0) + 1;
           if (!last || r.createdAt > last) last = r.createdAt;
         }
         return {
           resource: toResourceView(resource),
-          distinctReporters: open.length,
+          distinctReporters: fresh.length,
           byReason,
           lastReportedAt: last ? last.toISOString() : null,
         };
       }),
+    );
+
+    return disputed.filter(
+      (resource): resource is DisputedResourceView => resource !== null,
     );
   }
 }

--- a/apps/api/src/contexts/resources/application/report-resource-validity.ts
+++ b/apps/api/src/contexts/resources/application/report-resource-validity.ts
@@ -23,6 +23,8 @@ export interface ReportResourceValidityCommand {
 
 /** Distinct citizen reports that flip a resource to `disputed`. */
 export const DEFAULT_DISPUTE_THRESHOLD = 3;
+/** Reports older than this are ignored when counting dispute votes. */
+export const FRESHNESS_WINDOW_DAYS = 45;
 
 /**
  * A logged-in citizen reports that a published point is no longer valid. We
@@ -80,9 +82,13 @@ export class ReportResourceValidity {
     }
     await this.reports.save(report);
 
-    const distinct = await this.reports.countOpenByResource(cmd.resourceId);
-    let disputed = resource.disputed;
-    if (distinct >= this.threshold && !disputed) {
+    const open = await this.reports.findOpenByResource(cmd.resourceId);
+    const cutoff = new Date(
+      Date.now() - FRESHNESS_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+    );
+    const freshDistinct = open.filter((r) => r.createdAt >= cutoff).length;
+    let disputed = freshDistinct >= this.threshold;
+    if (disputed && !resource.disputed) {
       // Re-read so the flag decision uses the current persisted state, not the
       // snapshot loaded before this report was saved — two citizens crossing
       // the threshold at once must not each emit a ResourceDisputed event.

--- a/apps/api/test/resource-validity.e2e-spec.ts
+++ b/apps/api/test/resource-validity.e2e-spec.ts
@@ -6,7 +6,10 @@ import { inArray } from 'drizzle-orm';
 import { AppModule } from '../src/app.module';
 import { DomainExceptionFilter } from '../src/contexts/resources/infrastructure/http/domain-exception.filter';
 import { createDb } from '../src/shared/db';
-import { resourcesTable } from '../src/contexts/resources/infrastructure/drizzle/schema';
+import {
+  resourcesTable,
+  resourceValidityReportsTable,
+} from '../src/contexts/resources/infrastructure/drizzle/schema';
 import {
   usersTable,
   membershipsTable,
@@ -201,6 +204,37 @@ describe('Resource validity reports (e2e)', () => {
     expect(entry).toBeDefined();
     expect(entry?.distinctReporters).toBe(3);
     expect(entry?.byReason).toEqual({ closed: 2, moved: 1 });
+  });
+
+  it('ignores expired reports in the disputed queue', async () => {
+    const id = await createPublishedResource('Punto caducado');
+    await report(id, CIT1_ID).expect(201);
+    await report(id, CIT2_ID).expect(201);
+    await report(id, CIT3_ID).expect(201);
+
+    const { db, pool } = createDb(
+      process.env.DATABASE_URL ??
+        'postgres://reliefhub:reliefhub@localhost:5433/reliefhub',
+    );
+    try {
+      await db
+        .update(resourceValidityReportsTable)
+        .set({
+          createdAt: new Date('2025-01-01T00:00:00.000Z'),
+        })
+        .where(inArray(resourceValidityReportsTable.resourceId, [id]));
+    } finally {
+      await pool.end();
+    }
+
+    const res = await request(server)
+      .get(`/emergencies/${EM}/coordination/disputed`)
+      .set('Authorization', `Bearer ${tok[COORD_ID]}`)
+      .expect(200);
+    const entry = (res.body as Array<{ resource: { id: string } }>).find(
+      (d) => d.resource.id === id,
+    );
+    expect(entry).toBeUndefined();
   });
 
   it('a non-coordinator cannot read the disputed queue or resolve (403)', async () => {


### PR DESCRIPTION
@
Reemplazo limpio de #198, reaplicado sobre `main` actual.

## Qué hace
Recalcula la cola de disputas a partir de reportes abiertos **frescos** y evita que reportes antiguos sigan contando hacia la disputa de un recurso.

## Por qué una PR nueva
#198 arrastraba —duplicado— todo el bloque SupplyLine-expiry (ya aterrizado en `main` vía #231) y su migración con número colisionado. Esta PR contiene **solo** la feature de frescura de validez (3 ficheros), sin migración ni plumbing ajeno.

## Validación
- [x] `pnpm --filter api build` / `eslint` / `prettier`
- [x] Ficheros de la feature sin dependencia de supply-line; `main` no los había tocado desde la base (aplicación limpia)

## Cierre
- Closes #170

Sustituye a #198.
@