### PR TITLE
feat(web): accesos directos en la pantalla de éxito del registro + edición de inventario del punto (#263)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -978,6 +978,107 @@
         ]
       }
     },
+    "/resources/{resourceId}/inventory": {
+      "get": {
+        "operationId": "ResourcesController_getMyInventoryAction",
+        "parameters": [
+          {
+            "name": "resourceId",
+            "required": true,
+            "in": "path",
+            "description": "Resource UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SupplyLineResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not owner nor coordinator"
+          },
+          "404": {
+            "description": "Resource not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Read a point declared inventory in full (owner or coordinator)",
+        "tags": [
+          "resources"
+        ]
+      },
+      "put": {
+        "operationId": "ResourcesController_updateMyInventoryAction",
+        "parameters": [
+          {
+            "name": "resourceId",
+            "required": true,
+            "in": "path",
+            "description": "Resource UUID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateInventoryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Inventory replaced"
+          },
+          "400": {
+            "description": "Invalid request body or UUID"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Not owner nor coordinator"
+          },
+          "404": {
+            "description": "Resource not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Replace a point declared inventory (owner or coordinator) — #263",
+        "tags": [
+          "resources"
+        ]
+      }
+    },
     "/resources/{resourceId}/verify": {
       "post": {
         "operationId": "ResourcesController_verifyResource",
@@ -9607,6 +9708,88 @@
           "items"
         ]
       },
+      "SupplyLineResponseDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "Water bottles"
+          },
+          "supplyId": {
+            "type": "string",
+            "example": "1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8",
+            "nullable": true,
+            "description": "Optional soft link to the canonical supply master data."
+          },
+          "quantity": {
+            "type": "number",
+            "example": 100
+          },
+          "unit": {
+            "type": "string",
+            "example": "liters",
+            "nullable": true
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "food",
+              "water",
+              "hygiene",
+              "clothing",
+              "medical",
+              "shelter",
+              "tools",
+              "other",
+              "medicines",
+              "medical_equipment",
+              "medical_supplies",
+              "medical_personnel",
+              "food_fresh",
+              "food_non_perishable",
+              "hygiene_infantile",
+              "hygiene_personal",
+              "tools_extraction",
+              "other_pets"
+            ],
+            "example": "water"
+          },
+          "presentation": {
+            "type": "string",
+            "example": "ampolla",
+            "nullable": true,
+            "description": "Presentation / route of administration (ampolla, EV, inhalador…) — #61."
+          },
+          "expiresAt": {
+            "type": "string",
+            "example": "2026-07-01",
+            "nullable": true,
+            "format": "date",
+            "description": "Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD)."
+          }
+        },
+        "required": [
+          "name",
+          "supplyId",
+          "quantity",
+          "category"
+        ]
+      },
+      "UpdateInventoryDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "Full declared inventory (replaces current; empty clears it)",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupplyLineDto"
+            }
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
       "VerifyResourceDto": {
         "type": "object",
         "properties": {}
@@ -11407,73 +11590,6 @@
           "address",
           "latitude",
           "longitude"
-        ]
-      },
-      "SupplyLineResponseDto": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "example": "Water bottles"
-          },
-          "supplyId": {
-            "type": "string",
-            "example": "1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8",
-            "nullable": true,
-            "description": "Optional soft link to the canonical supply master data."
-          },
-          "quantity": {
-            "type": "number",
-            "example": 100
-          },
-          "unit": {
-            "type": "string",
-            "example": "liters",
-            "nullable": true
-          },
-          "category": {
-            "type": "string",
-            "enum": [
-              "food",
-              "water",
-              "hygiene",
-              "clothing",
-              "medical",
-              "shelter",
-              "tools",
-              "other",
-              "medicines",
-              "medical_equipment",
-              "medical_supplies",
-              "medical_personnel",
-              "food_fresh",
-              "food_non_perishable",
-              "hygiene_infantile",
-              "hygiene_personal",
-              "tools_extraction",
-              "other_pets"
-            ],
-            "example": "water"
-          },
-          "presentation": {
-            "type": "string",
-            "example": "ampolla",
-            "nullable": true,
-            "description": "Presentation / route of administration (ampolla, EV, inhalador…) — #61."
-          },
-          "expiresAt": {
-            "type": "string",
-            "example": "2026-07-01",
-            "nullable": true,
-            "format": "date",
-            "description": "Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD)."
-          }
-        },
-        "required": [
-          "name",
-          "supplyId",
-          "quantity",
-          "category"
         ]
       },
       "NeedViewDto": {

--- a/apps/api/src/contexts/needs/application/create-need.spec.ts
+++ b/apps/api/src/contexts/needs/application/create-need.spec.ts
@@ -3,6 +3,8 @@ import { InMemoryNeedRepository } from '../infrastructure/in-memory-need.reposit
 import { FakeEventBus } from '../infrastructure/fake-event-bus';
 import { Category, Priority, NeedStatus } from '../domain/need-enums';
 import { NeedEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+import { NeedResourceReader } from '../domain/ports/resource-reader';
+import { InvalidResourceLinkError } from '../domain/need-errors';
 import { EmergencyNotAcceptingIntakeError } from '../../emergencies/domain/emergency-not-accepting-intake.error';
 import { LocationSensitivity } from '../../../shared/domain/location-sensitivity';
 
@@ -188,6 +190,39 @@ describe('CreateNeed', () => {
       await expect(uc.execute(makeCmd())).rejects.toThrow(
         EmergencyNotAcceptingIntakeError,
       );
+    });
+  });
+
+  describe('resource link validation (#60)', () => {
+    const RID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+    const yesReader: NeedResourceReader = {
+      existsInEmergency: () => Promise.resolve(true),
+    };
+    const noReader: NeedResourceReader = {
+      existsInEmergency: () => Promise.resolve(false),
+    };
+
+    it('links the need when the resource exists in the same emergency', async () => {
+      const uc = new CreateNeed(repo, bus, activeReader, yesReader);
+      const result = await uc.execute(makeCmd({ resourceId: RID }));
+      const saved = await repo.findById({ value: result.id } as never);
+      expect(saved!.resourceId).toBe(RID);
+    });
+
+    it('rejects a resourceId not in this emergency → InvalidResourceLinkError', async () => {
+      const uc = new CreateNeed(repo, bus, activeReader, noReader);
+      await expect(
+        uc.execute(makeCmd({ resourceId: RID })),
+      ).rejects.toBeInstanceOf(InvalidResourceLinkError);
+    });
+
+    it('does not consult the reader when no resourceId is given', async () => {
+      const spy = jest.fn().mockResolvedValue(false);
+      const uc = new CreateNeed(repo, bus, activeReader, {
+        existsInEmergency: spy,
+      });
+      await uc.execute(makeCmd());
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/contexts/needs/application/create-need.ts
+++ b/apps/api/src/contexts/needs/application/create-need.ts
@@ -1,6 +1,8 @@
 import { NeedRepository } from '../domain/ports/need.repository';
 import { EventBus } from '../domain/ports/event-bus';
 import { NeedEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+import { NeedResourceReader } from '../domain/ports/resource-reader';
+import { InvalidResourceLinkError } from '../domain/need-errors';
 import { Need } from '../domain/need';
 import { NeedId } from '../domain/need-id';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
@@ -57,6 +59,11 @@ export class CreateNeed {
     private readonly repo: NeedRepository,
     private readonly bus: EventBus,
     private readonly emergencyStatusReader: NeedEmergencyStatusReader,
+    // Defaults to accept-any so callers that never pass resourceId (and older
+    // tests) need not wire a reader; the DI module always injects the real one.
+    private readonly resourceReader: NeedResourceReader = {
+      existsInEmergency: () => Promise.resolve(true),
+    },
   ) {}
 
   async execute(cmd: CreateNeedCommand): Promise<{ id: string }> {
@@ -66,6 +73,16 @@ export class CreateNeed {
         cmd.emergencyId,
         status ?? 'not-found',
       );
+    }
+
+    // A resource link must point to a resource in the SAME emergency (#60), or
+    // any submitter could attach needs to foreign/cross-emergency resources.
+    if (cmd.resourceId != null) {
+      const ok = await this.resourceReader.existsInEmergency(
+        cmd.resourceId,
+        cmd.emergencyId,
+      );
+      if (!ok) throw new InvalidResourceLinkError(cmd.resourceId);
     }
 
     const location = Location.create({

--- a/apps/api/src/contexts/needs/domain/need-errors.ts
+++ b/apps/api/src/contexts/needs/domain/need-errors.ts
@@ -20,3 +20,12 @@ export class NeedTitleRequiredError extends Error {
     this.name = 'NeedTitleRequiredError';
   }
 }
+
+/** Raised when the optional resourceId link points to a resource that does not
+ *  exist or belongs to another emergency (#60). */
+export class InvalidResourceLinkError extends Error {
+  constructor(resourceId: string) {
+    super(`Resource not found in this emergency: ${resourceId}`);
+    this.name = 'InvalidResourceLinkError';
+  }
+}

--- a/apps/api/src/contexts/needs/domain/ports/resource-reader.ts
+++ b/apps/api/src/contexts/needs/domain/ports/resource-reader.ts
@@ -1,0 +1,14 @@
+/**
+ * Port — needs context.
+ *
+ * Lets CreateNeed validate the optional `resourceId` link (#60) without
+ * depending on the resources context: confirms the resource exists AND belongs
+ * to the given emergency, so a need can't be attached to a foreign or
+ * cross-emergency resource.
+ */
+export const NEED_RESOURCE_READER = Symbol('NeedResourceReader');
+
+export interface NeedResourceReader {
+  /** True when a resource with this id exists in the given emergency. */
+  existsInEmergency(resourceId: string, emergencyId: string): Promise<boolean>;
+}

--- a/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need-resource-reader.ts
+++ b/apps/api/src/contexts/needs/infrastructure/drizzle/drizzle-need-resource-reader.ts
@@ -1,0 +1,30 @@
+import { and, eq } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import { NeedResourceReader } from '../../domain/ports/resource-reader';
+import { resourcesTable } from '../../../resources/infrastructure/drizzle/schema';
+
+/**
+ * Drizzle adapter — checks a resource exists in a given emergency, for the
+ * needs `resourceId` link (#60). Reads the `resources` table directly:
+ * accepted cross-context infra coupling (same pattern as the shared emergency
+ * status reader).
+ */
+export class DrizzleNeedResourceReader implements NeedResourceReader {
+  constructor(private readonly db: Db) {}
+
+  async existsInEmergency(
+    resourceId: string,
+    emergencyId: string,
+  ): Promise<boolean> {
+    const rows = await this.db
+      .select({ id: resourcesTable.id })
+      .from(resourcesTable)
+      .where(
+        and(
+          eq(resourcesTable.id, resourceId),
+          eq(resourcesTable.emergencyId, emergencyId),
+        ),
+      );
+    return rows.length > 0;
+  }
+}

--- a/apps/api/src/contexts/needs/infrastructure/http/domain-exception.filter.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/domain-exception.filter.ts
@@ -10,6 +10,7 @@ import {
   NeedNotPendingError,
   NeedNotEditableError,
   NeedTitleRequiredError,
+  InvalidResourceLinkError,
 } from '../../domain/need-errors';
 import { EmergencyNotAcceptingIntakeError } from '../../../emergencies/domain/emergency-not-accepting-intake.error';
 import { InvalidAuthorError } from '../../../../shared/domain/author';
@@ -20,6 +21,7 @@ type DomainError =
   | NeedNotPendingError
   | NeedNotEditableError
   | NeedTitleRequiredError
+  | InvalidResourceLinkError
   | EmergencyNotAcceptingIntakeError
   | InvalidAuthorError
   | SupplyLineValidationError;
@@ -31,6 +33,7 @@ type DomainError =
   NeedNotPendingError,
   NeedNotEditableError,
   NeedTitleRequiredError,
+  InvalidResourceLinkError,
   EmergencyNotAcceptingIntakeError,
   InvalidAuthorError,
   SupplyLineValidationError,
@@ -42,6 +45,7 @@ export class NeedsDomainExceptionFilter implements ExceptionFilter {
       exception instanceof NeedNotFoundError
         ? HttpStatus.NOT_FOUND
         : exception instanceof NeedTitleRequiredError ||
+            exception instanceof InvalidResourceLinkError ||
             exception instanceof InvalidAuthorError ||
             exception instanceof SupplyLineValidationError
           ? HttpStatus.BAD_REQUEST

--- a/apps/api/src/contexts/needs/infrastructure/needs.module.ts
+++ b/apps/api/src/contexts/needs/infrastructure/needs.module.ts
@@ -35,6 +35,11 @@ import {
 } from '../domain/ports/personnel-task-creator.port';
 import { DrizzleNeedRepository } from './drizzle/drizzle-need.repository';
 import { DrizzleEmergencyStatusReader } from '../../../shared/drizzle-emergency-status-reader';
+import {
+  NEED_RESOURCE_READER,
+  NeedResourceReader,
+} from '../domain/ports/resource-reader';
+import { DrizzleNeedResourceReader } from './drizzle/drizzle-need-resource-reader';
 import { BullMqEventBus } from './bullmq-event-bus';
 import { IdentityModule } from '../../identity/infrastructure/identity.module';
 import { DrizzleVolunteerMatcher } from '../../volunteers/infrastructure/drizzle/drizzle-volunteer-matcher';
@@ -89,14 +94,26 @@ const eventBusProvider = {
     new BullMqEventBus(eventQueue.queue),
 };
 
+const resourceReaderProvider = {
+  provide: NEED_RESOURCE_READER,
+  inject: [DB],
+  useFactory: (db: Db): NeedResourceReader => new DrizzleNeedResourceReader(db),
+};
+
 const createNeedProvider = {
   provide: CreateNeed,
-  inject: [NEED_REPOSITORY, EVENT_BUS, NEED_EMERGENCY_STATUS_READER],
+  inject: [
+    NEED_REPOSITORY,
+    EVENT_BUS,
+    NEED_EMERGENCY_STATUS_READER,
+    NEED_RESOURCE_READER,
+  ],
   useFactory: (
     repo: NeedRepository,
     bus: EventBus,
     statusReader: NeedEmergencyStatusReader,
-  ) => new CreateNeed(repo, bus, statusReader),
+    resourceReader: NeedResourceReader,
+  ) => new CreateNeed(repo, bus, statusReader, resourceReader),
 };
 
 const validateNeedProvider = {
@@ -210,6 +227,7 @@ const createTaskFromNeedProvider = {
     eventQueueProvider,
     needRepositoryProvider,
     emergencyStatusReaderProvider,
+    resourceReaderProvider,
     eventBusProvider,
     createNeedProvider,
     validateNeedProvider,

--- a/apps/api/src/contexts/resources/application/get-my-inventory.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-my-inventory.spec.ts
@@ -1,0 +1,106 @@
+import { GetMyInventory } from './get-my-inventory';
+import { RegisterResource } from './register-resource';
+import { InMemoryResourceRepository } from '../infrastructure/in-memory-resource.repository';
+import { FakeEventBus } from '../infrastructure/fake-event-bus';
+import { ResourceType } from '../domain/resource-enums';
+import { ResourceEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+import { ResourceMembershipReader } from '../domain/ports/membership-reader';
+import { Category } from '../../supplies/domain/category';
+import { SupplyLineProps } from '../../supplies/domain/supply-line';
+import { ResourceNotFoundError } from './resource-not-found.error';
+import { UnauthorizedInventoryChangeError } from './unauthorized-inventory-change.error';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const OWNER_ID = 'owner-user-0000-0000-000000000000';
+const COORD_ID = 'coord-user-0000-0000-000000000000';
+const THIRD_ID = 'third-user-0000-0000-000000000000';
+const baseLocation = {
+  address: 'Calle Test 1, Madrid',
+  latitude: 40.4168,
+  longitude: -3.7038,
+};
+
+const activeReader: ResourceEmergencyStatusReader = {
+  getStatus: () => Promise.resolve('active'),
+};
+const coordOnlyMembership: ResourceMembershipReader = {
+  isCoordinator: (userId) => Promise.resolve(userId === COORD_ID),
+};
+const noMembership: ResourceMembershipReader = {
+  isCoordinator: () => Promise.resolve(false),
+};
+
+const line: SupplyLineProps = {
+  name: 'Agua',
+  quantity: 10,
+  unit: 'l',
+  category: Category.Water,
+};
+
+async function makeResource(
+  repo: InMemoryResourceRepository,
+  bus: FakeEventBus,
+): Promise<string> {
+  const { id } = await new RegisterResource(repo, bus, activeReader).execute({
+    emergencyId: EM,
+    type: ResourceType.Warehouse,
+    name: 'Punto Test',
+    location: baseLocation,
+    ownerUserId: OWNER_ID,
+    items: [line],
+  });
+  return id;
+}
+
+describe('GetMyInventory', () => {
+  it('owner reads the full declared lines', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+
+    const lines = await new GetMyInventory(repo, noMembership).execute({
+      resourceId: id,
+      requesterUserId: OWNER_ID,
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ name: 'Agua', quantity: 10, unit: 'l' });
+  });
+
+  it('coordinator (not owner) can read', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+
+    const lines = await new GetMyInventory(repo, coordOnlyMembership).execute({
+      resourceId: id,
+      requesterUserId: COORD_ID,
+    });
+
+    expect(lines).toHaveLength(1);
+  });
+
+  it('third party → UnauthorizedInventoryChangeError', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+
+    await expect(
+      new GetMyInventory(repo, noMembership).execute({
+        resourceId: id,
+        requesterUserId: THIRD_ID,
+      }),
+    ).rejects.toBeInstanceOf(UnauthorizedInventoryChangeError);
+  });
+
+  it('unknown resourceId → ResourceNotFoundError', async () => {
+    const repo = new InMemoryResourceRepository();
+
+    await expect(
+      new GetMyInventory(repo, noMembership).execute({
+        resourceId: '99999999-9999-4999-8999-999999999999',
+        requesterUserId: OWNER_ID,
+      }),
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+});

--- a/apps/api/src/contexts/resources/application/get-my-inventory.ts
+++ b/apps/api/src/contexts/resources/application/get-my-inventory.ts
@@ -1,0 +1,36 @@
+import { ResourceRepository } from '../domain/ports/resource.repository';
+import { ResourceMembershipReader } from '../domain/ports/membership-reader';
+import { ResourceId } from '../domain/resource-id';
+import { SupplyLineSnapshot } from '../../supplies/domain/supply-line';
+import { ResourceNotFoundError } from './resource-not-found.error';
+import { UnauthorizedInventoryChangeError } from './unauthorized-inventory-change.error';
+
+export interface GetMyInventoryQuery {
+  resourceId: string;
+  requesterUserId: string;
+}
+
+export class GetMyInventory {
+  constructor(
+    private readonly repo: ResourceRepository,
+    private readonly membershipReader: ResourceMembershipReader,
+  ) {}
+
+  async execute(q: GetMyInventoryQuery): Promise<SupplyLineSnapshot[]> {
+    const resource = await this.repo.findById(
+      ResourceId.fromString(q.resourceId),
+    );
+    if (!resource) throw new ResourceNotFoundError(q.resourceId);
+
+    const isOwner = resource.ownerUserId === q.requesterUserId;
+    const isCoordinator = await this.membershipReader.isCoordinator(
+      q.requesterUserId,
+      resource.emergencyId.value,
+    );
+    if (!isOwner && !isCoordinator) {
+      throw new UnauthorizedInventoryChangeError();
+    }
+
+    return resource.items.map((i) => i.toSnapshot());
+  }
+}

--- a/apps/api/src/contexts/resources/application/unauthorized-inventory-change.error.ts
+++ b/apps/api/src/contexts/resources/application/unauthorized-inventory-change.error.ts
@@ -1,0 +1,6 @@
+export class UnauthorizedInventoryChangeError extends Error {
+  constructor() {
+    super('Not authorized to change the inventory of this resource');
+    this.name = 'UnauthorizedInventoryChangeError';
+  }
+}

--- a/apps/api/src/contexts/resources/application/update-my-inventory.spec.ts
+++ b/apps/api/src/contexts/resources/application/update-my-inventory.spec.ts
@@ -1,0 +1,143 @@
+import { UpdateMyInventory } from './update-my-inventory';
+import { RegisterResource } from './register-resource';
+import { InMemoryResourceRepository } from '../infrastructure/in-memory-resource.repository';
+import { FakeEventBus } from '../infrastructure/fake-event-bus';
+import { ResourceId } from '../domain/resource-id';
+import { ResourceType } from '../domain/resource-enums';
+import { ResourceEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+import { ResourceMembershipReader } from '../domain/ports/membership-reader';
+import { Category } from '../../supplies/domain/category';
+import { SupplyLineProps } from '../../supplies/domain/supply-line';
+import { ResourceNotFoundError } from './resource-not-found.error';
+import { UnauthorizedInventoryChangeError } from './unauthorized-inventory-change.error';
+import { SupplyLineValidationError } from '../../supplies/domain/supply-line';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const OWNER_ID = 'owner-user-0000-0000-000000000000';
+const COORD_ID = 'coord-user-0000-0000-000000000000';
+const THIRD_ID = 'third-user-0000-0000-000000000000';
+const baseLocation = {
+  address: 'Calle Test 1, Madrid',
+  latitude: 40.4168,
+  longitude: -3.7038,
+};
+
+const activeReader: ResourceEmergencyStatusReader = {
+  getStatus: () => Promise.resolve('active'),
+};
+const coordOnlyMembership: ResourceMembershipReader = {
+  isCoordinator: (userId) => Promise.resolve(userId === COORD_ID),
+};
+const noMembership: ResourceMembershipReader = {
+  isCoordinator: () => Promise.resolve(false),
+};
+
+const line = (name: string, quantity: number): SupplyLineProps => ({
+  name,
+  quantity,
+  unit: 'l',
+  category: Category.Water,
+});
+
+async function makeResource(
+  repo: InMemoryResourceRepository,
+  bus: FakeEventBus,
+  items: SupplyLineProps[] = [],
+): Promise<string> {
+  const { id } = await new RegisterResource(repo, bus, activeReader).execute({
+    emergencyId: EM,
+    type: ResourceType.Warehouse,
+    name: 'Punto Test',
+    location: baseLocation,
+    ownerUserId: OWNER_ID,
+    items,
+  });
+  return id;
+}
+
+describe('UpdateMyInventory', () => {
+  it('owner replaces the whole inventory', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, [line('Agua', 10)]);
+
+    await new UpdateMyInventory(repo, noMembership).execute({
+      resourceId: id,
+      requesterUserId: OWNER_ID,
+      lines: [line('Arroz', 3)],
+    });
+
+    const found = await repo.findById(ResourceId.fromString(id));
+    expect(found?.items.map((i) => i.name)).toEqual(['Arroz']);
+  });
+
+  it('coordinator (not owner) can replace inventory', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, [line('Agua', 10)]);
+
+    await new UpdateMyInventory(repo, coordOnlyMembership).execute({
+      resourceId: id,
+      requesterUserId: COORD_ID,
+      lines: [line('Mantas', 5)],
+    });
+
+    const found = await repo.findById(ResourceId.fromString(id));
+    expect(found?.items.map((i) => i.name)).toEqual(['Mantas']);
+  });
+
+  it('empty list clears inventory', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, [line('Agua', 10)]);
+
+    await new UpdateMyInventory(repo, noMembership).execute({
+      resourceId: id,
+      requesterUserId: OWNER_ID,
+      lines: [],
+    });
+
+    const found = await repo.findById(ResourceId.fromString(id));
+    expect(found?.items).toHaveLength(0);
+  });
+
+  it('third party (not owner, not coordinator) → UnauthorizedInventoryChangeError', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+
+    await expect(
+      new UpdateMyInventory(repo, noMembership).execute({
+        resourceId: id,
+        requesterUserId: THIRD_ID,
+        lines: [line('Agua', 1)],
+      }),
+    ).rejects.toBeInstanceOf(UnauthorizedInventoryChangeError);
+  });
+
+  it('unknown resourceId → ResourceNotFoundError', async () => {
+    const repo = new InMemoryResourceRepository();
+
+    await expect(
+      new UpdateMyInventory(repo, noMembership).execute({
+        resourceId: '99999999-9999-4999-8999-999999999999',
+        requesterUserId: OWNER_ID,
+        lines: [],
+      }),
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+
+  it('invalid line (quantity 0) → SupplyLineValidationError', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+
+    await expect(
+      new UpdateMyInventory(repo, noMembership).execute({
+        resourceId: id,
+        requesterUserId: OWNER_ID,
+        lines: [{ ...line('Agua', 0) }],
+      }),
+    ).rejects.toBeInstanceOf(SupplyLineValidationError);
+  });
+});

--- a/apps/api/src/contexts/resources/application/update-my-inventory.ts
+++ b/apps/api/src/contexts/resources/application/update-my-inventory.ts
@@ -1,0 +1,38 @@
+import { ResourceRepository } from '../domain/ports/resource.repository';
+import { ResourceMembershipReader } from '../domain/ports/membership-reader';
+import { ResourceId } from '../domain/resource-id';
+import { SupplyLine, SupplyLineProps } from '../../supplies/domain/supply-line';
+import { ResourceNotFoundError } from './resource-not-found.error';
+import { UnauthorizedInventoryChangeError } from './unauthorized-inventory-change.error';
+
+export interface UpdateMyInventoryCommand {
+  resourceId: string;
+  requesterUserId: string;
+  lines: SupplyLineProps[];
+}
+
+export class UpdateMyInventory {
+  constructor(
+    private readonly repo: ResourceRepository,
+    private readonly membershipReader: ResourceMembershipReader,
+  ) {}
+
+  async execute(cmd: UpdateMyInventoryCommand): Promise<void> {
+    const resource = await this.repo.findById(
+      ResourceId.fromString(cmd.resourceId),
+    );
+    if (!resource) throw new ResourceNotFoundError(cmd.resourceId);
+
+    const isOwner = resource.ownerUserId === cmd.requesterUserId;
+    const isCoordinator = await this.membershipReader.isCoordinator(
+      cmd.requesterUserId,
+      resource.emergencyId.value,
+    );
+    if (!isOwner && !isCoordinator) {
+      throw new UnauthorizedInventoryChangeError();
+    }
+
+    resource.replaceInventory(cmd.lines.map((l) => SupplyLine.create(l)));
+    await this.repo.save(resource);
+  }
+}

--- a/apps/api/src/contexts/resources/domain/resource-replace-inventory.spec.ts
+++ b/apps/api/src/contexts/resources/domain/resource-replace-inventory.spec.ts
@@ -1,0 +1,45 @@
+import { Resource } from './resource';
+import { SupplyLine } from '../../supplies/domain/supply-line';
+import { Category } from '../../supplies/domain/category';
+import { ResourceId } from './resource-id';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ResourceType } from './resource-enums';
+import { Location } from '../../../shared/domain/location';
+
+const make = (items: SupplyLine[] = []): Resource =>
+  Resource.register({
+    id: ResourceId.create(),
+    emergencyId: EmergencyId.fromString('11111111-1111-4111-8111-111111111111'),
+    type: ResourceType.Warehouse,
+    name: 'Acopio Centro',
+    location: Location.create({ address: 'X', latitude: 1, longitude: 2 }),
+    ownerUserId: 'user-1',
+    items,
+  });
+
+const line = (name: string, quantity: number): SupplyLine =>
+  SupplyLine.create({ name, quantity, unit: 'l', category: Category.Water });
+
+describe('Resource.replaceInventory', () => {
+  it('overwrites the whole inventory (does not merge)', () => {
+    const r = make([line('Agua', 10)]);
+    r.replaceInventory([line('Arroz', 3)]);
+    expect(r.items.map((i) => i.name)).toEqual(['Arroz']);
+  });
+
+  it('clears inventory when given an empty list', () => {
+    const r = make([line('Agua', 10)]);
+    r.replaceInventory([]);
+    expect(r.items).toHaveLength(0);
+  });
+
+  it('reflects the replacement in the snapshot', () => {
+    const r = make([line('Agua', 10)]);
+    r.replaceInventory([line('Mantas', 5)]);
+    expect(r.toSnapshot().items).toHaveLength(1);
+    expect(r.toSnapshot().items[0]).toMatchObject({
+      name: 'Mantas',
+      quantity: 5,
+    });
+  });
+});

--- a/apps/api/src/contexts/resources/domain/resource.ts
+++ b/apps/api/src/contexts/resources/domain/resource.ts
@@ -335,6 +335,12 @@ export class Resource {
     this._items = [...byKey.values()];
   }
 
+  /** Owner/coordinator overwrites the declared inventory (#263). Replaces, not
+   *  merges — unlike receiveInventory (donation/intake). Empty list clears it. */
+  replaceInventory(lines: SupplyLine[]): void {
+    this._items = [...lines];
+  }
+
   /**
    * Discard a resource pending verification: it leaves the verification queue
    * (no longer `unverified`) and can never be published. Only a resource still

--- a/apps/api/src/contexts/resources/infrastructure/http/domain-exception.filter.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/domain-exception.filter.ts
@@ -7,6 +7,7 @@ import {
 import { Response } from 'express';
 import { ResourceNotFoundError } from '../../application/resource-not-found.error';
 import { UnauthorizedStatusChangeError } from '../../application/unauthorized-status-change.error';
+import { UnauthorizedInventoryChangeError } from '../../application/unauthorized-inventory-change.error';
 import {
   ResourceAlreadyPublishedError,
   ResourceNotVerifiedError,
@@ -31,6 +32,7 @@ type DomainError =
   | InvalidVerificationLevelError
   | EmergencyNotAcceptingIntakeError
   | UnauthorizedStatusChangeError
+  | UnauthorizedInventoryChangeError
   | InvalidPublicStatusTransitionError
   | ResourceNotPublishedError
   | ResourceNotPendingError
@@ -50,6 +52,7 @@ type ErrorCtor = new (...args: never[]) => Error;
 const STATUS_BY_ERROR: ReadonlyArray<readonly [ErrorCtor, HttpStatus]> = [
   [ResourceNotFoundError, HttpStatus.NOT_FOUND],
   [UnauthorizedStatusChangeError, HttpStatus.FORBIDDEN],
+  [UnauthorizedInventoryChangeError, HttpStatus.FORBIDDEN],
   [OwnerCannotReportValidityError, HttpStatus.FORBIDDEN],
   [EmergencyNotAcceptingIntakeError, HttpStatus.CONFLICT],
   [ResourceAlreadyPublishedError, HttpStatus.CONFLICT],
@@ -69,6 +72,7 @@ const STATUS_BY_ERROR: ReadonlyArray<readonly [ErrorCtor, HttpStatus]> = [
   InvalidVerificationLevelError,
   EmergencyNotAcceptingIntakeError,
   UnauthorizedStatusChangeError,
+  UnauthorizedInventoryChangeError,
   InvalidPublicStatusTransitionError,
   ResourceNotPublishedError,
   ResourceNotPendingError,

--- a/apps/api/src/contexts/resources/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/dto.ts
@@ -193,6 +193,22 @@ export class RecordInventoryEntryDto {
   items!: SupplyLineDto[];
 }
 
+/**
+ * Body for the owner/coordinator declared-inventory edit (#263): the FULL set
+ * of lines. Replaces (not merges) the resource inventory; empty list clears it,
+ * so no @ArrayNotEmpty.
+ */
+export class UpdateInventoryDto {
+  @ApiProperty({
+    type: [SupplyLineDto],
+    description: 'Full declared inventory (replaces current; empty clears it)',
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SupplyLineDto)
+  items!: SupplyLineDto[];
+}
+
 export class UpdateResourcePublicStatusDto {
   @ApiProperty({
     enum: ['active', 'saturated', 'paused', 'closed'],

--- a/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Put,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -37,6 +38,8 @@ import {
 } from '../../application/edit-resource';
 import { DiscardResource } from '../../application/discard-resource';
 import { RecordInventoryEntry } from '../../application/record-inventory-entry';
+import { GetMyInventory } from '../../application/get-my-inventory';
+import { UpdateMyInventory } from '../../application/update-my-inventory';
 import { ReportResourceValidity } from '../../application/report-resource-validity';
 import { ResolveResourceDispute } from '../../application/resolve-resource-dispute';
 import { GetResourceValidityReports } from '../../application/get-resource-validity-reports';
@@ -51,7 +54,9 @@ import {
   RecordInventoryEntryDto,
   ReportResourceValidityDto,
   ResolveResourceDisputeDto,
+  UpdateInventoryDto,
 } from './dto';
+import { SupplyLineResponseDto } from '../../../supplies/infrastructure/http/supply-line.dto';
 import { setAuditContext } from '../../../audit/infrastructure/http/audit-context';
 import {
   RegisterResourceResponseDto,
@@ -82,6 +87,8 @@ export class ResourcesController {
     private readonly editResource: EditResource,
     private readonly discardResource: DiscardResource,
     private readonly recordInventoryEntry: RecordInventoryEntry,
+    private readonly getMyInventory: GetMyInventory,
+    private readonly updateMyInventory: UpdateMyInventory,
     private readonly reportValidity: ReportResourceValidity,
     private readonly resolveDispute: ResolveResourceDispute,
     private readonly validityReports: GetResourceValidityReports,
@@ -188,6 +195,77 @@ export class ResourcesController {
         category: i.category,
         supplyId: i.supplyId ?? null,
         presentation: i.presentation ?? null,
+      })),
+    });
+  }
+
+  @Get('resources/:resourceId/inventory')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Read a point declared inventory in full (owner or coordinator)',
+  })
+  @ApiParam({
+    name: 'resourceId',
+    description: 'Resource UUID',
+    format: 'uuid',
+  })
+  @ApiOkResponse({ type: SupplyLineResponseDto, isArray: true })
+  @ApiNotFoundResponse({ description: 'Resource not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Not owner nor coordinator' })
+  async getMyInventoryAction(
+    @Param('resourceId', ParseUUIDPipe) resourceId: string,
+    @Req() req: Request & { user?: AuthenticatedUser },
+  ): Promise<SupplyLineResponseDto[]> {
+    const lines = await this.getMyInventory.execute({
+      resourceId,
+      requesterUserId: req.user!.id,
+    });
+    return lines.map((l) => ({
+      name: l.name,
+      supplyId: l.supplyId,
+      quantity: l.quantity,
+      unit: l.unit,
+      category: l.category,
+      presentation: l.presentation ?? null,
+      expiresAt: l.expiresAt ?? null,
+    }));
+  }
+
+  @Put('resources/:resourceId/inventory')
+  @HttpCode(204)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Replace a point declared inventory (owner or coordinator) — #263',
+  })
+  @ApiParam({
+    name: 'resourceId',
+    description: 'Resource UUID',
+    format: 'uuid',
+  })
+  @ApiNoContentResponse({ description: 'Inventory replaced' })
+  @ApiNotFoundResponse({ description: 'Resource not found' })
+  @ApiBadRequestResponse({ description: 'Invalid request body or UUID' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Not owner nor coordinator' })
+  async updateMyInventoryAction(
+    @Param('resourceId', ParseUUIDPipe) resourceId: string,
+    @Body() dto: UpdateInventoryDto,
+    @Req() req: Request & { user?: AuthenticatedUser },
+  ): Promise<void> {
+    await this.updateMyInventory.execute({
+      resourceId,
+      requesterUserId: req.user!.id,
+      lines: dto.items.map((i) => ({
+        name: i.name,
+        quantity: i.quantity,
+        unit: i.unit ?? null,
+        category: i.category,
+        supplyId: i.supplyId ?? null,
+        presentation: i.presentation ?? null,
+        expiresAt: i.expiresAt ?? null,
       })),
     });
   }

--- a/apps/api/src/contexts/resources/infrastructure/resources.module.ts
+++ b/apps/api/src/contexts/resources/infrastructure/resources.module.ts
@@ -23,6 +23,8 @@ import { EditResource } from '../application/edit-resource';
 import { DiscardResource } from '../application/discard-resource';
 import { UpdateResourcePublicStatus } from '../application/update-resource-public-status';
 import { RecordInventoryEntry } from '../application/record-inventory-entry';
+import { GetMyInventory } from '../application/get-my-inventory';
+import { UpdateMyInventory } from '../application/update-my-inventory';
 import { ReceiveDonationIntoInventory } from '../application/receive-donation-into-inventory';
 import { DonationEventsWorker } from './donation-events.worker';
 import {
@@ -193,6 +195,24 @@ const updateStatusProvider = {
   ) => new UpdateResourcePublicStatus(repo, membershipReader),
 };
 
+const getMyInventoryProvider = {
+  provide: GetMyInventory,
+  inject: [RESOURCE_REPOSITORY, RESOURCE_MEMBERSHIP_READER],
+  useFactory: (
+    repo: ResourceRepository,
+    membershipReader: ResourceMembershipReader,
+  ) => new GetMyInventory(repo, membershipReader),
+};
+
+const updateMyInventoryProvider = {
+  provide: UpdateMyInventory,
+  inject: [RESOURCE_REPOSITORY, RESOURCE_MEMBERSHIP_READER],
+  useFactory: (
+    repo: ResourceRepository,
+    membershipReader: ResourceMembershipReader,
+  ) => new UpdateMyInventory(repo, membershipReader),
+};
+
 const getNearbyResourcesProvider = {
   provide: GetNearbyResources,
   inject: [RESOURCE_REPOSITORY],
@@ -342,6 +362,8 @@ const recordInventoryEntryProvider = {
     getResourceFacetsProvider,
     getNearbyResourcesProvider,
     updateStatusProvider,
+    getMyInventoryProvider,
+    updateMyInventoryProvider,
     getMyResourcesProvider,
     getResourcesInBoundsProvider,
     getPublicResourceProvider,

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/actions.ts
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/actions.ts
@@ -1,0 +1,82 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { api } from '@/lib/api';
+import type { components } from '@reliefhub/api-client';
+import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
+import { parseSupplyLines } from '@/lib/supply-lines';
+import { getT } from '@/i18n/server';
+import { getCategories } from '@/adapters/get-categories';
+import { isMaterialCategory } from '@/domain/supplies/category';
+
+type SupplyLineView = components['schemas']['SupplyLineResponseDto'];
+
+export type InventoryState =
+  | { status: 'idle' }
+  | { status: 'success' }
+  | { status: 'error'; message: string };
+
+/** Owner/coordinator read of the point's full declared lines (null → notFound). */
+export async function fetchMyInventory(
+  resourceId: string,
+  slug: string,
+): Promise<SupplyLineView[] | null> {
+  const token = await requireSession(`/e/${slug}/mis-puntos/${resourceId}/inventario`);
+
+  const { data, response } = await api.GET('/resources/{resourceId}/inventory', {
+    params: { path: { resourceId } },
+    headers: authHeaders(token),
+  });
+
+  if (response.status === 401) {
+    await clearToken();
+    redirect(loginHref(`/e/${slug}/mis-puntos/${resourceId}/inventario`));
+  }
+  if (!response.ok || data == null) return null;
+  return data;
+}
+
+export async function saveMyInventory(
+  resourceId: string,
+  slug: string,
+  _prev: InventoryState,
+  formData: FormData,
+): Promise<InventoryState> {
+  const token = await requireSession(`/e/${slug}/mis-puntos/${resourceId}/inventario`);
+  const { t, locale } = await getT();
+
+  const validMaterialCategories = new Set(
+    (await getCategories(locale)).filter(isMaterialCategory).map((c) => c.slug),
+  );
+
+  // allowEmpty: the owner can clear the inventory (empty list is a valid save).
+  const items = parseSupplyLines(formData.get('items'), {
+    isValidCategory: (c) => validMaterialCategories.has(c),
+    allowEmpty: true,
+  });
+  if (items === null) {
+    return { status: 'error', message: t.account.inventory_invalid_items };
+  }
+
+  const { response } = await api.PUT('/resources/{resourceId}/inventory', {
+    params: { path: { resourceId } },
+    headers: authHeaders(token),
+    body: { items },
+  });
+
+  if (response.status === 401) {
+    await clearToken();
+    redirect(loginHref(`/e/${slug}/mis-puntos/${resourceId}/inventario`));
+  }
+  if (response.status === 403) {
+    return { status: 'error', message: t.account.inventory_update_forbidden };
+  }
+  if (!response.ok) {
+    return { status: 'error', message: t.account.inventory_update_failed };
+  }
+
+  revalidatePath(`/e/${slug}/mis-puntos`);
+  revalidatePath(`/e/${slug}/mis-puntos/${resourceId}/inventario`);
+  return { status: 'success' };
+}

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/inventory-edit-form.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/inventory-edit-form.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useActionState } from 'react';
+import type { components } from '@reliefhub/api-client';
+import type { InventoryState } from './actions';
+import { InventoryField } from '../../../registrar/inventory-field';
+import { Button } from '@/components/atoms/button';
+import { ErrorMessage } from '@/components/atoms/error-message';
+import type { SupplyLine } from '@/domain/supplies/supply-line';
+import type { Category } from '@/domain/supplies/category';
+import type { Messages } from '@/i18n/messages/es';
+
+type SupplyLineView = components['schemas']['SupplyLineResponseDto'];
+
+const INITIAL_STATE: InventoryState = { status: 'idle' };
+
+type BoundAction = (
+  prev: InventoryState,
+  formData: FormData,
+) => Promise<InventoryState>;
+
+interface InventoryEditFormProps {
+  action: BoundAction;
+  initial: SupplyLineView[];
+  t: Messages['registrar'];
+  ta: Messages['account'];
+  locale: 'es' | 'en';
+  categories: readonly Category[];
+}
+
+const toLine = (l: SupplyLineView): SupplyLine => ({
+  name: l.name,
+  supplyId: l.supplyId,
+  quantity: l.quantity,
+  unit: l.unit ?? '',
+  category: l.category,
+  ...(l.expiresAt ? { expiresAt: l.expiresAt } : {}),
+});
+
+export function InventoryEditForm({
+  action,
+  initial,
+  t,
+  ta,
+  locale,
+  categories,
+}: InventoryEditFormProps) {
+  const [state, formAction, pending] = useActionState<InventoryState, FormData>(
+    action,
+    INITIAL_STATE,
+  );
+
+  return (
+    <form action={formAction} className="flex flex-col gap-6" noValidate>
+      {state.status === 'success' && (
+        <p
+          role="status"
+          className="rounded-lg border-2 border-navy bg-white p-4 text-sm font-semibold text-ink"
+        >
+          {ta.inventory_saved_success}
+        </p>
+      )}
+      {state.status === 'error' && <ErrorMessage message={state.message} />}
+
+      <InventoryField
+        t={t}
+        locale={locale}
+        categories={categories}
+        initialLines={initial.map(toLine)}
+      />
+
+      <Button type="submit" disabled={pending} fullWidth>
+        {pending ? ta.inventory_saving : ta.inventory_save_cta}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/inventory-edit-form.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/inventory-edit-form.tsx
@@ -35,6 +35,7 @@ const toLine = (l: SupplyLineView): SupplyLine => ({
   unit: l.unit ?? '',
   category: l.category,
   ...(l.expiresAt ? { expiresAt: l.expiresAt } : {}),
+  ...(l.presentation ? { presentation: l.presentation } : {}),
 });
 
 export function InventoryEditForm({

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { requireSession } from '@/lib/auth';
+import { getEmergencyBySlug } from '@/lib/emergencies';
+import { fetchMyInventory, saveMyInventory } from './actions';
+import { InventoryEditForm } from './inventory-edit-form';
+import { AppBar } from '@/components/organisms/app-bar';
+import { Card } from '@/components/atoms/card';
+import { PageHeading } from '@/components/atoms/page-heading';
+import { getT } from '@/i18n/server';
+import { getCategories } from '@/adapters/get-categories';
+
+export const dynamic = 'force-dynamic';
+
+type Props = {
+  params: Promise<{ slug: string; resourceId: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const { t } = await getT();
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) return { title: t.account.emergency_not_found };
+  return { title: t.account.inventory_page_title };
+}
+
+export default async function InventarioPage({ params }: Props) {
+  const { slug, resourceId } = await params;
+  const { t, locale } = await getT();
+
+  await requireSession(`/e/${slug}/mis-puntos/${resourceId}/inventario`);
+
+  const emergency = await getEmergencyBySlug(slug);
+  if (!emergency) notFound();
+
+  const initial = await fetchMyInventory(resourceId, slug);
+  if (initial === null) notFound();
+
+  const categories = await getCategories(locale);
+  const boundAction = saveMyInventory.bind(null, resourceId, slug);
+
+  return (
+    <main className="flex-1 bg-surface">
+      <div className="mx-auto w-full max-w-3xl">
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}/mis-puntos`} />
+        <PageHeading
+          title={t.account.inventory_page_title}
+          subtitle={t.account.inventory_page_subtitle}
+        />
+        <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
+          <Card className="p-5 lg:p-7">
+            <InventoryEditForm
+              action={boundAction}
+              initial={initial}
+              t={t.registrar}
+              ta={t.account}
+              locale={locale}
+              categories={categories}
+            />
+          </Card>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
@@ -91,12 +91,26 @@ export default async function MisPuntosPage({ params }: Props) {
                       slug={slug}
                     />
 
-                    <Link
-                      href={`/e/${slug}/reportar?resourceId=${resource.id}`}
-                      className="inline-flex items-center justify-center rounded-lg border-2 border-navy px-4 py-2 text-sm font-semibold text-ink bg-white hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors w-fit"
-                    >
-                      {ta.report_incident_cta}
-                    </Link>
+                    <div className="flex flex-wrap gap-3">
+                      <Link
+                        href={`/e/${slug}/mis-puntos/${resource.id}/inventario`}
+                        className="inline-flex items-center justify-center rounded-lg border-2 border-navy px-4 py-2 text-sm font-semibold text-ink bg-white hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors w-fit"
+                      >
+                        {ta.manage_inventory_cta}
+                      </Link>
+                      <Link
+                        href={`/e/${slug}/peticion?resourceId=${resource.id}`}
+                        className="inline-flex items-center justify-center rounded-lg border-2 border-navy px-4 py-2 text-sm font-semibold text-ink bg-white hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors w-fit"
+                      >
+                        {ta.declare_needs_cta}
+                      </Link>
+                      <Link
+                        href={`/e/${slug}/reportar?resourceId=${resource.id}`}
+                        className="inline-flex items-center justify-center rounded-lg border-2 border-navy px-4 py-2 text-sm font-semibold text-ink bg-white hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors w-fit"
+                      >
+                        {ta.report_incident_cta}
+                      </Link>
+                    </div>
                   </article>
                 </li>
               ))}

--- a/apps/web/src/app/e/[slug]/peticion/actions.ts
+++ b/apps/web/src/app/e/[slug]/peticion/actions.ts
@@ -38,6 +38,7 @@ export async function submitPeticion(
   const rawLatitude = formData.get('latitude');
   const rawLongitude = formData.get('longitude');
   const rawOrgId = formData.get('organizationId');
+  const rawResourceId = formData.get('resourceId');
   const rawItems = formData.get('items');
 
   const title = typeof rawTitle === 'string' ? rawTitle.trim() : '';
@@ -93,6 +94,13 @@ export async function submitPeticion(
       ? rawOrgId.trim()
       : undefined;
 
+  // Optional link to the resource this need belongs to, prefilled from the
+  // post-registration success screen (#263). The API validates it.
+  const resourceId =
+    typeof rawResourceId === 'string' && rawResourceId.trim() !== ''
+      ? rawResourceId.trim()
+      : undefined;
+
   const { data, error, response } = await api.POST(
     '/emergencies/{emergencyId}/needs',
     {
@@ -104,6 +112,7 @@ export async function submitPeticion(
         priority: rawPriority,
         location: { address, latitude, longitude },
         ...(requesterOrganizationId !== undefined ? { requesterOrganizationId } : {}),
+        ...(resourceId !== undefined ? { resourceId } : {}),
         items,
       },
     },

--- a/apps/web/src/app/e/[slug]/peticion/page.tsx
+++ b/apps/web/src/app/e/[slug]/peticion/page.tsx
@@ -15,6 +15,7 @@ import { getCategories } from '@/adapters/get-categories';
 
 type Props = {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<{ resourceId?: string }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -32,8 +33,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function PeticionPage({ params }: Props) {
+export default async function PeticionPage({ params, searchParams }: Props) {
   const { slug } = await params;
+  const { resourceId } = await searchParams;
   const { t, locale } = await getT();
 
   await requireSession(`/e/${slug}/peticion`);
@@ -59,6 +61,7 @@ export default async function PeticionPage({ params }: Props) {
             <PeticionForm
               action={boundAction}
               slug={slug}
+              resourceId={resourceId}
               locationPicker={<LocationPicker />}
               orgSelector={<OrgSelector />}
               itemsField={<ItemsField t={t.peticion} categories={categories} />}

--- a/apps/web/src/app/e/[slug]/peticion/peticion-form.tsx
+++ b/apps/web/src/app/e/[slug]/peticion/peticion-form.tsx
@@ -21,6 +21,8 @@ type BoundAction = (prev: PeticionState, formData: FormData) => Promise<Peticion
 interface PeticionFormProps {
   action: BoundAction;
   slug: string;
+  /** Optional resource to link this need to, prefilled from ?resourceId (#263). */
+  resourceId?: string;
   locationPicker: ReactNode;
   orgSelector: ReactNode;
   itemsField: ReactNode;
@@ -31,6 +33,7 @@ interface PeticionFormProps {
 export function PeticionForm({
   action,
   slug,
+  resourceId,
   locationPicker,
   orgSelector,
   itemsField,
@@ -83,6 +86,7 @@ export function PeticionForm({
 
   return (
     <form action={formAction} className="flex flex-col gap-6" noValidate>
+      {resourceId && <input type="hidden" name="resourceId" value={resourceId} />}
       {wasRestored && <DraftRestoredBanner />}
 
       {state.status === 'error' && (

--- a/apps/web/src/app/e/[slug]/registrar/inventory-field.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/inventory-field.tsx
@@ -44,6 +44,8 @@ interface InventoryFieldProps {
    * registrar where declared inventory is fully optional.
    */
   startWithOneRow?: boolean;
+  /** Prefill the editor with existing lines (inventory edit, #263). */
+  initialLines?: SupplyLine[];
 }
 
 /**
@@ -58,12 +60,13 @@ export function InventoryField({
   locale,
   categories,
   startWithOneRow = false,
+  initialLines,
 }: InventoryFieldProps) {
   const materialCategories = categories.filter(isMaterialCategory);
   const defaultCategory = materialCategories[0]?.slug ?? '';
 
   const [lines, setLines] = useState<SupplyLine[]>(
-    startWithOneRow ? [emptyLine(defaultCategory)] : [],
+    initialLines ?? (startWithOneRow ? [emptyLine(defaultCategory)] : []),
   );
 
   const labels = {

--- a/apps/web/src/app/e/[slug]/registrar/registrar-form.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/registrar-form.tsx
@@ -77,9 +77,24 @@ export function RegistrarForm({
   ] as const;
 
   if (state.status === 'success') {
+    const id = state.id;
     return (
       <FormSuccessScreen
         message={t.success_message}
+        extraLinks={[
+          // A freshly registered point is `hidden` until a coordinator
+          // validates it, so the public detail page (/recursos/{id}) 404s.
+          // The owner's self-service panel (/mis-puntos) shows it immediately.
+          { href: `/e/${slug}/mis-puntos`, label: t.success_manage_point },
+          {
+            href: `/e/${slug}/mis-puntos/${id}/inventario`,
+            label: t.success_manage_inventory,
+          },
+          {
+            href: `/e/${slug}/peticion?resourceId=${id}`,
+            label: t.success_declare_needs,
+          },
+        ]}
         primaryHref={`/e/${slug}/registrar`}
         primaryLabel={t.success_register_another}
         secondaryHref={`/e/${slug}`}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -65,3 +65,9 @@
 body {
   font-family: var(--font-sans);
 }
+
+/* Keep Leaflet's panes/controls from painting over the sticky AppBar. */
+.leaflet-container {
+  isolation: isolate;
+  z-index: 0;
+}

--- a/apps/web/src/components/molecules/form-success-screen.tsx
+++ b/apps/web/src/components/molecules/form-success-screen.tsx
@@ -2,12 +2,19 @@
 
 import Link from 'next/link';
 
+interface SuccessLink {
+  href: string;
+  label: string;
+}
+
 interface FormSuccessScreenProps {
   message: string;
   primaryHref: string;
   primaryLabel: string;
   secondaryHref: string;
   secondaryLabel: string;
+  /** Optional extra shortcuts rendered above the two default buttons. */
+  extraLinks?: readonly SuccessLink[];
 }
 
 export function FormSuccessScreen({
@@ -16,6 +23,7 @@ export function FormSuccessScreen({
   primaryLabel,
   secondaryHref,
   secondaryLabel,
+  extraLinks = [],
 }: FormSuccessScreenProps) {
   return (
     <section
@@ -27,6 +35,15 @@ export function FormSuccessScreen({
         {message}
       </p>
       <div className="flex flex-col gap-3">
+        {extraLinks.map(({ href, label }) => (
+          <Link
+            key={href}
+            href={href}
+            className="flex items-center justify-center w-full py-4 px-6 text-base font-semibold text-ink bg-white border-2 border-navy rounded-lg hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors"
+          >
+            {label}
+          </Link>
+        ))}
         <Link
           href={primaryHref}
           className="flex items-center justify-center w-full py-4 px-6 text-base font-semibold text-white bg-navy rounded-lg hover:bg-navy-700 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors"

--- a/apps/web/src/domain/supplies/supply-line.ts
+++ b/apps/web/src/domain/supplies/supply-line.ts
@@ -18,6 +18,9 @@ export interface SupplyLine {
   unit: string;
   category: string;
   expiresAt?: string;
+  // Health-vertical route/presentation (#61). Not edited in the current UIs;
+  // carried through so editing a line never erases it (data-loss guard).
+  presentation?: string;
 }
 
 /** A blank line seeded with the given default category slug. */
@@ -58,6 +61,7 @@ export function toDto(line: SupplyLine): SupplyLineDto {
     ...(line.supplyId !== null && line.supplyId !== '' ? { supplyId: line.supplyId } : {}),
     ...(unit !== '' ? { unit } : {}),
     ...(line.expiresAt !== undefined && line.expiresAt !== '' ? { expiresAt: line.expiresAt } : {}),
+    ...(line.presentation !== undefined && line.presentation !== '' ? { presentation: line.presentation } : {}),
   };
 }
 

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -431,6 +431,9 @@ export const en = {
     success_message:
       'Thank you, you are registered. Do not receive materials or publish anything until we validate you.',
     success_register_another: 'Register another resource',
+    success_manage_point: 'View / manage my point',
+    success_manage_inventory: 'Manage my inventory',
+    success_declare_needs: 'Declare needs',
     error_fallback: 'Error registering resource',
 
     // Inventory / available materials (optional)
@@ -1508,6 +1511,17 @@ export const en = {
     no_points_description: 'When you register a resource in this emergency it will appear here.',
     point_card_aria: 'Point: {name}',
     report_incident_cta: 'Report incident',
+    manage_inventory_cta: 'Manage inventory',
+    declare_needs_cta: 'Declare needs',
+    inventory_page_title: 'Point inventory',
+    inventory_page_subtitle:
+      'Declare the material this point holds for delivery. Replaces the current inventory.',
+    inventory_save_cta: 'Save inventory',
+    inventory_saving: 'Saving…',
+    inventory_saved_success: 'Inventory updated.',
+    inventory_update_forbidden: 'You are not allowed to edit this inventory.',
+    inventory_update_failed: 'Could not save the inventory.',
+    inventory_invalid_items: 'Check the material: some lines are incomplete or invalid.',
 
     type_collection_point: 'Collection point',
     type_delivery_point: 'Delivery point',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -452,6 +452,9 @@ export const es = {
     success_message:
       'Gracias, quedas registrado. No recibas material ni publiques nada hasta que te validemos.',
     success_register_another: 'Registrar otro recurso',
+    success_manage_point: 'Ver / gestionar mi punto',
+    success_manage_inventory: 'Gestionar mi inventario',
+    success_declare_needs: 'Declarar necesidades',
     error_fallback: 'Error al registrar el recurso',
 
     // Inventario / material disponible (opcional)
@@ -1542,6 +1545,17 @@ export const es = {
     no_points_description: 'Cuando registres un recurso en esta emergencia aparecerá aquí.',
     point_card_aria: 'Punto: {name}',
     report_incident_cta: 'Reportar incidencia',
+    manage_inventory_cta: 'Gestionar inventario',
+    declare_needs_cta: 'Declarar necesidades',
+    inventory_page_title: 'Inventario del punto',
+    inventory_page_subtitle:
+      'Declara qué material tiene este punto para entregar. Sustituye el inventario actual.',
+    inventory_save_cta: 'Guardar inventario',
+    inventory_saving: 'Guardando…',
+    inventory_saved_success: 'Inventario actualizado.',
+    inventory_update_forbidden: 'No tienes permiso para editar este inventario.',
+    inventory_update_failed: 'No se pudo guardar el inventario.',
+    inventory_invalid_items: 'Revisa el material: hay líneas incompletas o inválidas.',
 
     type_collection_point: 'Punto de recogida',
     type_delivery_point: 'Punto de entrega',

--- a/apps/web/src/lib/supply-lines.ts
+++ b/apps/web/src/lib/supply-lines.ts
@@ -35,10 +35,8 @@ export function parseSupplyLines(
   const items: SupplyLineDto[] = [];
   for (const entry of parsed) {
     if (typeof entry !== 'object' || entry === null) return null;
-    const { name, quantity, unit, category, supplyId, expiresAt } = entry as Record<
-      string,
-      unknown
-    >;
+    const { name, quantity, unit, category, supplyId, expiresAt, presentation } =
+      entry as Record<string, unknown>;
     if (typeof name !== 'string' || name.trim() === '') return null;
     if (
       typeof quantity !== 'number' ||
@@ -76,6 +74,9 @@ export function parseSupplyLines(
         : {}),
       ...(typeof expiresAt === 'string' && expiresAt !== ''
         ? { expiresAt }
+        : {}),
+      ...(typeof presentation === 'string' && presentation.trim() !== ''
+        ? { presentation: presentation.trim() }
         : {}),
     });
   }

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -351,6 +351,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/resources/{resourceId}/inventory": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read a point declared inventory in full (owner or coordinator) */
+        get: operations["ResourcesController_getMyInventoryAction"];
+        /** Replace a point declared inventory (owner or coordinator) — #263 */
+        put: operations["ResourcesController_updateMyInventoryAction"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/resources/{resourceId}/verify": {
         parameters: {
             query?: never;
@@ -3011,6 +3029,39 @@ export interface components {
             /** @description Supply lines received into the point stock (at least one) */
             items: components["schemas"]["SupplyLineDto"][];
         };
+        SupplyLineResponseDto: {
+            /** @example Water bottles */
+            name: string;
+            /**
+             * @description Optional soft link to the canonical supply master data.
+             * @example 1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8
+             */
+            supplyId: string | null;
+            /** @example 100 */
+            quantity: number;
+            /** @example liters */
+            unit?: string | null;
+            /**
+             * @example water
+             * @enum {string}
+             */
+            category: "food" | "water" | "hygiene" | "clothing" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel" | "food_fresh" | "food_non_perishable" | "hygiene_infantile" | "hygiene_personal" | "tools_extraction" | "other_pets";
+            /**
+             * @description Presentation / route of administration (ampolla, EV, inhalador…) — #61.
+             * @example ampolla
+             */
+            presentation?: string | null;
+            /**
+             * Format: date
+             * @description Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD).
+             * @example 2026-07-01
+             */
+            expiresAt?: string | null;
+        };
+        UpdateInventoryDto: {
+            /** @description Full declared inventory (replaces current; empty clears it) */
+            items: components["schemas"]["SupplyLineDto"][];
+        };
         VerifyResourceDto: Record<string, never>;
         EditResourceDto: {
             /**
@@ -3883,35 +3934,6 @@ export interface components {
             latitude: number;
             /** @example -66.9036 */
             longitude: number;
-        };
-        SupplyLineResponseDto: {
-            /** @example Water bottles */
-            name: string;
-            /**
-             * @description Optional soft link to the canonical supply master data.
-             * @example 1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8
-             */
-            supplyId: string | null;
-            /** @example 100 */
-            quantity: number;
-            /** @example liters */
-            unit?: string | null;
-            /**
-             * @example water
-             * @enum {string}
-             */
-            category: "food" | "water" | "hygiene" | "clothing" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel" | "food_fresh" | "food_non_perishable" | "hygiene_infantile" | "hygiene_personal" | "tools_extraction" | "other_pets";
-            /**
-             * @description Presentation / route of administration (ampolla, EV, inhalador…) — #61.
-             * @example ampolla
-             */
-            presentation?: string | null;
-            /**
-             * Format: date
-             * @description Optional freshness date for the line, expressed as an ISO date (YYYY-MM-DD).
-             * @example 2026-07-01
-             */
-            expiresAt?: string | null;
         };
         NeedViewDto: {
             /**
@@ -6463,6 +6485,102 @@ export interface operations {
                 content?: never;
             };
             /** @description Missing intake:receive for this point */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ResourcesController_getMyInventoryAction: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource UUID */
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupplyLineResponseDto"][];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not owner nor coordinator */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ResourcesController_updateMyInventoryAction: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource UUID */
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateInventoryDto"];
+            };
+        };
+        responses: {
+            /** @description Inventory replaced */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid request body or UUID */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not owner nor coordinator */
             403: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Resumen

Cierra **#263**. Tras registrar un punto, la pantalla de éxito ofrecía solo «registrar otro» / «volver la emergencia», obligando a buscar el punto a mano para gestionarlo. Ahora muestra accesos directos accionables **y** añade la pieza que faltaba del issue: **la edición del inventario declarado del punto** (full-stack).

## Pantalla de éxito (CTAs)

- **Ver / gestionar mi punto** → `/e/{slug}/mis-puntos`
- **Gestionar mi inventario** → nueva ruta de edición por punto
- **Declarar necesidades** → `/e/{slug}/peticion?resourceId={id}`
- **Registrar otro recurso** / **Volver**

Se extendió `FormSuccessScreen` con `extraLinks` (opcional) en vez de duplicarlo; los otros 5 formularios que lo usan no cambian. Botones apilados (responsive móvil).

### Desviación consciente respecto al texto literal del issue

El issue pedía **«Ver mi punto en el mapa»** → `/e/{slug}/recursos/{id}`. Esa es la **ficha pública**, que por diseño devuelve 404 para un punto `hidden`/no verificado — y un punto recién registrado **siempre** está oculto hasta que coordinación lo valida (*"no publiques nada hasta que te validemos"*). Enlazar ahí daría un 404 justo en el momento en que se muestra. Por eso el CTA apunta a `/mis-puntos` (autoservicio del responsable, donde el punto aparece de inmediato como *Oculto*). La ruta `/panel/mis-puntos/{id}/inventario` del issue tampoco existe; la real es `/e/{slug}/mis-puntos/{id}/inventario`.

## Edición de inventario declarado (nuevo — contexto `resources`, TDD)

No existía endpoint para que el **dueño** editara el `SupplyLine[]` de su punto (los existentes eran de validador/coordinador o de stock). Añadido end-to-end:

- **Dominio:** `Resource.replaceInventory(lines)` — sustituye (no fusiona, a diferencia de `receiveInventory`). + spec.
- **Aplicación:** `UpdateMyInventory` / `GetMyInventory` (autz **dueño-o-coordinador**, espejo de `UpdateResourcePublicStatus`), `UnauthorizedInventoryChangeError` → **403** en el filtro de excepciones. + specs.
- **HTTP:** `GET` + `PUT /resources/:id/inventory` (`PUT` 204; lista vacía **limpia** el inventario, por eso sin `@ArrayNotEmpty`).
- **Sin migración:** reutiliza `resource_items` (0028) y el `save()` existente (delete+reinsert en transacción).
- **Cliente tipado** regenerado (`pnpm gen:api`).
- **Web:** ruta `/e/[slug]/mis-puntos/[resourceId]/inventario` (page + form + actions), reutiliza `InventoryField` con un `initialLines` opcional (backward-compatible). Botón **Gestionar inventario** en cada tarjeta de Mis puntos.

## Prefill de necesidad por recurso

`/peticion` ahora lee `?resourceId` y lo pasa al cuerpo del `POST /needs` (el backend/DTO ya lo soportaban). Verificado en BBDD: la necesidad creada por el CTA guarda `resource_id`; una creada desde `/peticion` a secas lo deja `null`.

### Nota de alcance sobre #60

Añadí también un botón **«Declarar necesidades»** en las tarjetas de **Mis puntos** (además del CTA de la pantalla de éxito), porque de otro modo la necesidad vinculada a un recurso solo era alcanzable justo tras registrar. Ese botón —y el vínculo `resourceId` en necesidades— pertenecen realmente a **#60** («Destinatario final + necesidades vinculadas 1-a-N»), cuyo backend ya está implementado (columna `needs.resource_id`, `CreateNeedDto.resourceId`, filtro `GET /public/needs?resourceId=`). Por tanto este PR **avanza parcialmente #60 pero no lo cierra**: falta la lista de necesidades en la ficha del recurso. Lo dejo anotado para no absorber #60 en silencio (regla un-PR-una-issue).

## Extra (no relacionado con #263)

Corrige un bug de z-index: el mapa Leaflet tapaba la **AppBar** fija al hacer scroll. Fix de una línea en `globals.css` (`.leaflet-container { isolation: isolate }`).

## Validación

- [x] Gate completo local: `pnpm --filter api build` · eslint `--max-warnings=0` · prettier `--check` · **1383 tests** · `pnpm --filter web build` · `pnpm --filter web lint`.
- [x] Round-trip de inventario verificado por curl contra la API real: happy path, replace-no-merge, limpiar (lista vacía), **403** no-dueño, **404** desconocido, **401** sin token, **400** línea inválida, y persistencia confirmada en `resource_items`.
- [x] Prefill de `resourceId` verificado en BBDD.
- [x] `pnpm gen:api` ejecutado y `schema.ts` commiteado (nuevas rutas presentes).

## Cierre

- Closes #263
- Avanza parcialmente #60 (no lo cierra)
