### PR TITLE
feat(logistics): código único de expedición (Shipment.code + QR) (#163)

### DIFF
--- a/apps/api/drizzle/0049_shipment_code.sql
+++ b/apps/api/drizzle/0049_shipment_code.sql
@@ -1,0 +1,45 @@
+-- Código Único de expedición (#163): `shipments.code` (EXP-0001) + su allocator
+-- monótono por emergencia, espejo de containers.code (#140, migración 0032/0033).
+-- El código legible/QR identifica el camión/avión para aerolínea, aduana y
+-- destino, sin depender del UUID interno.
+
+-- Allocator por emergencia (upsert atómico, igual que container_code_sequences):
+-- a prueba de concurrencia y de borrados (el código nunca se reutiliza).
+CREATE TABLE IF NOT EXISTS "shipment_code_sequences" (
+	"emergency_id" uuid NOT NULL,
+	"last_value" integer NOT NULL,
+	CONSTRAINT "shipment_code_sequences_pkey" PRIMARY KEY ("emergency_id")
+);
+
+-- Columna nullable primero para poder rellenar las expediciones existentes.
+ALTER TABLE "shipments" ADD COLUMN IF NOT EXISTS "code" text;
+
+-- Backfill: EXP-NNNN por emergencia, en orden de creación.
+WITH numbered AS (
+	SELECT id,
+	       row_number() OVER (
+	         PARTITION BY emergency_id ORDER BY created_at, id
+	       ) AS seq
+	FROM "shipments"
+	WHERE "code" IS NULL
+)
+UPDATE "shipments" s
+SET "code" = 'EXP-' || lpad(numbered.seq::text, 4, '0')
+FROM numbered
+WHERE s.id = numbered.id;
+
+-- Sembrar el allocator al máximo usado por emergencia para que las nuevas
+-- expediciones continúen la secuencia sin colisionar con el backfill.
+INSERT INTO "shipment_code_sequences" ("emergency_id", "last_value")
+SELECT emergency_id, count(*)
+FROM "shipments"
+GROUP BY emergency_id
+ON CONFLICT ("emergency_id") DO UPDATE
+	SET "last_value" = GREATEST(
+		"shipment_code_sequences"."last_value", EXCLUDED."last_value"
+	);
+
+ALTER TABLE "shipments" ALTER COLUMN "code" SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "shipments_emergency_code_uniq"
+	ON "shipments" ("emergency_id", "code");

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -13886,6 +13886,11 @@
             "type": "string",
             "format": "uuid"
           },
+          "code": {
+            "type": "string",
+            "description": "Legible/QR \"Código Único\" of the expedition (#163)",
+            "example": "EXP-0001"
+          },
           "emergencyId": {
             "type": "string",
             "format": "uuid"
@@ -13960,6 +13965,7 @@
         },
         "required": [
           "id",
+          "code",
           "emergencyId",
           "originResourceId",
           "destinationResourceId",

--- a/apps/api/src/contexts/logistics/application/create-shipment.spec.ts
+++ b/apps/api/src/contexts/logistics/application/create-shipment.spec.ts
@@ -58,6 +58,20 @@ describe('CreateShipment', () => {
     expect(saved!.assignedCapacityId).toBeNull();
     expect(saved!.carrier).toBeNull();
     expect(saved!.items[0].name).toBe('Agua');
+    expect(saved!.code).toBe('EXP-0001');
+  });
+
+  it('assigns sequential per-emergency codes (código único, #163)', async () => {
+    const repo = new InMemoryShipmentRepository();
+    const { useCase } = makeUseCase(repo, 'active');
+
+    const first = await useCase.execute(baseCmd());
+    const second = await useCase.execute(baseCmd());
+
+    const a = await repo.findById(ShipmentId.fromString(first.id));
+    const b = await repo.findById(ShipmentId.fromString(second.id));
+    expect(a!.code).toBe('EXP-0001');
+    expect(b!.code).toBe('EXP-0002');
   });
 
   it('rejects creation in a paused emergency', async () => {

--- a/apps/api/src/contexts/logistics/application/create-shipment.ts
+++ b/apps/api/src/contexts/logistics/application/create-shipment.ts
@@ -3,6 +3,7 @@ import { LogisticsEmergencyStatusReader } from '../domain/ports/emergency-status
 import { ShipmentContainerPort } from '../domain/ports/shipment-container-port';
 import { Shipment } from '../domain/shipment';
 import { ShipmentId } from '../domain/shipment-id';
+import { formatShipmentCode } from '../domain/shipment-code';
 import { SupplyLine, SupplyLineProps } from '../../supplies/domain/supply-line';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
 import { EmergencyNotAcceptingIntakeError } from '../../emergencies/domain/emergency-not-accepting-intake.error';
@@ -36,9 +37,13 @@ export class CreateShipment {
       );
     }
 
+    const emergencyId = EmergencyId.fromString(cmd.emergencyId);
+    const code = formatShipmentCode(await this.repo.nextSequence(emergencyId));
+
     const shipment = Shipment.create({
       id: ShipmentId.create(),
-      emergencyId: EmergencyId.fromString(cmd.emergencyId),
+      code,
+      emergencyId,
       originResourceId: cmd.originResourceId,
       destinationResourceId: cmd.destinationResourceId,
       items: cmd.items.map((i) => SupplyLine.create(i)),

--- a/apps/api/src/contexts/logistics/application/shipment-view.ts
+++ b/apps/api/src/contexts/logistics/application/shipment-view.ts
@@ -11,6 +11,7 @@ export interface ShipmentItemView {
 
 export interface ShipmentView {
   id: string;
+  code: string;
   emergencyId: string;
   originResourceId: string;
   destinationResourceId: string;
@@ -39,6 +40,7 @@ export function toShipmentView(s: Shipment): ShipmentView {
   const snap = s.toSnapshot();
   return {
     id: snap.id,
+    code: snap.code,
     emergencyId: snap.emergencyId,
     originResourceId: snap.originResourceId,
     destinationResourceId: snap.destinationResourceId,

--- a/apps/api/src/contexts/logistics/domain/ports/shipment.repository.ts
+++ b/apps/api/src/contexts/logistics/domain/ports/shipment.repository.ts
@@ -12,6 +12,13 @@ export interface ListShipmentsFilter {
 
 export interface ShipmentRepository {
   save(shipment: Shipment): Promise<void>;
+  /**
+   * Atomically allocates the next expedition-code sequence for an emergency
+   * (mirror of the container-code allocator, #140/#163): monotonic, concurrency-
+   * safe, and decoupled from the live row count so a deleted shipment never
+   * frees its code.
+   */
+  nextSequence(emergencyId: EmergencyId): Promise<number>;
   findById(id: ShipmentId): Promise<Shipment | null>;
   findByEmergency(
     emergencyId: EmergencyId,

--- a/apps/api/src/contexts/logistics/domain/shipment-code.spec.ts
+++ b/apps/api/src/contexts/logistics/domain/shipment-code.spec.ts
@@ -1,0 +1,19 @@
+import { formatShipmentCode } from './shipment-code';
+import { InvalidShipmentRouteError } from './shipment-errors';
+
+describe('formatShipmentCode', () => {
+  it('formats the EXP prefix with a 4-digit zero-padded sequence', () => {
+    expect(formatShipmentCode(1)).toBe('EXP-0001');
+    expect(formatShipmentCode(42)).toBe('EXP-0042');
+  });
+
+  it('does not truncate sequences beyond 4 digits', () => {
+    expect(formatShipmentCode(12345)).toBe('EXP-12345');
+  });
+
+  it('rejects a non-positive or non-integer sequence', () => {
+    expect(() => formatShipmentCode(0)).toThrow(InvalidShipmentRouteError);
+    expect(() => formatShipmentCode(-1)).toThrow(InvalidShipmentRouteError);
+    expect(() => formatShipmentCode(1.5)).toThrow(InvalidShipmentRouteError);
+  });
+});

--- a/apps/api/src/contexts/logistics/domain/shipment-code.ts
+++ b/apps/api/src/contexts/logistics/domain/shipment-code.ts
@@ -1,0 +1,24 @@
+import { InvalidShipmentRouteError } from './shipment-errors';
+
+/**
+ * Builds the expedition's trackable code from a per-emergency sequence number,
+ * zero-padded to 4 digits (`EXP-0001`, `EXP-0042`). This is the legible label /
+ * QR payload printed on the truck/plane manifest — the "Código Único" of the
+ * expedition validated in the field (see #163), sibling of {@link
+ * formatContainerCode} (#140, the box's code).
+ *
+ * Single prefix (`EXP`, expedición) rather than one per carrier: the carrier is
+ * unknown at creation (a planned shipment has none) and the model has no
+ * truck/plane distinction to key on. Pure: the sequence itself is allocated by
+ * the repository (infrastructure); this only formats it so the format stays a
+ * single, testable domain rule.
+ * ponytail: one prefix + one sequence; split per carrier only if the field asks.
+ */
+export function formatShipmentCode(sequence: number): string {
+  if (!Number.isInteger(sequence) || sequence < 1) {
+    throw new InvalidShipmentRouteError(
+      'Shipment code sequence must be a positive integer',
+    );
+  }
+  return `EXP-${String(sequence).padStart(4, '0')}`;
+}

--- a/apps/api/src/contexts/logistics/domain/shipment.spec.ts
+++ b/apps/api/src/contexts/logistics/domain/shipment.spec.ts
@@ -44,6 +44,7 @@ function makeShipment(
 ): Shipment {
   return Shipment.create({
     id: ShipmentId.create(),
+    code: 'EXP-0001',
     emergencyId: EmergencyId.fromString(EM),
     originResourceId: overrides?.originResourceId ?? ORIGIN,
     destinationResourceId: overrides?.destinationResourceId ?? DEST,

--- a/apps/api/src/contexts/logistics/domain/shipment.ts
+++ b/apps/api/src/contexts/logistics/domain/shipment.ts
@@ -28,6 +28,8 @@ export interface CarrierPrincipal {
 
 export interface CreateShipmentProps {
   id: ShipmentId;
+  /** Legible/QR "Código Único" of the expedition (`EXP-0001`, #163). */
+  code: string;
   emergencyId: EmergencyId;
   originResourceId: string;
   destinationResourceId: string;
@@ -40,6 +42,7 @@ export interface CreateShipmentProps {
 
 export interface ShipmentSnapshot {
   id: string;
+  code: string;
   emergencyId: string;
   originResourceId: string;
   destinationResourceId: string;
@@ -76,6 +79,7 @@ export class Shipment {
 
   private constructor(
     public readonly id: ShipmentId,
+    public readonly code: string,
     public readonly emergencyId: EmergencyId,
     public readonly originResourceId: string,
     public readonly destinationResourceId: string,
@@ -105,9 +109,14 @@ export class Shipment {
     if (props.items.length === 0 && containerIds.length === 0) {
       throw new ShipmentMustHaveCargoError();
     }
+    const code = props.code.trim();
+    if (code.length === 0) {
+      throw new InvalidShipmentRouteError('Shipment code must not be empty');
+    }
     const now = new Date();
     return new Shipment(
       props.id,
+      code,
       props.emergencyId,
       props.originResourceId,
       props.destinationResourceId,
@@ -125,6 +134,7 @@ export class Shipment {
   static fromSnapshot(s: ShipmentSnapshot): Shipment {
     return new Shipment(
       ShipmentId.fromString(s.id),
+      s.code,
       EmergencyId.fromString(s.emergencyId),
       s.originResourceId,
       s.destinationResourceId,
@@ -234,6 +244,7 @@ export class Shipment {
   toSnapshot(): ShipmentSnapshot {
     return {
       id: this.id.value,
+      code: this.code,
       emergencyId: this.emergencyId.value,
       originResourceId: this.originResourceId,
       destinationResourceId: this.destinationResourceId,

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-shipment.repository.int-spec.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-shipment.repository.int-spec.ts
@@ -1,5 +1,5 @@
 import { createDb, Db } from '../../../../shared/db';
-import { shipmentsTable } from './schema';
+import { shipmentCodeSequencesTable, shipmentsTable } from './schema';
 import { DrizzleShipmentRepository } from './drizzle-shipment.repository';
 import { DrizzleShipmentAuthorizationLookup } from './drizzle-shipment-authorization-lookup';
 import { Shipment } from '../../domain/shipment';
@@ -70,6 +70,21 @@ describe('DrizzleShipmentRepository (integration)', () => {
 
   beforeEach(async () => {
     await db.delete(shipmentsTable);
+    await db.delete(shipmentCodeSequencesTable);
+  });
+
+  it('nextSequence allocates a monotonic per-emergency sequence, never reused', async () => {
+    const em = EmergencyId.fromString(EM);
+    // increments on every call, independent of how many rows exist
+    expect(await repo.nextSequence(em)).toBe(1);
+    expect(await repo.nextSequence(em)).toBe(2);
+    // a different emergency keeps its own sequence
+    expect(await repo.nextSequence(EmergencyId.fromString(OTHER_EM))).toBe(1);
+    // deleting shipments does NOT free a code for reuse — the sequence is
+    // monotonic, decoupled from the live row count.
+    await repo.save(makeShipment());
+    await db.delete(shipmentsTable);
+    expect(await repo.nextSequence(em)).toBe(3);
   });
 
   it('round-trips a planned shipment (jsonb SupplyLine items + container ids) through Postgres', async () => {
@@ -95,6 +110,7 @@ describe('DrizzleShipmentRepository (integration)', () => {
 
     expect(found).not.toBeNull();
     expect(found!.id.value).toBe(s.id.value);
+    expect(found!.code).toBe(s.code);
     expect(found!.status).toBe(ShipmentStatus.Planned);
     expect(found!.originResourceId).toBe(ORIGIN);
     expect(found!.destinationResourceId).toBe(DEST);

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-shipment.repository.int-spec.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-shipment.repository.int-spec.ts
@@ -4,6 +4,7 @@ import { DrizzleShipmentRepository } from './drizzle-shipment.repository';
 import { DrizzleShipmentAuthorizationLookup } from './drizzle-shipment-authorization-lookup';
 import { Shipment } from '../../domain/shipment';
 import { ShipmentId } from '../../domain/shipment-id';
+import { formatShipmentCode } from '../../domain/shipment-code';
 import { SupplyLine } from '../../../supplies/domain/supply-line';
 import { EmergencyId } from '../../../../shared/domain/emergency-id';
 import { CarrierType, ShipmentStatus } from '../../domain/shipment-enums';
@@ -22,6 +23,10 @@ const CARRIER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const CONTAINER_A = '11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const CONTAINER_B = '22222222-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 
+// Monotonic across the file so every created shipment gets a distinct code
+// (the unique (emergency_id, code) index rejects collisions).
+let codeSeq = 0;
+
 function makeShipment(opts?: {
   emergencyId?: string;
   items?: SupplyLine[];
@@ -30,6 +35,7 @@ function makeShipment(opts?: {
 }): Shipment {
   return Shipment.create({
     id: ShipmentId.create(),
+    code: formatShipmentCode(++codeSeq),
     emergencyId: EmergencyId.fromString(opts?.emergencyId ?? EM),
     originResourceId: ORIGIN,
     destinationResourceId: DEST,

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-shipment.repository.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/drizzle-shipment.repository.ts
@@ -1,6 +1,6 @@
-import { and, desc, eq, type SQL } from 'drizzle-orm';
+import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
 import { Db } from '../../../../shared/db';
-import { shipmentsTable } from './schema';
+import { shipmentCodeSequencesTable, shipmentsTable } from './schema';
 import {
   ListShipmentsFilter,
   ShipmentRepository,
@@ -15,6 +15,7 @@ type ShipmentRow = typeof shipmentsTable.$inferSelect;
 function rowToSnapshot(row: ShipmentRow): ShipmentSnapshot {
   return {
     id: row.id,
+    code: row.code,
     emergencyId: row.emergencyId,
     originResourceId: row.originResourceId,
     destinationResourceId: row.destinationResourceId,
@@ -39,6 +40,7 @@ export class DrizzleShipmentRepository implements ShipmentRepository {
       .insert(shipmentsTable)
       .values({
         id: s.id,
+        code: s.code,
         emergencyId: s.emergencyId,
         originResourceId: s.originResourceId,
         destinationResourceId: s.destinationResourceId,
@@ -62,6 +64,21 @@ export class DrizzleShipmentRepository implements ShipmentRepository {
           updatedAt: s.updatedAt,
         },
       });
+  }
+
+  async nextSequence(emergencyId: EmergencyId): Promise<number> {
+    const [row] = await this.db
+      .insert(shipmentCodeSequencesTable)
+      .values({ emergencyId: emergencyId.value, lastValue: 1 })
+      .onConflictDoUpdate({
+        target: shipmentCodeSequencesTable.emergencyId,
+        set: { lastValue: sql`${shipmentCodeSequencesTable.lastValue} + 1` },
+      })
+      .returning({ value: shipmentCodeSequencesTable.lastValue });
+    if (!row) {
+      throw new Error('Shipment code sequence allocation returned no row');
+    }
+    return row.value;
   }
 
   async findById(id: ShipmentId): Promise<Shipment | null> {

--- a/apps/api/src/contexts/logistics/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/drizzle/schema.ts
@@ -4,6 +4,7 @@ import {
   text,
   timestamp,
   doublePrecision,
+  integer,
   jsonb,
 } from 'drizzle-orm/pg-core';
 import { CoverageProps } from '../../domain/coverage';
@@ -34,6 +35,9 @@ export const transportCapacitiesTable = pgTable('transport_capacities', {
 
 export const shipmentsTable = pgTable('shipments', {
   id: uuid('id').primaryKey(),
+  // Legible/QR "Código Único" of the expedition (`EXP-0001`, #163). Unique per
+  // emergency (migration 0049); allocated via `shipment_code_sequences`.
+  code: text('code').notNull(),
   emergencyId: uuid('emergency_id').notNull(),
   // Route between two resource nodes (no FK — cross-context to resources).
   originResourceId: uuid('origin_resource_id').notNull(),
@@ -54,4 +58,17 @@ export const shipmentsTable = pgTable('shipments', {
   status: text('status').notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});
+
+/**
+ * Monotonic per-emergency allocator for expedition codes (`EXP-0001`), mirror
+ * of `container_code_sequences` (#140). An atomic upsert (INSERT … ON CONFLICT
+ * DO UPDATE SET last_value = last_value + 1 RETURNING) hands out the next value
+ * so concurrent creates never mint the same code and a deleted shipment never
+ * frees its code — keeping `shipments.code` unique per emergency. The primary
+ * key (emergency_id) lives in migration 0049.
+ */
+export const shipmentCodeSequencesTable = pgTable('shipment_code_sequences', {
+  emergencyId: uuid('emergency_id').notNull(),
+  lastValue: integer('last_value').notNull(),
 });

--- a/apps/api/src/contexts/logistics/infrastructure/http/shipment-response.dto.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/http/shipment-response.dto.ts
@@ -14,6 +14,12 @@ export class ShipmentViewDto {
   @ApiProperty({ format: 'uuid' })
   id!: string;
 
+  @ApiProperty({
+    description: 'Legible/QR "Código Único" of the expedition (#163)',
+    example: 'EXP-0001',
+  })
+  code!: string;
+
   @ApiProperty({ format: 'uuid' })
   emergencyId!: string;
 

--- a/apps/api/src/contexts/logistics/infrastructure/in-memory-shipment.repository.ts
+++ b/apps/api/src/contexts/logistics/infrastructure/in-memory-shipment.repository.ts
@@ -8,10 +8,17 @@ import { EmergencyId } from '../../../shared/domain/emergency-id';
 
 export class InMemoryShipmentRepository implements ShipmentRepository {
   private store = new Map<string, ShipmentSnapshot>();
+  private sequences = new Map<string, number>();
 
   save(shipment: Shipment): Promise<void> {
     this.store.set(shipment.id.value, shipment.toSnapshot());
     return Promise.resolve();
+  }
+
+  nextSequence(emergencyId: EmergencyId): Promise<number> {
+    const next = (this.sequences.get(emergencyId.value) ?? 0) + 1;
+    this.sequences.set(emergencyId.value, next);
+    return Promise.resolve(next);
   }
 
   findById(id: ShipmentId): Promise<Shipment | null> {

--- a/apps/web/src/components/organisms/shipment-detail.tsx
+++ b/apps/web/src/components/organisms/shipment-detail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useActionState, useState, useEffect, useTransition } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
 import {
   assignCapacity,
   getCapacitySuggestions,
@@ -380,6 +381,24 @@ export function ShipmentDetail({
       }
       footer={footer}
     >
+      <DetailSection title={tc.ship_section_code}>
+        {/* Código único legible + QR: viaja con el camión/avión (#163). El QR
+            codifica el propio código, resoluble por la consulta pública (#158). */}
+        <div className="flex items-center gap-4 py-2">
+          <div className="rounded-lg border-2 border-navy bg-white p-2">
+            <QRCodeSVG
+              value={shipment.code}
+              size={96}
+              title={tc.ship_code_qr_alt.replace('{code}', shipment.code)}
+              marginSize={0}
+            />
+          </div>
+          <span className="font-display text-2xl font-bold tracking-widest text-navy break-all">
+            {shipment.code}
+          </span>
+        </div>
+      </DetailSection>
+
       <DetailSection title={tc.ship_section_route}>
         <DetailField label={tc.ship_field_origin} value={originName} />
         <DetailField

--- a/apps/web/src/components/organisms/shipments-list.tsx
+++ b/apps/web/src/components/organisms/shipments-list.tsx
@@ -99,9 +99,14 @@ export function ShipmentsList({
                 aria-label={tc.ship_drawer_open.replace('{route}', route)}
               >
                 <div className="flex w-full items-start justify-between gap-3">
-                  <span className="text-base font-bold leading-tight text-ink break-words">
-                    {route}
-                  </span>
+                  <div className="flex flex-col gap-0.5">
+                    <span className="font-display text-sm font-bold tracking-widest text-navy break-all">
+                      {shipment.code}
+                    </span>
+                    <span className="text-base font-bold leading-tight text-ink break-words">
+                      {route}
+                    </span>
+                  </div>
                   <Badge variant={STATUS_BADGE[shipment.status]}>
                     {STATUS_LABELS[shipment.status]}
                   </Badge>

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -2488,6 +2488,9 @@ export const en = {
 
     ship_route: '{origin} → {destination}',
     ship_drawer_open: 'View shipment detail: {route}',
+    ship_section_code: 'Unique code',
+    ship_field_code: 'Code',
+    ship_code_qr_alt: 'QR code for shipment {code}',
     ship_section_route: 'Route',
     ship_section_items: 'Cargo',
     ship_section_assignment: 'Assignment',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -2528,6 +2528,9 @@ export const es = {
 
     ship_route: '{origin} → {destination}',
     ship_drawer_open: 'Ver detalle de la expedición: {route}',
+    ship_section_code: 'Código único',
+    ship_field_code: 'Código',
+    ship_code_qr_alt: 'Código QR de la expedición {code}',
     ship_section_route: 'Ruta',
     ship_section_items: 'Carga',
     ship_section_assignment: 'Asignación',

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -4950,6 +4950,11 @@ export interface components {
         ShipmentViewDto: {
             /** Format: uuid */
             id: string;
+            /**
+             * @description Legible/QR "Código Único" of the expedition (#163)
+             * @example EXP-0001
+             */
+            code: string;
             /** Format: uuid */
             emergencyId: string;
             /** Format: uuid */


### PR DESCRIPTION
Closes #163 · parte del EPIC de logística #103 · hermana de #140 · alimenta #157/#158.

## Qué

Cada expedición (camión/avión) tiene ahora su propio **código legible + QR** estable (`EXP-0001`), espejo de `Container.code` (#140). El código identifica inequívocamente *qué va en el vuelo/camión* para aerolínea, aduana y destino, sin depender del UUID interno.

## Cómo

- **Dominio:** `formatShipmentCode` (`EXP-NNNN`, pura + test) y `code` en el agregado `Shipment`. Prefijo único `EXP` (expedición): el transportista es opcional y desconocido al crear, y el modelo no tiene distinción camión/avión que discriminar — YAGNI hasta que el campo lo pida.
- **Allocator monótono por emergencia** (`shipment_code_sequences`, upsert atómico `ON CONFLICT DO UPDATE … +1`) en el repositorio, espejo exacto de `container_code_sequences`: a prueba de concurrencia y de borrados (un código nunca se reutiliza).
- **Migración `0049_shipment_code.sql`:** columna `code`, índice único `(emergency_id, code)`, backfill de las expediciones existentes (`EXP-NNNN` por orden de creación) y siembra del allocator al máximo usado.
- `code` en `ShipmentView`/`ShipmentViewDto` → `pnpm gen:api` (schema.ts regenerado).
- **Web:** código visible en la tarjeta de la lista y **código + QR** en el detalle (lista *mis-expediciones* y panel del coordinador). El QR codifica el propio código (resoluble por la consulta pública #158 cuando exista). i18n es/en.

## Alcance

La **consulta pública por código** (#158) y el **manifiesto exportable** (#157) *consumen* este código; se construyen en sus propias issues. Aquí solo se crea y se muestra.

## Gate

`api build` · `eslint` · `prettier` · `api test` (1391 ✅, incl. migración 0049 aplicada) · `web build` · `web lint` — todo en verde.