### PR TITLE
refactor(api): access-logs con atributos estándar de Datadog

### DIFF
--- a/apps/api/src/shared/http/http-logger.middleware.spec.ts
+++ b/apps/api/src/shared/http/http-logger.middleware.spec.ts
@@ -1,4 +1,3 @@
-import { Logger } from '@nestjs/common';
 import type { NextFunction, Request, Response } from 'express';
 
 // Avoid loading the real dd-trace in unit tests; no active span here.
@@ -15,6 +14,7 @@ function fakeReq(overrides: Partial<Request> = {}): Request {
   return {
     method: 'GET',
     path: '/resources',
+    originalUrl: '/resources?city=Caracas',
     ip: '203.0.113.7',
     get: (name: string) =>
       name.toLowerCase() === 'user-agent' ? 'curl/8.0' : undefined,
@@ -22,50 +22,59 @@ function fakeReq(overrides: Partial<Request> = {}): Request {
   } as unknown as Request;
 }
 
-function fakeRes(statusCode: number): {
-  res: Response;
-  finish: () => void;
-} {
+function fakeRes(statusCode: number): { res: Response; finish: () => void } {
   let handler: FinishHandler = () => undefined;
   const res = {
     statusCode,
     on: (event: string, cb: FinishHandler) => {
       if (event === 'finish') handler = cb;
     },
-    get: () => undefined,
+    get: () => '128',
   } as unknown as Response;
   return { res, finish: () => handler() };
 }
 
+function captureLine(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const spy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      lines.push(String(chunk));
+      return true;
+    });
+  return { lines, restore: () => spy.mockRestore() };
+}
+
 describe('httpLogger', () => {
-  it('logs one line with request metadata once the response finishes', () => {
-    const log = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  it('emits a Datadog-standard JSON line once the response finishes', () => {
+    const { lines, restore } = captureLine();
     const next = jest.fn() as unknown as NextFunction;
     const { res, finish } = fakeRes(200);
 
     httpLogger(fakeReq(), res, next);
     expect(next).toHaveBeenCalledTimes(1);
-    expect(log).not.toHaveBeenCalled(); // nothing logged until 'finish'
+    expect(lines).toHaveLength(0); // nothing until 'finish'
 
     finish();
+    restore();
 
-    expect(log).toHaveBeenCalledTimes(1);
-    const payload = log.mock.calls[0][0] as Record<string, unknown>;
-    expect(payload).toMatchObject({
-      method: 'GET',
-      path: '/resources',
-      statusCode: 200,
-      ip: '203.0.113.7',
-      userAgent: 'curl/8.0',
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]) as Record<string, unknown>;
+    expect(entry).toMatchObject({
+      status: 'info',
+      http: {
+        method: 'GET',
+        status_code: 200,
+        url: '/resources?city=Caracas',
+        useragent: 'curl/8.0',
+      },
+      network: { client: { ip: '203.0.113.7' }, bytes_written: 128 },
     });
-    expect(typeof payload.durationMs).toBe('number');
-
-    log.mockRestore();
+    expect(typeof entry.duration).toBe('number'); // nanoseconds
   });
 
-  it('routes 4xx to warn and 5xx to error', () => {
-    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    const error = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  it('maps 4xx to warn and 5xx to error in `status`', () => {
+    const { lines, restore } = captureLine();
     const next = jest.fn() as unknown as NextFunction;
 
     const a = fakeRes(404);
@@ -75,25 +84,22 @@ describe('httpLogger', () => {
     const b = fakeRes(500);
     httpLogger(fakeReq(), b.res, next);
     b.finish();
+    restore();
 
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(error).toHaveBeenCalledTimes(1);
-
-    warn.mockRestore();
-    error.mockRestore();
+    expect((JSON.parse(lines[0]) as { status: string }).status).toBe('warn');
+    expect((JSON.parse(lines[1]) as { status: string }).status).toBe('error');
   });
 
-  it('skips binary/noise prefixes without logging', () => {
-    const log = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  it('skips binary/noise prefixes without emitting a line', () => {
+    const { lines, restore } = captureLine();
     const next = jest.fn() as unknown as NextFunction;
     const { res, finish } = fakeRes(200);
 
     httpLogger(fakeReq({ path: '/files/abc.jpg' }), res, next);
     finish();
+    restore();
 
     expect(next).toHaveBeenCalledTimes(1);
-    expect(log).not.toHaveBeenCalled();
-
-    log.mockRestore();
+    expect(lines).toHaveLength(0);
   });
 });

--- a/apps/api/src/shared/http/http-logger.middleware.ts
+++ b/apps/api/src/shared/http/http-logger.middleware.ts
@@ -1,22 +1,28 @@
-import { Logger } from '@nestjs/common';
 import type { NextFunction, Request, Response } from 'express';
 import tracer from 'dd-trace';
 
 /** Binary/high-noise prefixes we don't emit an access line for. */
 const SKIP_PREFIXES = ['/files/', '/docs'];
 
-const logger = new Logger('HTTP');
-
 /**
- * Express middleware that emits ONE structured log line per HTTP request, once
+ * Express middleware that emits ONE structured JSON line per HTTP request, once
  * the response is flushed (so status, size and duration are final — this also
  * captures 404s and errors handled by the exception filters).
  *
- * Captures the request metadata needed to slice traffic in Datadog: method,
- * path, status, latency, client IP, user-agent and referer. The active
- * dd-trace span ids are injected as `dd.trace_id`/`dd.span_id` so each log
- * line links to its APM trace (the native ConsoleLogger isn't covered by
- * DD_LOGS_INJECTION, so we inject them by hand).
+ * Field names follow Datadog's **standard/reserved attributes** so the data
+ * lands on the out-of-the-box facets and pipelines with NO custom facet setup:
+ *   - `status`               → Status remapper (severity)
+ *   - `http.method` / `http.status_code` / `http.url` / `http.useragent` /
+ *     `http.referer`         → standard HTTP facets
+ *   - `network.client.ip`    → standard; also triggers Datadog's GeoIP
+ *                              (country/city facets) automatically
+ *   - `network.bytes_written`→ standard
+ *   - `duration` (nanoseconds)→ standard measure
+ *   - `dd.trace_id` / `dd.span_id` → log↔APM trace correlation
+ *
+ * Written straight to stdout (not via Nest's Logger) because the ConsoleLogger
+ * json mode nests the payload under `message.*`, which would break the standard
+ * attribute mapping. The Datadog agent collects the container's stdout.
  *
  * Deliberately omits request/response bodies and auth headers (passwords/PII).
  * `req.ip` is the real client only because `trust proxy` is set in main.ts
@@ -28,8 +34,7 @@ export function httpLogger(
   res: Response,
   next: NextFunction,
 ): void {
-  const path = req.path;
-  if (SKIP_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+  if (SKIP_PREFIXES.some((prefix) => req.path.startsWith(prefix))) {
     next();
     return;
   }
@@ -40,27 +45,39 @@ export function httpLogger(
   const span = tracer.scope().active();
 
   res.on('finish', () => {
-    const elapsedNs = Number(process.hrtime.bigint() - start);
-    const payload = {
-      method: req.method,
-      path,
-      statusCode: res.statusCode,
-      durationMs: Math.round(elapsedNs / 1e4) / 100,
-      ip: req.ip ?? null,
-      userAgent: req.get('user-agent') ?? null,
-      referer: req.get('referer') ?? null,
-      contentLength: res.get('content-length') ?? null,
+    const { statusCode } = res;
+    const status =
+      statusCode >= 500 ? 'error' : statusCode >= 400 ? 'warn' : 'info';
+    const contentLength = res.get('content-length');
+
+    // JSON.stringify drops undefined fields, so optional attributes simply
+    // don't appear when absent.
+    const entry = {
+      status,
+      message: `${req.method} ${req.originalUrl} ${statusCode}`,
+      http: {
+        method: req.method,
+        status_code: statusCode,
+        url: req.originalUrl,
+        useragent: req.get('user-agent'),
+        referer: req.get('referer'),
+      },
+      network: {
+        client: { ip: req.ip },
+        bytes_written: contentLength ? Number(contentLength) : undefined,
+      },
+      duration: Number(process.hrtime.bigint() - start),
       ...(span
         ? {
-            'dd.trace_id': span.context().toTraceId(),
-            'dd.span_id': span.context().toSpanId(),
+            dd: {
+              trace_id: span.context().toTraceId(),
+              span_id: span.context().toSpanId(),
+            },
           }
         : {}),
     };
 
-    if (res.statusCode >= 500) logger.error(payload);
-    else if (res.statusCode >= 400) logger.warn(payload);
-    else logger.log(payload);
+    process.stdout.write(`${JSON.stringify(entry)}\n`);
   });
 
   next();

--- a/deploy/datadog.md
+++ b/deploy/datadog.md
@@ -11,7 +11,7 @@ Corre como un servicio más del stack (`datadog` en `deploy/docker-compose.prod.
 - **Redis** — memoria, ops, clientes (integración `redisdb` por Autodiscovery).
 - **Logs** — de **todos** los contenedores (API, Postgres, Redis, Caddy) → ver errores en vivo.
 - **APM / trazas** — peticiones de la API instrumentadas con `dd-trace`: latencia y errores por endpoint, con spans de Postgres y Redis. Cada span lleva método, ruta, status, user-agent e **IP del cliente** (`DD_TRACE_CLIENT_IP_ENABLED`, leída del `X-Forwarded-For` de Caddy).
-- **Access logs** — una línea JSON por petición (middleware `http-logger.middleware.ts`): `method`, `path`, `statusCode`, `durationMs`, `ip`, `userAgent`, `referer`, `contentLength`, más `dd.trace_id`/`dd.span_id` para saltar del log a su traza APM. **No** registra bodies ni cabeceras de auth (contraseñas/PII). El IP real depende de `trust proxy` en `main.ts` (un único salto de Caddy).
+- **Access logs** — una línea JSON por petición (middleware `http-logger.middleware.ts`), con los **atributos estándar de Datadog** para que caigan en los facets y pipelines out-of-the-box **sin crear facets custom**: `status`, `http.method`, `http.status_code`, `http.url`, `http.useragent`, `http.referer`, `network.client.ip` (dispara el GeoIP → país/ciudad), `network.bytes_written`, `duration` (en ns), y `dd.trace_id`/`dd.span_id` para saltar del log a su traza APM. Se escribe directo a stdout (el `ConsoleLogger` json anidaría todo bajo `message.*` y rompería el mapeo estándar). **No** registra bodies ni cabeceras de auth (contraseñas/PII). El IP real depende de `trust proxy` en `main.ts` (un único salto de Caddy).
 
 ## Decisiones (caja pequeña)
 


### PR DESCRIPTION
Ajusta el access-log para usar los **atributos reservados/estándar de Datadog**, de modo que la telemetría caiga directamente en los facets y pipelines out-of-the-box **sin crear ni mantener facets custom**.

## Mapeo (custom → estándar Datadog)
| Antes | Ahora (estándar) |
|---|---|
| `statusCode` | `http.status_code` |
| `method` | `http.method` |
| `path` | `http.url` |
| `userAgent` | `http.useragent` |
| `referer` | `http.referer` |
| `ip` | `network.client.ip` *(dispara GeoIP → país/ciudad)* |
| `contentLength` | `network.bytes_written` |
| `durationMs` | `duration` *(en ns, measure estándar)* |
| *(nivel)* | `status` *(Status remapper)* |

`dd.trace_id`/`dd.span_id` se mantienen (ya eran los estándar de correlación log↔APM).

## Por qué a stdout
El `ConsoleLogger` de Nest en modo json anida el payload bajo `message.*`, lo que rompería el mapeo a los atributos estándar. El access-log se escribe directo a stdout (lo recoge el agente Datadog igual).

Test unitario actualizado a los nombres estándar. Sin cambios de DB/DTO.