### PR TITLE
feat(supplies): puerto SupplyRepository + códigos INS-NNNN (cierra #216)

### DIFF
--- a/apps/api/drizzle/0038_supply_codes_pad.sql
+++ b/apps/api/drizzle/0038_supply_codes_pad.sql
@@ -1,0 +1,12 @@
+-- Alinea los códigos de insumo al formato canónico INS-NNNN (4 dígitos) que
+-- valida el dominio (`Supply`, ^INS-\d{4}$). La semilla 0037 los sembró como
+-- INS-NNN (3 dígitos). Fix-forward: 0037 ya está aplicada y es inmutable, así
+-- que la corrección va en una migración nueva.
+--
+-- Idempotente: el WHERE solo matchea los de 3 dígitos, de modo que reaplicarla
+-- sobre códigos ya padeados (INS-0001) no hace nada. La unicidad se conserva
+-- (001->0001, 211->0211 siguen siendo distintos).
+
+UPDATE "supplies"
+SET "code" = 'INS-' || lpad(substring("code" FROM 5), 4, '0')
+WHERE "code" ~ '^INS-[0-9]{3}$';

--- a/apps/api/src/contexts/supplies/domain/ports/supply.repository.ts
+++ b/apps/api/src/contexts/supplies/domain/ports/supply.repository.ts
@@ -1,0 +1,25 @@
+import { Supply } from '../supply';
+
+export const SUPPLY_REPOSITORY = Symbol('SUPPLY_REPOSITORY');
+
+/** Parámetros de búsqueda/autocomplete del catálogo (#220). */
+export interface SupplySearchParams {
+  /** Texto libre: resuelto por nombre o alias (vía SupplyResolver). */
+  query?: string;
+  /** Filtra por categoría (slug de `categories`). */
+  categorySlug?: string;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Puerto de persistencia del catálogo maestro de insumos. La implementación
+ * Drizzle vive en infrastructure; el dominio/aplicación solo dependen de esta
+ * interfaz (DIP). Mockeable en tests.
+ */
+export interface SupplyRepository {
+  findById(id: string): Promise<Supply | null>;
+  findByCode(code: string): Promise<Supply | null>;
+  search(params: SupplySearchParams): Promise<Supply[]>;
+  save(supply: Supply): Promise<void>;
+}


### PR DESCRIPTION
Cierra #216 y completa lo que faltaba del dominio del catálogo.

## Cambios
- **Puerto `SupplyRepository`** (`domain/ports/supply.repository.ts`): `findById`, `findByCode`, `search(params)`, `save`. Solo interfaz (DIP); la impl Drizzle llega con la API pública (#220). Mockeable en tests.
- **Migración 0038**: paddea los códigos sembrados `INS-NNN` → `INS-NNNN` para casar con la validación del dominio (`^INS-\d{4}$`). **Fix-forward** sobre `0037` (inmutable), idempotente (`WHERE code ~ '^INS-[0-9]{3}$'`).

## Criterios de #216
- ✅ `Supply.create()` valida nombre, `INS-\d{4}`, `status` default `active` (ya en #230).
- ✅ variante con `variantOfId` + `attributes` (#230).
- ✅ **puerto `SupplyRepository` mockeable** (este PR).
- ✅ `domain/` sin imports de nest/drizzle (el puerto solo importa `Supply`).
- ✅ formato de código del dominio y de la semilla alineados.

## Nota
No cierro #219: su parte de **categorías finas como jerarquía `parent_slug`** sigue abierta (hoy van como `category_aliases`), ligada a la decisión de #218. Aquí solo se alinean los códigos.

Verificación: el guard de inmutabilidad (#239) pasa — este PR solo **añade** `0038`, no toca `0037`.