### PR TITLE
feat(supplies): category.kind (material|personnel)

### DIFF
--- a/apps/api/drizzle/0047_category_kind.sql
+++ b/apps/api/drizzle/0047_category_kind.sql
@@ -1,0 +1,10 @@
+-- Add "kind" to categories: distinguishes material aid (fungible/reusable) from
+-- personnel. Minimal start (material|personnel); a richer item classification
+-- (fungible/reusable/human) is deferred to issue #269. Enum-via-CHECK, not a
+-- boolean, so it can grow without a destructive migration.
+
+ALTER TABLE "categories"
+  ADD COLUMN IF NOT EXISTS "kind" text NOT NULL DEFAULT 'material'
+  CHECK ("kind" IN ('material', 'personnel'));
+
+UPDATE "categories" SET "kind" = 'personnel' WHERE "slug" = 'medical_personnel';

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -13874,6 +13874,15 @@
             "example": "MED",
             "nullable": true,
             "description": "Unique 3-letter prefix for supplies in this category, or null if inherited"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "material",
+              "personnel"
+            ],
+            "example": "material",
+            "description": "Whether the category is aid material or personnel. Personnel (medical_personnel) is excluded from material pickers."
           }
         },
         "required": [
@@ -13883,7 +13892,8 @@
           "parentSlug",
           "vertical",
           "sort",
-          "codePrefix"
+          "codePrefix",
+          "kind"
         ]
       },
       "CategoryTranslationDto": {

--- a/apps/api/src/contexts/supplies/application/list-categories.spec.ts
+++ b/apps/api/src/contexts/supplies/application/list-categories.spec.ts
@@ -10,6 +10,7 @@ const FOOD: CategoryDefinition = {
   parentSlug: null,
   vertical: 'general',
   sort: 10,
+  kind: 'material',
   codePrefix: 'FOD',
   archivedAt: null,
   translations: [

--- a/apps/api/src/contexts/supplies/application/update-category.spec.ts
+++ b/apps/api/src/contexts/supplies/application/update-category.spec.ts
@@ -11,6 +11,7 @@ const BASE: CategoryDefinition = {
   parentSlug: 'food',
   vertical: 'general',
   sort: 140,
+  kind: 'material',
   archivedAt: null,
   translations: [],
 };
@@ -72,6 +73,7 @@ describe('UpdateCategory — archive / restore', () => {
       ...BASE,
       slug: Category.Food,
       parentSlug: null,
+      kind: 'material',
     };
     const repo = makeRepo({ findBySlug: () => Promise.resolve(core) });
 

--- a/apps/api/src/contexts/supplies/domain/category-definition.ts
+++ b/apps/api/src/contexts/supplies/domain/category-definition.ts
@@ -13,6 +13,8 @@ export interface CategoryTranslation {
   label: string;
 }
 
+export type CategoryKind = 'material' | 'personnel';
+
 export interface CategoryDefinition {
   slug: string;
   labelEs: string;
@@ -21,6 +23,7 @@ export interface CategoryDefinition {
   vertical: string;
   sort: number;
   codePrefix: string | null;
+  kind: CategoryKind;
   archivedAt: Date | null;
   translations: readonly CategoryTranslation[];
 }

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.int-spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.int-spec.ts
@@ -1,0 +1,38 @@
+import { createDb, Db } from '../../../../shared/db';
+import { DrizzleCategoryRepository } from './drizzle-category.repository';
+import type { Pool } from 'pg';
+
+const URL =
+  process.env.DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub';
+
+describe('DrizzleCategoryRepository — kind (integration)', () => {
+  let db: Db;
+  let pool: Pool;
+  let repo: DrizzleCategoryRepository;
+
+  beforeAll(() => {
+    ({ db, pool } = createDb(URL));
+    repo = new DrizzleCategoryRepository(db);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('expone kind: medical_personnel es personnel, el resto material', async () => {
+    const categories = await repo.listCategories({ includeArchived: true });
+    const bySlug = new Map(categories.map((c) => [c.slug, c]));
+
+    expect(bySlug.get('medical_personnel')?.kind).toBe('personnel');
+    expect(bySlug.get('food')?.kind).toBe('material');
+    expect(bySlug.get('water')?.kind).toBe('material');
+  });
+
+  it('findBySlug también transporta kind', async () => {
+    const personnel = await repo.findBySlug('medical_personnel', {
+      includeArchived: true,
+    });
+    expect(personnel?.kind).toBe('personnel');
+  });
+});

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.ts
@@ -1,5 +1,8 @@
 import { and, asc, eq, inArray, isNull } from 'drizzle-orm';
-import { CategoryDefinition } from '../../domain/category-definition';
+import {
+  CategoryDefinition,
+  CategoryKind,
+} from '../../domain/category-definition';
 import {
   CategoryListOptions,
   CategoryRepository,
@@ -69,6 +72,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
       vertical: row.vertical,
       sort: row.sort,
       codePrefix: row.codePrefix ?? null,
+      kind: row.kind as CategoryKind,
       archivedAt: row.archivedAt ?? null,
       translations: (translationsBySlug.get(row.slug) ?? []).sort((a, b) =>
         a.locale.localeCompare(b.locale),
@@ -112,6 +116,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
       vertical: row.vertical,
       sort: row.sort,
       codePrefix: row.codePrefix ?? null,
+      kind: row.kind as CategoryKind,
       archivedAt: row.archivedAt ?? null,
       translations,
     };

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
@@ -24,6 +24,7 @@ export const categoriesTable = pgTable('categories', {
   vertical: text('vertical').notNull().default('general'),
   sort: integer('sort').notNull().default(0),
   codePrefix: text('code_prefix'),
+  kind: text('kind').notNull().default('material'),
   archivedAt: timestamp('archived_at', { withTimezone: true }),
 });
 

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
@@ -10,6 +10,7 @@ describe('CategoriesAdminController', () => {
     parentSlug: 'food',
     vertical: 'general',
     sort: 140,
+    kind: 'material',
     archivedAt: null,
     translations: [
       { locale: 'es', label: 'Alimentos para bebé' },

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.spec.ts
@@ -10,6 +10,7 @@ describe('CategoriesController', () => {
       parentSlug: null,
       vertical: 'general',
       sort: 1,
+      kind: 'material',
       archivedAt: null,
       translations: [
         { locale: 'es', label: 'Alimentos' },
@@ -52,6 +53,7 @@ describe('CategoriesController', () => {
       parentSlug: null,
       vertical: 'general',
       sort: 1,
+      kind: 'material',
     });
   });
 });

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.ts
@@ -45,6 +45,7 @@ export class CategoriesController {
       parentSlug: category.parentSlug,
       vertical: category.vertical,
       sort: category.sort,
+      kind: category.kind,
       codePrefix: category.codePrefix,
     }));
   }

--- a/apps/api/src/contexts/supplies/infrastructure/http/category-response.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/category-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { CategoryKind } from '../../domain/category-definition';
 
 /**
  * A category of the shared taxonomy (slug + localized labels + hierarchy).
@@ -39,4 +40,12 @@ export class CategoryDto {
       'Unique 3-letter prefix for supplies in this category, or null if inherited',
   })
   codePrefix!: string | null;
+
+  @ApiProperty({
+    enum: ['material', 'personnel'],
+    example: 'material',
+    description:
+      'Whether the category is aid material or personnel. Personnel (medical_personnel) is excluded from material pickers.',
+  })
+  kind!: CategoryKind;
 }

--- a/apps/api/src/contexts/supplies/infrastructure/http/category-response.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/category-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { CategoryKind } from '../../domain/category-definition';
+import type { CategoryKind } from '../../domain/category-definition';
 
 /**
  * A category of the shared taxonomy (slug + localized labels + hierarchy).

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -4918,6 +4918,12 @@ export interface components {
              * @example MED
              */
             codePrefix: string | null;
+            /**
+             * @description Whether the category is aid material or personnel. Personnel (medical_personnel) is excluded from material pickers.
+             * @example material
+             * @enum {string}
+             */
+            kind: "material" | "personnel";
         };
         CategoryTranslationDto: {
             /** @example fr */


### PR DESCRIPTION
Closes #271

## Qué

Añade una columna `kind` (`material` | `personnel`) a la taxonomía de categorías, la expone en `GET /categories` y regenera el SDK tipado. Base para que el frontend (PR 2) filtre los pickers de material con `kind !== 'personnel'` en vez de excluir `medical_personnel` con una lista hardcodeada.

## Cambios

- **Migración `0047_category_kind.sql`** (idempotente): `kind text NOT NULL DEFAULT 'material' CHECK (kind IN ('material','personnel'))`; `medical_personnel` → `personnel`.
- `CategoryDefinition.kind` (read model) + mapeo en el repositorio Drizzle (`listCategories`/`findBySlug`), cubierto por int-spec contra BBDD real.
- `CategoryDto.kind` expuesto en `GET /categories` + regeneración del SDK (`schema.ts`, `openapi.json`).
- Parcheo de 4 fixtures `CategoryDefinition` para incluir `kind` (consistencia de tipos).

## Decisiones

- `kind` es **enum-vía-CHECK** (no boolean) porque la clasificación crecerá; la clasificación rica de ítems (fungible/reutilizable/humano) se difiere a #269.
- **Ruta de escritura admin sin tocar**: las categorías nuevas heredan `DEFAULT 'material'` hasta #269.

## Verificación

Gate completo verde tras merge de `main`: `pnpm --filter api build` (tsc), eslint, prettier, `pnpm --filter api test` (incl. int-spec: `medical_personnel→personnel`, `food/water→material`), `api-client build`.