### PR TITLE
fix(deploy): corregir migrate.sh roto — psql no interpola :'var' con -c (hotfix producción)

### DIFF
--- a/deploy/migrate.sh
+++ b/deploy/migrate.sh
@@ -23,14 +23,19 @@ for f in /migrations/*.sql; do
   # Pass the filename as a bound psql variable and quote it with :'mname' so a
   # filename containing a quote can neither break the statement nor inject SQL
   # into the _migrations table (defense-in-depth; filenames are repo-controlled).
-  applied=$($PSQL -v mname="$name" -tAc "SELECT 1 FROM _migrations WHERE name = :'mname'")
+  # NOTE: psql only performs :'var' interpolation for SQL read from stdin/-f,
+  # NOT for -c strings, so the SQL is piped in (a -c form errors with
+  # "syntax error at or near \":\"").
+  applied=$(printf '%s' "SELECT 1 FROM _migrations WHERE name = :'mname';" \
+    | $PSQL -v mname="$name" -tA)
   if [ "$applied" = "1" ]; then
     echo "skip   $name"
     continue
   fi
   echo "apply  $name"
   $PSQL -f "$f"
-  $PSQL -v mname="$name" -c "INSERT INTO _migrations (name) VALUES (:'mname');"
+  printf '%s' "INSERT INTO _migrations (name) VALUES (:'mname');" \
+    | $PSQL -v mname="$name"
 done
 
 echo "migrations up to date"


### PR DESCRIPTION
## Resumen

**Hotfix de producción.** El deploy a EC2 lleva fallando desde el merge de #298: el servicio `migrate` sale con `exit 1` y aborta el `docker compose up`. Los deploys de `6b1035b` (#298) y `e29a537` (#299) fallaron ambos en ese paso.

**Causa:** el hardening P3-17 de #298 parametrizó el nombre de migración con `:'mname'` pero usando la forma `-c`/`-tAc`. **psql solo interpola variables `:'var'` cuando el SQL se lee por stdin o `-f`, NO en cadenas `-c`** → falla con `syntax error at or near ":"`. Reproducido en local:

```
$ psql ... -v mname=x -c "SELECT 1 FROM _migrations WHERE name = :'mname'"
ERROR:  syntax error at or near ":"
```

Como #298 no añadía ninguna migración nueva, el esquema de prod **no cambió**, pero el runner reventaba al comprobar la primera migración ya aplicada.

**Fix:** pasar el SQL por **stdin** (`printf '%s' "... :'mname' ..." | psql -v mname=...`), donde psql sí interpola. Mantiene el parametrizado seguro.

## Validación (local, Postgres 16)

- [x] Reproducido el fallo con la forma `-c` y confirmado el fix por stdin (`exit 0`).
- [x] Simulación completa del flujo apply → registrar → skip idempotente.
- [x] Probado con un nombre de fichero con comilla (`0052_o'brien.sql`): aplica y luego hace skip sin romper ni inyectar.
- [x] `sh -n deploy/migrate.sh` OK.

## Cierre

- Corrige la regresión introducida por #298. Tras mergear, el deploy a EC2 debe volver a completarse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013sSzK1nZV6jNxvemnw4Vzk)_