### PR TITLE
feat(deploy): tag de versión (git sha) en Datadog

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Deploy on EC2 via SSM
         run: |
           set -euo pipefail
-          CMD='cd /opt/responsegrid && git fetch origin && git reset --hard origin/main && install -m 644 deploy/responsegrid.service /etc/systemd/system/responsegrid.service && systemctl daemon-reload && systemctl enable responsegrid.service && docker compose -f deploy/docker-compose.prod.yml up -d --build && docker compose -f deploy/docker-compose.prod.yml ps'
+          CMD='cd /opt/responsegrid && git fetch origin && git reset --hard origin/main && printf "DD_VERSION=%s\n" "$(git rev-parse --short HEAD)" > deploy/.env.version && install -m 644 deploy/responsegrid.service /etc/systemd/system/responsegrid.service && systemctl daemon-reload && systemctl enable responsegrid.service && docker compose -f deploy/docker-compose.prod.yml up -d --build && docker compose -f deploy/docker-compose.prod.yml ps'
           PARAMS=$(jq -n --arg c "$CMD" '{commands: [$c]}')
           CID=$(aws ssm send-command \
             --instance-ids i-0f5979080ad5da6e5 \

--- a/deploy/datadog.md
+++ b/deploy/datadog.md
@@ -11,7 +11,23 @@ Corre como un servicio más del stack (`datadog` en `deploy/docker-compose.prod.
 - **Redis** — memoria, ops, clientes (integración `redisdb` por Autodiscovery).
 - **Logs** — de **todos** los contenedores (API, Postgres, Redis, Caddy) → ver errores en vivo.
 - **APM / trazas** — peticiones de la API instrumentadas con `dd-trace`: latencia y errores por endpoint, con spans de Postgres y Redis. Cada span lleva método, ruta, status, user-agent e **IP del cliente** (`DD_TRACE_CLIENT_IP_ENABLED`, leída del `X-Forwarded-For` de Caddy).
+- **Versión desplegada** — cada deploy escribe `DD_VERSION=<git short sha>` en `deploy/.env.version` (el `api` lo lee por `env_file`). `dd-trace` lo pone en las trazas (Deploy Tracking en APM) y el agente lo añade como tag `version` en logs y métricas. Automático: la versión = el commit que corre. Ver abajo.
 - **Access logs** — una línea JSON por petición (middleware `http-logger.middleware.ts`), con los **atributos estándar de Datadog** para que caigan en los facets y pipelines out-of-the-box **sin crear facets custom**: `status`, `http.method`, `http.status_code`, `http.url`, `http.useragent`, `http.referer`, `network.client.ip` (enriquecido a país/ciudad por el pipeline GeoIP, ver abajo), `network.bytes_written`, `duration` (en ns), y `dd.trace_id`/`dd.span_id` para saltar del log a su traza APM. Se escribe directo a stdout (el `ConsoleLogger` json anidaría todo bajo `message.*` y rompería el mapeo estándar). **No** registra bodies ni cabeceras de auth (contraseñas/PII). El IP real depende de `trust proxy` en `main.ts` (un único salto de Caddy).
+
+## Versión desplegada (`DD_VERSION`)
+
+El deploy (`.github/workflows/deploy.yml`), tras `git reset --hard origin/main`,
+escribe `deploy/.env.version` con `DD_VERSION=$(git rev-parse --short HEAD)`. El
+servicio `api` lo carga como `env_file` (opcional, `required:false`), así que:
+
+- **APM** — `dd-trace` etiqueta las trazas con `version` → Deploy Tracking, error
+  rate por versión, regresiones entre despliegues.
+- **Logs y métricas** — el agente lo recoge del env del contenedor (igual que
+  `env`/`service`) y lo añade como tag `version`.
+
+El fichero persiste en disco, así que el reboot por systemd (`docker compose up`)
+mantiene la versión correcta sin recalcular nada. `deploy/.env.version` está
+gitignorado (`.env.*`).
 
 ## Pipeline de logs — GeoIP
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -62,7 +62,13 @@ services:
       context: ..
       dockerfile: apps/api/Dockerfile
     restart: unless-stopped
-    env_file: .env
+    # .env.version holds `DD_VERSION=<git short sha>`, written by the deploy
+    # (and gitignored). Optional so the stack still boots if it's absent.
+    env_file:
+      - path: .env
+        required: true
+      - path: .env.version
+        required: false
     # APM: send traces to the datadog agent container; correlate logs with traces.
     environment:
       - DD_TRACE_ENABLED=true


### PR DESCRIPTION
Saber qué versión del código está desplegada, **automático y sin mantenimiento**.

## Qué hace
- El deploy, tras `git reset --hard origin/main`, escribe `deploy/.env.version` con `DD_VERSION=$(git rev-parse --short HEAD)`.
- El contenedor `api` lo carga vía `env_file` (opcional, `required:false`).
- Resultado:
  - **APM** → `dd-trace` etiqueta las trazas con `version` ⇒ Deploy Tracking, error rate por versión, detección de regresiones entre despliegues.
  - **Logs y métricas** → el agente añade el tag `version` (igual que ya hace con `env`/`service`).

## Por qué así (sin dolores de cabeza)
- La versión = el commit que corre (SHA corto). Nada manual, ningún tag que recordar.
- `deploy/.env.version` **persiste en disco**, así que el reboot por systemd (`docker compose up`) mantiene la versión correcta sin recalcular nada.
- Gitignorado (`.env.*`). Sin cambios de código de la app.

Sin migraciones ni cambios de DTO.