### PR TITLE
fix(resources): redacta el contacto en la API pública (privacidad real) + limpieza de stage

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -9774,7 +9774,13 @@
           "contact": {
             "type": "string",
             "example": "+58 212 555 0000",
-            "nullable": true
+            "nullable": true,
+            "description": "Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell \"hidden\" from \"absent\"."
+          },
+          "hasContact": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether a contact exists on file, regardless of whether `contact` is revealed to this caller."
           },
           "schedule": {
             "type": "string",
@@ -9842,6 +9848,7 @@
           "ownerOrganizationId",
           "accepts",
           "contact",
+          "hasContact",
           "schedule",
           "manager",
           "sourceName",
@@ -10143,7 +10150,13 @@
           "contact": {
             "type": "string",
             "example": "+58 212 555 0000",
-            "nullable": true
+            "nullable": true,
+            "description": "Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell \"hidden\" from \"absent\"."
+          },
+          "hasContact": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether a contact exists on file, regardless of whether `contact` is revealed to this caller."
           },
           "schedule": {
             "type": "string",
@@ -10216,6 +10229,7 @@
           "ownerOrganizationId",
           "accepts",
           "contact",
+          "hasContact",
           "schedule",
           "manager",
           "sourceName",
@@ -10358,7 +10372,13 @@
           "contact": {
             "type": "string",
             "example": "+58 212 555 0000",
-            "nullable": true
+            "nullable": true,
+            "description": "Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell \"hidden\" from \"absent\"."
+          },
+          "hasContact": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether a contact exists on file, regardless of whether `contact` is revealed to this caller."
           },
           "schedule": {
             "type": "string",
@@ -10437,6 +10457,7 @@
           "ownerOrganizationId",
           "accepts",
           "contact",
+          "hasContact",
           "schedule",
           "manager",
           "sourceName",
@@ -10558,7 +10579,13 @@
           "contact": {
             "type": "string",
             "example": "+58 212 555 0000",
-            "nullable": true
+            "nullable": true,
+            "description": "Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell \"hidden\" from \"absent\"."
+          },
+          "hasContact": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether a contact exists on file, regardless of whether `contact` is revealed to this caller."
           },
           "schedule": {
             "type": "string",
@@ -10648,6 +10675,7 @@
           "ownerOrganizationId",
           "accepts",
           "contact",
+          "hasContact",
           "schedule",
           "manager",
           "sourceName",
@@ -10763,7 +10791,13 @@
           "contact": {
             "type": "string",
             "example": "+58 212 555 0000",
-            "nullable": true
+            "nullable": true,
+            "description": "Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell \"hidden\" from \"absent\"."
+          },
+          "hasContact": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether a contact exists on file, regardless of whether `contact` is revealed to this caller."
           },
           "schedule": {
             "type": "string",
@@ -10871,6 +10905,7 @@
           "ownerOrganizationId",
           "accepts",
           "contact",
+          "hasContact",
           "schedule",
           "manager",
           "sourceName",

--- a/apps/api/src/contexts/resources/application/redact-contact.spec.ts
+++ b/apps/api/src/contexts/resources/application/redact-contact.spec.ts
@@ -1,0 +1,71 @@
+import { redactContact } from './redact-contact';
+import { ResourceView } from './resource-view';
+import {
+  ResourceType,
+  VerificationLevel,
+  PublicStatus,
+} from '../domain/resource-enums';
+
+function view(overrides: Partial<ResourceView> = {}): ResourceView {
+  return {
+    id: 'r1',
+    type: ResourceType.CollectionPoint,
+    name: 'Punto',
+    description: null,
+    location: { address: '—', latitude: 0, longitude: 0 },
+    verificationLevel: VerificationLevel.Unverified,
+    publicStatus: PublicStatus.Active,
+    ownerOrganizationId: null,
+    accepts: [],
+    contact: '+58 212 555 0000',
+    hasContact: true,
+    schedule: null,
+    manager: null,
+    sourceName: null,
+    externalUpdatedAt: null,
+    country: null,
+    city: null,
+    isFinalRecipient: false,
+    recipientType: null,
+    disputed: false,
+    disputedAt: null,
+    ...overrides,
+  };
+}
+
+describe('redactContact', () => {
+  it('hides the contact from an anonymous caller for a non-official resource', () => {
+    const result = redactContact(view(), false);
+    expect(result.contact).toBeNull();
+    // still signals that a contact exists behind auth
+    expect(result.hasContact).toBe(true);
+  });
+
+  it('reveals the contact to an authenticated caller', () => {
+    const result = redactContact(view(), true);
+    expect(result.contact).toBe('+58 212 555 0000');
+  });
+
+  it('reveals the contact of an official resource even to anonymous callers', () => {
+    const result = redactContact(
+      view({ verificationLevel: VerificationLevel.Official }),
+      false,
+    );
+    expect(result.contact).toBe('+58 212 555 0000');
+  });
+
+  it('leaves a null contact untouched (hasContact false)', () => {
+    const result = redactContact(
+      view({ contact: null, hasContact: false }),
+      false,
+    );
+    expect(result.contact).toBeNull();
+    expect(result.hasContact).toBe(false);
+  });
+
+  it('does not mutate the original view', () => {
+    const original = view();
+    redactContact(original, false);
+    expect(original.contact).toBe('+58 212 555 0000');
+  });
+});

--- a/apps/api/src/contexts/resources/application/redact-contact.ts
+++ b/apps/api/src/contexts/resources/application/redact-contact.ts
@@ -1,0 +1,21 @@
+import { ResourceView } from './resource-view';
+import { VerificationLevel } from '../domain/resource-enums';
+
+/**
+ * `contact` is personal data (a phone number / person's line). The public
+ * endpoints are anonymous, so we must not broadcast it to scrapers. Policy:
+ * the contact is only revealed when the caller is authenticated, OR the
+ * resource is an `official` source (an organisation whose public line is
+ * meant to be public). Otherwise `contact` is nulled — but `hasContact`
+ * stays true so the UI can honestly say "log in to see it" instead of
+ * "no contact".
+ */
+export function redactContact<T extends ResourceView>(
+  view: T,
+  authenticated: boolean,
+): T {
+  if (authenticated || view.verificationLevel === VerificationLevel.Official) {
+    return view;
+  }
+  return { ...view, contact: null };
+}

--- a/apps/api/src/contexts/resources/application/resource-view.ts
+++ b/apps/api/src/contexts/resources/application/resource-view.ts
@@ -19,6 +19,13 @@ export interface ResourceView {
   // enriched fields
   accepts: string[];
   contact: string | null;
+  /**
+   * Whether the resource has a contact on file, independent of whether
+   * `contact` is revealed to this caller. Lets the public UI show a
+   * "log in to see it" hint instead of "no contact" once `contact` is
+   * redacted for anonymous callers. See {@link redactContact}.
+   */
+  hasContact: boolean;
   schedule: string | null;
   manager: string | null;
   sourceName: string | null;
@@ -61,6 +68,7 @@ export function toResourceView(r: Resource): ResourceView {
     ownerOrganizationId: r.ownerOrganizationId,
     accepts: r.accepts,
     contact: r.contact,
+    hasContact: r.contact != null,
     schedule: r.schedule,
     manager: r.manager,
     sourceName: r.provenance?.sourceName ?? null,

--- a/apps/api/src/contexts/resources/infrastructure/http/public.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/public.controller.ts
@@ -5,7 +5,10 @@ import {
   Param,
   ParseUUIDPipe,
   Query,
+  Req,
+  UseGuards,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import {
   ApiTags,
   ApiOperation,
@@ -19,6 +22,9 @@ import { GetNearbyResources } from '../../application/get-nearby-resources';
 import { GetResourcesInBounds } from '../../application/get-resources-in-bounds';
 import { GetPublicResource } from '../../application/get-public-resource';
 import { ResourceDetailView } from '../../application/resource-view';
+import { redactContact } from '../../application/redact-contact';
+import { OptionalJwtAuthGuard } from '../../../identity/infrastructure/http/optional-jwt-auth.guard';
+import type { AuthenticatedUser } from '../../../identity/infrastructure/http/jwt-auth.guard';
 import {
   PagedResourcesDto,
   ResourceFacetsDto,
@@ -32,8 +38,13 @@ import {
   InBoundsQueryDto,
 } from './dto';
 
+type OptionalAuthedRequest = Request & { user?: AuthenticatedUser };
+
 @ApiTags('public')
 @Controller()
+// Optional auth: an anonymous caller gets `contact` redacted on non-official
+// resources (it's personal data); a caller with a valid Bearer token sees it.
+@UseGuards(OptionalJwtAuthGuard)
 export class PublicController {
   constructor(
     private readonly getPublicResources: GetPublicResources,
@@ -60,8 +71,9 @@ export class PublicController {
   async list(
     @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
     @Query() query: PublicResourcesQueryDto,
+    @Req() req: OptionalAuthedRequest,
   ): Promise<PagedResourcesDto> {
-    return this.getPublicResources.execute({
+    const result = await this.getPublicResources.execute({
       emergencyId,
       page: query.page ?? 1,
       limit: query.limit ?? 50,
@@ -69,6 +81,11 @@ export class PublicController {
       ...(query.country !== undefined && { country: query.country }),
       ...(query.q !== undefined && query.q !== '' && { q: query.q }),
     });
+    const authed = req.user != null;
+    return {
+      ...result,
+      items: result.items.map((item) => redactContact(item, authed)),
+    };
   }
 
   @Get('emergencies/:emergencyId/public/resources/nearby')
@@ -87,14 +104,19 @@ export class PublicController {
   async nearby(
     @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
     @Query() query: NearbyResourcesQueryDto,
+    @Req() req: OptionalAuthedRequest,
   ): Promise<NearbyResourcesResponseDto> {
-    return this.getNearbyResources.execute({
+    const result = await this.getNearbyResources.execute({
       emergencyId,
       lat: query.lat,
       lng: query.lng,
       radiusMeters: query.radius,
       limit: query.limit ?? 50,
     });
+    const authed = req.user != null;
+    return {
+      items: result.items.map((item) => redactContact(item, authed)),
+    };
   }
 
   @Get('emergencies/:emergencyId/public/resources/in-bounds')
@@ -113,8 +135,9 @@ export class PublicController {
   async inBounds(
     @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
     @Query() query: InBoundsQueryDto,
+    @Req() req: OptionalAuthedRequest,
   ): Promise<InBoundsResourcesDto> {
-    return this.getResourcesInBounds.execute({
+    const result = await this.getResourcesInBounds.execute({
       emergencyId,
       minLat: query.minLat,
       minLng: query.minLng,
@@ -122,6 +145,10 @@ export class PublicController {
       maxLng: query.maxLng,
       limit: query.limit ?? 500,
     });
+    const authed = req.user != null;
+    return {
+      items: result.items.map((item) => redactContact(item, authed)),
+    };
   }
 
   @Get('emergencies/:emergencyId/public/resources/facets')
@@ -166,6 +193,7 @@ export class PublicController {
   async getOne(
     @Param('emergencyId', ParseUUIDPipe) emergencyId: string,
     @Param('resourceId', ParseUUIDPipe) resourceId: string,
+    @Req() req: OptionalAuthedRequest,
   ): Promise<ResourceDetailView> {
     const resource = await this.getPublicResource.execute({
       emergencyId,
@@ -174,6 +202,6 @@ export class PublicController {
     if (resource === null) {
       throw new NotFoundException('Resource not found');
     }
-    return resource;
+    return redactContact(resource, req.user != null);
   }
 }

--- a/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
@@ -66,8 +66,21 @@ export class ResourceViewDto {
   @ApiProperty({ type: [String], example: ['water', 'food'] })
   accepts!: string[];
 
-  @ApiProperty({ example: '+58 212 555 0000', nullable: true, type: String })
+  @ApiProperty({
+    example: '+58 212 555 0000',
+    nullable: true,
+    type: String,
+    description:
+      'Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell "hidden" from "absent".',
+  })
   contact!: string | null;
+
+  @ApiProperty({
+    example: true,
+    description:
+      'Whether a contact exists on file, regardless of whether `contact` is revealed to this caller.',
+  })
+  hasContact!: boolean;
 
   @ApiProperty({ example: 'Lun-Vie 08-18', nullable: true, type: String })
   schedule!: string | null;

--- a/apps/api/test/global-setup.js
+++ b/apps/api/test/global-setup.js
@@ -21,10 +21,25 @@ const { Client } = require('pg');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const TEST_DB = 'reliefhub_test';
-/** Connect to the maintenance `postgres` DB so we can DROP/CREATE the test DB. */
-const ADMIN_URL = 'postgres://reliefhub:reliefhub@localhost:5433/postgres';
-const TEST_URL = `postgres://reliefhub:reliefhub@localhost:5433/${TEST_DB}`;
+/**
+ * Single source of truth for the test DB connection — the SAME env var the Jest
+ * workers read (see test/jest-setup-test-db.ts), so the schema is applied to
+ * exactly the DB the tests talk to. Defaults to the docker-compose port (5433,
+ * used by CI); override TEST_DATABASE_URL to point at another host/port locally.
+ */
+const TEST_URL =
+  process.env.TEST_DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub_test';
+
+/** Test DB name, parsed from the connection URL (e.g. `reliefhub_test`). */
+const TEST_DB = new URL(TEST_URL).pathname.replace(/^\//, '');
+
+/** Maintenance `postgres` DB on the same server — to DROP/CREATE the test DB. */
+const ADMIN_URL = (() => {
+  const url = new URL(TEST_URL);
+  url.pathname = '/postgres';
+  return url.toString();
+})();
 
 /** Directory that holds the Drizzle migration .sql files. */
 const DRIZZLE_DIR = path.resolve(__dirname, '../drizzle');

--- a/apps/api/test/public-resources-paged.e2e-spec.ts
+++ b/apps/api/test/public-resources-paged.e2e-spec.ts
@@ -25,12 +25,12 @@ interface ResourceViewBody {
   id: string;
   name: string;
   type: string;
-  stage: string;
   verificationLevel: string;
   publicStatus: string;
   location: { address: string; latitude: number; longitude: number };
   accepts: string[];
   contact: string | null;
+  hasContact: boolean;
   schedule: string | null;
   manager: string | null;
   country: string | null;
@@ -269,7 +269,8 @@ describe('Public resources paged (e2e)', () => {
           country: 'VE',
           city: 'Maracaibo',
         }).toSnapshot(),
-        verificationLevel: VerificationLevel.Verified,
+        // Official → contact is public (not redacted for anonymous callers).
+        verificationLevel: VerificationLevel.Official,
         publicStatus: PublicStatus.Active,
         createdAt: new Date(),
       });
@@ -283,10 +284,41 @@ describe('Public resources paged (e2e)', () => {
     const item = (res.body as PagedResourcesBody).items[0];
     expect(item.accepts).toEqual(['water']);
     expect(item.contact).toBe('+1-555-0100');
+    expect(item.hasContact).toBe(true);
     expect(item.schedule).toBe('Mon-Fri 9-17');
     expect(item.manager).toBe('María');
     expect(item.country).toBe('VE');
     expect(item.city).toBe('Maracaibo');
+  });
+
+  it('redacts contact from anonymous callers on non-official resources (hasContact stays true)', async () => {
+    await withCleanRepo(async (repo) => {
+      const r = Resource.fromSnapshot({
+        ...Resource.register({
+          id: ResourceId.create(),
+          emergencyId: EmergencyId.fromString(EM),
+          type: ResourceType.CollectionPoint,
+          name: 'Verified Resource',
+          location: baseLocation,
+          ownerUserId: OWNER_ID,
+          accepts: ['water'],
+          contact: '+1-555-0199',
+        }).toSnapshot(),
+        // Verified (not official) → contact is personal data, redacted for anon.
+        verificationLevel: VerificationLevel.Verified,
+        publicStatus: PublicStatus.Active,
+        createdAt: new Date(),
+      });
+      await repo.save(r);
+    });
+
+    const res = await request(server)
+      .get(`/emergencies/${EM}/public/resources`)
+      .expect(200);
+
+    const item = (res.body as PagedResourcesBody).items[0];
+    expect(item.contact).toBeNull();
+    expect(item.hasContact).toBe(true);
   });
 
   it('GET /emergencies/:id/public/resources?limit=200 returns 400 (exceeds @Max(100))', async () => {

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -173,7 +173,6 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
         description: te.points_empty_description,
       }}
       locale={locale}
-      authed={token !== null}
     />
   );
 

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { clearToken, getToken } from "@/lib/auth";
+import { authHeaders, clearToken, getToken } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { getEmergencyBySlug } from "@/lib/emergencies";
 import { getMe, getRoles } from "@/lib/navigation-data";
@@ -53,6 +53,8 @@ export default async function RecipientResourcePage({ params }: Props) {
   const [{ data: resource }, { data: needs }] = await Promise.all([
     api.GET("/emergencies/{emergencyId}/public/resources/{resourceId}", {
       params: { path: { emergencyId, resourceId } },
+      // Forward auth so logged-in users see the contact (redacted for anon).
+      ...(token !== null && { headers: authHeaders(token) }),
     }),
     api.GET("/emergencies/{emergencyId}/public/needs", {
       params: { path: { emergencyId }, query: { resourceId } },
@@ -97,7 +99,6 @@ export default async function RecipientResourcePage({ params }: Props) {
             tVerification={t.verification_badge}
             tStatusLight={t.status_light}
             locale={locale}
-            authed={token !== null}
           />
 
           {canPreRegister && (

--- a/apps/web/src/app/panel/administracion/centros/[id]/page.tsx
+++ b/apps/web/src/app/panel/administracion/centros/[id]/page.tsx
@@ -120,7 +120,6 @@ export default async function CentroDetailPage({ params }: Props) {
                   <dd>{resource.city}</dd>
                 </div>
               )}
-
               {resource.contact && (
                 <div className="flex flex-wrap gap-x-1.5">
                   <dt className="font-semibold text-ink-soft">

--- a/apps/web/src/app/panel/administracion/centros/centro-presentation.ts
+++ b/apps/web/src/app/panel/administracion/centros/centro-presentation.ts
@@ -99,4 +99,3 @@ export function reportStatusLabel(status: string, ta: AdminMessages): string {
   const key = REPORT_STATUS_KEYS[status];
   return key ? ta[key] : status;
 }
-

--- a/apps/web/src/components/organisms/emergency-map.tsx
+++ b/apps/web/src/components/organisms/emergency-map.tsx
@@ -355,11 +355,14 @@ export default function EmergencyMap({
 
 function GeolocateControl() {
   const map = useMap();
+  const t = getMessages(useLocale()).ui;
   const [loading, setLoading] = useState(false);
+  const [errored, setErrored] = useState(false);
 
   const handleGeolocate = () => {
     if (!navigator.geolocation) return;
     setLoading(true);
+    setErrored(false);
     navigator.geolocation.getCurrentPosition(
       (position) => {
         const { latitude, longitude } = position.coords;
@@ -369,19 +372,22 @@ function GeolocateControl() {
       (error) => {
         console.error('Error getting geolocation', error);
         setLoading(false);
+        setErrored(true);
       },
       { enableHighAccuracy: true, timeout: 5000, maximumAge: 0 }
     );
   };
+
+  const label = errored ? t.map_geolocate_error : t.map_geolocate;
 
   return (
     <button
       type="button"
       onClick={handleGeolocate}
       disabled={loading}
-      className="absolute bottom-3 right-3 z-[1000] flex h-10 w-10 items-center justify-center rounded-full border border-line bg-white shadow-md transition-colors hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy disabled:opacity-50"
-      aria-label="Geolocalizar"
-      title="Ir a mi ubicación"
+      className={`absolute bottom-3 right-3 z-[1000] flex h-10 w-10 items-center justify-center rounded-full border bg-white shadow-md transition-colors hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy disabled:opacity-50 ${errored ? 'border-danger' : 'border-line'}`}
+      aria-label={label}
+      title={label}
     >
       {loading ? (
         <span className="h-4 w-4 animate-spin rounded-full border-2 border-muted border-t-navy" />

--- a/apps/web/src/components/organisms/public-resource-card.tsx
+++ b/apps/web/src/components/organisms/public-resource-card.tsx
@@ -24,7 +24,6 @@ interface PublicResourceCardProps {
   locale?: Locale;
   /** When set, the card name links to the resource detail page (#59). */
   slug?: string;
-  authed?: boolean;
 }
 
 export function PublicResourceCard({
@@ -34,7 +33,6 @@ export function PublicResourceCard({
   tStatusLight,
   locale = 'es',
   slug,
-  authed = false,
 }: PublicResourceCardProps) {
   const typeLabels: Record<ResourceViewDto['type'], string> = {
     collection_point: t.type_collection_point,
@@ -119,10 +117,11 @@ export function PublicResourceCard({
       {/* sourceName is intentionally NOT rendered — ResponseGrid is the
           source of truth; external provenance is internal metadata only. */}
       {(resource.contact != null ||
+        resource.hasContact ||
         resource.schedule != null ||
         resource.manager != null) && (
         <dl className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted">
-          {resource.contact != null && (
+          {(resource.contact != null || resource.hasContact) && (
             <div className="flex items-center gap-1">
               <dt className="font-medium text-muted-soft">
                 {resource.verificationLevel === 'official'
@@ -130,9 +129,11 @@ export function PublicResourceCard({
                   : t.meta_contact}
               </dt>
               <dd>
-                {resource.verificationLevel === 'official' || authed ? (
+                {resource.contact != null ? (
+                  // Revealed by the API (official resource, or authenticated call).
                   resource.contact
                 ) : (
+                  // Redacted server-side: a contact exists but is gated behind auth.
                   <span className="italic text-muted-soft/80">
                     {t.contact_login_required}
                   </span>
@@ -155,7 +156,7 @@ export function PublicResourceCard({
         </dl>
       )}
 
-      {resource.contact == null && (
+      {resource.contact == null && !resource.hasContact && (
         <p className="text-xs italic text-muted-soft">
           {t.no_official_contact}
         </p>

--- a/apps/web/src/components/organisms/resource-detail.tsx
+++ b/apps/web/src/components/organisms/resource-detail.tsx
@@ -54,8 +54,6 @@ export function ResourceDetail({
     venue: tc.resource_type_venue,
   };
 
-
-
   const PUBLIC_STATUS_LABELS: Record<ResourceView['publicStatus'], string> = {
     hidden: tc.public_status_hidden,
     active: tc.public_status_active,
@@ -150,7 +148,6 @@ export function ResourceDetail({
           label={tc.detail_field_type}
           value={TYPE_LABELS[resource.type]}
         />
-
         <DetailField label={tc.detail_field_accepts} value={accepts} />
         <DetailField
           label={tc.detail_field_public_status}

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -43,7 +43,6 @@ interface ResourceListProps {
   locale: Locale;
   /** Emergency slug — enables linking each card to its resource detail page. */
   slug?: string;
-  authed?: boolean;
 }
 
 export function ResourceList({
@@ -61,7 +60,6 @@ export function ResourceList({
   tEmpty,
   locale,
   slug,
-  authed = false,
 }: ResourceListProps) {
   // ── Filter state (category/country) → triggers re-fetch ──────────────────
   const [activeCategory, setActiveCategory] = useState('');
@@ -240,7 +238,6 @@ export function ResourceList({
                   tStatusLight={tStatusLight}
                   locale={locale}
                   slug={slug}
-                  authed={authed}
                 />
                 <div className="mt-1 flex justify-end px-1">
                   <DistanceBadge distanceMeters={item.distanceMeters} locale={locale} />
@@ -366,7 +363,6 @@ export function ResourceList({
                       tStatusLight={tStatusLight}
                       locale={locale}
                       slug={slug}
-                      authed={authed}
                     />
                   </li>
                 ))}
@@ -392,7 +388,6 @@ export function ResourceList({
                       tStatusLight={tStatusLight}
                       locale={locale}
                       slug={slug}
-                      authed={authed}
                     />
                   </li>
                 ))}
@@ -418,7 +413,6 @@ export function ResourceList({
                       tStatusLight={tStatusLight}
                       locale={locale}
                       slug={slug}
-                      authed={authed}
                     />
                   </li>
                 ))}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -300,9 +300,6 @@ export const en = {
     type_transport: 'Transport',
     type_supplier: 'Supplier',
     type_venue: 'Venue / Space',
-    stage_origin: 'Origin',
-    stage_intermediate: 'Intermediate',
-    stage_destination: 'Destination',
     // Rich card extras
     accepts_label: 'Accepts',
     meta_contact: 'Contact:',
@@ -405,7 +402,6 @@ export const en = {
     meta_description: 'Register a logistics point (collection, warehouse, space) for {emergencyName}.',
 
     type_label: 'Resource type',
-    stage_label: 'Stage',
     name_label: 'Name',
     name_placeholder: 'e.g. Red Cross Madrid',
     description_label: 'Description',
@@ -420,12 +416,7 @@ export const en = {
     type_supplier: 'Supplier',
     type_venue: 'Venue / Space',
 
-    stage_origin: 'Origin',
-    stage_intermediate: 'Intermediate',
-    stage_destination: 'Destination',
-
     select_type_placeholder: 'Select a type…',
-    select_stage_placeholder: 'Select a stage…',
 
     submit: 'Register resource',
     submitting: 'Sending…',
@@ -455,7 +446,6 @@ export const en = {
 
     // server-action messages
     err_invalid_type: 'Invalid resource type.',
-    err_invalid_stage: 'Invalid stage.',
     err_name_too_short: 'Name must be at least 2 characters.',
     err_location_required: 'Select a location.',
     err_invalid_items:
@@ -1493,10 +1483,6 @@ export const en = {
     type_supplier: 'Supplier',
     type_venue: 'Venue / Space',
 
-    stage_origin: 'Origin',
-    stage_intermediate: 'Intermediate',
-    stage_destination: 'Destination',
-
     current_label: 'Current:',
     change_status_label: 'Change status',
     status_invalid: 'Invalid status.',
@@ -1758,15 +1744,11 @@ export const en = {
     centros_detail_contact_label: 'Contact:',
     centros_detail_schedule_label: 'Schedule:',
     centros_detail_manager_label: 'Manager:',
-    centros_detail_stage_label: 'Stage:',
     centros_detail_created_label: 'Created:',
     centros_detail_source_label: 'Source:',
     centros_detail_recipient_label: 'Final recipient',
     centros_detail_recipient_type_label: 'Recipient type:',
     centros_detail_none: '—',
-    centros_detail_stage_origin: 'Origin',
-    centros_detail_stage_intermediate: 'Intermediate',
-    centros_detail_stage_destination: 'Destination',
     centros_detail_inventory_heading: 'Declared inventory ({count})',
     centros_detail_inventory_empty: 'This center has not declared any inventory.',
     centros_detail_inventory_note:
@@ -2031,9 +2013,6 @@ export const en = {
     resource_type_transport: 'Transport',
     resource_type_supplier: 'Supplier',
     resource_type_venue: 'Venue / Space',
-    resource_stage_origin: 'Origin',
-    resource_stage_intermediate: 'Intermediate',
-    resource_stage_destination: 'Destination',
 
     offer_card_label: 'Offer: {description}',
     offer_status_open: 'Open',
@@ -2073,7 +2052,6 @@ export const en = {
     detail_field_created: 'Created',
     detail_field_expiry: 'Freshness',
     detail_field_type: 'Type',
-    detail_field_stage: 'Stage',
     detail_field_accepts: 'Accepts',
     detail_field_contact: 'Contact',
     detail_field_schedule: 'Schedule',
@@ -2509,6 +2487,8 @@ export const en = {
     map_disputed: 'In review · possible closure',
     map_report_cta: 'Something wrong? Tell us',
     map_no_locations: 'No locations on the map yet.',
+    map_geolocate: 'Go to my location',
+    map_geolocate_error: 'Could not get your location',
   },
 
   nav: {

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -315,9 +315,6 @@ export const es = {
     type_transport: 'Transporte',
     type_supplier: 'Proveedor',
     type_venue: 'Local / Espacio',
-    stage_origin: 'Origen',
-    stage_intermediate: 'Intermedio',
-    stage_destination: 'Destino',
     // Rich card extras
     accepts_label: 'Acepta',
     meta_contact: 'Contacto:',
@@ -425,7 +422,6 @@ export const es = {
     meta_description: 'Da de alta un punto logístico (acopio, almacén, espacio) para {emergencyName}.',
 
     type_label: 'Tipo de recurso',
-    stage_label: 'Etapa',
     name_label: 'Nombre',
     name_placeholder: 'Ej. Cruz Roja Madrid',
     description_label: 'Descripción',
@@ -440,12 +436,7 @@ export const es = {
     type_supplier: 'Proveedor',
     type_venue: 'Local / Espacio',
 
-    stage_origin: 'Origen',
-    stage_intermediate: 'Intermedio',
-    stage_destination: 'Destino',
-
     select_type_placeholder: 'Selecciona un tipo…',
-    select_stage_placeholder: 'Selecciona una etapa…',
 
     submit: 'Registrar recurso',
     submitting: 'Enviando…',
@@ -475,7 +466,6 @@ export const es = {
 
     // server-action messages
     err_invalid_type: 'Tipo de recurso no válido.',
-    err_invalid_stage: 'Etapa no válida.',
     err_name_too_short: 'El nombre debe tener al menos 2 caracteres.',
     err_location_required: 'Selecciona una ubicación.',
     err_invalid_items:
@@ -1526,10 +1516,6 @@ export const es = {
     type_supplier: 'Proveedor',
     type_venue: 'Local / Espacio',
 
-    stage_origin: 'Origen',
-    stage_intermediate: 'Intermedio',
-    stage_destination: 'Destino',
-
     current_label: 'Actual:',
     change_status_label: 'Cambiar estado',
     status_invalid: 'Estado no válido.',
@@ -1792,15 +1778,11 @@ export const es = {
     centros_detail_contact_label: 'Contacto:',
     centros_detail_schedule_label: 'Horario:',
     centros_detail_manager_label: 'Responsable:',
-    centros_detail_stage_label: 'Etapa:',
     centros_detail_created_label: 'Alta:',
     centros_detail_source_label: 'Fuente:',
     centros_detail_recipient_label: 'Destinatario final',
     centros_detail_recipient_type_label: 'Tipo de destinatario:',
     centros_detail_none: '—',
-    centros_detail_stage_origin: 'Origen',
-    centros_detail_stage_intermediate: 'Intermedio',
-    centros_detail_stage_destination: 'Destino',
     centros_detail_inventory_heading: 'Inventario declarado ({count})',
     centros_detail_inventory_empty: 'Este centro no ha declarado inventario.',
     centros_detail_inventory_note:
@@ -2065,9 +2047,6 @@ export const es = {
     resource_type_transport: 'Transporte',
     resource_type_supplier: 'Proveedor',
     resource_type_venue: 'Local / Espacio',
-    resource_stage_origin: 'Origen',
-    resource_stage_intermediate: 'Intermedio',
-    resource_stage_destination: 'Destino',
 
     offer_card_label: 'Oferta: {description}',
     offer_status_open: 'Abierta',
@@ -2107,7 +2086,6 @@ export const es = {
     detail_field_created: 'Creada',
     detail_field_expiry: 'Validez',
     detail_field_type: 'Tipo',
-    detail_field_stage: 'Etapa',
     detail_field_accepts: 'Acepta',
     detail_field_contact: 'Contacto',
     detail_field_schedule: 'Horario',
@@ -2546,6 +2524,8 @@ export const es = {
     map_disputed: 'En verificación · posible cierre',
     map_report_cta: '¿Algo va mal? Avísanos',
     map_no_locations: 'Aún no hay ubicaciones en el mapa.',
+    map_geolocate: 'Ir a mi ubicación',
+    map_geolocate_error: 'No se pudo obtener tu ubicación',
   },
 
   nav: {

--- a/apps/web/src/lib/group-by-country.test.ts
+++ b/apps/web/src/lib/group-by-country.test.ts
@@ -14,7 +14,6 @@ function makeResource(id: string, country: string | null): ResourceViewDto {
   return {
     id,
     type: 'collection_point',
-    stage: 'origin',
     name: `Resource ${id}`,
     description: null,
     location: { address: '—', latitude: 0, longitude: 0 },
@@ -23,6 +22,7 @@ function makeResource(id: string, country: string | null): ResourceViewDto {
     ownerOrganizationId: null,
     accepts: [],
     contact: null,
+    hasContact: false,
     schedule: null,
     manager: null,
     sourceName: null,

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -3085,8 +3085,16 @@ export interface components {
              *     ]
              */
             accepts: string[];
-            /** @example +58 212 555 0000 */
+            /**
+             * @description Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell "hidden" from "absent".
+             * @example +58 212 555 0000
+             */
             contact: string | null;
+            /**
+             * @description Whether a contact exists on file, regardless of whether `contact` is revealed to this caller.
+             * @example true
+             */
+            hasContact: boolean;
             /** @example Lun-Vie 08-18 */
             schedule: string | null;
             /** @example Juan Pérez */
@@ -3255,8 +3263,16 @@ export interface components {
              *     ]
              */
             accepts: string[];
-            /** @example +58 212 555 0000 */
+            /**
+             * @description Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell "hidden" from "absent".
+             * @example +58 212 555 0000
+             */
             contact: string | null;
+            /**
+             * @description Whether a contact exists on file, regardless of whether `contact` is revealed to this caller.
+             * @example true
+             */
+            hasContact: boolean;
             /** @example Lun-Vie 08-18 */
             schedule: string | null;
             /** @example Juan Pérez */
@@ -3361,8 +3377,16 @@ export interface components {
              *     ]
              */
             accepts: string[];
-            /** @example +58 212 555 0000 */
+            /**
+             * @description Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell "hidden" from "absent".
+             * @example +58 212 555 0000
+             */
             contact: string | null;
+            /**
+             * @description Whether a contact exists on file, regardless of whether `contact` is revealed to this caller.
+             * @example true
+             */
+            hasContact: boolean;
             /** @example Lun-Vie 08-18 */
             schedule: string | null;
             /** @example Juan Pérez */
@@ -3458,8 +3482,16 @@ export interface components {
              *     ]
              */
             accepts: string[];
-            /** @example +58 212 555 0000 */
+            /**
+             * @description Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell "hidden" from "absent".
+             * @example +58 212 555 0000
+             */
             contact: string | null;
+            /**
+             * @description Whether a contact exists on file, regardless of whether `contact` is revealed to this caller.
+             * @example true
+             */
+            hasContact: boolean;
             /** @example Lun-Vie 08-18 */
             schedule: string | null;
             /** @example Juan Pérez */
@@ -3556,8 +3588,16 @@ export interface components {
              *     ]
              */
             accepts: string[];
-            /** @example +58 212 555 0000 */
+            /**
+             * @description Contact line. Personal data: nulled for anonymous callers on non-official resources — authenticate to reveal it. Use `hasContact` to tell "hidden" from "absent".
+             * @example +58 212 555 0000
+             */
             contact: string | null;
+            /**
+             * @description Whether a contact exists on file, regardless of whether `contact` is revealed to this caller.
+             * @example true
+             */
+            hasContact: boolean;
             /** @example Lun-Vie 08-18 */
             schedule: string | null;
             /** @example Juan Pérez */


### PR DESCRIPTION
## Contexto

Revisión en profundidad de #265. El punto crítico: la "privacidad" del contacto que introdujo #265 era **solo cosmética** — la card lo ocultaba en React con un prop `authed`, pero la **API pública seguía enviando el teléfono en el JSON** a cualquiera (`curl` / pestaña Network). PII expuesta.

## Fix principal — redacción server-side

- **`redactContact(view, authenticated)`**: `contact → null` salvo que el llamante esté autenticado **o** el recurso sea `official`. Nuevo campo **`hasContact`** (existe contacto aunque esté redactado) para poder mostrar "Inicia sesión para ver" en vez de "sin contacto".
- **`PublicController`** usa el `OptionalJwtAuthGuard` (ya existente) y redacta en `list` / `nearby` / `in-bounds` / detalle.
- `ResourceViewDto` expone `hasContact`; `contact` documentado como PII en Swagger. `pnpm gen:api` regenerado.
- **Web**: la card decide por datos del servidor (`hasContact`); la **ficha de detalle** reenvía el token → los usuarios logueados ven el contacto; la lista queda redactada de forma consistente (su refetch es client-side y la cookie es httpOnly).

**Decisión de producto:** el contacto de recursos no-oficiales se revela a usuarios logueados **en la ficha de detalle**, no en las tarjetas de lista (por la arquitectura de browsing anónimo). Anónimos nunca lo reciben. Upgrade path documentado si se quisiera revelar también en lista.

## Fixes menores del review

- **GeolocateControl**: `aria-label`/`title` estaban hardcodeados en español → i18n (`map_geolocate`), y feedback de error (antes solo `console.error`).
- Fixtures de test obsoletos (`stage` fantasma) al día.

## Limpieza / refactor (Clean Code)

- Elimina **14 claves i18n muertas** de `stage` (es/en) — verificado 0 referencias — y blancos huérfanos que dejó #265 en `resource-detail`, `centros/[id]` y `centro-presentation`.
- Quita el prop cosmético `authed` (card/lista/páginas), ya redundante.
- **`test/global-setup.js`**: elimina el `localhost:5433` hardcodeado; deriva la conexión de `TEST_DATABASE_URL` (misma fuente que los workers en `jest-setup-test-db.ts`, *single source of truth*). Default idéntico → CI intacto.

## Verificación local

- **API**: `nest build` ✅ · eslint ✅ · prettier ✅ · **`pnpm test`: 215 suites / 1368 tests ✅** (incl. unit de `redactContact` + e2e de redacción).
- **Web**: build ✅ · lint ✅ (0 errores) · tests 44/44 ✅.
- `gen:api` + api-client build ✅ (`hasContact` en `schema.ts`).

Relacionado: #234 (sub-modelo de contactos verificados).