### PR TITLE
fix(security): auditoría de seguridad — hardening de autenticación, autorización, PII y configuración

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -7787,7 +7787,12 @@
             "description": "File content streamed"
           }
         },
-        "summary": "Download a stored file by key",
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Download a stored file by key (authenticated)",
         "tags": [
           "files"
         ]

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3960,6 +3960,9 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           }
         },
         "summary": "Geocode a free-text address query (Nominatim / OpenStreetMap)",
@@ -4756,7 +4759,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DonationIntakeViewDto"
+                  "$ref": "#/components/schemas/PublicDonationIntakeDto"
                 }
               }
             }
@@ -11566,7 +11569,9 @@
         "properties": {
           "address": {
             "type": "string",
-            "example": "123 Main Street, Caracas"
+            "example": "Caracas",
+            "nullable": true,
+            "description": "Street line is coarsened (locality only) or dropped for needs with approximate location sensitivity to protect the requester’s privacy."
           },
           "latitude": {
             "type": "number",
@@ -11578,7 +11583,6 @@
           }
         },
         "required": [
-          "address",
           "latitude",
           "longitude"
         ]
@@ -12998,14 +13002,6 @@
             "type": "string",
             "format": "uuid"
           },
-          "intakeCode": {
-            "type": "string",
-            "example": "ACO-7F3K"
-          },
-          "targetResourceId": {
-            "type": "string",
-            "format": "uuid"
-          },
           "itemCount": {
             "type": "number",
             "example": 2
@@ -13017,8 +13013,6 @@
         },
         "required": [
           "id",
-          "intakeCode",
-          "targetResourceId",
           "itemCount",
           "createdAt"
         ]
@@ -13309,6 +13303,130 @@
           "sortOrder"
         ]
       },
+      "PublicDonationIntakeDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "emergencyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "targetResourceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "intakeCode": {
+            "type": "string",
+            "example": "ACO-7F3K"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "received",
+              "rejected",
+              "incomplete"
+            ]
+          },
+          "donorName": {
+            "type": "string"
+          },
+          "donorPhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "donorEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "lines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntakeLineViewDto"
+            }
+          },
+          "receivedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "emergencyId",
+          "targetResourceId",
+          "intakeCode",
+          "status",
+          "donorName",
+          "lines",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "DonationIntakeSearchHitDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "intakeCode": {
+            "type": "string",
+            "example": "ACO-7F3K"
+          },
+          "donorName": {
+            "type": "string"
+          },
+          "donorPhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "donorEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "received",
+              "rejected",
+              "incomplete"
+            ]
+          },
+          "targetResourceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "itemCount": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "intakeCode",
+          "donorName",
+          "status",
+          "targetResourceId",
+          "itemCount",
+          "createdAt"
+        ]
+      },
       "DonationIntakeViewDto": {
         "type": "object",
         "properties": {
@@ -13401,59 +13519,6 @@
           "lines",
           "createdAt",
           "updatedAt"
-        ]
-      },
-      "DonationIntakeSearchHitDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "intakeCode": {
-            "type": "string",
-            "example": "ACO-7F3K"
-          },
-          "donorName": {
-            "type": "string"
-          },
-          "donorPhone": {
-            "type": "string",
-            "nullable": true
-          },
-          "donorEmail": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "pending",
-              "received",
-              "rejected",
-              "incomplete"
-            ]
-          },
-          "targetResourceId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "itemCount": {
-            "type": "number"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "required": [
-          "id",
-          "intakeCode",
-          "donorName",
-          "status",
-          "targetResourceId",
-          "itemCount",
-          "createdAt"
         ]
       },
       "IntakeDeepLinkDto": {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
-import { ThrottlerModule } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { DatabaseModule } from './shared/database.module';
 import { ResourcesModule } from './contexts/resources/infrastructure/resources.module';
 import { EmergenciesModule } from './contexts/emergencies/infrastructure/emergencies.module';
@@ -31,6 +32,14 @@ const isTestEnv = process.env.NODE_ENV === 'test';
       isTestEnv
         ? [] // disabled — no throttle in test
         : [
+            {
+              // Baseline per-IP limit that applies to EVERY route (the guard is
+              // registered globally below). Generous enough for legitimate map
+              // panning / dashboard use, but caps scraping and volumetric DoS.
+              name: 'default',
+              ttl: 60_000,
+              limit: 200,
+            },
             {
               // auth endpoints: 10 requests per 60 seconds per IP
               name: 'auth',
@@ -65,6 +74,12 @@ const isTestEnv = process.env.NODE_ENV === 'test';
     GroupsModule,
     SuppliesModule,
     EventsModule,
+  ],
+  providers: [
+    // Apply rate limiting to EVERY route by default. Individual routes tighten
+    // it with @Throttle (auth, intake, geocode…). In test env the throttler is
+    // configured with an empty ruleset, so this guard is a no-op there.
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],
 })
 export class AppModule {}

--- a/apps/api/src/contexts/files/domain/image-signature.spec.ts
+++ b/apps/api/src/contexts/files/domain/image-signature.spec.ts
@@ -1,0 +1,45 @@
+import { isSupportedImage } from './image-signature';
+
+/** Build a 16-byte buffer starting with the given signature bytes. */
+function bufWith(...bytes: number[]): Buffer {
+  const b = Buffer.alloc(16);
+  bytes.forEach((v, i) => (b[i] = v));
+  return b;
+}
+
+describe('isSupportedImage', () => {
+  it('accepts a JPEG signature', () => {
+    expect(isSupportedImage(bufWith(0xff, 0xd8, 0xff, 0xe0))).toBe(true);
+  });
+
+  it('accepts a PNG signature', () => {
+    expect(
+      isSupportedImage(bufWith(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)),
+    ).toBe(true);
+  });
+
+  it('accepts a GIF signature', () => {
+    expect(isSupportedImage(Buffer.from('GIF89a....................'))).toBe(
+      true,
+    );
+  });
+
+  it('accepts a WebP signature', () => {
+    const b = Buffer.from('RIFF0000WEBPVP8 ', 'ascii');
+    expect(isSupportedImage(b)).toBe(true);
+  });
+
+  it('rejects an HTML/script payload mislabelled as an image', () => {
+    const html = Buffer.from('<html><script>alert(1)</script></html>');
+    expect(isSupportedImage(html)).toBe(false);
+  });
+
+  it('rejects an SVG payload', () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    expect(isSupportedImage(svg)).toBe(false);
+  });
+
+  it('rejects a too-short buffer', () => {
+    expect(isSupportedImage(Buffer.from([0xff, 0xd8]))).toBe(false);
+  });
+});

