### PR TITLE
docs(deploy): pipeline GeoIP de Datadog

### DIFF
--- a/deploy/datadog.md
+++ b/deploy/datadog.md
@@ -11,7 +11,28 @@ Corre como un servicio más del stack (`datadog` en `deploy/docker-compose.prod.
 - **Redis** — memoria, ops, clientes (integración `redisdb` por Autodiscovery).
 - **Logs** — de **todos** los contenedores (API, Postgres, Redis, Caddy) → ver errores en vivo.
 - **APM / trazas** — peticiones de la API instrumentadas con `dd-trace`: latencia y errores por endpoint, con spans de Postgres y Redis. Cada span lleva método, ruta, status, user-agent e **IP del cliente** (`DD_TRACE_CLIENT_IP_ENABLED`, leída del `X-Forwarded-For` de Caddy).
-- **Access logs** — una línea JSON por petición (middleware `http-logger.middleware.ts`), con los **atributos estándar de Datadog** para que caigan en los facets y pipelines out-of-the-box **sin crear facets custom**: `status`, `http.method`, `http.status_code`, `http.url`, `http.useragent`, `http.referer`, `network.client.ip` (dispara el GeoIP → país/ciudad), `network.bytes_written`, `duration` (en ns), y `dd.trace_id`/`dd.span_id` para saltar del log a su traza APM. Se escribe directo a stdout (el `ConsoleLogger` json anidaría todo bajo `message.*` y rompería el mapeo estándar). **No** registra bodies ni cabeceras de auth (contraseñas/PII). El IP real depende de `trust proxy` en `main.ts` (un único salto de Caddy).
+- **Access logs** — una línea JSON por petición (middleware `http-logger.middleware.ts`), con los **atributos estándar de Datadog** para que caigan en los facets y pipelines out-of-the-box **sin crear facets custom**: `status`, `http.method`, `http.status_code`, `http.url`, `http.useragent`, `http.referer`, `network.client.ip` (enriquecido a país/ciudad por el pipeline GeoIP, ver abajo), `network.bytes_written`, `duration` (en ns), y `dd.trace_id`/`dd.span_id` para saltar del log a su traza APM. Se escribe directo a stdout (el `ConsoleLogger` json anidaría todo bajo `message.*` y rompería el mapeo estándar). **No** registra bodies ni cabeceras de auth (contraseñas/PII). El IP real depende de `trust proxy` en `main.ts` (un único salto de Caddy).
+
+## Pipeline de logs — GeoIP
+
+Pipeline **`ResponseGrid API`** (filtro `service:responsegrid-api`) con un único
+processor **GeoIP Parser** que enriquece `network.client.ip` →
+`network.client.geoip` (país, ciudad, ASN, coordenadas, timezone). Habilita los
+facets `@network.client.geoip.*` y el mapa geográfico de Logs. Solo afecta a
+logs ingeridos **después** de crearlo (no retroactivo).
+
+Se gestiona por API (no vive en el repo). Crear/recrear:
+
+```bash
+curl -X POST "https://api.datadoghq.eu/api/v1/logs/config/pipelines" \
+  -H "DD-API-KEY: $DD_API_KEY" -H "DD-APPLICATION-KEY: $DD_APP_KEY" \
+  -H "Content-Type: application/json" -d '{
+    "name":"ResponseGrid API","is_enabled":true,
+    "filter":{"query":"service:responsegrid-api"},
+    "processors":[{"type":"geo-ip-parser","name":"GeoIP de network.client.ip",
+      "is_enabled":true,"sources":["network.client.ip"],
+      "target":"network.client.geoip"}]}'
+```
 
 ## Decisiones (caja pequeña)
 


### PR DESCRIPTION
Documenta el pipeline de logs `ResponseGrid API` (GeoIP Parser sobre `network.client.ip` → `network.client.geoip`), creado vía API de Datadog. Incluye el curl para recrearlo. Solo docs.