### PR TITLE
fix(web): login/signup redirige al formulario de origen (#258)

### DIFF
--- a/apps/web/src/app/auth/complete/actions.ts
+++ b/apps/web/src/app/auth/complete/actions.ts
@@ -17,5 +17,5 @@ export async function completeOAuthAction(
     redirect('/login?error=oauth_failed');
   }
   await setToken(token.trim());
-  redirect(safeNextPath(next) ?? '/');
+  redirect(safeNextPath(next) ?? '/panel');
 }

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
@@ -23,13 +23,14 @@ function isCategory(value: unknown): value is OfferCategory {
 }
 
 export async function submitOffer(
+  slug: string,
   emergencyId: string,
   _prev: OfferState,
   formData: FormData,
 ): Promise<OfferState> {
   const token = await getToken();
   if (!token) {
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/donar/ofrecer`);
   }
 
   const { t } = await getT();
@@ -131,7 +132,7 @@ export async function submitOffer(
 
   if (response.status === 401) {
     await clearToken();
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/donar/ofrecer`);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
@@ -66,7 +66,7 @@ export default async function DonarPage({ params, searchParams }: Props) {
   const targetNeedId =
     targetNeedTitle !== undefined ? rawNeedId : undefined;
 
-  const boundAction = submitOffer.bind(null, emergency.id);
+  const boundAction = submitOffer.bind(null, slug, emergency.id);
 
   return (
     <main className="flex-1 bg-surface">

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
@@ -42,6 +42,7 @@ function parsePositive(raw: FormDataEntryValue | null): number | undefined | nul
  * bound server-side in the page so neither is trusted from the client form.
  */
 export async function submitCapacity(
+  slug: string,
   emergencyId: string,
   providerId: string,
   _prev: CapacityState,
@@ -49,7 +50,7 @@ export async function submitCapacity(
 ): Promise<CapacityState> {
   const token = await getToken();
   if (!token) {
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/ofrecer-transporte`);
   }
 
   const { t } = await getT();
@@ -135,7 +136,7 @@ export async function submitCapacity(
 
   if (response.status === 401) {
     await clearToken();
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/ofrecer-transporte`);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
@@ -54,7 +54,7 @@ export default async function OfrecerTransportePage({ params }: Props) {
 
   // Bind both the emergency and the provider id server-side so neither is
   // trusted from the client form.
-  const boundAction = submitCapacity.bind(null, emergency.id, me.id);
+  const boundAction = submitCapacity.bind(null, slug, emergency.id, me.id);
 
   return (
     <main className="flex-1 bg-surface">

--- a/apps/web/src/app/e/[slug]/peticion/actions.ts
+++ b/apps/web/src/app/e/[slug]/peticion/actions.ts
@@ -29,13 +29,14 @@ function isPriority(value: unknown): value is NeedPriority {
 }
 
 export async function submitPeticion(
+  slug: string,
   emergencyId: string,
   _prev: PeticionState,
   formData: FormData,
 ): Promise<PeticionState> {
   const token = await getToken();
   if (!token) {
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/peticion`);
   }
 
   const { t } = await getT();
@@ -115,7 +116,7 @@ export async function submitPeticion(
 
   if (response.status === 401) {
     await clearToken();
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/peticion`);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/peticion/page.tsx
+++ b/apps/web/src/app/e/[slug]/peticion/page.tsx
@@ -44,7 +44,7 @@ export default async function PeticionPage({ params }: Props) {
     notFound();
   }
 
-  const boundAction = submitPeticion.bind(null, emergency.id);
+  const boundAction = submitPeticion.bind(null, slug, emergency.id);
 
   return (
     <main className="flex-1 bg-surface">

--- a/apps/web/src/app/e/[slug]/registrar/actions.ts
+++ b/apps/web/src/app/e/[slug]/registrar/actions.ts
@@ -41,13 +41,14 @@ function isStage(value: unknown): value is Stage {
 }
 
 export async function registerResource(
+  slug: string,
   emergencyId: string,
   _prev: ActionState,
   formData: FormData,
 ): Promise<ActionState> {
   const token = await getToken();
   if (!token) {
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/registrar`);
   }
 
   const { t } = await getT();
@@ -124,7 +125,7 @@ export async function registerResource(
 
   if (response.status === 401) {
     await clearToken();
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/registrar`);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/registrar/page.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/page.tsx
@@ -43,7 +43,7 @@ export default async function RegistrarPage({ params }: Props) {
     notFound();
   }
 
-  const boundAction = registerResource.bind(null, emergency.id);
+  const boundAction = registerResource.bind(null, slug, emergency.id);
 
   return (
     <main className="flex-1 bg-surface">

--- a/apps/web/src/app/e/[slug]/voluntario/actions.ts
+++ b/apps/web/src/app/e/[slug]/voluntario/actions.ts
@@ -42,13 +42,14 @@ function isVehicle(value: unknown): value is Vehicle {
 }
 
 export async function registerVolunteer(
+  slug: string,
   emergencyId: string,
   _prev: VolunteerActionState,
   formData: FormData,
 ): Promise<VolunteerActionState> {
   const token = await getToken();
   if (!token) {
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/voluntario`);
   }
 
   const { t } = await getT();
@@ -107,7 +108,7 @@ export async function registerVolunteer(
 
   if (response.status === 401) {
     await clearToken();
-    redirect('/login');
+    redirect(`/login?next=/e/${slug}/voluntario`);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/voluntario/page.tsx
+++ b/apps/web/src/app/e/[slug]/voluntario/page.tsx
@@ -60,7 +60,7 @@ export default async function VoluntarioPage({ params }: Props) {
     existingProfile = data;
   }
 
-  const boundAction = registerVolunteer.bind(null, emergency.id);
+  const boundAction = registerVolunteer.bind(null, slug, emergency.id);
 
   return (
     <main className="flex-1 bg-surface">

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -19,7 +19,7 @@ type Props = {
 export default async function LoginPage({ searchParams }: Props) {
   const resolved = await searchParams;
   const next =
-    typeof resolved.next === 'string' ? resolved.next : '/';
+    typeof resolved.next === 'string' ? resolved.next : '/panel';
   const { t } = await getT();
 
   return (

--- a/apps/web/src/app/signup/actions.ts
+++ b/apps/web/src/app/signup/actions.ts
@@ -49,5 +49,5 @@ export async function signupAction(
 
   await setToken(data.accessToken);
   // Only allow internal relative paths (prevents open-redirect attacks).
-  redirect(safeNextPath(next) ?? '/');
+  redirect(safeNextPath(next) ?? '/panel');
 }

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 export default async function SignupPage({ searchParams }: Props) {
   const resolved = await searchParams;
-  const next = typeof resolved.next === 'string' ? resolved.next : '/';
+  const next = typeof resolved.next === 'string' ? resolved.next : '/panel';
   const { t } = await getT();
 
   return (

--- a/apps/web/src/components/organisms/login-form.tsx
+++ b/apps/web/src/components/organisms/login-form.tsx
@@ -65,7 +65,7 @@ export function LoginForm({ next, t }: LoginFormProps) {
       <p className="text-center text-sm text-muted">
         {t.no_account}{' '}
         <Link
-          href="/signup"
+          href={`/signup?next=${encodeURIComponent(next)}`}
           className="font-semibold text-ink underline underline-offset-2 hover:text-ink-soft"
         >
           {t.create_account}

--- a/apps/web/src/components/organisms/signup-form.tsx
+++ b/apps/web/src/components/organisms/signup-form.tsx
@@ -81,7 +81,7 @@ export function SignupForm({ next, t }: SignupFormProps) {
       <p className="text-center text-sm text-muted">
         {t.already_account}{' '}
         <Link
-          href="/login"
+          href={`/login?next=${encodeURIComponent(next)}`}
           className="font-semibold text-ink underline underline-offset-2 hover:text-ink-soft"
         >
           {t.login_link}

--- a/apps/web/src/lib/safe-next.test.ts
+++ b/apps/web/src/lib/safe-next.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { safeNextPath } from './safe-next.ts';
+
+/**
+ * #258: post-login redirect must return the user to the internal page they came
+ * from, never to an attacker-controlled external target (open-redirect).
+ */
+test('keeps a safe internal path (the origin form)', () => {
+  assert.equal(
+    safeNextPath('/e/terremoto-venezuela-2026/registrar'),
+    '/e/terremoto-venezuela-2026/registrar',
+  );
+});
+
+test('rejects open-redirect targets', () => {
+  assert.equal(safeNextPath('https://evil.com'), null); // absolute URL
+  assert.equal(safeNextPath('//evil.com'), null); // protocol-relative
+  assert.equal(safeNextPath('/\\evil.com'), null); // backslash → //evil.com
+  assert.equal(safeNextPath('relative'), null); // not rooted
+  assert.equal(safeNextPath(undefined), null); // absent
+});


### PR DESCRIPTION
Closes #258

## Qué

Tras autenticarse, el usuario vuelve al formulario donde estaba en lugar de aterrizar en `/`.

## Cambios

- **Enlaces cruzados login↔signup propagan `?next`**: quien va de `/login?next=X` a "crear cuenta" (y viceversa) conserva el destino. Era la causa de que el flujo de signup acabara en `/`.
- **Server actions con sesión caducada al enviar** (`registrar`, `peticion`, `donar/ofrecer`, `ofrecer-transporte`, `voluntario`) redirigen a `/login?next=<ruta>` en vez de `/login` pelado. El `slug` se bindea server-side.
- **Fallback a `/panel`** (antes `/`) en login, signup y OAuth complete cuando `next` está ausente o es inválido.
- Open-redirect ya cubierto por `safeNextPath` (rutas internas únicamente); añadido test.

## Criterios de aceptación

- [x] Server actions que redirigen a `/login` incluyen `?next=<ruta>` (no hay middleware en el web)
- [x] Login exitoso → `next` validado
- [x] Signup exitoso → ídem
- [x] Fallback a `/panel` cuando `next` ausente/ inválido
- [x] `next` nunca acepta URLs externas
- [x] Test de `safeNextPath` (ruta interna vs open-redirect)

## Gate

lint ✓ · api-client build ✓ · web build ✓ · tests 44/44 ✓