### PR TITLE
fix(web): acceso directo a «Mis puntos» en la home de emergencia (#262)

### DIFF
--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
+import { getToken } from '@/lib/auth';
 import { type ResourceViewDto } from '@/lib/group-by-country';
 import { AppBar } from '@/components/organisms/app-bar';
 import { ResourceList } from '@/components/organisms/resource-list';
@@ -78,6 +79,7 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
 
   const emergencyId = emergency.id;
   const isActive = emergency.status === 'active';
+  const token = await getToken();
 
   const rawCategory = typeof resolvedSearchParams.category === 'string' ? resolvedSearchParams.category : undefined;
   const rawPriority = typeof resolvedSearchParams.priority === 'string' ? resolvedSearchParams.priority : undefined;
@@ -439,6 +441,18 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
               </p>
             )}
           </section>
+
+          {token !== null && (
+            <section aria-labelledby="manage-heading" className="flex flex-col gap-3">
+              <h2 id="manage-heading" className={sectionTitle}>{te.manage_heading}</h2>
+              <HelpActionRow
+                href={`/e/${slug}/mis-puntos`}
+                icon="🗂️"
+                title={te.manage_my_points_title}
+                subtitle={te.manage_my_points_subtitle}
+              />
+            </section>
+          )}
 
           <section aria-labelledby="explore-heading" className="flex flex-col gap-3">
             <h2 id="explore-heading" className={sectionTitle}>{te.explore_heading}</h2>

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -276,6 +276,10 @@ export const en = {
     actions_paused:
       'Resource and request registration is paused. Check the available information and come back later.',
 
+    manage_heading: 'Management',
+    manage_my_points_title: 'My points in this emergency',
+    manage_my_points_subtitle: 'View and manage the points you have registered',
+
     quick_access_heading: 'Quick access',
     quick_access_card_label: 'At a glance',
     quick_access_help_intro: 'Go straight to the action area if you want to help right now.',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -281,6 +281,10 @@ export const es = {
     actions_paused:
       'El alta de recursos y peticiones está en pausa. Consulta la información disponible y vuelve más tarde.',
 
+    manage_heading: 'Gestión',
+    manage_my_points_title: 'Mis puntos en esta emergencia',
+    manage_my_points_subtitle: 'Ver y gestionar los puntos que has registrado',
+
     quick_access_heading: 'Acceso rápido',
     quick_access_card_label: 'Resumen',
     quick_access_help_intro: 'Ve directo a la zona de acciones si quieres ayudar ahora mismo.',


### PR DESCRIPTION
Closes #262

## Diagnóstico

El feedback («al crear un punto logístico debe agregarlo a esa emergencia») apuntaba a un fallo de vinculación, pero **la vinculación de datos ya funciona**: el recurso se crea con `ownerUserId` **y** `emergencyId` (endpoint anidado `POST /emergencies/{id}/resources`) y `GET /emergencies/{id}/resources/mine` lo devuelve sin filtrar por verificación.

El problema real (confirmado con el usuario) es de **discoverability**: tras registrar un punto, la única vía para reencontrarlo dentro de la emergencia era un micro-enlace subrayado de 12.5px enterrado en el pie de la home (`EmergencyQuickLinks`), invisible en la práctica.

## Cambio

Se promueve **«Mis puntos en esta emergencia»** a una sección de gestión de primer nivel (`HelpActionRow`) en la home de la emergencia, visible para usuarios autenticados y **fuera del gate `isActive`** (la gestión debe estar disponible aunque la emergencia esté en pausa). Enlaza a la página `/e/{slug}/mis-puntos` ya existente.

- Sin cambios de datos ni de API.
- i18n ES/EN.
- Complementa a #263 (CTAs en la pantalla de éxito): #263 es el momento inmediato post-creación; esto es el acceso persistente.

## Gate

- `pnpm --filter web lint` ✅ (solo warning preexistente ajeno)
- `pnpm --filter web build` ✅