### PR TITLE
fix(api): logs JSON en producción para Datadog

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import { ConsoleLogger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import helmet from 'helmet';
@@ -23,7 +24,13 @@ function validateJwtSecret(): void {
 async function bootstrap(): Promise<void> {
   validateJwtSecret();
 
-  const app = await NestFactory.create(AppModule);
+  // En producción emitimos logs JSON estructurados (sin colores ANSI) para que
+  // Datadog los parsee en campos; en dev seguimos con el logger coloreado.
+  const app = await NestFactory.create(AppModule, {
+    ...(process.env.NODE_ENV === 'production'
+      ? { logger: new ConsoleLogger({ json: true }) }
+      : {}),
+  });
 
   // ── Security headers (Helmet) ──────────────────────────────────────────────
   // crossOriginResourcePolicy: 'cross-origin' is required so that the Next.js


### PR DESCRIPTION
Los logs de la API salían con códigos de color ANSI (`[32m`, `[39m`…), ilegibles en Datadog.

En producción usamos `ConsoleLogger({ json: true })` (NestJS 11) para emitir logs estructurados que Datadog parsea en campos nativos (level, message, timestamp). En dev se mantiene el logger coloreado de siempre.

Sin cambios de DB, DTOs ni API. Una sola línea de bootstrap.