### PR TITLE
feat(api): access-logs HTTP estructurados + IP de cliente en APM

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,10 +1,12 @@
 import 'dotenv/config';
 import { ConsoleLogger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { configureHttpApp } from './shared/configure-http-app';
+import { httpLogger } from './shared/http/http-logger.middleware';
 
 /**
  * Validates that JWT_SECRET is strong enough in production.
@@ -26,11 +28,15 @@ async function bootstrap(): Promise<void> {
 
   // En producción emitimos logs JSON estructurados (sin colores ANSI) para que
   // Datadog los parsee en campos; en dev seguimos con el logger coloreado.
-  const app = await NestFactory.create(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     ...(process.env.NODE_ENV === 'production'
       ? { logger: new ConsoleLogger({ json: true }) }
       : {}),
   });
+
+  // Behind Caddy (single proxy hop): trust it so req.ip / X-Forwarded-For
+  // resolve the real client IP instead of the proxy's.
+  app.set('trust proxy', 1);
 
   // ── Security headers (Helmet) ──────────────────────────────────────────────
   // crossOriginResourcePolicy: 'cross-origin' is required so that the Next.js
@@ -57,6 +63,10 @@ async function bootstrap(): Promise<void> {
     origin: (process.env.FRONTEND_URL ?? 'http://localhost:3001').split(','),
     credentials: true,
   });
+
+  // One structured access-log line per request (method, status, latency, IP,
+  // user-agent…) correlated with its APM trace. See http-logger.middleware.ts.
+  app.use(httpLogger);
 
   configureHttpApp(app);
   app.enableShutdownHooks();

--- a/apps/api/src/shared/http/http-logger.middleware.spec.ts
+++ b/apps/api/src/shared/http/http-logger.middleware.spec.ts
@@ -1,0 +1,99 @@
+import { Logger } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+
+// Avoid loading the real dd-trace in unit tests; no active span here.
+jest.mock('dd-trace', () => ({
+  __esModule: true,
+  default: { scope: () => ({ active: () => null }) },
+}));
+
+import { httpLogger } from './http-logger.middleware';
+
+type FinishHandler = () => void;
+
+function fakeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'GET',
+    path: '/resources',
+    ip: '203.0.113.7',
+    get: (name: string) =>
+      name.toLowerCase() === 'user-agent' ? 'curl/8.0' : undefined,
+    ...overrides,
+  } as unknown as Request;
+}
+
+function fakeRes(statusCode: number): {
+  res: Response;
+  finish: () => void;
+} {
+  let handler: FinishHandler = () => undefined;
+  const res = {
+    statusCode,
+    on: (event: string, cb: FinishHandler) => {
+      if (event === 'finish') handler = cb;
+    },
+    get: () => undefined,
+  } as unknown as Response;
+  return { res, finish: () => handler() };
+}
+
+describe('httpLogger', () => {
+  it('logs one line with request metadata once the response finishes', () => {
+    const log = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const next = jest.fn() as unknown as NextFunction;
+    const { res, finish } = fakeRes(200);
+
+    httpLogger(fakeReq(), res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(log).not.toHaveBeenCalled(); // nothing logged until 'finish'
+
+    finish();
+
+    expect(log).toHaveBeenCalledTimes(1);
+    const payload = log.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      method: 'GET',
+      path: '/resources',
+      statusCode: 200,
+      ip: '203.0.113.7',
+      userAgent: 'curl/8.0',
+    });
+    expect(typeof payload.durationMs).toBe('number');
+
+    log.mockRestore();
+  });
+
+  it('routes 4xx to warn and 5xx to error', () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const error = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    const next = jest.fn() as unknown as NextFunction;
+
+    const a = fakeRes(404);
+    httpLogger(fakeReq(), a.res, next);
+    a.finish();
+
+    const b = fakeRes(500);
+    httpLogger(fakeReq(), b.res, next);
+    b.finish();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledTimes(1);
+
+    warn.mockRestore();
+    error.mockRestore();
+  });
+
+  it('skips binary/noise prefixes without logging', () => {
+    const log = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const next = jest.fn() as unknown as NextFunction;
+    const { res, finish } = fakeRes(200);
+
+    httpLogger(fakeReq({ path: '/files/abc.jpg' }), res, next);
+    finish();
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(log).not.toHaveBeenCalled();
+
+    log.mockRestore();
+  });
+});

--- a/apps/api/src/shared/http/http-logger.middleware.ts
+++ b/apps/api/src/shared/http/http-logger.middleware.ts
@@ -1,0 +1,67 @@
+import { Logger } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+import tracer from 'dd-trace';
+
+/** Binary/high-noise prefixes we don't emit an access line for. */
+const SKIP_PREFIXES = ['/files/', '/docs'];
+
+const logger = new Logger('HTTP');
+
+/**
+ * Express middleware that emits ONE structured log line per HTTP request, once
+ * the response is flushed (so status, size and duration are final — this also
+ * captures 404s and errors handled by the exception filters).
+ *
+ * Captures the request metadata needed to slice traffic in Datadog: method,
+ * path, status, latency, client IP, user-agent and referer. The active
+ * dd-trace span ids are injected as `dd.trace_id`/`dd.span_id` so each log
+ * line links to its APM trace (the native ConsoleLogger isn't covered by
+ * DD_LOGS_INJECTION, so we inject them by hand).
+ *
+ * Deliberately omits request/response bodies and auth headers (passwords/PII).
+ * `req.ip` is the real client only because `trust proxy` is set in main.ts
+ * (a single Caddy hop). // ponytail: access log only — full body capture would
+ * need redaction; add per-route opt-in if ever needed.
+ */
+export function httpLogger(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const path = req.path;
+  if (SKIP_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+    next();
+    return;
+  }
+
+  const start = process.hrtime.bigint();
+  // Captured here, inside the active request scope; the 'finish' callback may
+  // run after the scope has cleared.
+  const span = tracer.scope().active();
+
+  res.on('finish', () => {
+    const elapsedNs = Number(process.hrtime.bigint() - start);
+    const payload = {
+      method: req.method,
+      path,
+      statusCode: res.statusCode,
+      durationMs: Math.round(elapsedNs / 1e4) / 100,
+      ip: req.ip ?? null,
+      userAgent: req.get('user-agent') ?? null,
+      referer: req.get('referer') ?? null,
+      contentLength: res.get('content-length') ?? null,
+      ...(span
+        ? {
+            'dd.trace_id': span.context().toTraceId(),
+            'dd.span_id': span.context().toSpanId(),
+          }
+        : {}),
+    };
+
+    if (res.statusCode >= 500) logger.error(payload);
+    else if (res.statusCode >= 400) logger.warn(payload);
+    else logger.log(payload);
+  });
+
+  next();
+}

--- a/deploy/datadog.md
+++ b/deploy/datadog.md
@@ -10,7 +10,8 @@ Corre como un servicio más del stack (`datadog` en `deploy/docker-compose.prod.
 - **Postgres** — conexiones, locks, tamaño de BD, transacciones (integración `postgres` por Autodiscovery; usuario de solo lectura `datadog` con rol `pg_monitor`).
 - **Redis** — memoria, ops, clientes (integración `redisdb` por Autodiscovery).
 - **Logs** — de **todos** los contenedores (API, Postgres, Redis, Caddy) → ver errores en vivo.
-- **APM / trazas** — peticiones de la API instrumentadas con `dd-trace`: latencia y errores por endpoint, con spans de Postgres y Redis. Correlación logs↔trazas (`DD_LOGS_INJECTION`).
+- **APM / trazas** — peticiones de la API instrumentadas con `dd-trace`: latencia y errores por endpoint, con spans de Postgres y Redis. Cada span lleva método, ruta, status, user-agent e **IP del cliente** (`DD_TRACE_CLIENT_IP_ENABLED`, leída del `X-Forwarded-For` de Caddy).
+- **Access logs** — una línea JSON por petición (middleware `http-logger.middleware.ts`): `method`, `path`, `statusCode`, `durationMs`, `ip`, `userAgent`, `referer`, `contentLength`, más `dd.trace_id`/`dd.span_id` para saltar del log a su traza APM. **No** registra bodies ni cabeceras de auth (contraseñas/PII). El IP real depende de `trust proxy` en `main.ts` (un único salto de Caddy).
 
 ## Decisiones (caja pequeña)
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -71,6 +71,9 @@ services:
       - DD_ENV=prod
       - DD_SERVICE=responsegrid-api
       - DD_LOGS_INJECTION=true
+      # Tag the real client IP on request spans (read from X-Forwarded-For,
+      # set by Caddy) so APM can slice traffic by IP, not just the proxy's.
+      - DD_TRACE_CLIENT_IP_ENABLED=true
     depends_on:
       migrate:
         condition: service_completed_successfully


### PR DESCRIPTION
Para poder trazar las peticiones HTTP completas en Datadog (IPs, user-agents, status, latencia) y enlazarlas con su traza APM.

## Qué añade
- **Middleware de access-log** (`apps/api/src/shared/http/http-logger.middleware.ts`): una línea JSON por petición con `method`, `path`, `statusCode`, `durationMs`, `ip`, `userAgent`, `referer`, `contentLength`. Se emite en `res.on('finish')`, así captura también 404s y errores de los exception filters.
- **Correlación log↔APM**: inyecta `dd.trace_id`/`dd.span_id` del span activo (el `ConsoleLogger` nativo no lo cubre `DD_LOGS_INJECTION`), para saltar del log a la traza.
- **IP real tras Caddy**: `trust proxy = 1` en main.ts → `req.ip` = cliente, no el proxy.
- **IP en APM**: `DD_TRACE_CLIENT_IP_ENABLED=true` en el compose → el span también etiqueta la IP del cliente.

## Seguridad
- **No** registra bodies ni cabeceras de auth (contraseñas/PII). Las IPs/UA son datos personales; ojo con la retención en Datadog.

## Notas
- El **APM por petición ya funcionaba** (dd-trace vía `--require dd-trace/init`); esto completa la parte de **logs**.
- Test unitario del middleware incluido. Sin cambios de DB/DTO.