--- a/apps/api/src/contexts/files/domain/image-signature.ts
+++ b/apps/api/src/contexts/files/domain/image-signature.ts
@@ -1,0 +1,65 @@
+/**
+ * Content-based image detection ("magic bytes").
+ *
+ * The upload endpoint's Multer fileFilter trusts the client-supplied MIME type,
+ * which an attacker fully controls. This inspects the actual first bytes of the
+ * uploaded buffer so we can reject files whose content is not one of the image
+ * formats we serve — a mislabelled payload (e.g. an HTML/SVG document sent as
+ * image/png) never reaches storage.
+ *
+ * Pure domain helper — no framework/infra dependency.
+ */
+export function isSupportedImage(buffer: Buffer): boolean {
+  if (buffer.length < 12) return false;
+
+  // JPEG — FF D8 FF
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return true;
+  }
+  // PNG — 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return true;
+  }
+  // GIF — "GIF87a" / "GIF89a"
+  if (
+    buffer.toString('ascii', 0, 6) === 'GIF87a' ||
+    buffer.toString('ascii', 0, 6) === 'GIF89a'
+  ) {
+    return true;
+  }
+  // WebP — "RIFF" .... "WEBP"
+  if (
+    buffer.toString('ascii', 0, 4) === 'RIFF' &&
+    buffer.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return true;
+  }
+  // BMP — "BM"
+  if (buffer[0] === 0x42 && buffer[1] === 0x4d) {
+    return true;
+  }
+  // TIFF — "II*\0" (little-endian) or "MM\0*" (big-endian)
+  if (
+    (buffer[0] === 0x49 &&
+      buffer[1] === 0x49 &&
+      buffer[2] === 0x2a &&
+      buffer[3] === 0x00) ||
+    (buffer[0] === 0x4d &&
+      buffer[1] === 0x4d &&
+      buffer[2] === 0x00 &&
+      buffer[3] === 0x2a)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/apps/api/src/contexts/files/infrastructure/files.controller.ts
+++ b/apps/api/src/contexts/files/infrastructure/files.controller.ts
@@ -117,7 +117,9 @@ export class FilesController {
    * Streams the file directly from disk.
    */
   @Get(':key')
-  @ApiOperation({ summary: 'Download a stored file by key' })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Download a stored file by key (authenticated)' })
   @ApiParam({ name: 'key', description: 'Storage key returned by POST /files' })
   @ApiOkResponse({ description: 'File content streamed' })
   async serve(@Param('key') key: string, @Res() res: Response): Promise<void> {

--- a/apps/api/src/contexts/files/infrastructure/files.controller.ts
+++ b/apps/api/src/contexts/files/infrastructure/files.controller.ts
@@ -27,6 +27,7 @@ import type { Response } from 'express';
 import { JwtAuthGuard } from '../../identity/infrastructure/http/jwt-auth.guard';
 import { FILE_STORAGE } from '../domain/ports/file-storage';
 import type { FileStorage } from '../domain/ports/file-storage';
+import { isSupportedImage } from '../domain/image-signature';
 
 const MAX_FILE_BYTES = 5 * 1024 * 1024; // 5 MB
 
@@ -104,6 +105,14 @@ export class FilesController {
   ): Promise<{ key: string; url: string }> {
     if (!file) {
       throw new UnprocessableEntityException('No file received');
+    }
+    // The fileFilter only sees the client-declared MIME type. Verify the actual
+    // bytes are a supported image so a mislabelled payload (HTML/SVG sent as
+    // image/png) can never be stored.
+    if (!isSupportedImage(file.buffer)) {
+      throw new UnprocessableEntityException(
+        'File content is not a supported image (JPEG, PNG, GIF, WebP, BMP, TIFF)',
+      );
     }
     return this.fileStorage.save({
       buffer: file.buffer,

--- a/apps/api/src/contexts/geocoding/infrastructure/http/geocoding.controller.ts
+++ b/apps/api/src/contexts/geocoding/infrastructure/http/geocoding.controller.ts
@@ -1,9 +1,11 @@
 import { Controller, Get, Query } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import {
   ApiOkResponse,
   ApiOperation,
   ApiQuery,
   ApiTags,
+  ApiTooManyRequestsResponse,
 } from '@nestjs/swagger';
 import { SearchAddress } from '../../application/search-address';
 import { GeocodeResultDto } from './geocode-result.dto';
@@ -15,9 +17,15 @@ export class GeocodingController {
   constructor(private readonly searchAddress: SearchAddress) {}
 
   @Get()
+  // This endpoint proxies an unauthenticated free-text query to the external
+  // Nominatim service, whose usage policy forbids heavy automated traffic.
+  // A tight per-IP cap protects both our API (DoS) and our upstream reputation
+  // (getting the server IP banned would break geocoding for everyone).
+  @Throttle({ default: { ttl: 60_000, limit: 20 } })
   @ApiOperation({
     summary: 'Geocode a free-text address query (Nominatim / OpenStreetMap)',
   })
+  @ApiTooManyRequestsResponse({ description: 'Rate limit exceeded' })
   @ApiQuery({
     name: 'q',
     description: 'Address or place name to search',

--- a/apps/api/src/contexts/identity/application/authenticate-with-provider.spec.ts
+++ b/apps/api/src/contexts/identity/application/authenticate-with-provider.spec.ts
@@ -6,6 +6,7 @@ import { User } from '../domain/user';
 import { UserId } from '../domain/user-id';
 import { Email } from '../domain/email';
 import { AccountLinkRequiresAuthError } from '../domain/account-link-requires-auth.error';
+import { UnverifiedProviderEmailError } from '../domain/unverified-provider-email.error';
 import type { TokenService, TokenPayload } from '../domain/ports/token.service';
 
 class FakeTokenService implements TokenService {
@@ -61,6 +62,7 @@ describe('AuthenticateWithProvider', () => {
     providerUserId: 'google-uid-123',
     email: 'social@example.com',
     name: 'Social User',
+    emailVerified: true,
   };
 
   describe('Path 1 — identity already linked', () => {
@@ -227,6 +229,7 @@ describe('AuthenticateWithProvider', () => {
         providerUserId: 'fb-uid-456',
         email: 'fb@example.com',
         name: 'FB User',
+        emailVerified: true,
       });
 
       expect(result.accessToken).toContain('fb@example.com');
@@ -254,6 +257,7 @@ describe('AuthenticateWithProvider', () => {
           providerUserId: 'attacker-google-uid',
           email: 'victim@example.com',
           name: 'Attacker',
+          emailVerified: true,
         }),
       ).rejects.toThrow(AccountLinkRequiresAuthError);
     });
@@ -275,6 +279,7 @@ describe('AuthenticateWithProvider', () => {
           providerUserId: 'attacker-google-uid',
           email: 'victim@example.com',
           name: 'Attacker',
+          emailVerified: true,
         }));
       } catch {
         // expected
@@ -298,6 +303,7 @@ describe('AuthenticateWithProvider', () => {
           providerUserId: 'attacker-google-uid',
           email: 'victim@example.com',
           name: 'Attacker',
+          emailVerified: true,
         });
       } catch {
         // expected
@@ -309,6 +315,63 @@ describe('AuthenticateWithProvider', () => {
         'attacker-google-uid',
       );
       expect(linkedId).toBeNull();
+    });
+
+    it('throws UnverifiedProviderEmailError when a social-only email is NOT provider-verified', async () => {
+      // The victim signed up with Google (social-only) as victim@example.com.
+      // An attacker logs in with a second provider claiming victim@example.com
+      // WITHOUT the provider having verified it. Auto-linking must be refused.
+      const userRepo = await buildRepoWithSocialUser('victim@example.com');
+      const identityRepo = new InMemoryUserIdentityRepository();
+
+      const useCase = new AuthenticateWithProvider(
+        userRepo,
+        identityRepo,
+        tokenService,
+      );
+
+      await expect(
+        useCase.execute({
+          provider: AuthProvider.Facebook,
+          providerUserId: 'attacker-fb-uid',
+          email: 'victim@example.com',
+          name: 'Attacker',
+          emailVerified: false,
+        }),
+      ).rejects.toThrow(UnverifiedProviderEmailError);
+
+      // No identity linked and no token issued.
+      const linkedId = await identityRepo.findByProvider(
+        AuthProvider.Facebook,
+        'attacker-fb-uid',
+      );
+      expect(linkedId).toBeNull();
+    });
+
+    it('links a social-only account when the provider email IS verified (Path 2 happy path)', async () => {
+      const userRepo = await buildRepoWithSocialUser('victim@example.com');
+      const identityRepo = new InMemoryUserIdentityRepository();
+
+      const useCase = new AuthenticateWithProvider(
+        userRepo,
+        identityRepo,
+        tokenService,
+      );
+
+      const result = await useCase.execute({
+        provider: AuthProvider.Facebook,
+        providerUserId: 'owner-fb-uid',
+        email: 'victim@example.com',
+        name: 'Owner',
+        emailVerified: true,
+      });
+
+      expect(result.accessToken).toContain(EXISTING_USER_ID);
+      const linkedId = await identityRepo.findByProvider(
+        AuthProvider.Facebook,
+        'owner-fb-uid',
+      );
+      expect(linkedId?.value).toBe(EXISTING_USER_ID);
     });
 
     it('allows social login for a password account that already has an identity for that provider (Path 1)', async () => {
@@ -331,6 +394,7 @@ describe('AuthenticateWithProvider', () => {
         providerUserId: 'user-own-google-uid',
         email: 'linked@example.com',
         name: 'Linked User',
+        emailVerified: true,
       });
 
       expect(result.accessToken).toContain(EXISTING_USER_ID);

--- a/apps/api/src/contexts/identity/application/authenticate-with-provider.ts
+++ b/apps/api/src/contexts/identity/application/authenticate-with-provider.ts
@@ -7,12 +7,19 @@ import { User } from '../domain/user';
 import { UserId } from '../domain/user-id';
 import { Email } from '../domain/email';
 import { AccountLinkRequiresAuthError } from '../domain/account-link-requires-auth.error';
+import { UnverifiedProviderEmailError } from '../domain/unverified-provider-email.error';
 
 export interface AuthenticateWithProviderCommand {
   provider: AuthProvider;
   providerUserId: string;
   email: string;
   name: string;
+  /**
+   * Whether the provider asserted it verified ownership of `email`. When false,
+   * the email cannot be trusted as proof of identity, so unifying by email
+   * (Path 2) is refused to prevent account takeover.
+   */
+  emailVerified: boolean;
 }
 
 /**
@@ -66,7 +73,14 @@ export class AuthenticateWithProvider {
       if (userByEmail.passwordHash !== null) {
         throw new AccountLinkRequiresAuthError(cmd.provider);
       }
-      // Social-only account with matching email — safe to link
+      // SECURITY: even for a social-only account, the email is only trustworthy
+      // as an identity proof if the provider actually verified ownership of it.
+      // An unverified email lets an attacker claim the victim's address on a
+      // second provider and unify into the victim's account. Refuse to link.
+      if (!cmd.emailVerified) {
+        throw new UnverifiedProviderEmailError(cmd.provider);
+      }
+      // Social-only account with a provider-verified matching email — safe to link
       await this.identityRepo.link(userByEmail.id, identity);
       return { accessToken: this.tokenService.sign(this.payload(userByEmail)) };
     }

--- a/apps/api/src/contexts/identity/application/login.spec.ts
+++ b/apps/api/src/contexts/identity/application/login.spec.ts
@@ -111,4 +111,39 @@ describe('Login', () => {
     });
     expect(result.accessToken).toBeTruthy();
   });
+
+  describe('timing side-channel hardening (user enumeration)', () => {
+    it('still performs a password comparison when the email is unknown', async () => {
+      const repo = new InMemoryUserRepository(); // empty
+      const spy = new FakePasswordHasher();
+      const compareSpy = jest.spyOn(spy, 'compare');
+      const login = new Login(repo, spy, tokenService);
+
+      await expect(
+        login.execute({ email: 'unknown@example.com', password: 'pass' }),
+      ).rejects.toThrow(InvalidCredentialsError);
+      // A comparison must run so the miss path is not measurably faster.
+      expect(compareSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('still performs a password comparison for a social-only account (no password)', async () => {
+      const repo = new InMemoryUserRepository();
+      const socialUser = User.create({
+        id: UserId.fromString('22222222-2222-4222-8222-222222222222'),
+        email: Email.fromString('social@example.com'),
+        passwordHash: null,
+        name: 'Social',
+        isAdmin: false,
+      });
+      await repo.save(socialUser);
+      const spy = new FakePasswordHasher();
+      const compareSpy = jest.spyOn(spy, 'compare');
+      const login = new Login(repo, spy, tokenService);
+
+      await expect(
+        login.execute({ email: 'social@example.com', password: 'pass' }),
+      ).rejects.toThrow(InvalidCredentialsError);
+      expect(compareSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/apps/api/src/contexts/identity/application/login.ts
+++ b/apps/api/src/contexts/identity/application/login.ts
@@ -9,6 +9,15 @@ export interface LoginCommand {
   password: string;
 }
 
+/**
+ * A syntactically valid bcrypt hash (cost 12) that no real password produces.
+ * Used to spend a comparable amount of CPU on the "user missing" / "social-only
+ * account" paths so that login response time does not leak whether an email is
+ * registered with a password (user-enumeration timing side-channel).
+ */
+const DUMMY_PASSWORD_HASH =
+  '$2b$12$d3A2Aawyuk7gBC5LgF1WpObQlzEgXstlefw5U.8kYOzYUU0kiaCEy';
+
 export class Login {
   constructor(
     private readonly userRepo: UserRepository,
@@ -25,13 +34,18 @@ export class Login {
     }
 
     const user = await this.userRepo.findByEmail(email);
-    if (!user) throw new InvalidCredentialsError();
 
-    // Social-only accounts have no password — disallow email/password login for them
-    if (user.passwordHash === null) throw new InvalidCredentialsError();
+    // SECURITY: always run a bcrypt comparison, even when the account does not
+    // exist or is social-only (no password). Returning early would make those
+    // paths measurably faster than a real password check, letting an attacker
+    // enumerate registered accounts by timing. We compare against a dummy hash
+    // to keep the timing profile uniform before returning the generic error.
+    const hashToCompare = user?.passwordHash ?? DUMMY_PASSWORD_HASH;
+    const valid = await this.hasher.compare(cmd.password, hashToCompare);
 
-    const valid = await this.hasher.compare(cmd.password, user.passwordHash);
-    if (!valid) throw new InvalidCredentialsError();
+    if (!user || user.passwordHash === null || !valid) {
+      throw new InvalidCredentialsError();
+    }
 
     // Stamp last login for the admin users console (#176). Best-effort: a write
     // failure here must not deny an otherwise-valid login.

--- a/apps/api/src/contexts/identity/application/revoke-grant.spec.ts
+++ b/apps/api/src/contexts/identity/application/revoke-grant.spec.ts
@@ -96,6 +96,28 @@ describe('RevokeGrant', () => {
     );
   });
 
+  it('forbids revoking a more-privileged role than the actor holds (attenuation)', async () => {
+    // An org_admin holds role:revoke at their organization, but does NOT hold
+    // the permissions of an emergency_coordinator. They must not be able to
+    // strip a coordinator-grade grant sitting at that org scope.
+    await repo.save(
+      Grant.create({
+        id: GRANT_ID,
+        principalId: TARGET,
+        roleId: 'emergency_coordinator',
+        scope: ScopeRef.organization('o1'),
+      }),
+    );
+    const actor = actorWith({
+      roleId: 'org_admin',
+      scope: ScopeRef.organization('o1'),
+    });
+    await expect(useCase.execute({ actor, grantId: GRANT_ID })).rejects.toThrow(
+      NotAuthorizedToRevokeError,
+    );
+    expect(await repo.findById(GRANT_ID)).not.toBeNull();
+  });
+
   it('uses the owning emergency when revoking a resource entity grant', async () => {
     await seedTargetGrant(repo);
     const actor = actorWith({

--- a/apps/api/src/contexts/identity/application/revoke-grant.ts
+++ b/apps/api/src/contexts/identity/application/revoke-grant.ts
@@ -10,6 +10,7 @@ import {
   NotAuthorizedToRevokeError,
 } from '../domain/authorization/errors';
 import { ResourceEmergencyLookup } from '../domain/ports/resource-emergency-lookup';
+import { permissionsForRole } from '../domain/authorization/role-catalog';
 import { authorizationChainForScope } from './scope-chain';
 
 export interface RevokeGrantCommand {
@@ -61,6 +62,17 @@ export class RevokeGrant {
       chain,
     );
     if (!actorPermissions.has('role:revoke')) {
+      throw new NotAuthorizedToRevokeError(grant.scope.toPlain());
+    }
+
+    // Attenuation (mirror of GrantRole rule 2): you may only revoke a grant of a
+    // role you could also have granted here — i.e. every permission it confers
+    // is one you hold at this scope. Without this, a holder of `role:revoke`
+    // could strip a MORE-privileged peer's grant despite not dominating it.
+    const missing = permissionsForRole(grant.roleId).filter(
+      (p) => !actorPermissions.has(p),
+    );
+    if (missing.length > 0) {
       throw new NotAuthorizedToRevokeError(grant.scope.toPlain());
     }
 

--- a/apps/api/src/contexts/identity/domain/authorization/local-access-control.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/local-access-control.spec.ts
@@ -233,5 +233,11 @@ describe('LocalAccessControl', () => {
     );
     expect(perms.has('offer:create')).toBe(true);
     expect(perms.has('resource:verify')).toBe(false);
+    // SECURITY (P3-1): the platform-scoped `citizen` role must NOT carry the
+    // read permissions that gate coordinator queues, or it would expose every
+    // emergency's unvalidated data.
+    expect(perms.has('resource:read')).toBe(false);
+    expect(perms.has('need:read')).toBe(false);
+    expect(perms.has('offer:read')).toBe(false);
   });
 });

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
@@ -238,15 +238,17 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
   citizen: {
     id: 'citizen',
     description:
-      'Ciudadano autenticado (rol por defecto de cualquier usuario).',
+      'Ciudadano autenticado (rol por defecto de cualquier usuario). Solo ' +
+      'acciones de grado ciudadano (crear/registrar). SEGURIDAD: NO incluye ' +
+      'resource:read / need:read / offer:read, porque esos permisos gatean las ' +
+      'colas de coordinación (queue/disputed/expired); concederlos aquí — y este ' +
+      'rol tiene scope por defecto `platform` — expondría datos sin validar de ' +
+      'todas las emergencias. Las lecturas públicas no requieren permiso.',
     defaultScopeType: 'platform',
     permissions: [
       'offer:create',
-      'offer:read',
       'capacity:publish',
       'resource:register',
-      'resource:read',
-      'need:read',
       'campaign:read',
       'volunteer:register',
     ],

--- a/apps/api/src/contexts/identity/domain/unverified-provider-email.error.ts
+++ b/apps/api/src/contexts/identity/domain/unverified-provider-email.error.ts
@@ -1,0 +1,20 @@
+/**
+ * Thrown when a social provider login brings an email that matches an existing
+ * (social-only) account, but the provider did NOT assert that it verified
+ * ownership of that email address.
+ *
+ * Auto-linking on an unverified email would let an attacker register a provider
+ * identity claiming the victim's email and silently take over the victim's
+ * existing account. Linking is therefore refused until the user authenticates
+ * and links the provider explicitly from account settings.
+ */
+export class UnverifiedProviderEmailError extends Error {
+  constructor(provider: string) {
+    super(
+      `The ${provider} account did not verify ownership of this email address, ` +
+        `so it cannot be linked automatically. Please sign in first and link ` +
+        `your ${provider} account from account settings.`,
+    );
+    this.name = 'UnverifiedProviderEmailError';
+  }
+}

--- a/apps/api/src/contexts/identity/infrastructure/bcrypt-password-hasher.ts
+++ b/apps/api/src/contexts/identity/infrastructure/bcrypt-password-hasher.ts
@@ -1,7 +1,10 @@
 import * as bcrypt from 'bcryptjs';
 import { PasswordHasher } from '../domain/ports/password-hasher';
 
-const SALT_ROUNDS = 10;
+// Work factor for bcrypt. 12 aligns with current OWASP guidance (>=10-12) and
+// stays fast enough at login time. Existing cost-10 hashes keep verifying (the
+// cost is embedded in each hash), so this only affects newly created passwords.
+const SALT_ROUNDS = 12;
 
 export class BcryptPasswordHasher implements PasswordHasher {
   async hash(plain: string): Promise<string> {

--- a/apps/api/src/contexts/identity/infrastructure/http/auth.controller.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/auth.controller.ts
@@ -11,7 +11,7 @@ import {
   UseFilters,
   UseGuards,
 } from '@nestjs/common';
-import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { Throttle } from '@nestjs/throttler';
 import {
   ApiTags,
   ApiOperation,
@@ -76,7 +76,6 @@ export class AuthController {
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
-  @UseGuards(ThrottlerGuard)
   @Throttle({ auth: { ttl: 60_000, limit: 10 } })
   @ApiOperation({ summary: 'Authenticate and obtain a JWT access token' })
   @ApiOkResponse({ description: 'Login successful', type: LoginResponseDto })
@@ -91,7 +90,6 @@ export class AuthController {
 
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
-  @UseGuards(ThrottlerGuard)
   @Throttle({ auth: { ttl: 60_000, limit: 10 } })
   @ApiOperation({
     summary: 'Register a new user account (auto-login returns JWT)',

--- a/apps/api/src/contexts/identity/infrastructure/http/facebook.strategy.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/facebook.strategy.ts
@@ -53,11 +53,17 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
         .join(' ') ||
       email;
 
+    // SECURITY: passport-facebook does not expose a per-email verification
+    // flag, so we cannot assert the provider verified ownership of this email.
+    // We therefore treat Facebook emails as unverified: the identity can still
+    // create a brand-new account or reuse its own prior link, but it can never
+    // auto-unify into a pre-existing account by email match (takeover vector).
     return this.authenticateWithProvider.execute({
       provider: AuthProvider.Facebook,
       providerUserId: profile.id,
       email,
       name,
+      emailVerified: false,
     });
   }
 }

--- a/apps/api/src/contexts/identity/infrastructure/http/google.strategy.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/google.strategy.ts
@@ -41,10 +41,17 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     _refreshToken: string,
     profile: Profile,
   ): Promise<{ accessToken: string }> {
-    const email = profile.emails?.[0]?.value;
+    const emailEntry = profile.emails?.[0];
+    const email = emailEntry?.value;
     if (!email) {
       throw new Error('Google profile did not return an email address');
     }
+
+    // Google's OIDC userinfo exposes `email_verified`; passport surfaces it as
+    // `emails[].verified` (a boolean or the string 'true'). Only a truthy,
+    // explicit verification counts — anything else is treated as unverified.
+    const verifiedFlag = emailEntry?.verified as boolean | string | undefined;
+    const emailVerified = verifiedFlag === true || verifiedFlag === 'true';
 
     const name =
       profile.displayName ||
@@ -58,6 +65,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       providerUserId: profile.id,
       email,
       name,
+      emailVerified,
     });
   }
 }

--- a/apps/api/src/contexts/identity/infrastructure/http/oauth-state.guard.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/oauth-state.guard.ts
@@ -88,7 +88,12 @@ export function OAuthInitiateGuard(
         sameSite: 'lax' as const,
         path: '/auth',
         maxAge: STATE_MAX_AGE_MS,
-        secure: process.env.COOKIE_SECURE === 'true',
+        // Secure by default in production (fail-safe); an HTTPS-terminating-
+        // upstream deployment serving plain HTTP can opt out with
+        // COOKIE_SECURE=false. Off outside production for local/proxy runs.
+        secure:
+          process.env.NODE_ENV === 'production' &&
+          process.env.COOKIE_SECURE !== 'false',
       };
 
       res.cookie(STATE_COOKIE, state, cookieOptions);

--- a/apps/api/src/contexts/identity/infrastructure/identity.module.ts
+++ b/apps/api/src/contexts/identity/infrastructure/identity.module.ts
@@ -99,7 +99,7 @@ import { SCOPE_RESOLVER } from './http/scope-resolver';
 import { EntityAwareScopeResolver } from './http/entity-aware-scope-resolver';
 import { DrizzleUserIdentityRepository } from './drizzle/drizzle-user-identity.repository';
 import { BcryptPasswordHasher } from './bcrypt-password-hasher';
-import { JwtTokenService } from './jwt-token.service';
+import { JwtTokenService, JWT_ISSUER, JWT_AUDIENCE } from './jwt-token.service';
 import { JwtAuthGuard } from './http/jwt-auth.guard';
 import { OptionalJwtAuthGuard } from './http/optional-jwt-auth.guard';
 import { RequireAdminGuard } from './http/require-admin.guard';
@@ -460,7 +460,14 @@ const updateProfileProvider = {
       useFactory: () => {
         const secret = process.env.JWT_SECRET;
         if (!secret) throw new Error('JWT_SECRET is required');
-        return { secret, signOptions: { expiresIn: '12h' } };
+        return {
+          secret,
+          signOptions: {
+            expiresIn: '12h',
+            issuer: JWT_ISSUER,
+            audience: JWT_AUDIENCE,
+          },
+        };
       },
     }),
   ],

--- a/apps/api/src/contexts/identity/infrastructure/jwt-token.service.ts
+++ b/apps/api/src/contexts/identity/infrastructure/jwt-token.service.ts
@@ -1,6 +1,16 @@
 import { JwtService } from '@nestjs/jwt';
 import { TokenService, TokenPayload } from '../domain/ports/token.service';
 
+/**
+ * Issuer/audience bound into every access token and checked on verify. Binding
+ * `iss`/`aud` means a token minted for this API cannot be replayed against a
+ * different service that ever shares the same JWT secret (defence-in-depth).
+ * Applied to sign via JwtModule signOptions (identity.module.ts) and to verify
+ * here — keep both in sync.
+ */
+export const JWT_ISSUER = 'responsegrid';
+export const JWT_AUDIENCE = 'responsegrid-api';
+
 export class JwtTokenService implements TokenService {
   constructor(private readonly jwtService: JwtService) {}
 
@@ -11,9 +21,12 @@ export class JwtTokenService implements TokenService {
   verify(token: string): TokenPayload {
     // Pin the accepted algorithm. The current setup is symmetric (HS256), so
     // this is defence-in-depth against algorithm-confusion if an asymmetric key
-    // is ever introduced; it also rejects `alg: none` explicitly.
+    // is ever introduced; it also rejects `alg: none` explicitly. Also bind the
+    // issuer/audience so a token is only accepted for this service.
     return this.jwtService.verify<TokenPayload>(token, {
       algorithms: ['HS256'],
+      issuer: JWT_ISSUER,
+      audience: JWT_AUDIENCE,
     });
   }
 }

--- a/apps/api/src/contexts/needs/application/get-public-needs.spec.ts
+++ b/apps/api/src/contexts/needs/application/get-public-needs.spec.ts
@@ -89,7 +89,9 @@ describe('GetPublicNeeds', () => {
 
     const result = await getPublicNeeds.execute({ emergencyId: EM });
     expect(result[0].description).toBe('Urgent water need');
-    expect(result[0].location.address).toBe('Plaza Bolívar, Caracas');
+    // Individual requester → Approximate sensitivity → the street line is
+    // coarsened to the locality only (privacy; the exact address must not leak).
+    expect(result[0].location.address).toBe('Caracas');
     expect(result[0].items).toHaveLength(2);
   });
 

--- a/apps/api/src/contexts/needs/application/need-view.spec.ts
+++ b/apps/api/src/contexts/needs/application/need-view.spec.ts
@@ -1,0 +1,70 @@
+import { toPublicNeedView, toCoordinatorNeedView } from './need-view';
+import { Need } from '../domain/need';
+import { NeedId } from '../domain/need-id';
+import { SupplyLine } from '../../supplies/domain/supply-line';
+import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { Priority, Category } from '../domain/need-enums';
+import { Location } from '../../../shared/domain/location';
+import { LocationSensitivity } from '../../../shared/domain/location-sensitivity';
+
+const EM = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const USER_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+const EXACT_ADDRESS = 'Calle Los Rosales #123, Apt 4B, Chacao, Caracas';
+
+function makeNeed(sensitivity: LocationSensitivity): Need {
+  return Need.create({
+    id: NeedId.create(),
+    emergencyId: EmergencyId.fromString(EM),
+    title: 'Alimentos',
+    description: null,
+    location: Location.create({
+      address: EXACT_ADDRESS,
+      latitude: 10.4806,
+      longitude: -66.9036,
+    }),
+    priority: Priority.High,
+    requesterUserId: USER_ID,
+    requesterOrganizationId: null,
+    locationSensitivity: sensitivity,
+    items: [
+      SupplyLine.create({
+        name: 'Agua',
+        quantity: 10,
+        unit: 'litros',
+        category: Category.Water,
+      }),
+    ],
+  });
+}
+
+describe('toPublicNeedView — location privacy', () => {
+  it('coarsens the street address for approximate-sensitivity needs', () => {
+    const view = toPublicNeedView(makeNeed(LocationSensitivity.Approximate));
+    // The exact street line must NOT be present; only coarse locality remains.
+    expect(view.location.address).toBe('Apt 4B, Chacao, Caracas');
+    expect(view.location.address).not.toContain('Calle Los Rosales #123');
+  });
+
+  it('jitters the coordinates for approximate-sensitivity needs', () => {
+    const need = makeNeed(LocationSensitivity.Approximate);
+    const view = toPublicNeedView(need);
+    const exact = need.location.toPlain();
+    // Coordinates are offset (not equal to the exact position).
+    expect(view.location.latitude).not.toBe(exact.latitude);
+    expect(view.location.longitude).not.toBe(exact.longitude);
+  });
+
+  it('keeps the exact address for public-sensitivity needs', () => {
+    const view = toPublicNeedView(makeNeed(LocationSensitivity.Public));
+    expect(view.location.address).toBe(EXACT_ADDRESS);
+  });
+});
+
+describe('toCoordinatorNeedView — exact location', () => {
+  it('always returns the exact address regardless of sensitivity', () => {
+    const view = toCoordinatorNeedView(
+      makeNeed(LocationSensitivity.Approximate),
+    );
+    expect(view.location.address).toBe(EXACT_ADDRESS);
+  });
+});

--- a/apps/api/src/contexts/needs/application/need-view.ts
+++ b/apps/api/src/contexts/needs/application/need-view.ts
@@ -1,8 +1,19 @@
 import { Need } from '../domain/need';
-import { LocationProps } from '../../../shared/domain/location';
+
+/**
+ * Location as exposed in a NeedView. The address is nullable because the public
+ * view coarsens (and may fully drop) the street line of location-sensitive
+ * needs; coordinators always receive the exact, non-null address.
+ */
+export interface NeedLocationView {
+  address: string | null;
+  latitude: number;
+  longitude: number;
+}
 import { SupplyLineSnapshot } from '../../supplies/domain/supply-line';
 import { LocationSensitivity } from '../../../shared/domain/location-sensitivity';
 import { approximateLocation } from '../../../shared/domain/approximate-location';
+import { coarsenAddress } from '../../../shared/domain/coarsen-address';
 import { PersonnelSkill } from '../domain/need-enums';
 import { AuthorSnapshot } from '../../../shared/domain/author';
 
@@ -11,7 +22,7 @@ export interface NeedView {
   emergencyId: string;
   title: string;
   description: string | null;
-  location: LocationProps;
+  location: NeedLocationView;
   locationSensitivity: LocationSensitivity;
   priority: string;
   requesterOrganizationId: string | null;
@@ -50,7 +61,7 @@ export interface CoordinatorNeedView extends NeedView {
 export function toPublicNeedView(n: Need): NeedView {
   const exactLocation = n.location.toPlain();
 
-  let publicLocation: LocationProps;
+  let publicLocation: NeedLocationView;
   if (n.locationSensitivity === LocationSensitivity.Approximate) {
     const approx = approximateLocation(
       exactLocation.latitude,
@@ -58,7 +69,10 @@ export function toPublicNeedView(n: Need): NeedView {
       n.id.value,
     );
     publicLocation = {
-      address: exactLocation.address,
+      // SECURITY: coarsen the street address too. Jittering the coordinates
+      // while returning the exact street line ("Calle X #123") would defeat the
+      // whole point of Approximate sensitivity and disclose the requester's home.
+      address: coarsenAddress(exactLocation.address),
       latitude: approx.lat,
       longitude: approx.lng,
     };

--- a/apps/api/src/contexts/needs/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/response.dto.ts
@@ -13,8 +13,15 @@ export class CreateNeedResponseDto {
 }
 
 export class NeedLocationResponseDto {
-  @ApiProperty({ example: '123 Main Street, Caracas' })
-  address!: string;
+  @ApiPropertyOptional({
+    example: 'Caracas',
+    nullable: true,
+    type: String,
+    description:
+      'Street line is coarsened (locality only) or dropped for needs with ' +
+      'approximate location sensitivity to protect the requester’s privacy.',
+  })
+  address!: string | null;
 
   @ApiProperty({ example: 10.4806 })
   latitude!: number;

--- a/apps/api/src/contexts/offers/application/donation-intake.use-cases.spec.ts
+++ b/apps/api/src/contexts/offers/application/donation-intake.use-cases.spec.ts
@@ -217,6 +217,25 @@ describe('DonationIntake use cases', () => {
       expect(result.pendingIntakes).toHaveLength(1);
       expect(result.pendingIntakes[0]?.id).toBe(created.id);
     });
+
+    it('does NOT expose the intake code or target resource (tamper-credential leak)', async () => {
+      // The endpoint is public and keyed on a guessable contact. Echoing the
+      // intake code back would hand an attacker the exact credential the public
+      // PATCH requires to tamper with the victim's donation. The summary must
+      // stay non-actionable.
+      await create.execute(makeCmd());
+      const lookup = new LookupDonorByContact(repo);
+      const result = await lookup.execute({
+        emergencyId: EM,
+        donorPhone: '+52 55 1234 5678',
+        donorEmail: null,
+      });
+      const summary = result.pendingIntakes[0] as Record<string, unknown>;
+      expect(summary).toBeDefined();
+      expect(summary['intakeCode']).toBeUndefined();
+      expect(summary['targetResourceId']).toBeUndefined();
+      expect(summary['itemCount']).toBe(1);
+    });
   });
 
   describe('UpdateDonationIntake', () => {

--- a/apps/api/src/contexts/offers/application/lookup-donor-by-contact.ts
+++ b/apps/api/src/contexts/offers/application/lookup-donor-by-contact.ts
@@ -8,10 +8,17 @@ export interface LookupDonorByContactCommand {
   donorEmail: string | null;
 }
 
+/**
+ * Non-actionable summary of a donor's pending intake.
+ *
+ * SECURITY: this endpoint is public and keyed only on a (guessable) phone/email,
+ * so the summary deliberately OMITS the `intakeCode` and `targetResourceId`.
+ * The intake code is the credential the public PATCH requires; re-disclosing it
+ * on a contact-only lookup would let an attacker tamper with a stranger's
+ * donation. The code is delivered to the donor at creation time (receipt) only.
+ */
 export interface PendingIntakeSummary {
   id: string;
-  intakeCode: string;
-  targetResourceId: string;
   itemCount: number;
   createdAt: Date;
 }
@@ -42,8 +49,6 @@ export class LookupDonorByContact {
       donorName,
       pendingIntakes: pending.map((intake) => ({
         id: intake.id.value,
-        intakeCode: intake.intakeCode,
-        targetResourceId: intake.targetResourceId,
         itemCount: intake.lines.length,
         createdAt: intake.createdAt,
       })),

--- a/apps/api/src/contexts/offers/infrastructure/http/donation-intake-response.dto.ts
+++ b/apps/api/src/contexts/offers/infrastructure/http/donation-intake-response.dto.ts
@@ -20,12 +20,6 @@ export class PendingIntakeSummaryDto {
   @ApiProperty({ format: 'uuid' })
   id!: string;
 
-  @ApiProperty({ example: 'ACO-7F3K' })
-  intakeCode!: string;
-
-  @ApiProperty({ format: 'uuid' })
-  targetResourceId!: string;
-
   @ApiProperty({ example: 2 })
   itemCount!: number;
 
@@ -121,6 +115,77 @@ export class DonationIntakeViewDto {
 
   @ApiProperty({ type: String, format: 'date-time' })
   updatedAt!: Date;
+}
+
+/**
+ * Public-safe projection returned by the anonymous PATCH /donation-intakes/:id.
+ *
+ * The caller proved ownership (code + contact) so we echo back their OWN
+ * submitted data + status, but we deliberately DROP the coordinator-only,
+ * internal fields that the donor never supplied: `donorUserId`,
+ * `receivedByUserId`, `evidenceFileKey`, `volunteerNotes` and
+ * `receptionAdjustmentReason`.
+ */
+export class PublicDonationIntakeDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  emergencyId!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  targetResourceId!: string;
+
+  @ApiProperty({ example: 'ACO-7F3K' })
+  intakeCode!: string;
+
+  @ApiProperty({ enum: DonationIntakeStatus })
+  status!: string;
+
+  @ApiProperty()
+  donorName!: string;
+
+  @ApiPropertyOptional({ nullable: true, type: String })
+  donorPhone!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, type: String })
+  donorEmail!: string | null;
+
+  @ApiProperty({ type: [IntakeLineViewDto] })
+  lines!: IntakeLineViewDto[];
+
+  @ApiPropertyOptional({ type: String, format: 'date-time', nullable: true })
+  receivedAt!: Date | null;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt!: Date;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  updatedAt!: Date;
+}
+
+/**
+ * Map the full (coordinator) intake view to the public-safe projection,
+ * stripping internal fields. Keep this in the DTO module so the whitelist of
+ * exposed fields lives next to the DTO definition.
+ */
+export function toPublicDonationIntakeDto(
+  view: DonationIntakeViewDto,
+): PublicDonationIntakeDto {
+  return {
+    id: view.id,
+    emergencyId: view.emergencyId,
+    targetResourceId: view.targetResourceId,
+    intakeCode: view.intakeCode,
+    status: view.status,
+    donorName: view.donorName,
+    donorPhone: view.donorPhone,
+    donorEmail: view.donorEmail,
+    lines: view.lines,
+    receivedAt: view.receivedAt,
+    createdAt: view.createdAt,
+    updatedAt: view.updatedAt,
+  };
 }
 
 export class DonationIntakeSearchHitDto {

--- a/apps/api/src/contexts/offers/infrastructure/http/donation-intakes.controller.ts
+++ b/apps/api/src/contexts/offers/infrastructure/http/donation-intakes.controller.ts
@@ -55,6 +55,8 @@ import {
   CreateDonationIntakeResponseDto,
   LookupDonorByContactResponseDto,
   DonationIntakeViewDto,
+  PublicDonationIntakeDto,
+  toPublicDonationIntakeDto,
   DonationIntakeSearchHitDto,
   IntakeDeepLinkDto,
   DonationIntakeTrackingDto,
@@ -210,7 +212,7 @@ export class DonationIntakesController {
     summary: 'Update a pending intake (public, requires code + contact)',
   })
   @ApiParam({ name: 'intakeId', format: 'uuid' })
-  @ApiOkResponse({ type: DonationIntakeViewDto })
+  @ApiOkResponse({ type: PublicDonationIntakeDto })
   @ApiBadRequestResponse({ description: 'Invalid request body' })
   @ApiForbiddenResponse({ description: 'Contact or code mismatch' })
   @ApiNotFoundResponse({ description: 'Intake not found' })
@@ -219,7 +221,7 @@ export class DonationIntakesController {
   async update(
     @Param('intakeId', ParseUUIDPipe) intakeId: string,
     @Body() dto: UpdateDonationIntakeDto,
-  ): Promise<DonationIntakeViewDto> {
+  ): Promise<PublicDonationIntakeDto> {
     await this.updateDonationIntake.execute({
       intakeId,
       intakeCode: dto.intakeCode,
@@ -228,7 +230,10 @@ export class DonationIntakesController {
       donorEmail: dto.donorEmail ?? null,
       items: mapItems(dto.items),
     });
-    return this.getDonationIntakeById.execute(intakeId);
+    // Public caller: return a projection without coordinator-only internal
+    // fields (evidenceFileKey, volunteerNotes, receivedByUserId, donorUserId…).
+    const full = await this.getDonationIntakeById.execute(intakeId);
+    return toPublicDonationIntakeDto(full);
   }
 
   @Get('emergencies/:emergencyId/donation-intakes/search')

--- a/apps/api/src/contexts/offers/infrastructure/http/donation-intakes.controller.ts
+++ b/apps/api/src/contexts/offers/infrastructure/http/donation-intakes.controller.ts
@@ -12,7 +12,7 @@ import {
   StreamableFile,
   UseGuards,
 } from '@nestjs/common';
-import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { Throttle } from '@nestjs/throttler';
 import {
   ApiTags,
   ApiOperation,
@@ -107,7 +107,7 @@ export class DonationIntakesController {
 
   @Post('emergencies/:emergencyId/donation-intakes')
   @HttpCode(201)
-  @UseGuards(ThrottlerGuard, OptionalJwtAuthGuard)
+  @UseGuards(OptionalJwtAuthGuard)
   @Throttle({ intake: { ttl: 60_000, limit: 5 } })
   @ApiOperation({
     summary: 'Pre-register a donation at a collection point (public)',
@@ -141,7 +141,6 @@ export class DonationIntakesController {
 
   @Post('emergencies/:emergencyId/donation-intakes/lookup-contact')
   @HttpCode(200)
-  @UseGuards(ThrottlerGuard)
   @Throttle({ intake: { ttl: 60_000, limit: 5 } })
   @ApiOperation({
     summary: 'Recognize a returning donor by phone or email (public)',
@@ -162,7 +161,6 @@ export class DonationIntakesController {
   }
 
   @Get('emergencies/:emergencyId/donation-intakes/by-code/:code')
-  @UseGuards(ThrottlerGuard)
   @Throttle({ intake: { ttl: 60_000, limit: 10 } })
   @ApiOperation({ summary: 'Track a donation by its code (public, no PII)' })
   @ApiParam({ name: 'emergencyId', format: 'uuid' })
@@ -207,7 +205,6 @@ export class DonationIntakesController {
   }
 
   @Patch('donation-intakes/:intakeId')
-  @UseGuards(ThrottlerGuard)
   @Throttle({ intake: { ttl: 60_000, limit: 5 } })
   @ApiOperation({
     summary: 'Update a pending intake (public, requires code + contact)',

--- a/apps/api/src/contexts/resources/application/redact-contact.spec.ts
+++ b/apps/api/src/contexts/resources/application/redact-contact.spec.ts
@@ -41,6 +41,27 @@ describe('redactContact', () => {
     expect(result.hasContact).toBe(true);
   });
 
+  it('hides the manager (personal name) from an anonymous caller for a non-official resource', () => {
+    const result = redactContact(view({ manager: 'Juan Pérez' }), false);
+    expect(result.manager).toBeNull();
+  });
+
+  it('reveals the manager to an authenticated caller', () => {
+    const result = redactContact(view({ manager: 'Juan Pérez' }), true);
+    expect(result.manager).toBe('Juan Pérez');
+  });
+
+  it('reveals the manager of an official resource to anonymous callers', () => {
+    const result = redactContact(
+      view({
+        manager: 'Coordinación Oficial',
+        verificationLevel: VerificationLevel.Official,
+      }),
+      false,
+    );
+    expect(result.manager).toBe('Coordinación Oficial');
+  });
+
   it('reveals the contact to an authenticated caller', () => {
     const result = redactContact(view(), true);
     expect(result.contact).toBe('+58 212 555 0000');

--- a/apps/api/src/contexts/resources/application/redact-contact.ts
+++ b/apps/api/src/contexts/resources/application/redact-contact.ts
@@ -2,13 +2,13 @@ import { ResourceView } from './resource-view';
 import { VerificationLevel } from '../domain/resource-enums';
 
 /**
- * `contact` is personal data (a phone number / person's line). The public
- * endpoints are anonymous, so we must not broadcast it to scrapers. Policy:
- * the contact is only revealed when the caller is authenticated, OR the
- * resource is an `official` source (an organisation whose public line is
- * meant to be public). Otherwise `contact` is nulled — but `hasContact`
- * stays true so the UI can honestly say "log in to see it" instead of
- * "no contact".
+ * `contact` and `manager` are personal data (a phone number / a person's line,
+ * and a person's name for citizen-submitted points). The public endpoints are
+ * anonymous, so we must not broadcast them to scrapers. Policy: they are only
+ * revealed when the caller is authenticated, OR the resource is an `official`
+ * source (an organisation whose public line/manager is meant to be public).
+ * Otherwise both are nulled — but `hasContact` stays true so the UI can
+ * honestly say "log in to see it" instead of "no contact".
  */
 export function redactContact<T extends ResourceView>(
   view: T,
@@ -17,5 +17,5 @@ export function redactContact<T extends ResourceView>(
   if (authenticated || view.verificationLevel === VerificationLevel.Official) {
     return view;
   }
-  return { ...view, contact: null };
+  return { ...view, contact: null, manager: null };
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -57,10 +57,21 @@ async function bootstrap(): Promise<void> {
   // The Next.js frontend issues client-side fetches (e.g. the public resource
   // points consumed by the Leaflet map) to this API from a different origin
   // (3001 → 3000). Without CORS the browser blocks those responses ("Failed to
-  // fetch"). credentials:true allows the httpOnly auth cookie on client-side
-  // authenticated calls. Origin is restricted to FRONTEND_URL (no wildcard).
+  // fetch"). credentials:true is required for client-side authenticated calls.
+  // Origin is restricted to FRONTEND_URL (no wildcard, no reflection).
+  //
+  // In production FRONTEND_URL must be set explicitly: falling back to
+  // localhost would silently break the real frontend, so we fail fast instead.
+  if (process.env.NODE_ENV === 'production' && !process.env.FRONTEND_URL) {
+    throw new Error(
+      'FRONTEND_URL must be set in production (CORS allow-list).',
+    );
+  }
   app.enableCors({
-    origin: (process.env.FRONTEND_URL ?? 'http://localhost:3001').split(','),
+    origin: (process.env.FRONTEND_URL ?? 'http://localhost:3001')
+      .split(',')
+      .map((o) => o.trim())
+      .filter((o) => o.length > 0),
     credentials: true,
   });
 

--- a/apps/api/src/shared/domain/coarsen-address.spec.ts
+++ b/apps/api/src/shared/domain/coarsen-address.spec.ts
@@ -1,0 +1,32 @@
+import { coarsenAddress } from './coarsen-address';
+
+describe('coarsenAddress', () => {
+  it('drops the street line and keeps the locality context', () => {
+    expect(
+      coarsenAddress('Calle Los Rosales #123, Apt 4B, Chacao, Caracas'),
+    ).toBe('Apt 4B, Chacao, Caracas');
+  });
+
+  it('keeps a simple city tail when only two segments are present', () => {
+    expect(coarsenAddress('Av. Principal 45, Caracas')).toBe('Caracas');
+  });
+
+  it('returns null for a single-segment address (assumed to be a street line)', () => {
+    expect(coarsenAddress('Calle Los Rosales #123')).toBeNull();
+  });
+
+  it('returns null for null input', () => {
+    expect(coarsenAddress(null)).toBeNull();
+  });
+
+  it('returns null for a blank / comma-only address', () => {
+    expect(coarsenAddress('   ')).toBeNull();
+    expect(coarsenAddress(', ,')).toBeNull();
+  });
+
+  it('trims whitespace around retained segments', () => {
+    expect(coarsenAddress('Calle 1 ,  Baruta ,  Miranda ')).toBe(
+      'Baruta, Miranda',
+    );
+  });
+});

--- a/apps/api/src/shared/domain/coarsen-address.ts
+++ b/apps/api/src/shared/domain/coarsen-address.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared Kernel — Address coarsening helper.
+ *
+ * Pure function that strips the most identifying part of a postal address (the
+ * street line — name + number + unit) while keeping the coarse locality context
+ * (neighbourhood / city / region). Used for the public view of location-
+ * sensitive needs: the coordinates are already jittered, so returning the exact
+ * street address would defeat that protection and disclose an individual's home.
+ *
+ * Heuristic: addresses are conventionally written most-specific-first, comma
+ * separated ("Calle X #123, Apt 4B, Chacao, Caracas"). We drop the first
+ * segment (the street line) and keep the rest. A single-segment address is
+ * assumed to BE a street line and is removed entirely, since we cannot separate
+ * street from locality safely.
+ *
+ * No framework/infra dependency — this is a pure domain concern.
+ */
+export function coarsenAddress(address: string | null): string | null {
+  if (address === null) return null;
+
+  const segments = address
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  // Nothing usable, or only the street line → hide entirely.
+  if (segments.length <= 1) return null;
+
+  // Drop the leading street line, keep the coarser locality context.
+  return segments.slice(1).join(', ');
+}

--- a/apps/api/test/files-upload.e2e-spec.ts
+++ b/apps/api/test/files-upload.e2e-spec.ts
@@ -136,6 +136,18 @@ describe('Files upload (e2e)', () => {
       .expect(422);
   });
 
+  it('POST /files with a non-image payload mislabelled as image/png returns 422 (magic-byte check)', async () => {
+    const fakePng = Buffer.from('<html><script>alert(1)</script></html>');
+    await request(server)
+      .post('/files')
+      .set('Authorization', `Bearer ${userToken}`)
+      .attach('file', fakePng, {
+        filename: 'fake.png',
+        contentType: 'image/png',
+      })
+      .expect(422);
+  });
+
   it('POST /files with image/svg+xml is rejected with 422 (XSS prevention)', async () => {
     const svgBuf = Buffer.from(
       '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',

--- a/apps/api/test/files-upload.e2e-spec.ts
+++ b/apps/api/test/files-upload.e2e-spec.ts
@@ -100,8 +100,28 @@ describe('Files upload (e2e)', () => {
     expect(typeof key).toBe('string');
     expect(url).toBe(`/files/${key}`);
 
-    const getRes = await request(server).get(`/files/${key}`).expect(200);
+    const getRes = await request(server)
+      .get(`/files/${key}`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .expect(200);
     expect(getRes.headers['content-type']).toContain('image/png');
+  });
+
+  it('GET /files/:key without a token returns 401 (files are not world-readable)', async () => {
+    const pngBuf = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      'base64',
+    );
+    const uploadRes = await request(server)
+      .post('/files')
+      .set('Authorization', `Bearer ${userToken}`)
+      .attach('file', pngBuf, {
+        filename: 'private.png',
+        contentType: 'image/png',
+      })
+      .expect(201);
+    const { key } = uploadRes.body as { key: string };
+    await request(server).get(`/files/${key}`).expect(401);
   });
 
   it('POST /files with non-image returns 422', async () => {
@@ -144,11 +164,17 @@ describe('Files upload (e2e)', () => {
       })
       .expect(201);
     const { key } = uploadRes.body as { key: string; url: string };
-    const getRes = await request(server).get(`/files/${key}`).expect(200);
+    const getRes = await request(server)
+      .get(`/files/${key}`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .expect(200);
     expect(getRes.headers['x-content-type-options']).toBe('nosniff');
   });
 
   it('GET /files/:key with unknown key returns 404', async () => {
-    await request(server).get('/files/nonexistent-key.png').expect(404);
+    await request(server)
+      .get('/files/nonexistent-key.png')
+      .set('Authorization', `Bearer ${userToken}`)
+      .expect(404);
   });
 });

--- a/apps/api/test/resource-admin.e2e-spec.ts
+++ b/apps/api/test/resource-admin.e2e-spec.ts
@@ -72,6 +72,9 @@ describe('Admin resources console (e2e)', () => {
         .delete(usersTable)
         .where(inArray(usersTable.id, [ADMIN_ID, OWNER_ID, COORD_ID]));
 
+      // Upsert (not onConflictDoNothing): another e2e file may have already
+      // inserted this shared emergency id under a different name, and this spec
+      // asserts the canonical name. Force it so the test is order-independent.
       await db
         .insert(emergenciesTable)
         .values({
@@ -82,7 +85,15 @@ describe('Admin resources console (e2e)', () => {
           status: 'active',
           createdAt: new Date(),
         })
-        .onConflictDoNothing();
+        .onConflictDoUpdate({
+          target: emergenciesTable.id,
+          set: {
+            name: 'Terremoto Venezuela 2026',
+            slug: 'terremoto-venezuela-2026',
+            country: 'VE',
+            status: 'active',
+          },
+        });
 
       const [adminHash, ownerHash, coordHash] = await Promise.all([
         bcrypt.hash('admin1234', 10),

--- a/apps/web/src/app/api/files/[key]/route.ts
+++ b/apps/web/src/app/api/files/[key]/route.ts
@@ -1,0 +1,53 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { getToken, authHeaders } from '@/lib/auth';
+
+const API_BASE = process.env.API_URL ?? 'http://localhost:3000';
+
+/**
+ * GET /api/files/:key
+ *
+ * Same-origin, authenticated proxy for stored files. The backend now requires a
+ * Bearer token on GET /files/:key (files are no longer world-readable), but an
+ * <img>/<a> in the browser cannot attach the httpOnly session cookie as a
+ * bearer header. This route reads the session token server-side and forwards
+ * the request, streaming the file back so images keep rendering while access is
+ * gated by the session.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ key: string }> },
+): Promise<NextResponse> {
+  const token = await getToken();
+  if (token === null) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { key } = await params;
+  // Defence-in-depth: the dynamic segment is already a single path component,
+  // but reject anything that could escape the /files/ prefix upstream.
+  if (key.includes('/') || key.includes('\\') || key.includes('..')) {
+    return NextResponse.json({ error: 'Invalid key' }, { status: 400 });
+  }
+
+  const upstream = await fetch(`${API_BASE}/files/${encodeURIComponent(key)}`, {
+    headers: authHeaders(token),
+  });
+
+  if (!upstream.ok || upstream.body === null) {
+    return NextResponse.json(
+      { error: 'Not found' },
+      { status: upstream.status === 401 ? 401 : 404 },
+    );
+  }
+
+  const headers = new Headers();
+  const contentType =
+    upstream.headers.get('content-type') ?? 'application/octet-stream';
+  headers.set('content-type', contentType);
+  headers.set('x-content-type-options', 'nosniff');
+  // Private: cacheable by the user's browser but never by shared proxies, since
+  // the content is access-controlled.
+  headers.set('cache-control', 'private, max-age=300');
+
+  return new NextResponse(upstream.body, { status: 200, headers });
+}

--- a/apps/web/src/components/molecules/notification-item.tsx
+++ b/apps/web/src/components/molecules/notification-item.tsx
@@ -6,6 +6,7 @@ import { markNotificationReadAction } from '@/app/dashboard/notifications/action
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
 import { LocalDate } from '@/components/atoms/local-date';
+import { safeNextPath } from '@/lib/safe-next';
 
 export interface NotificationItemProps {
   id: string;
@@ -31,6 +32,12 @@ export function NotificationItem({
       await markNotificationReadAction(id);
     });
   };
+
+  // SECURITY: notification links come from the backend (stored data). Render
+  // them only when they are safe internal app routes; reject absolute /
+  // protocol-relative / `javascript:` targets that could enable DOM XSS or
+  // open redirects. Falls back to non-linked content when unsafe.
+  const safeLink = safeNextPath(link);
 
   const innerContent = (
     <div className="flex flex-col gap-1 flex-1 min-w-0">
@@ -63,9 +70,9 @@ export function NotificationItem({
         aria-hidden="true"
       />
 
-      {link != null ? (
+      {safeLink != null ? (
         <Link
-          href={link}
+          href={safeLink}
           onClick={read ? undefined : handleMarkRead}
           className="flex-1 min-w-0 hover:opacity-70 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 rounded transition-opacity"
         >
@@ -75,9 +82,9 @@ export function NotificationItem({
         innerContent
       )}
 
-      {/* Mark read button — only shown for unread notifications without a link
-          (linked notifications mark themselves read on click) */}
-      {!read && link === null && (
+      {/* Mark read button — only shown for unread notifications without a
+          (safe) link (linked notifications mark themselves read on click) */}
+      {!read && safeLink === null && (
         <button
           type="button"
           onClick={handleMarkRead}

--- a/apps/web/src/components/organisms/disputed-queue.tsx
+++ b/apps/web/src/components/organisms/disputed-queue.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/atoms/button';
 import { ErrorMessage } from '@/components/atoms/error-message';
 import { LocalDate } from '@/components/atoms/local-date';
 import { EmptyState } from '@/components/molecules/empty-state';
+import { fileSrc } from '@/lib/file-src';
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
 import { formatDate } from '@/lib/format-date';
@@ -210,7 +211,7 @@ function DisputedCard({
                     {report.photoUrls.map((url, i) => (
                       <a
                         key={url}
-                        href={url}
+                        href={fileSrc(url)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-info underline"

--- a/apps/web/src/components/organisms/report-card.tsx
+++ b/apps/web/src/components/organisms/report-card.tsx
@@ -14,10 +14,9 @@ import {
   type EditField,
 } from '@/components/organisms/validation-actions';
 import { LocalDate } from '@/components/atoms/local-date';
+import { fileSrc } from '@/lib/file-src';
 import { useLocale } from '@/i18n/locale-context';
 import { getMessages } from '@/i18n';
-
-const API_BASE = (process.env.NEXT_PUBLIC_API_URL ?? '').replace(/\/$/, '');
 
 /** Report timestamp format: "05 jun, 14:32" — preserved from the original. */
 const REPORT_DATE_OPTS: Intl.DateTimeFormatOptions = {
@@ -148,11 +147,7 @@ export function ReportCard({ report, slug }: ReportCardProps) {
       {report.photoUrls != null && report.photoUrls.length > 0 && (
         <ul className="flex flex-wrap gap-2" aria-label={tc.report_photos_label}>
           {report.photoUrls.filter((u) => u !== '').map((urlOrKey) => {
-            const src = urlOrKey.startsWith('http')
-              ? urlOrKey
-              : urlOrKey.startsWith('/')
-                ? `${API_BASE}${urlOrKey}`
-                : `${API_BASE}/files/${urlOrKey}`;
+            const src = fileSrc(urlOrKey);
             return (
               <li key={urlOrKey}>
                 <a

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -35,10 +35,13 @@ export async function setToken(token: string): Promise<void> {
     httpOnly: true,
     sameSite: 'lax',
     path: '/',
-    // Secure only when explicitly enabled (set COOKIE_SECURE=true behind HTTPS).
-    // Tying it to NODE_ENV breaks sessions when a production build is served over
-    // plain HTTP (local runs, reverse proxies that don't forward HTTPS).
-    secure: process.env.COOKIE_SECURE === 'true',
+    // Secure by default in production so the session JWT is never sent over plain
+    // HTTP (fail-safe). A production deployment that genuinely terminates HTTPS
+    // upstream and serves the app over plain HTTP can opt out with
+    // COOKIE_SECURE=false; outside production it stays off so local/proxy runs work.
+    secure:
+      process.env.NODE_ENV === 'production' &&
+      process.env.COOKIE_SECURE !== 'false',
     maxAge: SESSION_MAX_AGE_SECONDS,
   });
 }

--- a/apps/web/src/lib/file-src.ts
+++ b/apps/web/src/lib/file-src.ts
@@ -1,0 +1,22 @@
+/**
+ * Maps a stored-file reference (a bare storage key, a `/files/<key>` path, or an
+ * absolute `…/files/<key>` URL) to the same-origin authenticated proxy route
+ * `/api/files/<key>`.
+ *
+ * Files are no longer world-readable on the API; they must be fetched through
+ * the session-authenticated proxy (see app/api/files/[key]/route.ts). Truly
+ * external URLs (that don't point at our files endpoint) are returned as-is.
+ */
+export function fileSrc(urlOrKey: string): string {
+  const marker = '/files/';
+  const idx = urlOrKey.indexOf(marker);
+  if (idx !== -1) {
+    return `/api/files/${urlOrKey.slice(idx + marker.length)}`;
+  }
+  if (/^https?:\/\//i.test(urlOrKey)) {
+    // Absolute URL that is not one of our file references — leave untouched.
+    return urlOrKey;
+  }
+  // Bare storage key.
+  return `/api/files/${urlOrKey.replace(/^\//, '')}`;
+}

--- a/deploy/migrate.sh
+++ b/deploy/migrate.sh
@@ -20,14 +20,17 @@ $PSQL -c "CREATE TABLE IF NOT EXISTS _migrations (name text PRIMARY KEY, applied
 for f in /migrations/*.sql; do
   [ -e "$f" ] || continue
   name=$(basename "$f")
-  applied=$($PSQL -tAc "SELECT 1 FROM _migrations WHERE name = '$name'")
+  # Pass the filename as a bound psql variable and quote it with :'mname' so a
+  # filename containing a quote can neither break the statement nor inject SQL
+  # into the _migrations table (defense-in-depth; filenames are repo-controlled).
+  applied=$($PSQL -v mname="$name" -tAc "SELECT 1 FROM _migrations WHERE name = :'mname'")
   if [ "$applied" = "1" ]; then
     echo "skip   $name"
     continue
   fi
   echo "apply  $name"
   $PSQL -f "$f"
-  $PSQL -c "INSERT INTO _migrations (name) VALUES ('$name');"
+  $PSQL -v mname="$name" -c "INSERT INTO _migrations (name) VALUES (:'mname');"
 done
 
 echo "migrations up to date"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   },
   "pnpm": {
     "overrides": {
-      "ioredis": "5.10.1"
+      "ioredis": "5.10.1",
+      "multer": ">=2.2.0",
+      "postcss": ">=8.5.10",
+      "js-yaml": ">=4.2.0"
     }
   }
 }

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -3956,8 +3956,11 @@ export interface components {
             id: string;
         };
         NeedLocationResponseDto: {
-            /** @example 123 Main Street, Caracas */
-            address: string;
+            /**
+             * @description Street line is coarsened (locality only) or dropped for needs with approximate location sensitivity to protect the requester’s privacy.
+             * @example Caracas
+             */
+            address?: string | null;
             /** @example 10.4806 */
             latitude: number;
             /** @example -66.9036 */
@@ -4558,10 +4561,6 @@ export interface components {
         PendingIntakeSummaryDto: {
             /** Format: uuid */
             id: string;
-            /** @example ACO-7F3K */
-            intakeCode: string;
-            /** Format: uuid */
-            targetResourceId: string;
             /** @example 2 */
             itemCount: number;
             /** Format: date-time */
@@ -4671,6 +4670,44 @@ export interface components {
             id: string;
             sortOrder: number;
         };
+        PublicDonationIntakeDto: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            emergencyId: string;
+            /** Format: uuid */
+            targetResourceId: string;
+            /** @example ACO-7F3K */
+            intakeCode: string;
+            /** @enum {string} */
+            status: "pending" | "received" | "rejected" | "incomplete";
+            donorName: string;
+            donorPhone?: string | null;
+            donorEmail?: string | null;
+            lines: components["schemas"]["IntakeLineViewDto"][];
+            /** Format: date-time */
+            receivedAt?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        DonationIntakeSearchHitDto: {
+            /** Format: uuid */
+            id: string;
+            /** @example ACO-7F3K */
+            intakeCode: string;
+            donorName: string;
+            donorPhone?: string | null;
+            donorEmail?: string | null;
+            /** @enum {string} */
+            status: "pending" | "received" | "rejected" | "incomplete";
+            /** Format: uuid */
+            targetResourceId: string;
+            itemCount: number;
+            /** Format: date-time */
+            createdAt: string;
+        };
         DonationIntakeViewDto: {
             /** Format: uuid */
             id: string;
@@ -4700,22 +4737,6 @@ export interface components {
             createdAt: string;
             /** Format: date-time */
             updatedAt: string;
-        };
-        DonationIntakeSearchHitDto: {
-            /** Format: uuid */
-            id: string;
-            /** @example ACO-7F3K */
-            intakeCode: string;
-            donorName: string;
-            donorPhone?: string | null;
-            donorEmail?: string | null;
-            /** @enum {string} */
-            status: "pending" | "received" | "rejected" | "incomplete";
-            /** Format: uuid */
-            targetResourceId: string;
-            itemCount: number;
-            /** Format: date-time */
-            createdAt: string;
         };
         IntakeDeepLinkDto: {
             /** @example http://localhost:3001/e/mexico-demo/pre-registro?resourceId=33333333-3333-4333-8333-333333333331 */
@@ -8922,6 +8943,13 @@ export interface operations {
                     "application/json": components["schemas"]["GeocodeResultDto"][];
                 };
             };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     MetricsController_metrics: {
@@ -9666,7 +9694,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DonationIntakeViewDto"];
+                    "application/json": components["schemas"]["PublicDonationIntakeDto"];
                 };
             };
             /** @description Invalid request body */

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -2386,7 +2386,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Download a stored file by key */
+        /** Download a stored file by key (authenticated) */
         get: operations["FilesController_serve"];
         put?: never;
         post?: never;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 overrides:
   ioredis: 5.10.1
+  multer: '>=2.2.0'
+  postcss: '>=8.5.10'
+  js-yaml: '>=4.2.0'
 
 importers:
 
@@ -65,7 +68,7 @@ importers:
         specifier: 5.10.1
         version: 5.10.1
       multer:
-        specifier: ^2.2.0
+        specifier: '>=2.2.0'
         version: 2.2.0
       passport:
         specifier: ^0.7.0
@@ -2612,9 +2615,6 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4105,14 +4105,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -4461,10 +4453,6 @@ packages:
   msgpackr@2.0.2:
     resolution: {integrity: sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==}
 
-  multer@2.1.1:
-    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
-    engines: {node: '>= 10.16.0'}
-
   multer@2.2.0:
     resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
@@ -4789,10 +4777,6 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5112,9 +5096,6 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -6760,7 +6741,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -7090,7 +7071,7 @@ snapshots:
       '@nestjs/core': 11.1.27(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.27)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cors: 2.8.6
       express: 5.2.1
-      multer: 2.1.1
+      multer: 2.2.0
       path-to-regexp: 8.4.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7115,7 +7096,7 @@ snapshots:
       '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.27(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.27)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       lodash: 4.18.1
       path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
@@ -7298,7 +7279,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -7988,10 +7969,6 @@ snapshots:
   append-field@1.0.0: {}
 
   arg@4.1.3: {}
-
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -9891,15 +9868,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -10192,13 +10160,6 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 
-  multer@2.1.1:
-    dependencies:
-      append-field: 1.0.0
-      busboy: 1.6.0
-      concat-stream: 2.0.0
-      type-is: 1.6.18
-
   multer@2.2.0:
     dependencies:
       append-field: 1.0.0
@@ -10224,7 +10185,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
@@ -10546,12 +10507,6 @@ snapshots:
   pngjs@5.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.15
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:
@@ -10927,8 +10882,6 @@ snapshots:
     optional: true
 
   split2@4.2.0: {}
-
-  sprintf-js@1.0.3: {}
 
   stable-hash@0.0.5: {}
 


### PR DESCRIPTION
## Resumen

Auditoría de seguridad completa de la plataforma (API + web + cliente) y remediación de los hallazgos. **No se encontró ningún bypass crítico (P0):** el núcleo de autorización, la parametrización SQL, el aislamiento multi-tenant y el manejo de secretos ya eran sólidos. Todo con TDD (test primero) y respetando DDD/SOLID/clean-code.

### Cambios por commit

**`fix(identity)` — autenticación (P1/P2)**
- **Toma de control de cuenta OAuth (P1):** `AuthenticateWithProvider` ya no auto-vincula una identidad social a una cuenta existente salvo que el proveedor haya verificado el email. Google lee `email_verified`; Facebook se trata como no verificado.
- **Enumeración por timing en login (P2):** `Login` ejecuta siempre una comparación bcrypt (contra un hash dummy) en las rutas de usuario inexistente / sin contraseña.

**`fix(security)` — rate-limiting global (P1/P2)**
- `ThrottlerGuard` como `APP_GUARD` con limitador `default` (200/min por IP) para **toda** la API. `@Throttle` estricto (20/min) en el proxy de geocoding.

**`fix(deps)` — dependencias (P1/P3)**
- Overrides pnpm: `multer >=2.2.0` (advisory High), `postcss >=8.5.10`, `js-yaml >=4.2.0`. `pnpm audit --prod` limpio.

**`fix(privacy)` — filtración de PII (P2/P3)**
- Lookup de donante sin `intakeCode`/`targetResourceId`; necesidades públicas con dirección coarsened en modo `approximate`; PATCH público de intake con proyección sin campos internos; redacción de `manager` en recursos públicos.

**`fix(security)` — configuración (P2/P3)**
- Cookies `Secure` por defecto en prod (web + OAuth API); CORS fail-fast + trim; bcrypt coste 12; rol `citizen` sin `resource:read`/`need:read`/`offer:read`.

**`fix(security)` — misceláneos (P3)**
- `notification-item`: `link` validado con `safeNextPath`. `migrate.sh`: nombre parametrizado (`:'mname'`).

**`fix(security)` — ficheros autenticados (P2)**
- `GET /files/:key` deja de ser world-readable (`JwtAuthGuard`). Proxy same-origin en Next (`app/api/files/[key]`) que reenvía la cookie de sesión como bearer y hace streaming, para que las imágenes sigan cargando. Las fotos solo se muestran en páginas `/manage` autenticadas.

**`fix(security)` — JWT / autorización / subidas (P3)**
- JWT con `issuer`/`audience` emitidos y verificados (además del pin HS256).
- `RevokeGrant` con atenuación: solo se revoca un rol cuyos permisos posee el actor en ese scope (evita despojar a un par más privilegiado).
- Subidas validadas por **magic-bytes** del contenido real, no solo el MIME declarado.

### Decisiones de diseño (documentadas, sin cambio de código)
- **JWT revocation por `tokenVersion` (P3-5):** no existe flujo de cambio de contraseña / logout-all / deshabilitar usuario donde incrementarlo, así que añadir la columna+claim ahora sería infraestructura muerta. El guard ya recarga usuario/grants por request (revocación de grants y borrado son inmediatos). Follow-up: añadirlo junto con ese flujo.
- **Bloqueo por cuenta (P3-9):** introduce un DoS contra la víctima (lockout inducido); con el throttle global por IP y el login timing-safe ya cubiertos, se sigue la recomendación OWASP de no bloquear por cuenta de forma naíf.
- **`GET /groups/:id` (P3-12):** diseño intencional — cualquier autenticado lee la info básica (sin PII; el listado de miembros está gateado) para poder solicitar unirse. Gatearlo rompería ese flujo.
- **`GET /grants/at-scope` (P3-11):** el scope es dinámico (query), la autorización se enforce correctamente en el use case; un decorador estático sería engañoso.
- **Swagger `/docs` (P2-6):** el AGENTS.md lo declara portal público de desarrollador intencional.

## Validación

- [x] Gate completo local (Postgres/Redis en el contenedor): `api build` + `eslint` + `prettier` + `test` **1469/1469**; e2e **318/318**; `api-client build` + `web build` + `web lint`.
- [x] Verifiqué el comportamiento ejecutando toda la suite (unit + e2e).
- [x] `pnpm gen:api` regenerado tras los cambios de DTO/endpoints.

## Cierre

- Trabajo de auditoría ad-hoc (sin issue previo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)