### PR TITLE
refactor(web): follow-ups de la AppBar (a11y, i18n, PageHeading, recursos)

### DIFF
--- a/apps/web/src/app/e/[slug]/donacion/[code]/page.tsx
+++ b/apps/web/src/app/e/[slug]/donacion/[code]/page.tsx
@@ -4,6 +4,7 @@ import { getEmergencyBySlug } from '@/lib/emergencies';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import { AppBar } from '@/components/organisms/app-bar';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { categoryLabel } from '@/lib/categories';
 import { formatDate } from '@/lib/format-date';
@@ -48,12 +49,7 @@ export default async function DonacionTrackingPage({ params }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-md">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {td.page_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">{td.page_subtitle}</p>
-        </div>
+        <PageHeading title={td.page_title} subtitle={td.page_subtitle} />
         <div className="flex flex-col gap-6 px-4 pb-12 pt-6">{children}</div>
       </div>
     </main>

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
@@ -9,6 +9,7 @@ import { submitOffer } from './actions';
 import { DonarForm } from './donar-form';
 import { AppBar } from '@/components/organisms/app-bar';
 import { Card } from '@/components/atoms/card';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 type Props = {
@@ -69,14 +70,10 @@ export default async function DonarPage({ params, searchParams }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {t.donar.page_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">
-            {t.donar.page_subtitle.replace('{emergencyName}', emergency.name)}
-          </p>
-        </div>
+        <PageHeading
+          title={t.donar.page_title}
+          subtitle={t.donar.page_subtitle.replace('{emergencyName}', emergency.name)}
+        />
         <div className="px-5 pb-12 pt-6 lg:px-8">
           <Card className="p-5 lg:p-7">
             <DonarForm

--- a/apps/web/src/app/e/[slug]/donar/page.tsx
+++ b/apps/web/src/app/e/[slug]/donar/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { AppBar } from '@/components/organisms/app-bar';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { HelpActionRow } from '@/components/molecules/help-action-row';
 import { getT } from '@/i18n/server';
 
@@ -50,12 +51,7 @@ export default async function DonarSelectorPage({ params }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {td.choose_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">{td.choose_subtitle}</p>
-        </div>
+        <PageHeading title={td.choose_title} subtitle={td.choose_subtitle} />
         <div className="flex flex-col gap-3 px-4 pb-12 pt-6">
           <HelpActionRow
             href={`/e/${slug}/pre-registro`}

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
@@ -8,6 +8,7 @@ import { TaskCard } from './task-card';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { Badge } from '@/components/atoms/badge';
 import { AppBar } from '@/components/organisms/app-bar';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 export const dynamic = 'force-dynamic';
@@ -77,12 +78,7 @@ export default async function MiVoluntariadoPage({ params }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {ta.vol_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">{ta.vol_subtitle}</p>
-        </div>
+        <PageHeading title={ta.vol_title} subtitle={ta.vol_subtitle} />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
 
         <section aria-labelledby="profile-heading" className="flex flex-col gap-4">

--- a/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
@@ -5,6 +5,7 @@ import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { ShipmentsList } from '@/components/organisms/shipments-list';
 import { AppBar } from '@/components/organisms/app-bar';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 export const dynamic = 'force-dynamic';
@@ -71,12 +72,7 @@ export default async function MisExpedicionesPage({ params }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {ta.ship_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">{ta.ship_subtitle}</p>
-        </div>
+        <PageHeading title={ta.ship_title} subtitle={ta.ship_subtitle} />
         <div className="flex flex-col gap-6 px-5 pb-12 pt-6 lg:px-8">
           <ShipmentsList
             shipments={shipments}

--- a/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
@@ -7,6 +7,7 @@ import { fetchMyResources } from './actions';
 import { StatusForm } from './status-form';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { AppBar } from '@/components/organisms/app-bar';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 export const dynamic = 'force-dynamic';
@@ -54,12 +55,7 @@ export default async function MisPuntosPage({ params }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {ta.points_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">{ta.points_subtitle}</p>
-        </div>
+        <PageHeading title={ta.points_title} subtitle={ta.points_subtitle} />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
 
         <section aria-labelledby="my-points-heading" className="flex flex-col gap-4">

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
@@ -7,6 +7,7 @@ import { submitCapacity } from './actions';
 import { OfrecerTransporteForm } from './ofrecer-transporte-form';
 import { AppBar } from '@/components/organisms/app-bar';
 import { Card } from '@/components/atoms/card';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 type Props = {
@@ -57,17 +58,13 @@ export default async function OfrecerTransportePage({ params }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {t.ofrecerTransporte.page_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">
-            {t.ofrecerTransporte.page_subtitle.replace(
-              '{emergencyName}',
-              emergency.name,
-            )}
-          </p>
-        </div>
+        <PageHeading
+          title={t.ofrecerTransporte.page_title}
+          subtitle={t.ofrecerTransporte.page_subtitle.replace(
+            '{emergencyName}',
+            emergency.name,
+          )}
+        />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
           <Card className="p-5 lg:p-7">
             <OfrecerTransporteForm

--- a/apps/web/src/app/e/[slug]/peticion/page.tsx
+++ b/apps/web/src/app/e/[slug]/peticion/page.tsx
@@ -9,6 +9,7 @@ import { PeticionForm } from './peticion-form';
 import { ItemsField } from './items-field';
 import { AppBar } from '@/components/organisms/app-bar';
 import { Card } from '@/components/atoms/card';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 type Props = {
@@ -47,14 +48,10 @@ export default async function PeticionPage({ params }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {t.peticion.page_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">
-            {t.peticion.page_subtitle.replace('{emergencyName}', emergency.name)}
-          </p>
-        </div>
+        <PageHeading
+          title={t.peticion.page_title}
+          subtitle={t.peticion.page_subtitle.replace('{emergencyName}', emergency.name)}
+        />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
           <Card className="p-5 lg:p-7">
             <PeticionForm

--- a/apps/web/src/app/e/[slug]/pre-registro/page.tsx
+++ b/apps/web/src/app/e/[slug]/pre-registro/page.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/api';
 import { getMe } from '@/lib/navigation-data';
 import { getT } from '@/i18n/server';
 import { AppBar } from '@/components/organisms/app-bar';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { submitPreRegistration } from './actions';
 import { PreRegistroForm } from './pre-registro-form';
@@ -76,12 +77,7 @@ export default async function PreRegistroPage({ params, searchParams }: Props) {
       <main className="flex-1 bg-surface">
         <div className="mx-auto w-full max-w-3xl">
           <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-          <div className="px-4 pt-6">
-            <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-              {tp.pick_title}
-            </h1>
-            <p className="mt-1.5 text-sm text-muted">{tp.pick_hint}</p>
-          </div>
+          <PageHeading title={tp.pick_title} subtitle={tp.pick_hint} />
           <div className="flex flex-col gap-5 px-4 pb-12 pt-6">
             <form method="get" role="search" className="flex gap-2">
               <input
@@ -163,16 +159,13 @@ export default async function PreRegistroPage({ params, searchParams }: Props) {
           slug={slug}
           backHref={`/e/${slug}/pre-registro`}
         />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {tp.page_title}
-          </h1>
-          {eligible && resource !== undefined && (
-            <p className="mt-1.5 text-sm text-muted">
-              {tp.page_subtitle.replace('{pointName}', resource.name)}
-            </p>
-          )}
-        </div>
+        <PageHeading
+          title={tp.page_title}
+          {...(eligible &&
+            resource !== undefined && {
+              subtitle: tp.page_subtitle.replace('{pointName}', resource.name),
+            })}
+        />
         <div className="flex flex-col gap-6 px-4 pb-12 pt-6">
           {eligible && resource !== undefined ? (
             <PreRegistroForm

--- a/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/emergency-permissions';
 import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
 import { AppBar } from '@/components/organisms/app-bar';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 import { categoryLabel } from '@/lib/categories';
 import { formatDate } from '@/lib/format-date';
@@ -103,11 +104,7 @@ export default async function IntakeDetailPage({ params }: Props) {
           slug={slug}
           backHref={`/e/${slug}/recepcion`}
         />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {tr.detail_subtitle.replace('{code}', intake.intakeCode)}
-          </h1>
-        </div>
+        <PageHeading title={tr.detail_subtitle.replace('{code}', intake.intakeCode)} />
         <div className="flex flex-col gap-6 px-4 pb-12 pt-6">
           <span className="w-fit rounded-full bg-surface-alt px-3 py-1 text-sm font-semibold text-ink">
             {statusLabel}

--- a/apps/web/src/app/e/[slug]/recepcion/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/page.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/emergency-permissions';
 import type { MeGrant, RoleCatalogEntry } from '@/lib/admin-scopes';
 import { AppBar } from '@/components/organisms/app-bar';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { formatDate } from '@/lib/format-date';
 import { categoryLabel } from '@/lib/categories';
@@ -144,12 +145,7 @@ export default async function RecepcionPage({ params, searchParams }: Props) {
           slug={slug}
           backHref={`/e/${slug}/coordinacion`}
         />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {tr.page_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">{tr.page_subtitle}</p>
-        </div>
+        <PageHeading title={tr.page_title} subtitle={tr.page_subtitle} />
         <div className="flex flex-col gap-5 px-4 pb-12 pt-6">
           <Link
             href={`/e/${slug}/pre-registro`}

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
@@ -9,6 +9,8 @@ import {
   resolveEmergencyAccess,
   type EmergencyAccess,
 } from "@/lib/emergency-permissions";
+import { AppBar } from "@/components/organisms/app-bar";
+import { PageHeading } from "@/components/atoms/page-heading";
 import { PublicResourceCard } from "@/components/organisms/public-resource-card";
 import { NeedCard } from "@/components/molecules/need-card";
 import { EmptyState } from "@/components/molecules/empty-state";
@@ -85,14 +87,9 @@ export default async function RecipientResourcePage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl bg-surface">
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <PageHeading title={resource.name} />
         <div className="flex flex-col gap-5 px-4 pb-12 pt-5 lg:gap-6 lg:px-8">
-          <Link
-            href={`/e/${slug}`}
-            className="w-fit text-sm font-semibold text-navy hover:underline"
-          >
-            ← {td.back}
-          </Link>
-
           <PublicResourceCard
             resource={resource}
             t={t.resource_card}

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/page.tsx
@@ -6,6 +6,7 @@ import { reportValidity } from './actions';
 import { ReportValidezForm } from './report-validez-form';
 import { AppBar } from '@/components/organisms/app-bar';
 import { Card } from '@/components/atoms/card';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 type Props = {
@@ -49,12 +50,7 @@ export default async function ReportarEstadoPage({ params }: Props) {
           slug={slug}
           backHref={`/e/${slug}/recursos/${resourceId}`}
         />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {t.reportar_validez.page_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">{emergency.name}</p>
-        </div>
+        <PageHeading title={t.reportar_validez.page_title} subtitle={emergency.name} />
         <div className="flex flex-col gap-6 px-5 pb-12 pt-6 lg:px-8">
           <Card className="flex flex-col gap-6 p-5 lg:p-7">
             <p className="text-sm text-muted">{t.reportar_validez.intro}</p>

--- a/apps/web/src/app/e/[slug]/registrar/page.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/page.tsx
@@ -8,6 +8,7 @@ import { registerResource } from './actions';
 import { RegistrarForm } from './registrar-form';
 import { AppBar } from '@/components/organisms/app-bar';
 import { Card } from '@/components/atoms/card';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 type Props = {
@@ -46,14 +47,10 @@ export default async function RegistrarPage({ params }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {t.registrar.page_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">
-            {t.registrar.page_subtitle.replace('{emergencyName}', emergency.name)}
-          </p>
-        </div>
+        <PageHeading
+          title={t.registrar.page_title}
+          subtitle={t.registrar.page_subtitle.replace('{emergencyName}', emergency.name)}
+        />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
           <Card className="p-5 lg:p-7">
             <RegistrarForm

--- a/apps/web/src/app/e/[slug]/reportar/page.tsx
+++ b/apps/web/src/app/e/[slug]/reportar/page.tsx
@@ -7,6 +7,7 @@ import { submitReport } from './actions';
 import { ReportForm } from './report-form';
 import { AppBar } from '@/components/organisms/app-bar';
 import { Card } from '@/components/atoms/card';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 type Props = {
@@ -72,12 +73,7 @@ export default async function ReportarPage({ params, searchParams }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {t.reportar.page_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">{emergency.name}</p>
-        </div>
+        <PageHeading title={t.reportar.page_title} subtitle={emergency.name} />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
           <Card className="p-5 lg:p-7">
             <ReportForm

--- a/apps/web/src/app/e/[slug]/voluntario/page.tsx
+++ b/apps/web/src/app/e/[slug]/voluntario/page.tsx
@@ -8,6 +8,7 @@ import { registerVolunteer } from './actions';
 import { VoluntarioForm } from './voluntario-form';
 import { AppBar } from '@/components/organisms/app-bar';
 import { Card } from '@/components/atoms/card';
+import { PageHeading } from '@/components/atoms/page-heading';
 import { getT } from '@/i18n/server';
 
 export const dynamic = 'force-dynamic';
@@ -63,14 +64,10 @@ export default async function VoluntarioPage({ params }: Props) {
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
         <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
-        <div className="px-4 pt-6">
-          <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">
-            {t.voluntario.page_title}
-          </h1>
-          <p className="mt-1.5 text-sm text-muted">
-            {t.voluntario.page_subtitle.replace('{emergencyName}', emergency.name)}
-          </p>
-        </div>
+        <PageHeading
+          title={t.voluntario.page_title}
+          subtitle={t.voluntario.page_subtitle.replace('{emergencyName}', emergency.name)}
+        />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
           <Card className="p-5 lg:p-7">
             <VoluntarioForm

--- a/apps/web/src/components/atoms/page-heading.tsx
+++ b/apps/web/src/components/atoms/page-heading.tsx
@@ -1,0 +1,13 @@
+interface PageHeadingProps {
+  title: string;
+  subtitle?: string;
+}
+
+export function PageHeading({ title, subtitle }: PageHeadingProps) {
+  return (
+    <div className="px-4 pt-6">
+      <h1 className="font-display text-2xl font-extrabold tracking-tight text-navy">{title}</h1>
+      {subtitle !== undefined && <p className="mt-1.5 text-sm text-muted">{subtitle}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/organisms/app-bar.tsx
+++ b/apps/web/src/components/organisms/app-bar.tsx
@@ -183,7 +183,7 @@ export async function AppBar({ variant, slug, emergency, backHref }: AppBarProps
             brand={brand}
             account={<div className="px-3">{account}</div>}
             links={infoLinks}
-            labels={{ openMenu: ta.menu_aria, closeMenu: ta.menu_aria, navAria: ta.menu_aria }}
+            labels={{ openMenu: ta.open_menu, closeMenu: ta.close_menu, navAria: ta.menu_aria }}
             {...(isEmergency && slug !== undefined
               ? { requestCta: { href: `/e/${slug}/peticion`, label: ta.request } }
               : {})}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -59,6 +59,8 @@ export const en = {
     see_emergencies: 'See emergencies',
     account_aria: 'Account menu',
     menu_aria: 'Menu',
+    open_menu: 'Open menu',
+    close_menu: 'Close menu',
     section_emergency: 'In this emergency',
     my_points: 'My points',
     my_volunteering: 'My volunteering',

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -83,20 +83,7 @@ export const en = {
     no_emergencies_title: 'No active emergencies at the moment.',
     no_emergencies_description: 'When an emergency is activated it will appear here.',
     emergency_status_active: 'Active',
-    my_orgs: 'My organizations',
-    administration: 'Administration',
-    notifications: 'Notifications',
-    notifications_with_count: 'Notifications ({count})',
-    coordination_access: 'Coordination access',
-    admin: 'Admin',
-    templates: 'Templates',
-    audit: 'Audit',
-    my_permissions: 'My permissions',
-    groups: 'My groups',
-    admin_permissions: 'Permissions & roles',
-    admin_api_keys: 'API keys',
     aria_emergency_list: 'List of active emergencies',
-    aria_secondary_nav: 'Secondary navigation',
     enter_operation: 'Enter the operation',
     active_count: '{count} ongoing',
     closed_label: 'Closed · report available',
@@ -123,9 +110,6 @@ export const en = {
     trust_unverified: 'In queue · do not bring supplies',
     trust_verified: 'Validated by local coordination',
     trust_official: 'Accredited organisation',
-
-    // Account access (home secondary bar)
-    account_heading: 'Your account',
 
     meta_title: 'ResponseGrid — Active emergencies',
     meta_description:

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -84,20 +84,7 @@ export const es = {
     no_emergencies_title: 'No hay emergencias activas en este momento.',
     no_emergencies_description: 'Cuando se active una emergencia aparecerá aquí.',
     emergency_status_active: 'Activa',
-    my_orgs: 'Mis organizaciones',
-    administration: 'Administración',
-    notifications: 'Notificaciones',
-    notifications_with_count: 'Notificaciones ({count})',
-    coordination_access: 'Acceso coordinación',
-    admin: 'Admin',
-    templates: 'Plantillas',
-    audit: 'Auditoría',
-    my_permissions: 'Mis permisos',
-    groups: 'Mis grupos',
-    admin_permissions: 'Permisos y roles',
-    admin_api_keys: 'API keys',
     aria_emergency_list: 'Lista de emergencias activas',
-    aria_secondary_nav: 'Navegación secundaria',
     enter_operation: 'Entrar al operativo',
     active_count: '{count} en curso',
     closed_label: 'Cerrada · informe disponible',
@@ -124,9 +111,6 @@ export const es = {
     trust_unverified: 'En cola · no llevar material',
     trust_verified: 'Validado por coordinación local',
     trust_official: 'Organización acreditada',
-
-    // Accesos de cuenta (barra secundaria del home)
-    account_heading: 'Tu cuenta',
 
     meta_title: 'ResponseGrid — Emergencias activas',
     meta_description:

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -59,6 +59,8 @@ export const es = {
     see_emergencies: 'Ver emergencias',
     account_aria: 'Menú de cuenta',
     menu_aria: 'Menú',
+    open_menu: 'Abrir menú',
+    close_menu: 'Cerrar menú',
     section_emergency: 'En esta emergencia',
     my_points: 'Mis puntos',
     my_volunteering: 'Mi voluntariado',


### PR DESCRIPTION
Follow-ups de la revisión de #276. Cambios pequeños y de bajo riesgo.

## Incluye
- **#273** — labels a11y distintos para abrir/cerrar el drawer móvil (`appbar.open_menu`/`close_menu` en es/en; antes los tres labels eran el mismo "Menú").
- **#275** — elimina 14 claves i18n huérfanas de `t.home` que solo usaba el borrado `AccountNav` (verificadas por grep; se conservaron las homónimas del namespace `nav.*`, que sí se usan).
- **#279** — extrae el átomo `PageHeading` (h1 + subtítulo) y lo aplica en 14 páginas de acción (15 ocurrencias), eliminando el bloque duplicado.
- **#274** — `recursos/[resourceId]` pasa a usar `AppBar variant="action"` + `PageHeading` (era la única página pública sin la barra unificada).

## Verificación
`pnpm --filter @reliefhub/api-client build && pnpm --filter web build` + `pnpm --filter web lint` en verde (1 warning preexistente ajeno en `apple-icon.tsx`).

## No incluidos (con motivo)
- **#277** (2 llamadas API por página): ya van en `Promise.all` (paralelo, 1 latencia); coste inherente a mostrar cuenta + badge de notificaciones. Sin arreglo simple con valor real → se deja abierto.
- **#278** (`next` del login preciso): requiere middleware/`proxy.ts` (no existe en el web) para exponer el pathname a un Server Component, o cablearlo por ~20 páginas. No es simple ni es regresión → se deja abierto.

Closes #273
Closes #274
Closes #275
Closes #279