### PR TITLE
fix(web): clearToken() best-effort — el 401 con token caducado redirige a login en vez de romper el render

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -47,12 +47,20 @@ export async function setToken(token: string): Promise<void> {
 }
 
 /**
- * Removes the auth token cookie (logout).
- * Must only be called from Server Actions.
+ * Removes the auth token cookie (logout). Best-effort: Next.js only allows
+ * cookie mutation in Server Actions and Route Handlers, so when this runs
+ * during Server Component render (a fetch helper reacting to a 401 from an
+ * expired token) the deletion is skipped instead of crashing the render —
+ * callers redirect to login right after, and the stale cookie is overwritten
+ * by the next successful login.
  */
 export async function clearToken(): Promise<void> {
   const jar = await cookies();
-  jar.delete(COOKIE_NAME);
+  try {
+    jar.delete(COOKIE_NAME);
+  } catch {
+    // Server Component render: cookies are read-only here.
+  }
 }
 
 /**


### PR DESCRIPTION
## Resumen

Los helpers de fetch que las páginas llaman durante el render de Server Components (`fetchMyInventory`, `fetchMyResources`, `resolveManageAccess`, los `fetch*` de admin, las páginas de `/manage`, recepción, etc.) manejan el 401 con `await clearToken(); redirect(loginHref(next))`. Next.js solo permite mutar cookies en Server Actions y Route Handlers, así que con un token **presente pero caducado** (volver a una pestaña abierta con la sesión de 8h vencida) `clearToken()` lanzaba `Cookies can only be modified in a Server Action or Route Handler` y el usuario veía un 500 en lugar del redirect a login.

En vez de tocar los ~25 ficheros afectados call site a call site, el fix va a la raíz compartida: `clearToken()` (`apps/web/src/lib/auth.ts`) pasa a ser **best-effort** — intenta borrar la cookie y, si el runtime lo prohíbe (camino de render), lo omite y deja que el `redirect(loginHref(next))` que siempre le sigue haga su trabajo. La cookie obsoleta que queda es inocua (el JWT ya no valida; cualquier página protegida vuelve a redirigir a login) y se sobreescribe en el siguiente login. En Server Actions (logout, submits) el comportamiento no cambia. Esto cubre también los call sites futuros que repitan el patrón.

## Validación

- [x] Pasé el gate que toca para esta zona del repo: `pnpm --filter @reliefhub/api-client build`, `pnpm --filter web build`, `pnpm --filter web lint` (solo la warning preexistente de `no-img-element`, no relacionada) y `pnpm --filter web test` (86 pass). Cambio web-only: no toca API ni DTOs.
- [x] Verifiqué el comportamiento manualmente: build de producción (`next start`) contra un stub de API que responde 401 a todo, con cookie `rh_token` caducada/basura:
  - **Antes** — `GET /e/{slug}/mis-puntos/{id}/inventario` → **500** + `⨯ Error: Cookies can only be modified in a Server Action or Route Handler` en el log del servidor.
  - **Después** — misma petición → **307** a `/login?next=%2Fe%2F...%2Finventario` (vuelve a la página exacta) y cero errores en el log.
- [x] Docs/migraciones/cliente API: no aplica (sin cambios de esquema ni de endpoints); el contrato queda documentado en el docstring de `clearToken()`.

## Cierre

- Closes #295

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJbo9K6vbfn6e8dTiuAvET)_