### PR TITLE
ci(deploy): smoke-test del runner de migraciones en CI (para que un migrate.sh roto falle antes del deploy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,3 +284,56 @@ jobs:
         uses: github/codeql-action/upload-sarif@703b9949c65fcfced30e2f9f41569c4adfcb657f # v3.36.3
         with:
           sarif_file: semgrep.sarif
+
+  # ── Migrate smoke test ──────────────────────────────────────────────────────
+  # Runs the ACTUAL prod migration runner (deploy/migrate.sh) against a real
+  # Postgres and asserts it (1) applies cleanly and (2) is idempotent on re-run.
+  # This is the check that would have caught the psql `:'var'` interpolation bug
+  # that broke the EC2 deploy — the unit/e2e gate never exercises migrate.sh.
+  migrate-smoke:
+    name: Migrate smoke test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: reliefhub
+          POSTGRES_PASSWORD: reliefhub
+          POSTGRES_DB: reliefhub
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd="pg_isready -U reliefhub"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      # migrate.sh reads these; PGHOST/PGPORT/MIGRATIONS_DIR override the prod
+      # container defaults so the same script runs against the mapped service.
+      PGHOST: localhost
+      PGPORT: "5433"
+      POSTGRES_USER: reliefhub
+      POSTGRES_PASSWORD: reliefhub
+      POSTGRES_DB: reliefhub
+      MIGRATIONS_DIR: ${{ github.workspace }}/apps/api/drizzle
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install psql client
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+
+      - name: Apply migrations (fresh DB)
+        run: sh deploy/migrate.sh
+
+      - name: Re-run must be idempotent (nothing re-applied)
+        run: |
+          out=$(sh deploy/migrate.sh)
+          echo "$out"
+          if echo "$out" | grep -q '^apply '; then
+            echo "::error::migrate.sh no es idempotente: reaplicó migraciones en la segunda pasada"
+            exit 1
+          fi
+          echo "OK — segunda pasada sin reaplicar (idempotente)."

--- a/deploy/migrate.sh
+++ b/deploy/migrate.sh
@@ -4,8 +4,16 @@
 # Safe to re-run on every `docker compose up`.
 set -e
 
+# Connection + migrations dir default to the prod container layout, but are
+# overridable so the exact same script can be smoke-tested in CI against a
+# port-mapped Postgres (see the "Migrate smoke test" job). Prod sets none of
+# these, so the defaults below preserve the original behaviour.
+PGHOST="${PGHOST:-postgres}"
+PGPORT="${PGPORT:-5432}"
+MIGRATIONS_DIR="${MIGRATIONS_DIR:-/migrations}"
+
 export PGPASSWORD="$POSTGRES_PASSWORD"
-PSQL="psql -h postgres -U $POSTGRES_USER -d $POSTGRES_DB -v ON_ERROR_STOP=1"
+PSQL="psql -h $PGHOST -p $PGPORT -U $POSTGRES_USER -d $POSTGRES_DB -v ON_ERROR_STOP=1"
 
 # Wait for Postgres (compose healthcheck already gates us, this is a belt-and-braces retry).
 i=0
@@ -17,7 +25,7 @@ done
 
 $PSQL -c "CREATE TABLE IF NOT EXISTS _migrations (name text PRIMARY KEY, applied_at timestamptz DEFAULT now());"
 
-for f in /migrations/*.sql; do
+for f in "$MIGRATIONS_DIR"/*.sql; do
   [ -e "$f" ] || continue
   name=$(basename "$f")
   # Pass the filename as a bound psql variable and quote it with :'mname' so a


### PR DESCRIPTION
## Resumen

Cierra el hueco que dejó caer producción: **el gate de CI nunca ejecutaba `deploy/migrate.sh`**, así que un bug en el runner de migraciones (el `psql :'var'` con `-c`) llegó a un deploy real y tumbó el API. Este PR añade un job que corre el **runner real** contra un Postgres de servicio y verifica que aplica limpio y es idempotente. Un `migrate.sh` roto ahora falla en CI, no en producción.

## Cambios

**`deploy/migrate.sh` — parametrizado (sin cambiar el comportamiento de prod)**
- Nuevas variables con **defaults idénticos al layout del contenedor de producción**: `PGHOST` (`postgres`), `PGPORT` (`5432`), `MIGRATIONS_DIR` (`/migrations`). Prod no define ninguna → comportamiento intacto. Solo sirven para que el **mismo** script se pueda ejecutar en CI contra el Postgres mapeado del runner.

**`.github/workflows/ci.yml` — job `Migrate smoke test`**
- Levanta un `postgres:16` de servicio y ejecuta `deploy/migrate.sh` dos veces:
  1. **Primera pasada:** aplica todas las migraciones desde cero (debe salir `exit 0`).
  2. **Segunda pasada:** debe ser **idempotente** — falla el job si alguna migración se reaplica.

> El `migrate.sh` que rompió el deploy habría fallado la primera pasada con `syntax error at or near ":"`, así que este job lo habría cazado antes de mergear.

## Validación (local, Postgres 16)

- [x] `sh -n deploy/migrate.sh` OK · YAML de `ci.yml` OK.
- [x] Ejecutado el script parametrizado contra una BD limpia: **58 migraciones aplicadas** (1ª pasada, exit 0), **58 `skip` / 0 `apply`** (2ª pasada, idempotente, exit 0).
- [x] Confirmado que los defaults preservan el comportamiento de producción (host `postgres`, dir `/migrations`).

## Recomendación

Añadir **`Migrate smoke test`** (y, cuando triéis su línea base, `Test e2e`) a los **required status checks** de la protección de `main` para que bloqueen el merge. Este PR solo puede añadir el job; marcarlo como requerido es un ajuste de settings del repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013sSzK1nZV6jNxvemnw4Vzk)_