### PR TITLE
refactor(web): centraliza el redirect a login en loginHref/requireSession

### DIFF
--- a/apps/web/src/app/e/[slug]/coordinacion/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import type { components } from '@reliefhub/api-client';
 import { api } from '@/lib/api';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 /** A reason is mandatory for every edit/discard; mirror the API's min length. */
@@ -47,7 +47,7 @@ export async function matchOffer(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -61,7 +61,7 @@ export async function matchOffer(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_match };
@@ -85,7 +85,7 @@ export async function fulfillOffer(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -98,7 +98,7 @@ export async function fulfillOffer(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_fulfill };
@@ -119,7 +119,7 @@ export async function cancelOffer(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -132,7 +132,7 @@ export async function cancelOffer(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_cancel };
@@ -158,7 +158,7 @@ export async function verifyAndPublish(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -181,7 +181,7 @@ export async function verifyAndPublish(
   if (!verifyResponse.ok) {
     if (verifyResponse.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return {
       status: 'error',
@@ -200,7 +200,7 @@ export async function verifyAndPublish(
   if (publishError !== undefined) {
     if (publishResponse.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     // The verify step already persisted; refresh so the queue/badge reflect the
     // now-verified state even though publishing failed (avoids a stale "Sin
@@ -222,7 +222,7 @@ export async function validateNeed(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -237,7 +237,7 @@ export async function validateNeed(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return {
       status: 'error',
@@ -258,7 +258,7 @@ export async function renewNeed(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -271,7 +271,7 @@ export async function renewNeed(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_renew };
@@ -301,7 +301,7 @@ export async function pauseEmergency(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -314,7 +314,7 @@ export async function pauseEmergency(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_pause };
@@ -336,7 +336,7 @@ export async function resumeEmergency(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -349,7 +349,7 @@ export async function resumeEmergency(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_resume };
@@ -374,8 +374,7 @@ export async function editNeed(
   slug: string,
   input: EditNeedInput,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) redirect(`/login?next=/e/${slug}/coordinacion`);
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
   if (reasonTooShort(input.reason)) {
@@ -398,7 +397,7 @@ export async function editNeed(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return { status: 'error', message: t.coord.err_edit_failed };
   }
@@ -412,8 +411,7 @@ export async function discardNeed(
   slug: string,
   reason: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) redirect(`/login?next=/e/${slug}/coordinacion`);
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
   if (reasonTooShort(reason)) {
@@ -429,7 +427,7 @@ export async function discardNeed(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return { status: 'error', message: t.coord.err_discard_failed };
   }
@@ -443,8 +441,7 @@ export async function editResource(
   slug: string,
   input: EditResourceInput,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) redirect(`/login?next=/e/${slug}/coordinacion`);
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
   if (reasonTooShort(input.reason)) {
@@ -468,7 +465,7 @@ export async function editResource(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return { status: 'error', message: t.coord.err_edit_failed };
   }
@@ -482,8 +479,7 @@ export async function discardResource(
   slug: string,
   reason: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) redirect(`/login?next=/e/${slug}/coordinacion`);
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
   if (reasonTooShort(reason)) {
@@ -499,7 +495,7 @@ export async function discardResource(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return { status: 'error', message: t.coord.err_discard_failed };
   }
@@ -525,7 +521,7 @@ export async function resolveDispute(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null)
-    redirect(`/login?next=/e/${slug}/coordinacion/puntos-en-duda`);
+    redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
 
   const { t } = await getT();
   if (reasonTooShort(reason)) {
@@ -544,7 +540,7 @@ export async function resolveDispute(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/puntos-en-duda`);
+      redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
     }
     return { status: 'error', message: t.coord.err_resolve_dispute_failed };
   }
@@ -572,7 +568,7 @@ export async function getValidityReports(
 ): Promise<ValidityReportsResult> {
   const token = await getToken();
   if (token === null)
-    redirect(`/login?next=/e/${slug}/coordinacion/puntos-en-duda`);
+    redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
 
   const { t } = await getT();
 
@@ -587,7 +583,7 @@ export async function getValidityReports(
   if (error !== undefined || data === undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/puntos-en-duda`);
+      redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
     }
     return { status: 'error', message: t.coord.err_load_reports_failed };
   }
@@ -600,8 +596,7 @@ export async function editOffer(
   slug: string,
   input: EditOfferInput,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) redirect(`/login?next=/e/${slug}/coordinacion`);
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
   if (reasonTooShort(input.reason)) {
@@ -620,7 +615,7 @@ export async function editOffer(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return { status: 'error', message: t.coord.err_edit_failed };
   }
@@ -634,8 +629,7 @@ export async function discardOffer(
   slug: string,
   reason: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) redirect(`/login?next=/e/${slug}/coordinacion`);
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
   if (reasonTooShort(reason)) {
@@ -651,7 +645,7 @@ export async function discardOffer(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return { status: 'error', message: t.coord.err_discard_failed };
   }
@@ -665,8 +659,7 @@ export async function editReport(
   slug: string,
   input: EditReportInput,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) redirect(`/login?next=/e/${slug}/coordinacion`);
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
   if (reasonTooShort(input.reason)) {
@@ -686,7 +679,7 @@ export async function editReport(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return { status: 'error', message: t.coord.err_edit_failed };
   }
@@ -700,8 +693,7 @@ export async function discardReport(
   slug: string,
   reason: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) redirect(`/login?next=/e/${slug}/coordinacion`);
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
   if (reasonTooShort(reason)) {
@@ -717,7 +709,7 @@ export async function discardReport(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     return { status: 'error', message: t.coord.err_discard_failed };
   }
@@ -733,7 +725,7 @@ export async function publishAnnouncement(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -747,7 +739,7 @@ export async function publishAnnouncement(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_announce };

--- a/apps/web/src/app/e/[slug]/coordinacion/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import type { components } from '@reliefhub/api-client';
 import { api } from '@/lib/api';
-import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 /** A reason is mandatory for every edit/discard; mirror the API's min length. */
@@ -45,10 +45,7 @@ export async function matchOffer(
   needId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 
@@ -83,10 +80,7 @@ export async function fulfillOffer(
   offerId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 
@@ -117,10 +111,7 @@ export async function cancelOffer(
   offerId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 
@@ -156,10 +147,7 @@ export async function verifyAndPublish(
   resourceId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 
@@ -220,10 +208,7 @@ export async function validateNeed(
   needId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 
@@ -256,10 +241,7 @@ export async function renewNeed(
   needId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 
@@ -299,10 +281,7 @@ export async function pauseEmergency(
   emergencyId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 
@@ -334,10 +313,7 @@ export async function resumeEmergency(
   emergencyId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 
@@ -519,9 +495,7 @@ export async function resolveDispute(
   resolution: DisputeResolution,
   reason: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null)
-    redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
+  const token = await requireSession(`/e/${slug}/coordinacion/puntos-en-duda`);
 
   const { t } = await getT();
   if (reasonTooShort(reason)) {
@@ -566,9 +540,7 @@ export async function getValidityReports(
   resourceId: string,
   slug: string,
 ): Promise<ValidityReportsResult> {
-  const token = await getToken();
-  if (token === null)
-    redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
+  const token = await requireSession(`/e/${slug}/coordinacion/puntos-en-duda`);
 
   const { t } = await getT();
 
@@ -723,10 +695,7 @@ export async function publishAnnouncement(
   slug: string,
   message: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/coordinacion/actividad/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/actividad/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -39,7 +39,7 @@ export default async function CoordinacionActividadPage({ params }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/actividad`);
+    redirect(loginHref(`/e/${slug}/coordinacion/actividad`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -53,7 +53,7 @@ export default async function CoordinacionActividadPage({ params }: Props) {
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/actividad`);
+    redirect(loginHref(`/e/${slug}/coordinacion/actividad`));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -78,7 +78,7 @@ export default async function CoordinacionActividadPage({ params }: Props) {
     .then(async (r) => {
       if (r.response.status === 401) {
         await clearToken();
-        redirect(`/login?next=/e/${slug}/coordinacion/actividad`);
+        redirect(loginHref(`/e/${slug}/coordinacion/actividad`));
       }
       if (r.response.status === 403) redirect(`/e/${slug}/coordinacion`);
       return r.data?.entries ?? [];

--- a/apps/web/src/app/e/[slug]/coordinacion/actividad/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/actividad/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -37,10 +37,7 @@ function formatValue(value: unknown): string {
 export default async function CoordinacionActividadPage({ params }: Props) {
   const { slug } = await params;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/actividad`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/actividad`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
 
@@ -35,7 +35,7 @@ export async function createShipment(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
   }
 
   const { t } = await getT();
@@ -67,7 +67,7 @@ export async function createShipment(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+      redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_create };
@@ -95,7 +95,7 @@ export async function assignCapacity(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
   }
 
   const { t } = await getT();
@@ -117,7 +117,7 @@ export async function assignCapacity(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+      redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_assign };
@@ -146,7 +146,7 @@ export async function getCapacitySuggestions(
 ): Promise<SuggestionsResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
   }
 
   const { t } = await getT();
@@ -163,7 +163,7 @@ export async function getCapacitySuggestions(
   if (error !== undefined || data === undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+      redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_assign };
@@ -187,7 +187,7 @@ export async function markInTransit(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=${loginNext}`);
+    redirect(loginHref(loginNext));
   }
 
   const { t } = await getT();
@@ -204,7 +204,7 @@ export async function markInTransit(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=${loginNext}`);
+      redirect(loginHref(loginNext));
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_act };
@@ -230,7 +230,7 @@ export async function confirmDelivery(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=${loginNext}`);
+    redirect(loginHref(loginNext));
   }
 
   const { t } = await getT();
@@ -247,7 +247,7 @@ export async function confirmDelivery(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=${loginNext}`);
+      redirect(loginHref(loginNext));
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_act };
@@ -271,7 +271,7 @@ export async function cancelShipment(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
   }
 
   const { t } = await getT();
@@ -288,7 +288,7 @@ export async function cancelShipment(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+      redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_cancel };

--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
 
@@ -33,10 +33,7 @@ export async function createShipment(
     manifest?: string;
   },
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/expediciones`);
 
   const { t } = await getT();
   const ts = t.coord;
@@ -93,10 +90,7 @@ export async function assignCapacity(
   capacityId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/expediciones`);
 
   const { t } = await getT();
   const ts = t.coord;
@@ -144,10 +138,7 @@ export async function getCapacitySuggestions(
   shipmentId: string,
   slug: string,
 ): Promise<SuggestionsResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/expediciones`);
 
   const { t } = await getT();
   const ts = t.coord;
@@ -185,10 +176,7 @@ export async function markInTransit(
   /** Path to revalidate after the transition. */
   revalidate = `/e/${slug}/coordinacion/expediciones`,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(loginNext));
-  }
+  const token = await requireSession(loginNext);
 
   const { t } = await getT();
   const ts = t.coord;
@@ -228,10 +216,7 @@ export async function confirmDelivery(
   loginNext = `/e/${slug}/coordinacion/expediciones`,
   revalidate = `/e/${slug}/coordinacion/expediciones`,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(loginNext));
-  }
+  const token = await requireSession(loginNext);
 
   const { t } = await getT();
   const ts = t.coord;
@@ -269,10 +254,7 @@ export async function cancelShipment(
   shipmentId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/expediciones`);
 
   const { t } = await getT();
   const ts = t.coord;

--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -66,10 +66,7 @@ export default async function CoordinacionExpedicionesPage({
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/expediciones`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/coordinacion/expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/expediciones/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -68,7 +68,7 @@ export default async function CoordinacionExpedicionesPage({
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -82,7 +82,7 @@ export default async function CoordinacionExpedicionesPage({
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+    redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -128,7 +128,7 @@ export default async function CoordinacionExpedicionesPage({
   const onUnauthorized = async (statusCode: number): Promise<void> => {
     if (statusCode === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/expediciones`);
+      redirect(loginHref(`/e/${slug}/coordinacion/expediciones`));
     }
   };
 

--- a/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken } from '@/lib/auth';
+import { loginHref, getToken, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -45,7 +45,7 @@ export default async function CoordinacionLayout({
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -56,7 +56,7 @@ export default async function CoordinacionLayout({
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(

--- a/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken } from '@/lib/auth';
+import { requireSession, loginHref, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -43,10 +43,7 @@ export default async function CoordinacionLayout({
 }) {
   const { slug } = await params;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  await requireSession(`/e/${slug}/coordinacion`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/coordinacion/ofertas/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/ofertas/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -48,10 +48,7 @@ export default async function CoordinacionOfertasPage({
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/ofertas`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/ofertas`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/coordinacion/ofertas/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/ofertas/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -50,7 +50,7 @@ export default async function CoordinacionOfertasPage({
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/ofertas`);
+    redirect(loginHref(`/e/${slug}/coordinacion/ofertas`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -64,7 +64,7 @@ export default async function CoordinacionOfertasPage({
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/ofertas`);
+    redirect(loginHref(`/e/${slug}/coordinacion/ofertas`));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -97,7 +97,7 @@ export default async function CoordinacionOfertasPage({
   const onUnauthorized = async (statusCode: number): Promise<void> => {
     if (statusCode === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/ofertas`);
+      redirect(loginHref(`/e/${slug}/coordinacion/ofertas`));
     }
   };
 

--- a/apps/web/src/app/e/[slug]/coordinacion/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -36,7 +36,7 @@ export default async function CoordinacionPage({ params }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -50,7 +50,7 @@ export default async function CoordinacionPage({ params }: Props) {
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -65,7 +65,7 @@ export default async function CoordinacionPage({ params }: Props) {
   const onUnauthorized = async (status: number): Promise<void> => {
     if (status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion`);
+      redirect(loginHref(`/e/${slug}/coordinacion`));
     }
   };
 

--- a/apps/web/src/app/e/[slug]/coordinacion/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -34,10 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function CoordinacionPage({ params }: Props) {
   const { slug } = await params;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/coordinacion/personnel-actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/personnel-actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type PersonnelActionResult =
@@ -19,7 +19,7 @@ export async function createTaskFromNeed(
 ): Promise<PersonnelActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   const { t } = await getT();
@@ -35,7 +35,7 @@ export async function createTaskFromNeed(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion`);
+    redirect(loginHref(`/e/${slug}/coordinacion`));
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/e/[slug]/coordinacion/personnel-actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/personnel-actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type PersonnelActionResult =
@@ -17,10 +17,7 @@ export async function createTaskFromNeed(
   volunteerIds: string[],
   dueDate?: string,
 ): Promise<PersonnelActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion`);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/coordinacion/peticiones/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/peticiones/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -51,7 +51,7 @@ export default async function CoordinacionPeticionesPage({
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/peticiones`);
+    redirect(loginHref(`/e/${slug}/coordinacion/peticiones`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -65,7 +65,7 @@ export default async function CoordinacionPeticionesPage({
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/peticiones`);
+    redirect(loginHref(`/e/${slug}/coordinacion/peticiones`));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -101,7 +101,7 @@ export default async function CoordinacionPeticionesPage({
   const onUnauthorized = async (status: number): Promise<void> => {
     if (status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/peticiones`);
+      redirect(loginHref(`/e/${slug}/coordinacion/peticiones`));
     }
   };
 

--- a/apps/web/src/app/e/[slug]/coordinacion/peticiones/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/peticiones/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -49,10 +49,7 @@ export default async function CoordinacionPeticionesPage({
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/peticiones`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/peticiones`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/coordinacion/puntos-en-duda/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/puntos-en-duda/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -35,10 +35,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function CoordinacionDisputesPage({ params }: Props) {
   const { slug } = await params;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/puntos-en-duda`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/coordinacion/puntos-en-duda/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/puntos-en-duda/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -37,7 +37,7 @@ export default async function CoordinacionDisputesPage({ params }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/puntos-en-duda`);
+    redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -51,7 +51,7 @@ export default async function CoordinacionDisputesPage({ params }: Props) {
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/puntos-en-duda`);
+    redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -72,7 +72,7 @@ export default async function CoordinacionDisputesPage({ params }: Props) {
 
   if (result.response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/puntos-en-duda`);
+    redirect(loginHref(`/e/${slug}/coordinacion/puntos-en-duda`));
   }
   if (result.response.status === 403) {
     redirect(`/e/${slug}/coordinacion`);

--- a/apps/web/src/app/e/[slug]/coordinacion/recursos/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/recursos/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -56,10 +56,7 @@ export default async function CoordinacionRecursosPage({
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/recursos`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/recursos`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/coordinacion/recursos/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/recursos/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -58,7 +58,7 @@ export default async function CoordinacionRecursosPage({
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/recursos`);
+    redirect(loginHref(`/e/${slug}/coordinacion/recursos`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -72,7 +72,7 @@ export default async function CoordinacionRecursosPage({
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/recursos`);
+    redirect(loginHref(`/e/${slug}/coordinacion/recursos`));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -120,7 +120,7 @@ export default async function CoordinacionRecursosPage({
 
   if (result.response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/recursos`);
+    redirect(loginHref(`/e/${slug}/coordinacion/recursos`));
   }
   if (result.response.status === 403) {
     redirect(`/e/${slug}/coordinacion`);

--- a/apps/web/src/app/e/[slug]/coordinacion/reportes/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/reportes/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -39,10 +39,7 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/reportes`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/reportes`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/coordinacion/reportes/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/reportes/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -41,7 +41,7 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/reportes`);
+    redirect(loginHref(`/e/${slug}/coordinacion/reportes`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -89,7 +89,7 @@ export default async function CoordinacionReportesPage({ params, searchParams }:
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/reportes`);
+    redirect(loginHref(`/e/${slug}/coordinacion/reportes`));
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/e/[slug]/coordinacion/voluntarios/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/voluntarios/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type ActionResult =
@@ -18,7 +18,7 @@ export async function updateVolunteerStatus(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
   }
 
   const { t } = await getT();
@@ -32,7 +32,7 @@ export async function updateVolunteerStatus(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+      redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_status };
@@ -54,7 +54,7 @@ export async function createTask(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
   }
 
   const { t } = await getT();
@@ -101,7 +101,7 @@ export async function createTask(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+      redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_create };
@@ -120,7 +120,7 @@ export async function assignVolunteer(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
   }
 
   const { t } = await getT();
@@ -134,7 +134,7 @@ export async function assignVolunteer(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+      redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_assign };
@@ -159,7 +159,7 @@ export async function unassignVolunteer(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
   }
 
   const { t } = await getT();
@@ -173,7 +173,7 @@ export async function unassignVolunteer(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+      redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_unassign };
@@ -197,7 +197,7 @@ export async function completeTask(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
   }
 
   const { t } = await getT();
@@ -210,7 +210,7 @@ export async function completeTask(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+      redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_complete };
@@ -231,7 +231,7 @@ export async function cancelTask(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
   }
 
   const { t } = await getT();
@@ -244,7 +244,7 @@ export async function cancelTask(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+      redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_cancel };

--- a/apps/web/src/app/e/[slug]/coordinacion/voluntarios/actions.ts
+++ b/apps/web/src/app/e/[slug]/coordinacion/voluntarios/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type ActionResult =
@@ -16,10 +16,7 @@ export async function updateVolunteerStatus(
   status: 'available' | 'assigned' | 'inactive',
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/voluntarios`);
 
   const { t } = await getT();
 
@@ -52,10 +49,7 @@ export async function createTask(
   slug: string,
   formData: FormData,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/voluntarios`);
 
   const { t } = await getT();
 
@@ -118,10 +112,7 @@ export async function assignVolunteer(
   volunteerId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/voluntarios`);
 
   const { t } = await getT();
 
@@ -157,10 +148,7 @@ export async function unassignVolunteer(
   volunteerId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/voluntarios`);
 
   const { t } = await getT();
 
@@ -195,10 +183,7 @@ export async function completeTask(
   taskId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/voluntarios`);
 
   const { t } = await getT();
 
@@ -229,10 +214,7 @@ export async function cancelTask(
   taskId: string,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/voluntarios`);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/coordinacion/voluntarios/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/voluntarios/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { VolunteerCard } from '@/components/molecules/volunteer-card';
@@ -40,7 +40,7 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -87,7 +87,7 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
 
   if (rosterResult.response.status === 401 || tasksResult.response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/voluntarios`);
+    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
   }
 
   if (rosterResult.response.status === 403 || tasksResult.response.status === 403) {

--- a/apps/web/src/app/e/[slug]/coordinacion/voluntarios/page.tsx
+++ b/apps/web/src/app/e/[slug]/coordinacion/voluntarios/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { VolunteerCard } from '@/components/molecules/volunteer-card';
@@ -38,10 +38,7 @@ export default async function CoordinacionVoluntariosPage({ params, searchParams
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/voluntarios`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/voluntarios`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { MATERIAL_CATEGORIES } from '@/lib/categories';
 
@@ -28,10 +28,7 @@ export async function submitOffer(
   _prev: OfferState,
   formData: FormData,
 ): Promise<OfferState> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/donar/ofrecer`));
-  }
+  const token = await requireSession(`/e/${slug}/donar/ofrecer`);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { getToken, authHeaders, clearToken } from '@/lib/auth';
+import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { MATERIAL_CATEGORIES } from '@/lib/categories';
 
@@ -30,7 +30,7 @@ export async function submitOffer(
 ): Promise<OfferState> {
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/donar/ofrecer`);
+    redirect(loginHref(`/e/${slug}/donar/ofrecer`));
   }
 
   const { t } = await getT();
@@ -132,7 +132,7 @@ export async function submitOffer(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/donar/ofrecer`);
+    redirect(loginHref(`/e/${slug}/donar/ofrecer`));
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { getToken } from '@/lib/auth';
+import { loginHref, getToken } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { OrgSelector } from '@/components/molecules/org-selector';
 import { LocationPicker } from '@/components/organisms/location-picker';
@@ -38,7 +38,7 @@ export default async function DonarPage({ params, searchParams }: Props) {
 
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/donar/ofrecer`);
+    redirect(loginHref(`/e/${slug}/donar/ofrecer`));
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { loginHref, getToken } from '@/lib/auth';
+import { requireSession } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { OrgSelector } from '@/components/molecules/org-selector';
 import { LocationPicker } from '@/components/organisms/location-picker';
@@ -36,10 +36,7 @@ export default async function DonarPage({ params, searchParams }: Props) {
   const resolvedSearchParams = await searchParams;
   const { t } = await getT();
 
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/donar/ofrecer`));
-  }
+  await requireSession(`/e/${slug}/donar/ofrecer`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
@@ -19,10 +19,7 @@ export async function fetchMyVolunteerProfile(
   emergencyId: string,
   slug: string,
 ): Promise<VolunteerProfile | null> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
-  }
+  const token = await requireSession(`/e/${slug}/mi-voluntariado`);
 
   const { data, response } = await api.GET(
     '/emergencies/{emergencyId}/volunteers/me',
@@ -48,10 +45,7 @@ export async function fetchMyTasks(
   emergencyId: string,
   slug: string,
 ): Promise<MyTask[]> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
-  }
+  const token = await requireSession(`/e/${slug}/mi-voluntariado`);
 
   const { data, response } = await api.GET(
     '/emergencies/{emergencyId}/tasks/mine',
@@ -74,10 +68,7 @@ export async function checkInTask(
   volunteerId: string,
   slug: string,
 ): Promise<CheckActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
-  }
+  const token = await requireSession(`/e/${slug}/mi-voluntariado`);
 
   const { response } = await api.POST('/tasks/{taskId}/check-in', {
     params: { path: { taskId } },
@@ -109,10 +100,7 @@ export async function checkOutTask(
   volunteerId: string,
   slug: string,
 ): Promise<CheckActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
-  }
+  const token = await requireSession(`/e/${slug}/mi-voluntariado`);
 
   const { response } = await api.POST('/tasks/{taskId}/check-out', {
     params: { path: { taskId } },

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders, clearToken } from '@/lib/auth';
+import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
@@ -21,7 +21,7 @@ export async function fetchMyVolunteerProfile(
 ): Promise<VolunteerProfile | null> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/mi-voluntariado`);
+    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
   }
 
   const { data, response } = await api.GET(
@@ -34,7 +34,7 @@ export async function fetchMyVolunteerProfile(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/mi-voluntariado`);
+    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
   }
 
   if (response.status === 404 || data === undefined) {
@@ -50,7 +50,7 @@ export async function fetchMyTasks(
 ): Promise<MyTask[]> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/mi-voluntariado`);
+    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
   }
 
   const { data, response } = await api.GET(
@@ -63,7 +63,7 @@ export async function fetchMyTasks(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/mi-voluntariado`);
+    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
   }
 
   return data ?? [];
@@ -76,7 +76,7 @@ export async function checkInTask(
 ): Promise<CheckActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/mi-voluntariado`);
+    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
   }
 
   const { response } = await api.POST('/tasks/{taskId}/check-in', {
@@ -87,7 +87,7 @@ export async function checkInTask(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/mi-voluntariado`);
+    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
   }
 
   if (response.status === 403) {
@@ -111,7 +111,7 @@ export async function checkOutTask(
 ): Promise<CheckActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/mi-voluntariado`);
+    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
   }
 
   const { response } = await api.POST('/tasks/{taskId}/check-out', {
@@ -122,7 +122,7 @@ export async function checkOutTask(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/mi-voluntariado`);
+    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
-import { getToken } from '@/lib/auth';
+import { loginHref, getToken } from '@/lib/auth';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { fetchMyVolunteerProfile, fetchMyTasks } from './actions';
 import { TaskCard } from './task-card';
@@ -63,7 +63,7 @@ export default async function MiVoluntariadoPage({ params }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/mi-voluntariado`);
+    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken } from '@/lib/auth';
+import { notFound } from 'next/navigation';
+import { requireSession } from '@/lib/auth';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { fetchMyVolunteerProfile, fetchMyTasks } from './actions';
 import { TaskCard } from './task-card';
@@ -61,10 +61,7 @@ export default async function MiVoluntariadoPage({ params }: Props) {
     inactive: ta.vol_status_inactive,
   };
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
-  }
+  await requireSession(`/e/${slug}/mi-voluntariado`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { ShipmentsList } from '@/components/organisms/shipments-list';
@@ -31,10 +31,7 @@ export default async function MisExpedicionesPage({ params }: Props) {
   const { t } = await getT();
   const ta = t.account;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/mis-expediciones`));
-  }
+  const token = await requireSession(`/e/${slug}/mis-expediciones`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { ShipmentsList } from '@/components/organisms/shipments-list';
@@ -33,7 +33,7 @@ export default async function MisExpedicionesPage({ params }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/mis-expediciones`);
+    redirect(loginHref(`/e/${slug}/mis-expediciones`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -53,7 +53,7 @@ export default async function MisExpedicionesPage({ params }: Props) {
       .then(async (r) => {
         if (r.response.status === 401) {
           await clearToken();
-          redirect(`/login?next=/e/${slug}/mis-expediciones`);
+          redirect(loginHref(`/e/${slug}/mis-expediciones`));
         }
         return r.data ?? [];
       }),

--- a/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
+++ b/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
@@ -20,7 +20,7 @@ export async function fetchMyResources(
 ): Promise<components['schemas']['ResourceViewDto'][]> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/mis-puntos`);
+    redirect(loginHref(`/e/${slug}/mis-puntos`));
   }
 
   const { data, response } = await api.GET(
@@ -33,7 +33,7 @@ export async function fetchMyResources(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/mis-puntos`);
+    redirect(loginHref(`/e/${slug}/mis-puntos`));
   }
 
   if (!response.ok || data == null) {
@@ -50,7 +50,7 @@ export async function updateResourceStatus(
 ): Promise<ActionResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/mis-puntos`);
+    redirect(loginHref(`/e/${slug}/mis-puntos`));
   }
 
   const { response } = await api.POST('/resources/{resourceId}/status', {
@@ -62,7 +62,7 @@ export async function updateResourceStatus(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/mis-puntos`);
+    redirect(loginHref(`/e/${slug}/mis-puntos`));
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
+++ b/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
@@ -18,10 +18,7 @@ export async function fetchMyResources(
   emergencyId: string,
   slug: string,
 ): Promise<components['schemas']['ResourceViewDto'][]> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/mis-puntos`));
-  }
+  const token = await requireSession(`/e/${slug}/mis-puntos`);
 
   const { data, response } = await api.GET(
     '/emergencies/{emergencyId}/resources/mine',
@@ -48,10 +45,7 @@ export async function updateResourceStatus(
   status: PublicStatus,
   slug: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/mis-puntos`));
-  }
+  const token = await requireSession(`/e/${slug}/mis-puntos`);
 
   const { response } = await api.POST('/resources/{resourceId}/status', {
     params: { path: { resourceId } },

--- a/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
-import { getToken } from '@/lib/auth';
+import { loginHref, getToken } from '@/lib/auth';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { fetchMyResources } from './actions';
 import { StatusForm } from './status-form';
@@ -49,7 +49,7 @@ export default async function MisPuntosPage({ params }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/mis-puntos`);
+    redirect(loginHref(`/e/${slug}/mis-puntos`));
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken } from '@/lib/auth';
+import { notFound } from 'next/navigation';
+import { requireSession } from '@/lib/auth';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { fetchMyResources } from './actions';
 import { StatusForm } from './status-form';
@@ -47,10 +47,7 @@ export default async function MisPuntosPage({ params }: Props) {
     destination: ta.stage_destination,
   };
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/mis-puntos`));
-  }
+  await requireSession(`/e/${slug}/mis-puntos`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { getToken, authHeaders, clearToken } from '@/lib/auth';
+import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 type CapacityMode = components['schemas']['PublishCapacityDto']['mode'];
@@ -50,7 +50,7 @@ export async function submitCapacity(
 ): Promise<CapacityState> {
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/ofrecer-transporte`);
+    redirect(loginHref(`/e/${slug}/ofrecer-transporte`));
   }
 
   const { t } = await getT();
@@ -136,7 +136,7 @@ export async function submitCapacity(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/ofrecer-transporte`);
+    redirect(loginHref(`/e/${slug}/ofrecer-transporte`));
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 type CapacityMode = components['schemas']['PublishCapacityDto']['mode'];
@@ -48,10 +48,7 @@ export async function submitCapacity(
   _prev: CapacityState,
   formData: FormData,
 ): Promise<CapacityState> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/ofrecer-transporte`));
-  }
+  const token = await requireSession(`/e/${slug}/ofrecer-transporte`);
 
   const { t } = await getT();
   const tt = t.ofrecerTransporte;

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { getToken } from '@/lib/auth';
+import { loginHref, getToken } from '@/lib/auth';
 import { getMe } from '@/lib/navigation-data';
 import { submitCapacity } from './actions';
 import { OfrecerTransporteForm } from './ofrecer-transporte-form';
@@ -38,13 +38,13 @@ export default async function OfrecerTransportePage({ params }: Props) {
   // Publishing a capacity REQUIRES auth (capacity:publish, citizen-grade).
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/ofrecer-transporte`);
+    redirect(loginHref(`/e/${slug}/ofrecer-transporte`));
   }
 
   // Resolve the current user — they are the provider (type: volunteer).
   const me = await getMe();
   if (me == null) {
-    redirect(`/login?next=/e/${slug}/ofrecer-transporte`);
+    redirect(loginHref(`/e/${slug}/ofrecer-transporte`));
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { loginHref, getToken } from '@/lib/auth';
+import { requireSession, loginHref } from '@/lib/auth';
 import { getMe } from '@/lib/navigation-data';
 import { submitCapacity } from './actions';
 import { OfrecerTransporteForm } from './ofrecer-transporte-form';
@@ -36,10 +36,7 @@ export default async function OfrecerTransportePage({ params }: Props) {
   const { t } = await getT();
 
   // Publishing a capacity REQUIRES auth (capacity:publish, citizen-grade).
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/ofrecer-transporte`));
-  }
+  await requireSession(`/e/${slug}/ofrecer-transporte`);
 
   // Resolve the current user — they are the provider (type: volunteer).
   const me = await getMe();

--- a/apps/web/src/app/e/[slug]/peticion/actions.ts
+++ b/apps/web/src/app/e/[slug]/peticion/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { getToken, authHeaders, clearToken } from '@/lib/auth';
+import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
 import { ALL_CATEGORIES } from '@/lib/categories';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { getT } from '@/i18n/server';
@@ -36,7 +36,7 @@ export async function submitPeticion(
 ): Promise<PeticionState> {
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/peticion`);
+    redirect(loginHref(`/e/${slug}/peticion`));
   }
 
   const { t } = await getT();
@@ -116,7 +116,7 @@ export async function submitPeticion(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/peticion`);
+    redirect(loginHref(`/e/${slug}/peticion`));
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/peticion/actions.ts
+++ b/apps/web/src/app/e/[slug]/peticion/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
 import { ALL_CATEGORIES } from '@/lib/categories';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { getT } from '@/i18n/server';
@@ -34,10 +34,7 @@ export async function submitPeticion(
   _prev: PeticionState,
   formData: FormData,
 ): Promise<PeticionState> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/peticion`));
-  }
+  const token = await requireSession(`/e/${slug}/peticion`);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/peticion/page.tsx
+++ b/apps/web/src/app/e/[slug]/peticion/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { getToken } from '@/lib/auth';
+import { loginHref, getToken } from '@/lib/auth';
 import { OrgSelector } from '@/components/molecules/org-selector';
 import { LocationPicker } from '@/components/organisms/location-picker';
 import { submitPeticion } from './actions';
@@ -36,7 +36,7 @@ export default async function PeticionPage({ params }: Props) {
 
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/peticion`);
+    redirect(loginHref(`/e/${slug}/peticion`));
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/peticion/page.tsx
+++ b/apps/web/src/app/e/[slug]/peticion/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { loginHref, getToken } from '@/lib/auth';
+import { requireSession } from '@/lib/auth';
 import { OrgSelector } from '@/components/molecules/org-selector';
 import { LocationPicker } from '@/components/organisms/location-picker';
 import { submitPeticion } from './actions';
@@ -34,10 +34,7 @@ export default async function PeticionPage({ params }: Props) {
   const { slug } = await params;
   const { t } = await getT();
 
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/peticion`));
-  }
+  await requireSession(`/e/${slug}/peticion`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -38,7 +38,7 @@ export default async function IntakeDetailPage({ params }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=${next}`);
+    redirect(loginHref(next));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -51,7 +51,7 @@ export default async function IntakeDetailPage({ params }: Props) {
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=${next}`);
+    redirect(loginHref(next));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -69,7 +69,7 @@ export default async function IntakeDetailPage({ params }: Props) {
   });
   if (res.response.status === 401) {
     await clearToken();
-    redirect(`/login?next=${next}`);
+    redirect(loginHref(next));
   }
   if (res.response.status === 403) {
     redirect(`/e/${slug}/recepcion`);

--- a/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -36,10 +36,7 @@ export default async function IntakeDetailPage({ params }: Props) {
   const { slug, intakeId } = await params;
   const next = `/e/${slug}/recepcion/${intakeId}`;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(next));
-  }
+  const token = await requireSession(next);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/recepcion/actions.ts
+++ b/apps/web/src/app/e/[slug]/recepcion/actions.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { getToken, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type ReceptionActionState =
@@ -27,8 +27,7 @@ export async function submitReception(
   _prev: ReceptionActionState,
   formData: FormData,
 ): Promise<ReceptionActionState> {
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/e/${slug}/recepcion`);
+  const token = await requireSession(`/e/${slug}/recepcion`);
 
   const { t } = await getT();
   const tr = t.recepcion;
@@ -67,7 +66,7 @@ export async function submitReception(
 
   if (result.response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/recepcion`);
+    redirect(loginHref(`/e/${slug}/recepcion`));
   }
   if (result.response.status === 409) {
     return { status: 'error', message: tr.err_already_processed };

--- a/apps/web/src/app/e/[slug]/recepcion/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -43,7 +43,7 @@ export default async function RecepcionPage({ params, searchParams }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/recepcion`);
+    redirect(loginHref(`/e/${slug}/recepcion`));
   }
 
   const emergency = await getEmergencyBySlug(slug);
@@ -57,7 +57,7 @@ export default async function RecepcionPage({ params, searchParams }: Props) {
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/recepcion`);
+    redirect(loginHref(`/e/${slug}/recepcion`));
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -82,7 +82,7 @@ export default async function RecepcionPage({ params, searchParams }: Props) {
   });
   if (mineRes.response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/recepcion`);
+    redirect(loginHref(`/e/${slug}/recepcion`));
   }
   const myPoints = (mineRes.data ?? []).filter((r) =>
     COLLECTION_TYPES.has(r.type),

--- a/apps/web/src/app/e/[slug]/recepcion/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -41,10 +41,7 @@ export default async function RecepcionPage({ params, searchParams }: Props) {
   const { slug } = await params;
   const sp = await searchParams;
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/recepcion`));
-  }
+  const token = await requireSession(`/e/${slug}/recepcion`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/actions.ts
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { api } from "@/lib/api";
-import { authHeaders, clearToken, getToken } from "@/lib/auth";
+import { authHeaders, clearToken, getToken, requireSession, loginHref } from "@/lib/auth";
 
 export interface ResourceGrantView {
   id: string;
@@ -78,8 +78,7 @@ export async function grantResourceRoleAction(
   const resourceId = String(formData.get("resourceId") ?? "").trim();
   const principalInput = String(formData.get("principal") ?? "").trim();
   const roleId = String(formData.get("roleId") ?? "").trim();
-  const token = await getToken();
-  if (!token) redirect(resourcePath(slug, resourceId));
+  const token = await requireSession(resourcePath(slug, resourceId));
 
   const scopeType = String(formData.get("scopeType") ?? "").trim();
   const scopeEntityType = String(formData.get("scopeEntityType") ?? "").trim();
@@ -122,7 +121,7 @@ export async function grantResourceRoleAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(resourcePath(slug, resourceId));
+      redirect(loginHref(resourcePath(slug, resourceId)));
     }
     if (response.status === 403) {
       return {
@@ -149,8 +148,7 @@ export async function revokeResourceGrantAction(
   slug: string,
   resourceId: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (!token) redirect(resourcePath(slug, resourceId));
+  const token = await requireSession(resourcePath(slug, resourceId));
 
   const { error, response } = await api.DELETE("/grants/{id}", {
     params: { path: { id: grantId } },
@@ -160,7 +158,7 @@ export async function revokeResourceGrantAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(resourcePath(slug, resourceId));
+      redirect(loginHref(resourcePath(slug, resourceId)));
     }
     if (response.status === 403) {
       return {

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/actions.ts
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/actions.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { getToken, clearToken, authHeaders, loginHref } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { getT } from '@/i18n/server';
@@ -31,7 +31,7 @@ export async function reportValidity(
   _prev: ReportValidityState,
   formData: FormData,
 ): Promise<ReportValidityState> {
-  const loginNext = `/login?next=/e/${slug}/recursos/${resourceId}/reportar-estado`;
+  const loginNext = loginHref(`/e/${slug}/recursos/${resourceId}/reportar-estado`);
   const token = await getToken();
   if (token === null) {
     redirect(loginNext);

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { getToken } from '@/lib/auth';
+import { loginHref, getToken } from '@/lib/auth';
 import { reportValidity } from './actions';
 import { ReportValidezForm } from './report-validez-form';
 import { PageHeaderBand } from '@/components/molecules/page-header-band';
@@ -34,7 +34,7 @@ export default async function ReportarEstadoPage({ params }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/recursos/${resourceId}/reportar-estado`);
+    redirect(loginHref(`/e/${slug}/recursos/${resourceId}/reportar-estado`));
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { loginHref, getToken } from '@/lib/auth';
+import { requireSession } from '@/lib/auth';
 import { reportValidity } from './actions';
 import { ReportValidezForm } from './report-validez-form';
 import { PageHeaderBand } from '@/components/molecules/page-header-band';
@@ -32,10 +32,7 @@ export default async function ReportarEstadoPage({ params }: Props) {
   const { slug, resourceId } = await params;
   const { t } = await getT();
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/recursos/${resourceId}/reportar-estado`));
-  }
+  await requireSession(`/e/${slug}/recursos/${resourceId}/reportar-estado`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/registrar/actions.ts
+++ b/apps/web/src/app/e/[slug]/registrar/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
 import { MATERIAL_CATEGORIES } from '@/lib/categories';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { getT } from '@/i18n/server';
@@ -46,10 +46,7 @@ export async function registerResource(
   _prev: ActionState,
   formData: FormData,
 ): Promise<ActionState> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/registrar`));
-  }
+  const token = await requireSession(`/e/${slug}/registrar`);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/registrar/actions.ts
+++ b/apps/web/src/app/e/[slug]/registrar/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { getToken, authHeaders, clearToken } from '@/lib/auth';
+import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
 import { MATERIAL_CATEGORIES } from '@/lib/categories';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { getT } from '@/i18n/server';
@@ -48,7 +48,7 @@ export async function registerResource(
 ): Promise<ActionState> {
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/registrar`);
+    redirect(loginHref(`/e/${slug}/registrar`));
   }
 
   const { t } = await getT();
@@ -125,7 +125,7 @@ export async function registerResource(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/registrar`);
+    redirect(loginHref(`/e/${slug}/registrar`));
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/registrar/page.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { loginHref, getToken } from '@/lib/auth';
+import { requireSession } from '@/lib/auth';
 import { OrgSelector } from '@/components/molecules/org-selector';
 import { LocationPicker } from '@/components/organisms/location-picker';
 import { registerResource } from './actions';
@@ -33,10 +33,7 @@ export default async function RegistrarPage({ params }: Props) {
   const { slug } = await params;
   const { t, locale } = await getT();
 
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/registrar`));
-  }
+  await requireSession(`/e/${slug}/registrar`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/registrar/page.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { getToken } from '@/lib/auth';
+import { loginHref, getToken } from '@/lib/auth';
 import { OrgSelector } from '@/components/molecules/org-selector';
 import { LocationPicker } from '@/components/organisms/location-picker';
 import { registerResource } from './actions';
@@ -35,7 +35,7 @@ export default async function RegistrarPage({ params }: Props) {
 
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/registrar`);
+    redirect(loginHref(`/e/${slug}/registrar`));
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/reportar/actions.ts
+++ b/apps/web/src/app/e/[slug]/reportar/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { getT } from '@/i18n/server';
@@ -109,7 +109,7 @@ export async function reviewReport(
 ): Promise<ReviewReportResult> {
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/coordinacion/reportes`);
+    redirect(loginHref(`/e/${slug}/coordinacion/reportes`));
   }
 
   const { t } = await getT();
@@ -121,7 +121,7 @@ export async function reviewReport(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/coordinacion/reportes`);
+    redirect(loginHref(`/e/${slug}/coordinacion/reportes`));
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/e/[slug]/reportar/actions.ts
+++ b/apps/web/src/app/e/[slug]/reportar/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { getT } from '@/i18n/server';
@@ -107,10 +107,7 @@ export async function reviewReport(
   reportId: string,
   slug: string,
 ): Promise<ReviewReportResult> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/coordinacion/reportes`));
-  }
+  const token = await requireSession(`/e/${slug}/coordinacion/reportes`);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/reportar/page.tsx
+++ b/apps/web/src/app/e/[slug]/reportar/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { submitReport } from './actions';
 import { ReportForm } from './report-form';
@@ -34,7 +34,7 @@ export default async function ReportarPage({ params, searchParams }: Props) {
 
   const token = await getToken();
   if (token === null) {
-    redirect(`/login?next=/e/${slug}/reportar`);
+    redirect(loginHref(`/e/${slug}/reportar`));
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/reportar/page.tsx
+++ b/apps/web/src/app/e/[slug]/reportar/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { submitReport } from './actions';
 import { ReportForm } from './report-form';
@@ -32,10 +32,7 @@ export default async function ReportarPage({ params, searchParams }: Props) {
   const resolvedSearchParams = await searchParams;
   const { t } = await getT();
 
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(`/e/${slug}/reportar`));
-  }
+  const token = await requireSession(`/e/${slug}/reportar`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/voluntario/actions.ts
+++ b/apps/web/src/app/e/[slug]/voluntario/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 type Skill = components['schemas']['RegisterVolunteerDto']['skills'][number];
@@ -47,10 +47,7 @@ export async function registerVolunteer(
   _prev: VolunteerActionState,
   formData: FormData,
 ): Promise<VolunteerActionState> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/voluntario`));
-  }
+  const token = await requireSession(`/e/${slug}/voluntario`);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/voluntario/actions.ts
+++ b/apps/web/src/app/e/[slug]/voluntario/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { getToken, authHeaders, clearToken } from '@/lib/auth';
+import { loginHref, getToken, authHeaders, clearToken } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 type Skill = components['schemas']['RegisterVolunteerDto']['skills'][number];
@@ -49,7 +49,7 @@ export async function registerVolunteer(
 ): Promise<VolunteerActionState> {
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/voluntario`);
+    redirect(loginHref(`/e/${slug}/voluntario`));
   }
 
   const { t } = await getT();
@@ -108,7 +108,7 @@ export async function registerVolunteer(
 
   if (response.status === 401) {
     await clearToken();
-    redirect(`/login?next=/e/${slug}/voluntario`);
+    redirect(loginHref(`/e/${slug}/voluntario`));
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/voluntario/page.tsx
+++ b/apps/web/src/app/e/[slug]/voluntario/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { registerVolunteer } from './actions';
@@ -37,10 +37,7 @@ export default async function VoluntarioPage({ params }: Props) {
   const { slug } = await params;
   const { t } = await getT();
 
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/e/${slug}/voluntario`));
-  }
+  const token = await requireSession(`/e/${slug}/voluntario`);
 
   const emergency = await getEmergencyBySlug(slug);
   if (!emergency) {

--- a/apps/web/src/app/e/[slug]/voluntario/page.tsx
+++ b/apps/web/src/app/e/[slug]/voluntario/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { registerVolunteer } from './actions';
@@ -39,7 +39,7 @@ export default async function VoluntarioPage({ params }: Props) {
 
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/e/${slug}/voluntario`);
+    redirect(loginHref(`/e/${slug}/voluntario`));
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/panel/administracion/acreditaciones/actions.ts
+++ b/apps/web/src/app/panel/administracion/acreditaciones/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
@@ -49,10 +49,7 @@ export async function grantAccreditationAction(
   _prev: AccreditationActionResult,
   formData: FormData,
 ): Promise<AccreditationActionResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/acreditaciones'));
-  }
+  const token = await requireSession('/panel/administracion/acreditaciones');
 
   const { t } = await getT();
   const ta = t.admin;
@@ -101,10 +98,7 @@ export async function grantAccreditationAction(
 export async function revokeAccreditationAction(
   id: string,
 ): Promise<AccreditationActionResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/acreditaciones'));
-  }
+  const token = await requireSession('/panel/administracion/acreditaciones');
 
   const { t } = await getT();
   const ta = t.admin;

--- a/apps/web/src/app/panel/administracion/acreditaciones/actions.ts
+++ b/apps/web/src/app/panel/administracion/acreditaciones/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
@@ -51,7 +51,7 @@ export async function grantAccreditationAction(
 ): Promise<AccreditationActionResult> {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/acreditaciones');
+    redirect(loginHref('/panel/administracion/acreditaciones'));
   }
 
   const { t } = await getT();
@@ -83,7 +83,7 @@ export async function grantAccreditationAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/acreditaciones');
+      redirect(loginHref('/panel/administracion/acreditaciones'));
     }
     if (response.status === 403) {
       return { status: 'error', message: ta.acc_err_grant_forbidden };
@@ -103,7 +103,7 @@ export async function revokeAccreditationAction(
 ): Promise<AccreditationActionResult> {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/acreditaciones');
+    redirect(loginHref('/panel/administracion/acreditaciones'));
   }
 
   const { t } = await getT();
@@ -117,7 +117,7 @@ export async function revokeAccreditationAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/acreditaciones');
+      redirect(loginHref('/panel/administracion/acreditaciones'));
     }
     if (response.status === 403) {
       return { status: 'error', message: ta.acc_err_revoke_forbidden };

--- a/apps/web/src/app/panel/administracion/acreditaciones/page.tsx
+++ b/apps/web/src/app/panel/administracion/acreditaciones/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchAccreditations } from './actions';
 import { GrantAccreditationForm } from './grant-form';
@@ -22,10 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function AcreditacionesPage() {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/acreditaciones'));
-  }
+  const token = await requireSession('/panel/administracion/acreditaciones');
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),

--- a/apps/web/src/app/panel/administracion/acreditaciones/page.tsx
+++ b/apps/web/src/app/panel/administracion/acreditaciones/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchAccreditations } from './actions';
 import { GrantAccreditationForm } from './grant-form';
@@ -24,7 +24,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function AcreditacionesPage() {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/acreditaciones');
+    redirect(loginHref('/panel/administracion/acreditaciones'));
   }
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
@@ -32,7 +32,7 @@ export default async function AcreditacionesPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect('/login?next=/panel/administracion/acreditaciones');
+    redirect(loginHref('/panel/administracion/acreditaciones'));
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/panel/administracion/ambito/[scopeType]/[id]/actions.ts
+++ b/apps/web/src/app/panel/administracion/ambito/[scopeType]/[id]/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { getToken, requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { parseDateInput } from '@/lib/parse-date-input';
 
@@ -104,8 +104,7 @@ export async function grantRoleAction(
 ): Promise<ActionResult> {
   const scopeType = String(formData.get('scopeType') ?? '').trim() as ScopeType;
   const scopeId = String(formData.get('scopeId') ?? '').trim();
-  const token = await getToken();
-  if (!token) redirect(path(scopeType, scopeId));
+  const token = await requireSession(path(scopeType, scopeId));
 
   const principalInput = String(formData.get('principal') ?? '').trim();
   const roleId = String(formData.get('roleId') ?? '').trim();
@@ -136,7 +135,7 @@ export async function grantRoleAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(path(scopeType, scopeId));
+      redirect(loginHref(path(scopeType, scopeId)));
     }
     if (response.status === 403) {
       return {
@@ -160,8 +159,7 @@ export async function revokeGrantAction(
   scopeType: ScopeType,
   scopeId: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (!token) redirect(path(scopeType, scopeId));
+  const token = await requireSession(path(scopeType, scopeId));
 
   const { error, response } = await api.DELETE('/grants/{id}', {
     params: { path: { id: grantId } },
@@ -171,7 +169,7 @@ export async function revokeGrantAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(path(scopeType, scopeId));
+      redirect(loginHref(path(scopeType, scopeId)));
     }
     if (response.status === 403) {
       return { status: 'error', message: 'No tienes permiso para revocar este rol.' };
@@ -220,8 +218,7 @@ export async function createServiceAccountAction(
   orgId: string,
   name: string,
 ): Promise<ActionResult> {
-  const token = await getToken();
-  if (!token) redirect(path('organization', orgId));
+  const token = await requireSession(path('organization', orgId));
   if (!name.trim()) return { status: 'error', message: 'El nombre es obligatorio.' };
 
   const { error, response } = await api.POST('/service-accounts', {

--- a/apps/web/src/app/panel/administracion/ambito/[scopeType]/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/ambito/[scopeType]/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect, notFound } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -44,15 +44,14 @@ export default async function ScopeAdminPage({ params }: PageProps) {
   const scopeType = rawType;
   const next = `/panel/administracion/ambito/${scopeType}/${scopeId}`;
 
-  const token = await getToken();
-  if (!token) redirect(`/login?next=${next}`);
+  const token = await requireSession(next);
 
   const [meRes, roles] = await Promise.all([
     api.GET('/auth/me', { headers: authHeaders(token) }),
     fetchRoles(),
   ]);
   const me = meRes.data;
-  if (meRes.response.status === 401 || !me) redirect(`/login?next=${next}`);
+  if (meRes.response.status === 401 || !me) redirect(loginHref(next));
 
   // Authorize: the caller must actually administer THIS scope.
   const scope = administrableScopes(me.grants ?? [], roles).find(

--- a/apps/web/src/app/panel/administracion/api-keys/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/api-keys/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchServiceAccounts, fetchApiKeys } from '../actions';
 import { IssueKeyButton } from '../issue-key-button';
@@ -21,13 +21,12 @@ type Props = { params: Promise<{ id: string }> };
 export default async function ServiceAccountDetailPage({ params }: Props) {
   const { id } = await params;
 
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/administracion/api-keys/${id}`);
+  const token = await requireSession(`/panel/administracion/api-keys/${id}`);
 
   const { data: me, response: meRes } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
-  if (meRes.status === 401 || !me) redirect(`/login?next=/panel/administracion/api-keys/${id}`);
+  if (meRes.status === 401 || !me) redirect(loginHref(`/panel/administracion/api-keys/${id}`));
   if (!me.isAdmin) redirect('/');
 
   const [accounts, keys] = await Promise.all([

--- a/apps/web/src/app/panel/administracion/api-keys/actions.ts
+++ b/apps/web/src/app/panel/administracion/api-keys/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 
 export type ApiKeyActionResult =
@@ -63,8 +63,7 @@ export async function createServiceAccountAction(
   _prev: ApiKeyActionResult,
   formData: FormData,
 ): Promise<ApiKeyActionResult> {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/api-keys');
+  const token = await requireSession('/panel/administracion/api-keys');
 
   const name = String(formData.get('name') ?? '').trim();
   const ownerOrganizationId = String(
@@ -84,7 +83,7 @@ export async function createServiceAccountAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/api-keys');
+      redirect(loginHref('/panel/administracion/api-keys'));
     }
     if (response.status === 403) {
       return {
@@ -102,8 +101,7 @@ export async function createServiceAccountAction(
 export async function issueApiKeyAction(
   serviceAccountId: string,
 ): Promise<IssueKeyResult> {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/api-keys');
+  const token = await requireSession('/panel/administracion/api-keys');
 
   const { data, error, response } = await api.POST(
     '/service-accounts/{serviceAccountId}/api-keys',
@@ -129,8 +127,7 @@ export async function revokeApiKeyAction(
   keyId: string,
   serviceAccountId: string,
 ): Promise<ApiKeyActionResult> {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/api-keys');
+  const token = await requireSession('/panel/administracion/api-keys');
 
   const { error, response } = await api.DELETE('/api-keys/{keyId}', {
     params: { path: { keyId } },

--- a/apps/web/src/app/panel/administracion/api-keys/page.tsx
+++ b/apps/web/src/app/panel/administracion/api-keys/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchServiceAccounts } from './actions';
 import { CreateServiceAccountForm } from './create-sa-form';
@@ -17,13 +17,12 @@ export const metadata: Metadata = {
 };
 
 export default async function ApiKeysPage() {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/api-keys');
+  const token = await requireSession('/panel/administracion/api-keys');
 
   const { data: me, response: meRes } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
-  if (meRes.status === 401 || !me) redirect('/login?next=/panel/administracion/api-keys');
+  if (meRes.status === 401 || !me) redirect(loginHref('/panel/administracion/api-keys'));
   if (!me.isAdmin) redirect('/');
 
   const accounts = await fetchServiceAccounts();

--- a/apps/web/src/app/panel/administracion/auditoria/page.tsx
+++ b/apps/web/src/app/panel/administracion/auditoria/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchAuditEntries } from './actions';
 import { AuditFilter } from './audit-filter';
@@ -33,7 +33,7 @@ const PAGE_LIMIT = 50;
 export default async function AuditoriaPage({ searchParams }: PageProps) {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/auditoria');
+    redirect(loginHref('/panel/administracion/auditoria'));
   }
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
@@ -41,7 +41,7 @@ export default async function AuditoriaPage({ searchParams }: PageProps) {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect('/login?next=/panel/administracion/auditoria');
+    redirect(loginHref('/panel/administracion/auditoria'));
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/panel/administracion/auditoria/page.tsx
+++ b/apps/web/src/app/panel/administracion/auditoria/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchAuditEntries } from './actions';
 import { AuditFilter } from './audit-filter';
@@ -31,10 +31,7 @@ interface PageProps {
 const PAGE_LIMIT = 50;
 
 export default async function AuditoriaPage({ searchParams }: PageProps) {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/auditoria'));
-  }
+  const token = await requireSession('/panel/administracion/auditoria');
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),

--- a/apps/web/src/app/panel/administracion/centros/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/centros/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -32,14 +32,13 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function CentroDetailPage({ params }: Props) {
   const { id } = await params;
 
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/administracion/centros/${id}`);
+  const token = await requireSession(`/panel/administracion/centros/${id}`);
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
   if (meResponse.status === 401 || !me) {
-    redirect(`/login?next=/panel/administracion/centros/${id}`);
+    redirect(loginHref(`/panel/administracion/centros/${id}`));
   }
   if (!me.isAdmin) redirect('/');
 

--- a/apps/web/src/app/panel/administracion/centros/actions.ts
+++ b/apps/web/src/app/panel/administracion/centros/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
 import { api } from '@/lib/api';
@@ -21,8 +21,7 @@ export type RecordEntryResult =
 // Unlike the public listing, returns resources of every status and
 // verification level (admin-only view).
 export async function fetchAdminResources(): Promise<ResourceAdminListItem[]> {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/centros');
+  const token = await requireSession('/panel/administracion/centros');
 
   // Pull a generous page: the client filters/searches in-memory like the
   // users/organizations lists. (Pagination can be layered on later if needed.)
@@ -34,7 +33,7 @@ export async function fetchAdminResources(): Promise<ResourceAdminListItem[]> {
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/centros');
+      redirect(loginHref('/panel/administracion/centros'));
     }
     return [];
   }
@@ -46,8 +45,7 @@ export async function fetchAdminResources(): Promise<ResourceAdminListItem[]> {
 export async function fetchAdminResourceDetail(
   id: string,
 ): Promise<ResourceAdminDetail | null> {
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/administracion/centros/${id}`);
+  const token = await requireSession(`/panel/administracion/centros/${id}`);
 
   const { data, error, response } = await api.GET('/resources/{id}', {
     params: { path: { id } },
@@ -57,7 +55,7 @@ export async function fetchAdminResourceDetail(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/panel/administracion/centros/${id}`);
+      redirect(loginHref(`/panel/administracion/centros/${id}`));
     }
     if (response.status === 404) return null;
     return null;
@@ -73,8 +71,7 @@ export async function recordInventoryEntry(
   resourceId: string,
   items: SupplyLineInput[],
 ): Promise<RecordEntryResult> {
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/administracion/centros/${resourceId}`);
+  const token = await requireSession(`/panel/administracion/centros/${resourceId}`);
 
   const { t } = await getT();
   const ta = t.admin;
@@ -95,7 +92,7 @@ export async function recordInventoryEntry(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/panel/administracion/centros/${resourceId}`);
+      redirect(loginHref(`/panel/administracion/centros/${resourceId}`));
     }
     if (response.status === 403) {
       return { status: 'error', message: ta.centros_detail_inv_err_forbidden };

--- a/apps/web/src/app/panel/administracion/centros/page.tsx
+++ b/apps/web/src/app/panel/administracion/centros/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { getT } from '@/i18n/server';
@@ -20,7 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function CentrosPage() {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/centros');
+    redirect(loginHref('/panel/administracion/centros'));
   }
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
@@ -28,7 +28,7 @@ export default async function CentrosPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect('/login?next=/panel/administracion/centros');
+    redirect(loginHref('/panel/administracion/centros'));
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/panel/administracion/centros/page.tsx
+++ b/apps/web/src/app/panel/administracion/centros/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { getT } from '@/i18n/server';
@@ -18,10 +18,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function CentrosPage() {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/centros'));
-  }
+  const token = await requireSession('/panel/administracion/centros');
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),

--- a/apps/web/src/app/panel/administracion/organizaciones/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/organizaciones/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -30,14 +30,13 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function OrganizacionDetailPage({ params }: Props) {
   const { id } = await params;
 
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/administracion/organizaciones/${id}`);
+  const token = await requireSession(`/panel/administracion/organizaciones/${id}`);
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
   if (meResponse.status === 401 || !me) {
-    redirect(`/login?next=/panel/administracion/organizaciones/${id}`);
+    redirect(loginHref(`/panel/administracion/organizaciones/${id}`));
   }
   if (!me.isAdmin) redirect('/');
 

--- a/apps/web/src/app/panel/administracion/organizaciones/actions.ts
+++ b/apps/web/src/app/panel/administracion/organizaciones/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 
@@ -58,8 +58,7 @@ export interface OrganizationDetail {
 }
 
 export async function fetchOrganizations(): Promise<OrganizationListItem[]> {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/organizaciones');
+  const token = await requireSession('/panel/administracion/organizaciones');
 
   const { data, error, response } = await api.GET('/organizations/admin', {
     headers: authHeaders(token),
@@ -68,7 +67,7 @@ export async function fetchOrganizations(): Promise<OrganizationListItem[]> {
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/organizaciones');
+      redirect(loginHref('/panel/administracion/organizaciones'));
     }
     return [];
   }
@@ -80,8 +79,7 @@ export async function fetchOrganizations(): Promise<OrganizationListItem[]> {
 export async function fetchOrganizationDetail(
   id: string,
 ): Promise<OrganizationDetail | null> {
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/administracion/organizaciones/${id}`);
+  const token = await requireSession(`/panel/administracion/organizaciones/${id}`);
 
   const { data, error, response } = await api.GET('/organizations/{id}', {
     params: { path: { id } },
@@ -91,7 +89,7 @@ export async function fetchOrganizationDetail(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/panel/administracion/organizaciones/${id}`);
+      redirect(loginHref(`/panel/administracion/organizaciones/${id}`));
     }
     if (response.status === 404) return null;
     return null;

--- a/apps/web/src/app/panel/administracion/organizaciones/page.tsx
+++ b/apps/web/src/app/panel/administracion/organizaciones/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { getT } from '@/i18n/server';
@@ -18,10 +18,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function OrganizacionesPage() {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/organizaciones'));
-  }
+  const token = await requireSession('/panel/administracion/organizaciones');
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),

--- a/apps/web/src/app/panel/administracion/organizaciones/page.tsx
+++ b/apps/web/src/app/panel/administracion/organizaciones/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { getT } from '@/i18n/server';
@@ -20,7 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function OrganizacionesPage() {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/organizaciones');
+    redirect(loginHref('/panel/administracion/organizaciones'));
   }
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
@@ -28,7 +28,7 @@ export default async function OrganizacionesPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect('/login?next=/panel/administracion/organizaciones');
+    redirect(loginHref('/panel/administracion/organizaciones'));
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/panel/administracion/page.tsx
+++ b/apps/web/src/app/panel/administracion/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { Card } from '@/components/atoms/card';
@@ -30,8 +30,7 @@ function capChips(scope: AdminScope): string[] {
 }
 
 export default async function AdministracionPage() {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion');
+  const token = await requireSession('/panel/administracion');
 
   const [meRes, rolesRes, emergenciesRes] = await Promise.all([
     api.GET('/auth/me', { headers: authHeaders(token) }),
@@ -40,7 +39,7 @@ export default async function AdministracionPage() {
   ]);
 
   const me = meRes.data;
-  if (meRes.response.status === 401 || !me) redirect('/login?next=/panel/administracion');
+  if (meRes.response.status === 401 || !me) redirect(loginHref('/panel/administracion'));
 
   const roles = (rolesRes.data ?? []) as { id: string; permissions: string[] }[];
   const scopes = sortAdminScopes(administrableScopes(me.grants ?? [], roles));

--- a/apps/web/src/app/panel/administracion/permisos/actions.ts
+++ b/apps/web/src/app/panel/administracion/permisos/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { parseDateInput } from '@/lib/parse-date-input';
 
@@ -87,8 +87,7 @@ export async function grantRoleAction(
   _prev: GrantActionResult,
   formData: FormData,
 ): Promise<GrantActionResult> {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/permisos');
+  const token = await requireSession('/panel/administracion/permisos');
 
   const principalId = String(formData.get('principalId') ?? '').trim();
   const roleId = String(formData.get('roleId') ?? '').trim();
@@ -125,7 +124,7 @@ export async function grantRoleAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/permisos');
+      redirect(loginHref('/panel/administracion/permisos'));
     }
     if (response.status === 403) {
       return {
@@ -147,8 +146,7 @@ export async function grantRoleAction(
 export async function revokeGrantAction(
   grantId: string,
 ): Promise<GrantActionResult> {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/permisos');
+  const token = await requireSession('/panel/administracion/permisos');
 
   const { error, response } = await api.DELETE('/grants/{id}', {
     params: { path: { id: grantId } },

--- a/apps/web/src/app/panel/administracion/permisos/page.tsx
+++ b/apps/web/src/app/panel/administracion/permisos/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchRoles, fetchGrants, resolvePrincipal } from './actions';
 import { GrantRoleForm } from './grant-role-form';
@@ -20,13 +20,12 @@ export const metadata: Metadata = {
 type Props = { searchParams: Promise<{ principalId?: string }> };
 
 export default async function PermisosPage({ searchParams }: Props) {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/permisos');
+  const token = await requireSession('/panel/administracion/permisos');
 
   const { data: me, response: meRes } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
-  if (meRes.status === 401 || !me) redirect('/login?next=/panel/administracion/permisos');
+  if (meRes.status === 401 || !me) redirect(loginHref('/panel/administracion/permisos'));
   if (!me.isAdmin) redirect('/');
 
   const { principalId } = await searchParams;

--- a/apps/web/src/app/panel/administracion/plantillas/actions.ts
+++ b/apps/web/src/app/panel/administracion/plantillas/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
@@ -33,7 +33,7 @@ export async function createTemplateAction(
 ): Promise<TemplateActionResult> {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/plantillas');
+    redirect(loginHref('/panel/administracion/plantillas'));
   }
 
   const { t } = await getT();
@@ -71,7 +71,7 @@ export async function createTemplateAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/plantillas');
+      redirect(loginHref('/panel/administracion/plantillas'));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.templates.err_no_permission_create };
@@ -89,7 +89,7 @@ export async function createTemplateAction(
 export async function deleteTemplateAction(id: string): Promise<TemplateActionResult> {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/plantillas');
+    redirect(loginHref('/panel/administracion/plantillas'));
   }
 
   const { t } = await getT();
@@ -102,7 +102,7 @@ export async function deleteTemplateAction(id: string): Promise<TemplateActionRe
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/plantillas');
+      redirect(loginHref('/panel/administracion/plantillas'));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.templates.err_no_permission_delete };
@@ -128,7 +128,7 @@ export async function createFromTemplateAction(
 ): Promise<CreateFromTemplateResult> {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/plantillas');
+    redirect(loginHref('/panel/administracion/plantillas'));
   }
 
   const { t } = await getT();
@@ -159,7 +159,7 @@ export async function createFromTemplateAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/plantillas');
+      redirect(loginHref('/panel/administracion/plantillas'));
     }
     if (response.status === 403) {
       return { status: 'error', message: t.templates.err_no_permission_create_emergency };

--- a/apps/web/src/app/panel/administracion/plantillas/actions.ts
+++ b/apps/web/src/app/panel/administracion/plantillas/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
@@ -31,10 +31,7 @@ export async function createTemplateAction(
   _prev: TemplateActionResult,
   formData: FormData,
 ): Promise<TemplateActionResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/plantillas'));
-  }
+  const token = await requireSession('/panel/administracion/plantillas');
 
   const { t } = await getT();
 
@@ -87,10 +84,7 @@ export async function createTemplateAction(
 }
 
 export async function deleteTemplateAction(id: string): Promise<TemplateActionResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/plantillas'));
-  }
+  const token = await requireSession('/panel/administracion/plantillas');
 
   const { t } = await getT();
 
@@ -126,10 +120,7 @@ export async function createFromTemplateAction(
   _prev: CreateFromTemplateResult,
   formData: FormData,
 ): Promise<CreateFromTemplateResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/plantillas'));
-  }
+  const token = await requireSession('/panel/administracion/plantillas');
 
   const { t } = await getT();
 

--- a/apps/web/src/app/panel/administracion/plantillas/page.tsx
+++ b/apps/web/src/app/panel/administracion/plantillas/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import { fetchTemplates } from './actions';
@@ -24,7 +24,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function TemplatesPage() {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/plantillas');
+    redirect(loginHref('/panel/administracion/plantillas'));
   }
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
@@ -32,7 +32,7 @@ export default async function TemplatesPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect('/login?next=/panel/administracion/plantillas');
+    redirect(loginHref('/panel/administracion/plantillas'));
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/panel/administracion/plantillas/page.tsx
+++ b/apps/web/src/app/panel/administracion/plantillas/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import { fetchTemplates } from './actions';
@@ -22,10 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function TemplatesPage() {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/plantillas'));
-  }
+  const token = await requireSession('/panel/administracion/plantillas');
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),

--- a/apps/web/src/app/panel/administracion/usuarios/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/usuarios/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -24,14 +24,13 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function UsuarioDetailPage({ params }: Props) {
   const { id } = await params;
 
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/administracion/usuarios/${id}`);
+  const token = await requireSession(`/panel/administracion/usuarios/${id}`);
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
   if (meResponse.status === 401 || !me) {
-    redirect(`/login?next=/panel/administracion/usuarios/${id}`);
+    redirect(loginHref(`/panel/administracion/usuarios/${id}`));
   }
   if (!me.isAdmin) redirect('/');
 

--- a/apps/web/src/app/panel/administracion/usuarios/actions.ts
+++ b/apps/web/src/app/panel/administracion/usuarios/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 
@@ -57,8 +57,7 @@ export interface UserDetail {
 }
 
 export async function fetchUsers(): Promise<UserListItem[]> {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/administracion/usuarios');
+  const token = await requireSession('/panel/administracion/usuarios');
 
   const { data, error, response } = await api.GET('/users', {
     headers: authHeaders(token),
@@ -67,7 +66,7 @@ export async function fetchUsers(): Promise<UserListItem[]> {
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/administracion/usuarios');
+      redirect(loginHref('/panel/administracion/usuarios'));
     }
     return [];
   }
@@ -77,8 +76,7 @@ export async function fetchUsers(): Promise<UserListItem[]> {
 
 // Returns null on 404 so the page can render a not-found state.
 export async function fetchUserDetail(id: string): Promise<UserDetail | null> {
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/administracion/usuarios/${id}`);
+  const token = await requireSession(`/panel/administracion/usuarios/${id}`);
 
   const { data, error, response } = await api.GET('/users/{id}', {
     params: { path: { id } },
@@ -88,7 +86,7 @@ export async function fetchUserDetail(id: string): Promise<UserDetail | null> {
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect(`/login?next=/panel/administracion/usuarios/${id}`);
+      redirect(loginHref(`/panel/administracion/usuarios/${id}`));
     }
     if (response.status === 404) return null;
     return null;

--- a/apps/web/src/app/panel/administracion/usuarios/page.tsx
+++ b/apps/web/src/app/panel/administracion/usuarios/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { getT } from '@/i18n/server';
@@ -20,7 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function UsuariosPage() {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/administracion/usuarios');
+    redirect(loginHref('/panel/administracion/usuarios'));
   }
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
@@ -28,7 +28,7 @@ export default async function UsuariosPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect('/login?next=/panel/administracion/usuarios');
+    redirect(loginHref('/panel/administracion/usuarios'));
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/panel/administracion/usuarios/page.tsx
+++ b/apps/web/src/app/panel/administracion/usuarios/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { getT } from '@/i18n/server';
@@ -18,10 +18,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function UsuariosPage() {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/administracion/usuarios'));
-  }
+  const token = await requireSession('/panel/administracion/usuarios');
 
   const { data: me, response: meResponse } = await api.GET('/auth/me', {
     headers: authHeaders(token),

--- a/apps/web/src/app/panel/grupos/[id]/page.tsx
+++ b/apps/web/src/app/panel/grupos/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
-import { loginHref, getToken } from '@/lib/auth';
+import { notFound } from 'next/navigation';
+import { requireSession } from '@/lib/auth';
 import {
   fetchGroup,
   fetchGroupMembers,
@@ -25,10 +25,7 @@ type Props = { params: Promise<{ id: string }> };
 export default async function GroupDetailPage({ params }: Props) {
   const { id } = await params;
 
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/panel/grupos/${id}`));
-  }
+  await requireSession(`/panel/grupos/${id}`);
 
   const group = await fetchGroup(id);
   if (!group) {

--- a/apps/web/src/app/panel/grupos/[id]/page.tsx
+++ b/apps/web/src/app/panel/grupos/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getToken } from '@/lib/auth';
+import { loginHref, getToken } from '@/lib/auth';
 import {
   fetchGroup,
   fetchGroupMembers,
@@ -27,7 +27,7 @@ export default async function GroupDetailPage({ params }: Props) {
 
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/panel/grupos/${id}`);
+    redirect(loginHref(`/panel/grupos/${id}`));
   }
 
   const group = await fetchGroup(id);

--- a/apps/web/src/app/panel/grupos/actions.ts
+++ b/apps/web/src/app/panel/grupos/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 
 export type GroupActionResult =
@@ -79,8 +79,7 @@ export async function createGroupAction(
   _prev: GroupActionResult,
   formData: FormData,
 ): Promise<GroupActionResult> {
-  const token = await getToken();
-  if (!token) redirect('/login?next=/panel/grupos');
+  const token = await requireSession('/panel/grupos');
 
   const name = String(formData.get('name') ?? '').trim();
   const visibility = String(formData.get('visibility') ?? 'private');
@@ -108,7 +107,7 @@ export async function createGroupAction(
   if (error !== undefined) {
     if (response.status === 401) {
       await clearToken();
-      redirect('/login?next=/panel/grupos');
+      redirect(loginHref('/panel/grupos'));
     }
     if (response.status === 403) {
       return {
@@ -126,8 +125,7 @@ export async function createGroupAction(
 export async function requestToJoinAction(
   groupId: string,
 ): Promise<GroupActionResult> {
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/grupos/${groupId}`);
+  const token = await requireSession(`/panel/grupos/${groupId}`);
 
   const { error, response } = await api.POST('/groups/{groupId}/join', {
     params: { path: { groupId } },
@@ -152,8 +150,7 @@ export async function approveMemberAction(
   groupId: string,
   userId: string,
 ): Promise<GroupActionResult> {
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/grupos/${groupId}`);
+  const token = await requireSession(`/panel/grupos/${groupId}`);
 
   const { error } = await api.POST(
     '/groups/{groupId}/members/{userId}/approve',
@@ -176,7 +173,7 @@ export async function addMemberByEmailAction(
 ): Promise<GroupActionResult> {
   const token = await getToken();
   const groupId = String(formData.get('groupId') ?? '');
-  if (!token) redirect(`/login?next=/panel/grupos/${groupId}`);
+  if (!token) redirect(loginHref(`/panel/grupos/${groupId}`));
 
   const email = String(formData.get('email') ?? '').trim();
   if (!email) return { status: 'error', message: 'El email es obligatorio.' };
@@ -211,8 +208,7 @@ export async function assignManagerAction(
   groupId: string,
   userId: string,
 ): Promise<GroupActionResult> {
-  const token = await getToken();
-  if (!token) redirect(`/login?next=/panel/grupos/${groupId}`);
+  const token = await requireSession(`/panel/grupos/${groupId}`);
 
   const { error, response } = await api.POST('/groups/{groupId}/managers', {
     params: { path: { groupId } },

--- a/apps/web/src/app/panel/grupos/page.tsx
+++ b/apps/web/src/app/panel/grupos/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchMyGroups } from './actions';
 import { CreateGroupForm } from './create-group-form';
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 export default async function GruposPage() {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/grupos');
+    redirect(loginHref('/panel/grupos'));
   }
 
   const [{ data: me, response: meRes }, { data: roles }, myGroups] =
@@ -31,7 +31,7 @@ export default async function GruposPage() {
     ]);
 
   if (meRes.status === 401 || !me) {
-    redirect('/login?next=/panel/grupos');
+    redirect(loginHref('/panel/grupos'));
   }
 
   const roleMap = new Map((roles ?? []).map((r) => [r.id, r]));

--- a/apps/web/src/app/panel/grupos/page.tsx
+++ b/apps/web/src/app/panel/grupos/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchMyGroups } from './actions';
 import { CreateGroupForm } from './create-group-form';
@@ -18,10 +18,7 @@ export const metadata: Metadata = {
 };
 
 export default async function GruposPage() {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/grupos'));
-  }
+  const token = await requireSession('/panel/grupos');
 
   const [{ data: me, response: meRes }, { data: roles }, myGroups] =
     await Promise.all([

--- a/apps/web/src/app/panel/mi-perfil/page.tsx
+++ b/apps/web/src/app/panel/mi-perfil/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -18,8 +18,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function MiPerfilPage() {
-  const token = await getToken();
-  if (token === null) redirect('/login?next=/panel/mi-perfil');
+  const token = await requireSession('/panel/mi-perfil');
 
   const { t } = await getT();
   const tm = t.miPerfil;
@@ -28,7 +27,7 @@ export default async function MiPerfilPage() {
     headers: authHeaders(token),
   });
 
-  if (me === undefined) redirect('/login?next=/panel/mi-perfil');
+  if (me === undefined) redirect(loginHref('/panel/mi-perfil'));
 
   return (
     <main className="flex-1 bg-surface">

--- a/apps/web/src/app/panel/mis-donaciones/page.tsx
+++ b/apps/web/src/app/panel/mis-donaciones/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getToken, clearToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -29,7 +29,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function MisDonacionesPage() {
   const token = await getToken();
   if (token === null) {
-    redirect('/login?next=/panel/mis-donaciones');
+    redirect(loginHref('/panel/mis-donaciones'));
   }
 
   const { t, locale } = await getT();
@@ -40,7 +40,7 @@ export default async function MisDonacionesPage() {
   });
   if (res.response.status === 401) {
     await clearToken();
-    redirect('/login?next=/panel/mis-donaciones');
+    redirect(loginHref('/panel/mis-donaciones'));
   }
   const donations = res.data ?? [];
 

--- a/apps/web/src/app/panel/mis-donaciones/page.tsx
+++ b/apps/web/src/app/panel/mis-donaciones/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -27,10 +27,7 @@ export async function generateMetadata(): Promise<Metadata> {
  * search is a separate, permission-gated surface.
  */
 export default async function MisDonacionesPage() {
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref('/panel/mis-donaciones'));
-  }
+  const token = await requireSession('/panel/mis-donaciones');
 
   const { t, locale } = await getT();
   const tm = t.misDonaciones;

--- a/apps/web/src/app/panel/mis-permisos/page.tsx
+++ b/apps/web/src/app/panel/mis-permisos/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { scopeLabel } from '@/lib/permissions';
 import { formatDate } from '@/lib/format-date';
@@ -16,10 +16,7 @@ export const metadata: Metadata = {
 };
 
 export default async function MisPermisosPage() {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/mis-permisos'));
-  }
+  const token = await requireSession('/panel/mis-permisos');
 
   const [{ data: me, response: meRes }, { data: roles }] = await Promise.all([
     api.GET('/auth/me', { headers: authHeaders(token) }),

--- a/apps/web/src/app/panel/mis-permisos/page.tsx
+++ b/apps/web/src/app/panel/mis-permisos/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { scopeLabel } from '@/lib/permissions';
 import { formatDate } from '@/lib/format-date';
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 export default async function MisPermisosPage() {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/mis-permisos');
+    redirect(loginHref('/panel/mis-permisos'));
   }
 
   const [{ data: me, response: meRes }, { data: roles }] = await Promise.all([
@@ -27,7 +27,7 @@ export default async function MisPermisosPage() {
   ]);
 
   if (meRes.status === 401 || !me) {
-    redirect('/login?next=/panel/mis-permisos');
+    redirect(loginHref('/panel/mis-permisos'));
   }
 
   const roleMap = new Map((roles ?? []).map((r) => [r.id, r]));

--- a/apps/web/src/app/panel/notificaciones/actions.ts
+++ b/apps/web/src/app/panel/notificaciones/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type NotificationActionResult =
@@ -18,10 +18,7 @@ export type NotificationActionResult =
 export async function markNotificationReadAction(
   id: string,
 ): Promise<NotificationActionResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/notificaciones'));
-  }
+  const token = await requireSession('/panel/notificaciones');
 
   const { t } = await getT();
 
@@ -47,10 +44,7 @@ export async function markNotificationReadAction(
 }
 
 export async function markAllNotificationsReadAction(): Promise<NotificationActionResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/notificaciones'));
-  }
+  const token = await requireSession('/panel/notificaciones');
 
   const { t } = await getT();
 

--- a/apps/web/src/app/panel/notificaciones/actions.ts
+++ b/apps/web/src/app/panel/notificaciones/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type NotificationActionResult =
@@ -20,7 +20,7 @@ export async function markNotificationReadAction(
 ): Promise<NotificationActionResult> {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/notificaciones');
+    redirect(loginHref('/panel/notificaciones'));
   }
 
   const { t } = await getT();
@@ -31,7 +31,7 @@ export async function markNotificationReadAction(
   });
 
   if (error !== undefined) {
-    if (response.status === 401) redirect('/login?next=/panel/notificaciones');
+    if (response.status === 401) redirect(loginHref('/panel/notificaciones'));
     if (response.status === 403) {
       return { status: 'error', message: t.notificaciones.err_mark_read_forbidden };
     }
@@ -49,7 +49,7 @@ export async function markNotificationReadAction(
 export async function markAllNotificationsReadAction(): Promise<NotificationActionResult> {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/notificaciones');
+    redirect(loginHref('/panel/notificaciones'));
   }
 
   const { t } = await getT();
@@ -59,7 +59,7 @@ export async function markAllNotificationsReadAction(): Promise<NotificationActi
   });
 
   if (error !== undefined) {
-    if (response.status === 401) redirect('/login?next=/panel/notificaciones');
+    if (response.status === 401) redirect(loginHref('/panel/notificaciones'));
     return { status: 'error', message: t.notificaciones.err_mark_all_read_failed };
   }
 

--- a/apps/web/src/app/panel/notificaciones/page.tsx
+++ b/apps/web/src/app/panel/notificaciones/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { NotificationItem } from '@/components/molecules/notification-item';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function NotificacionesPage() {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/notificaciones');
+    redirect(loginHref('/panel/notificaciones'));
   }
 
   const { data } = await api.GET('/notifications/mine', {

--- a/apps/web/src/app/panel/notificaciones/page.tsx
+++ b/apps/web/src/app/panel/notificaciones/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
+
 import { api } from '@/lib/api';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders } from '@/lib/auth';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { NotificationItem } from '@/components/molecules/notification-item';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -20,10 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function NotificacionesPage() {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/notificaciones'));
-  }
+  const token = await requireSession('/panel/notificaciones');
 
   const { data } = await api.GET('/notifications/mine', {
     headers: authHeaders(token),

--- a/apps/web/src/app/panel/organizaciones/[id]/page.tsx
+++ b/apps/web/src/app/panel/organizaciones/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders } from '@/lib/auth';
 import { AddMemberForm } from './add-member-form';
 import { RemoveMemberButton } from './remove-member-button';
 import { Badge } from '@/components/atoms/badge';
@@ -23,10 +23,7 @@ type Props = {
 export default async function OrganizationDetailPage({ params }: Props) {
   const { id } = await params;
 
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/panel/organizaciones/${id}`));
-  }
+  const token = await requireSession(`/panel/organizaciones/${id}`);
 
   const { data: me } = await api.GET('/auth/me', {
     headers: authHeaders(token),

--- a/apps/web/src/app/panel/organizaciones/[id]/page.tsx
+++ b/apps/web/src/app/panel/organizaciones/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { AddMemberForm } from './add-member-form';
 import { RemoveMemberButton } from './remove-member-button';
 import { Badge } from '@/components/atoms/badge';
@@ -25,7 +25,7 @@ export default async function OrganizationDetailPage({ params }: Props) {
 
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/panel/organizaciones/${id}`);
+    redirect(loginHref(`/panel/organizaciones/${id}`));
   }
 
   const { data: me } = await api.GET('/auth/me', {

--- a/apps/web/src/app/panel/organizaciones/actions.ts
+++ b/apps/web/src/app/panel/organizaciones/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type OrgActionResult =
@@ -17,7 +17,7 @@ export async function createOrganizationAction(
 ): Promise<OrgActionResult> {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/organizaciones');
+    redirect(loginHref('/panel/organizaciones'));
   }
 
   const { t } = await getT();
@@ -41,7 +41,7 @@ export async function createOrganizationAction(
   });
 
   if (error !== undefined || data === undefined) {
-    if (response.status === 401) redirect('/login?next=/panel/organizaciones');
+    if (response.status === 401) redirect(loginHref('/panel/organizaciones'));
     return { status: 'error', message: t.organizaciones.err_create_failed };
   }
 
@@ -56,7 +56,7 @@ export async function addMemberAction(
 ): Promise<OrgActionResult> {
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/panel/organizaciones/${orgId}`);
+    redirect(loginHref(`/panel/organizaciones/${orgId}`));
   }
 
   const { t } = await getT();
@@ -73,7 +73,7 @@ export async function addMemberAction(
   });
 
   if (error !== undefined) {
-    if (response.status === 401) redirect(`/login?next=/panel/organizaciones/${orgId}`);
+    if (response.status === 401) redirect(loginHref(`/panel/organizaciones/${orgId}`));
     if (response.status === 403) {
       return { status: 'error', message: t.organizaciones.err_owner_only };
     }
@@ -96,7 +96,7 @@ export async function removeMemberAction(
 ): Promise<OrgActionResult> {
   const token = await getToken();
   if (!token) {
-    redirect(`/login?next=/panel/organizaciones/${orgId}`);
+    redirect(loginHref(`/panel/organizaciones/${orgId}`));
   }
 
   const { t } = await getT();
@@ -107,7 +107,7 @@ export async function removeMemberAction(
   });
 
   if (error !== undefined) {
-    if (response.status === 401) redirect(`/login?next=/panel/organizaciones/${orgId}`);
+    if (response.status === 401) redirect(loginHref(`/panel/organizaciones/${orgId}`));
     if (response.status === 403) {
       return { status: 'error', message: t.organizaciones.err_owner_only };
     }

--- a/apps/web/src/app/panel/organizaciones/actions.ts
+++ b/apps/web/src/app/panel/organizaciones/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type OrgActionResult =
@@ -15,10 +15,7 @@ export async function createOrganizationAction(
   _prev: OrgActionResult,
   formData: FormData,
 ): Promise<OrgActionResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/organizaciones'));
-  }
+  const token = await requireSession('/panel/organizaciones');
 
   const { t } = await getT();
 
@@ -54,10 +51,7 @@ export async function addMemberAction(
   _prev: OrgActionResult,
   formData: FormData,
 ): Promise<OrgActionResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/panel/organizaciones/${orgId}`));
-  }
+  const token = await requireSession(`/panel/organizaciones/${orgId}`);
 
   const { t } = await getT();
 
@@ -94,10 +88,7 @@ export async function removeMemberAction(
   orgId: string,
   userId: string,
 ): Promise<OrgActionResult> {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref(`/panel/organizaciones/${orgId}`));
-  }
+  const token = await requireSession(`/panel/organizaciones/${orgId}`);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/panel/organizaciones/page.tsx
+++ b/apps/web/src/app/panel/organizaciones/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { getToken, authHeaders } from '@/lib/auth';
+import { loginHref, getToken, authHeaders } from '@/lib/auth';
 import { CreateOrgForm } from './create-org-form';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function OrganizacionesPage() {
   const token = await getToken();
   if (!token) {
-    redirect('/login?next=/panel/organizaciones');
+    redirect(loginHref('/panel/organizaciones'));
   }
 
   const { data: orgs } = await api.GET('/organizations/mine', {

--- a/apps/web/src/app/panel/organizaciones/page.tsx
+++ b/apps/web/src/app/panel/organizaciones/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
+
 import { api } from '@/lib/api';
-import { loginHref, getToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders } from '@/lib/auth';
 import { CreateOrgForm } from './create-org-form';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -20,10 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function OrganizacionesPage() {
-  const token = await getToken();
-  if (!token) {
-    redirect(loginHref('/panel/organizaciones'));
-  }
+  const token = await requireSession('/panel/organizaciones');
 
   const { data: orgs } = await api.GET('/organizations/mine', {
     headers: authHeaders(token),

--- a/apps/web/src/app/panel/page.tsx
+++ b/apps/web/src/app/panel/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import {
@@ -32,11 +32,10 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function PanelPage() {
-  const token = await getToken();
-  if (token == null) redirect('/login?next=/panel');
+  const token = await requireSession('/panel');
 
   const me = await getMe();
-  if (me == null) redirect('/login?next=/panel');
+  if (me == null) redirect(loginHref('/panel'));
 
   const { t } = await getT();
   const tp = t.panel;

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,4 +1,11 @@
 import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { loginHref } from './safe-next';
+
+// Re-exported so server callers can pull the login-redirect contract and the
+// session gate from one place (`@/lib/auth`); defined in `safe-next` because it
+// is pure and must stay importable from client components too.
+export { loginHref };
 
 const COOKIE_NAME = 'rh_token';
 
@@ -49,4 +56,19 @@ export async function clearToken(): Promise<void> {
  */
 export function authHeaders(token: string): { Authorization: string } {
   return { Authorization: `Bearer ${token}` };
+}
+
+/**
+ * Coarse authentication gate for Server Components and Server Actions: returns
+ * the session token, or redirects to login — preserving `next` — when there is
+ * no session cookie.
+ *
+ * It only checks for the presence of the cookie; it does NOT validate the token
+ * against the API. Callers that additionally call `/auth/me` still handle a 401
+ * from that call and redirect via {@link loginHref}.
+ */
+export async function requireSession(next?: string | null): Promise<string> {
+  const token = await getToken();
+  if (!token) redirect(loginHref(next));
+  return token;
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,13 +1,14 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { loginHref } from './safe-next';
+import { SESSION_COOKIE } from './session-cookie';
 
 // Re-exported so server callers can pull the login-redirect contract and the
 // session gate from one place (`@/lib/auth`); defined in `safe-next` because it
 // is pure and must stay importable from client components too.
 export { loginHref };
 
-const COOKIE_NAME = 'rh_token';
+const COOKIE_NAME = SESSION_COOKIE;
 
 /**
  * Session lifetime in seconds. Defaults to 8 hours; override with SESSION_MAX_AGE_SECONDS

--- a/apps/web/src/lib/safe-next.test.ts
+++ b/apps/web/src/lib/safe-next.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { safeNextPath } from './safe-next.ts';
+import { safeNextPath, loginHref } from './safe-next.ts';
 
 /**
  * #258: post-login redirect must return the user to the internal page they came
@@ -19,4 +19,23 @@ test('rejects open-redirect targets', () => {
   assert.equal(safeNextPath('/\\evil.com'), null); // backslash → //evil.com
   assert.equal(safeNextPath('relative'), null); // not rooted
   assert.equal(safeNextPath(undefined), null); // absent
+});
+
+/**
+ * loginHref is the single source of truth for the `?next=` contract: every
+ * login redirect goes through it, so a safe origin round-trips and an unsafe or
+ * absent one collapses to a plain `/login` (never an open redirect).
+ */
+test('loginHref embeds a safe origin as an encoded next param', () => {
+  assert.equal(
+    loginHref('/e/terremoto-venezuela-2026/registrar'),
+    '/login?next=%2Fe%2Fterremoto-venezuela-2026%2Fregistrar',
+  );
+});
+
+test('loginHref falls back to plain /login for unsafe or missing next', () => {
+  assert.equal(loginHref('https://evil.com'), '/login'); // open-redirect dropped
+  assert.equal(loginHref('//evil.com'), '/login');
+  assert.equal(loginHref(undefined), '/login');
+  assert.equal(loginHref(null), '/login');
 });

--- a/apps/web/src/lib/safe-next.ts
+++ b/apps/web/src/lib/safe-next.ts
@@ -13,3 +13,20 @@ export function safeNextPath(value: unknown): string | null {
   if (value.includes('\\')) return null;
   return value;
 }
+
+/**
+ * Single source of truth for the "send the user to login and bring them back"
+ * contract. Given the internal route the user is on, returns the login URL that
+ * restores it afterwards (`/login?next=<route>`). `next` is sanitised via
+ * {@link safeNextPath}, so callers can pass a raw route without risking an open
+ * redirect, and an absent/unsafe value collapses to a plain `/login`.
+ *
+ * Build every login redirect through this helper — never hand-write the
+ * `?next=` query string — so the return path can't be forgotten (the #258 bug).
+ * Pure and client-safe; server callers usually reach it re-exported from
+ * `@/lib/auth` alongside {@link requireSession}.
+ */
+export function loginHref(next?: string | null): string {
+  const safe = safeNextPath(next);
+  return safe ? `/login?next=${encodeURIComponent(safe)}` : '/login';
+}

--- a/apps/web/src/lib/session-cookie.ts
+++ b/apps/web/src/lib/session-cookie.ts
@@ -1,0 +1,6 @@
+/**
+ * Name of the httpOnly cookie that holds the session JWT. Lives in its own pure
+ * module so both the server session helpers (`@/lib/auth`) and the edge proxy
+ * (`proxy.ts`, which must not import `next/headers`) share one source of truth.
+ */
+export const SESSION_COOKIE = 'rh_token';

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,0 +1,36 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { loginHref } from '@/lib/safe-next';
+import { SESSION_COOKIE } from '@/lib/session-cookie';
+
+/**
+ * Optimistic auth gate — Next 16 "proxy" (the renamed middleware).
+ *
+ * Runs at the edge before rendering and bounces unauthenticated visitors of
+ * fully-protected areas straight to login, preserving where they were headed
+ * via `?next=` (built through the same {@link loginHref} contract as the rest
+ * of the app). It only checks for the presence of the session cookie.
+ *
+ * This is deliberately an OPTIMISTIC check, per the Next docs: proxy must not be
+ * the sole gate. Every protected page and every server action still calls
+ * `requireSession` and validates the token against the API — server actions in
+ * particular aren't reliably covered by the matcher. So if this matcher ever
+ * drifts, the per-page gate still protects the route; the only thing lost is the
+ * earlier redirect.
+ *
+ * Scope: whole segments that are protected in their entirety (`/panel/*` and the
+ * coordination workspace). Scattered single-page forms under `/e/:slug`
+ * (registrar, peticion, …) keep their authoritative per-page `requireSession`
+ * gate rather than being enumerated here, where the list would silently drift.
+ */
+export function proxy(request: NextRequest): NextResponse {
+  if (request.cookies.has(SESSION_COOKIE)) return NextResponse.next();
+  const { pathname, search } = request.nextUrl;
+  return NextResponse.redirect(new URL(loginHref(pathname + search), request.url));
+}
+
+export const config = {
+  matcher: [
+    '/panel/:path*',
+    '/e/:slug/coordinacion/:path*',
+  ],
+};


### PR DESCRIPTION
Refactor de la **causa raíz** de #258 + cierre de los dos huecos detectados en revisión.

## Problema

`#258` fue un síntoma: el contrato `?next=` estaba a mano en 227 sitios de 70 archivos. Olvidarlo era trivial — y pasó. Viola DRY / Single-Point-of-Truth y SRP.

## Solución (SOLID / Clean Code)

- **`loginHref(next)`** (`lib/safe-next.ts`) — punto único del contrato: `/login?next=<ruta>` con `safeNextPath` incorporado. No se puede construir el redirect sin sanitizar → muere la clase de bug. Puro y client-safe.
- **`requireSession(next)`** (`lib/auth.ts`) — gate de sesión: token o redirect a login preservando origen. Re-exporta `loginHref`.
- **Patrón único en todo el web:** `requireSession(next)` para el gate de cookie, `loginHref(next)` para el check secundario (`me==null`/401). Cero `/login?next=` a mano.
- Tests de `loginHref` (round-trip interno + colapso a `/login` si inseguro).

## Huecos de la revisión (ahora resueltos)

- **Admin redirigía a la página del recurso en `!token`/401** (ámbito y recursos), rebotando a login sin `?next`. Ahora usan `requireSession`/`loginHref` → login directo con `?next=<página>`.
- **Proxy (middleware) de gating optimista** — `apps/web/src/proxy.ts` (Next 16 renombra middleware→proxy). Redirige a login con `?next=` en `/panel/*` y `/e/:slug/coordinacion/*` si no hay cookie, antes de renderizar. Es un check **optimista** (lo que recomiendan los docs): la autorización real sigue por página/action vía `requireSession` + validación del token (los server actions no los cubre el matcher de forma fiable). Nombre de cookie extraído a `lib/session-cookie` (SPOT). Segmentos sueltos bajo `/e/:slug` (registrar, peticion…) siguen con su gate por página, autoritativo, para no enumerar una lista que derivaría.

## Verificación

- **HTTP real (sin cookie):** `/panel`, `/panel/grupos`, `/panel/administracion/usuarios/1`, `/e/foo/coordinacion(+sub)` → 307 a `/login?next=…`; `/` y `/login` → 200. `/e/foo/registrar` → 307 vía el gate de página (mismo destino).
- lint ✓ (solo el warning pre-existente de `<img>`) · api-client build ✓ · web build ✓ (`ƒ Proxy` reconocido) · tests 46/46 ✓.
- Neto **−180 líneas**.

Relacionado con #258 (ya mergeado; esto ataca la causa).