### PR TITLE
fix(resources): GET /resources/mine cross-emergency para gestores con grant entity-scoped

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1380,6 +1380,40 @@
         ]
       }
     },
+    "/resources/mine": {
+      "get": {
+        "description": "Union of the resources the principal owns and the ones reached through an entity-scoped grant (e.g. `point_manager`). Unlike `/emergencies/{emergencyId}/resources/mine`, this needs no emergency in the path, so it also serves principals whose only grant is entity-scoped (#285). Each row carries its emergency id and slug.",
+        "operationId": "ResourcesController_listMineAcrossEmergencies",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Resources the principal manages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MyManagedResourceDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List the resources the authenticated principal manages, across every emergency",
+        "tags": [
+          "resources"
+        ]
+      }
+    },
     "/emergencies/{emergencyId}/resources/mine": {
       "get": {
         "operationId": "ResourcesController_listMyResources",
@@ -10020,6 +10054,50 @@
         },
         "required": [
           "status"
+        ]
+      },
+      "MyManagedResourceDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "collection_point",
+              "delivery_point",
+              "collection_and_delivery",
+              "warehouse",
+              "transport",
+              "supplier",
+              "venue"
+            ],
+            "example": "collection_point"
+          },
+          "name": {
+            "type": "string",
+            "example": "Cruz Roja Madrid"
+          },
+          "emergencyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "emergencySlug": {
+            "type": "string",
+            "example": "terremoto-venezuela-2026",
+            "nullable": true,
+            "description": "Slug of the owning emergency; null if its row is missing."
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "name",
+          "emergencyId",
+          "emergencySlug"
         ]
       },
       "LocationViewDto": {

--- a/apps/api/src/contexts/resources/application/get-my-managed-resources.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-my-managed-resources.spec.ts
@@ -1,0 +1,173 @@
+import {
+  GetMyManagedResources,
+  PrincipalGrant,
+} from './get-my-managed-resources';
+import { RegisterResource } from './register-resource';
+import { InMemoryResourceRepository } from '../infrastructure/in-memory-resource.repository';
+import { FakeEventBus } from '../infrastructure/fake-event-bus';
+import { ResourceType } from '../domain/resource-enums';
+import { ResourceEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const EM_2 = '22222222-2222-4222-8222-222222222222';
+const OWNER_ID = 'owner-user-0000-0000-000000000000';
+const MANAGER_ID = 'manager-user-0000-0000-000000000000';
+const baseLocation = {
+  address: 'Calle Test 1, Madrid',
+  latitude: 40.4168,
+  longitude: -3.7038,
+};
+
+const activeReader: ResourceEmergencyStatusReader = {
+  getStatus: () => Promise.resolve('active'),
+};
+
+const NOW = new Date('2026-07-02T12:00:00Z');
+
+function entityGrant(
+  resourceId: string,
+  overrides: Partial<PrincipalGrant> = {},
+): PrincipalGrant {
+  return {
+    roleId: 'point_manager',
+    scope: { type: 'entity', entityType: 'resource', id: resourceId },
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+async function makeResource(
+  repo: InMemoryResourceRepository,
+  bus: FakeEventBus,
+  q: { name: string; ownerUserId: string; emergencyId?: string },
+): Promise<string> {
+  const { id } = await new RegisterResource(repo, bus, activeReader).execute({
+    emergencyId: q.emergencyId ?? EM,
+    type: ResourceType.CollectionPoint,
+    name: q.name,
+    location: baseLocation,
+    ownerUserId: q.ownerUserId,
+  });
+  return id;
+}
+
+describe('GetMyManagedResources', () => {
+  it('returns the resources the principal owns, across emergencies', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    await makeResource(repo, bus, { name: 'Acopio A', ownerUserId: OWNER_ID });
+    await makeResource(repo, bus, {
+      name: 'Acopio B',
+      ownerUserId: OWNER_ID,
+      emergencyId: EM_2,
+    });
+    await makeResource(repo, bus, { name: 'Ajeno', ownerUserId: 'other' });
+
+    const views = await new GetMyManagedResources(repo).execute(
+      OWNER_ID,
+      [],
+      NOW,
+    );
+
+    expect(views.map((v) => v.name).sort()).toEqual(['Acopio A', 'Acopio B']);
+    expect(views.map((v) => v.emergencyId).sort()).toEqual([EM, EM_2]);
+  });
+
+  it('returns resources reached only through an entity-scoped grant (issue #285)', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, {
+      name: 'Acopio gestionado',
+      ownerUserId: OWNER_ID,
+    });
+
+    const views = await new GetMyManagedResources(repo).execute(
+      MANAGER_ID,
+      [entityGrant(id)],
+      NOW,
+    );
+
+    expect(views).toEqual([
+      {
+        id,
+        type: ResourceType.CollectionPoint,
+        name: 'Acopio gestionado',
+        emergencyId: EM,
+        emergencySlug: null,
+      },
+    ]);
+  });
+
+  it('does not duplicate a resource that is both owned and granted', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, {
+      name: 'Acopio propio',
+      ownerUserId: OWNER_ID,
+    });
+
+    const views = await new GetMyManagedResources(repo).execute(
+      OWNER_ID,
+      [entityGrant(id)],
+      NOW,
+    );
+
+    expect(views).toHaveLength(1);
+  });
+
+  it('ignores expired grants', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, {
+      name: 'Acopio caducado',
+      ownerUserId: OWNER_ID,
+    });
+
+    const views = await new GetMyManagedResources(repo).execute(
+      MANAGER_ID,
+      [entityGrant(id, { expiresAt: '2026-07-01T00:00:00Z' })],
+      NOW,
+    );
+
+    expect(views).toEqual([]);
+  });
+
+  it('ignores grants that are not entity-scoped to a resource', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, {
+      name: 'Acopio',
+      ownerUserId: OWNER_ID,
+    });
+
+    const views = await new GetMyManagedResources(repo).execute(MANAGER_ID, [
+      {
+        roleId: 'coordinator',
+        scope: { type: 'emergency', id: EM },
+        expiresAt: null,
+      },
+      {
+        roleId: 'group_manager',
+        scope: { type: 'entity', entityType: 'group', id },
+        expiresAt: null,
+      },
+      {
+        roleId: 'point_manager',
+        scope: { type: 'entity', entityType: 'resource' },
+        expiresAt: null,
+      },
+    ]);
+
+    expect(views).toEqual([]);
+  });
+
+  it('returns an empty list for a principal with nothing to manage', async () => {
+    const repo = new InMemoryResourceRepository();
+    const views = await new GetMyManagedResources(repo).execute(
+      MANAGER_ID,
+      [],
+      NOW,
+    );
+    expect(views).toEqual([]);
+  });
+});

--- a/apps/api/src/contexts/resources/application/get-my-managed-resources.ts
+++ b/apps/api/src/contexts/resources/application/get-my-managed-resources.ts
@@ -1,0 +1,71 @@
+import { ResourceRepository } from '../domain/ports/resource.repository';
+import { ResourceType } from '../domain/resource-enums';
+
+/**
+ * One resource the principal manages, reduced to what the app shell needs to
+ * list and link it (issue #285). Deliberately NOT the full ResourceView: this
+ * backs a navigation surface, so it carries no address/contact/inventory.
+ */
+export interface MyManagedResourceView {
+  id: string;
+  type: ResourceType;
+  name: string;
+  emergencyId: string;
+  /** Null when the owning emergency row is missing. */
+  emergencySlug: string | null;
+}
+
+/**
+ * A grant as it reaches this use case — the controller passes the
+ * already-resolved request grants (see {@link AuthenticatedUser}). Only the
+ * fields needed to resolve resource entity scope are required.
+ */
+export interface PrincipalGrant {
+  roleId: string;
+  scope: { type: string; entityType?: string; id?: string };
+  expiresAt: string | null;
+}
+
+/**
+ * Lists the resources the authenticated principal manages, across every
+ * emergency: the ones they own (`ownerUserId`) plus the ones reached through
+ * an active entity-scoped grant on a resource (e.g. `point_manager`). This is
+ * what `/emergencies/{id}/resources/mine` cannot answer for a principal whose
+ * only grant is entity-scoped — they hold no emergency grant, so the emergency
+ * to iterate is unknown (issue #285). Expired grants are ignored; the role is
+ * irrelevant (any entity grant on the resource surfaces it).
+ */
+export class GetMyManagedResources {
+  constructor(private readonly repo: ResourceRepository) {}
+
+  async execute(
+    userId: string,
+    grants: PrincipalGrant[],
+    now: Date = new Date(),
+  ): Promise<MyManagedResourceView[]> {
+    const grantedIds = new Set<string>();
+    for (const g of grants) {
+      if (g.scope.type !== 'entity' || g.scope.entityType !== 'resource') {
+        continue;
+      }
+      const scopeId = g.scope.id;
+      if (scopeId == null || scopeId === '') continue;
+      if (
+        g.expiresAt != null &&
+        new Date(g.expiresAt).getTime() <= now.getTime()
+      ) {
+        continue;
+      }
+      grantedIds.add(scopeId);
+    }
+
+    const rows = await this.repo.findOwnedOrGranted(userId, [...grantedIds]);
+    return rows.map(({ resource, emergencySlug }) => ({
+      id: resource.id.value,
+      type: resource.type,
+      name: resource.name,
+      emergencyId: resource.emergencyId.value,
+      emergencySlug,
+    }));
+  }
+}

--- a/apps/api/src/contexts/resources/domain/ports/resource.repository.ts
+++ b/apps/api/src/contexts/resources/domain/ports/resource.repository.ts
@@ -20,6 +20,18 @@ export interface ResourceWithEmergency {
   emergencyName: string | null;
 }
 
+/**
+ * A resource the principal manages, labelled with its emergency slug so the
+ * caller can build per-emergency links without an extra lookup. Cross-emergency
+ * by design: it backs `GET /resources/mine`, which must surface a point whose
+ * manager holds only an entity-scoped grant (no emergency grant, issue #285).
+ * `emergencySlug` is null when the emergency row is missing.
+ */
+export interface ResourceWithEmergencySlug {
+  resource: Resource;
+  emergencySlug: string | null;
+}
+
 export interface ResourceRepository {
   save(resource: Resource): Promise<void>;
   findById(id: ResourceId): Promise<Resource | null>;
@@ -49,6 +61,16 @@ export interface ResourceRepository {
     ownerUserId: string,
     emergencyId: EmergencyId,
   ): Promise<Resource[]>;
+  /**
+   * Resources the principal manages, across ALL emergencies (any status):
+   * the ones they own (`ownerUserId`) plus the ones reached through an
+   * entity-scoped grant (`grantedResourceIds`). Each row carries its emergency
+   * slug (see {@link ResourceWithEmergencySlug}).
+   */
+  findOwnedOrGranted(
+    ownerUserId: string,
+    grantedResourceIds: string[],
+  ): Promise<ResourceWithEmergencySlug[]>;
   /** Visible public resources: Active, Saturated, Paused (excludes Hidden and Closed). */
   findVisibleByEmergency(emergencyId: EmergencyId): Promise<Resource[]>;
   /** Resources currently flagged `disputed` (citizen reports pending review). */

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
@@ -1719,4 +1719,84 @@ describe('DrizzleResourceRepository (integration)', () => {
       expect(found).toBeNull();
     });
   });
+
+  // ── Cross-emergency "mine" read (#285): owner ∪ entity-granted, with slug ──
+  describe('findOwnedOrGranted', () => {
+    const EM3 = '55555555-5555-4555-8555-555555555555';
+    const MANAGER_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    async function seed(props: {
+      emergencyId: string;
+      name: string;
+      ownerUserId: string;
+    }): Promise<string> {
+      const r = Resource.register({
+        id: ResourceId.create(),
+        emergencyId: EmergencyId.fromString(props.emergencyId),
+        type: ResourceType.CollectionPoint,
+        name: props.name,
+        location: baseLocation,
+        ownerUserId: props.ownerUserId,
+      });
+      await repo.save(r);
+      return r.id.value;
+    }
+
+    beforeAll(async () => {
+      await db
+        .insert(emergenciesTable)
+        .values({
+          id: EM3,
+          name: 'Terremoto Test 285',
+          slug: 'terremoto-test-285',
+          country: 'VE',
+          status: 'active',
+          createdAt: new Date(),
+        })
+        .onConflictDoNothing();
+    });
+
+    it('returns owned ∪ granted across emergencies, each with its slug, without duplicates', async () => {
+      const owned = await seed({
+        emergencyId: EM3,
+        name: 'Acopio propio',
+        ownerUserId: OWNER_ID,
+      });
+      const granted = await seed({
+        emergencyId: EM,
+        name: 'Acopio gestionado',
+        ownerUserId: MANAGER_ID,
+      });
+      await seed({
+        emergencyId: EM,
+        name: 'Acopio ajeno',
+        ownerUserId: MANAGER_ID,
+      });
+
+      const rows = await repo.findOwnedOrGranted(OWNER_ID, [granted, owned]);
+
+      expect(rows).toHaveLength(2);
+      const byId = new Map(rows.map((r) => [r.resource.id.value, r]));
+      expect(byId.get(owned)?.emergencySlug).toBe('terremoto-test-285');
+      expect(byId.get(granted)?.resource.name).toBe('Acopio gestionado');
+    });
+
+    it('with no granted ids returns only the owned resources', async () => {
+      await seed({
+        emergencyId: EM3,
+        name: 'Solo propio',
+        ownerUserId: OWNER_ID,
+      });
+      await seed({
+        emergencyId: EM3,
+        name: 'De otro',
+        ownerUserId: MANAGER_ID,
+      });
+
+      const rows = await repo.findOwnedOrGranted(OWNER_ID, []);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.resource.name).toBe('Solo propio');
+    });
+  });
 });

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, between, count, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, between, count, eq, inArray, or, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { Db } from '../../../../shared/db';
 import { resourcesTable, resourceItemsTable } from './schema';
@@ -6,6 +6,7 @@ import { emergenciesTable } from '../../../emergencies/infrastructure/drizzle/sc
 import {
   ResourceRepository,
   ResourceWithEmergency,
+  ResourceWithEmergencySlug,
 } from '../../domain/ports/resource.repository';
 import { Resource, ResourceSnapshot, Provenance } from '../../domain/resource';
 import { AuthorSnapshot } from '../../../../shared/domain/author';
@@ -402,6 +403,41 @@ export class DrizzleResourceRepository implements ResourceRepository {
         ),
       );
     return rows.map((r) => Resource.fromSnapshot(rowToSnapshot(r)));
+  }
+
+  async findOwnedOrGranted(
+    ownerUserId: string,
+    grantedResourceIds: string[],
+  ): Promise<ResourceWithEmergencySlug[]> {
+    // A single OR keeps a resource that is both owned and granted as one row.
+    // Guard the inArray: drizzle rejects an empty id list.
+    const whereClause =
+      grantedResourceIds.length > 0
+        ? or(
+            eq(resourcesTable.ownerUserId, ownerUserId),
+            inArray(resourcesTable.id, grantedResourceIds),
+          )
+        : eq(resourcesTable.ownerUserId, ownerUserId);
+
+    // LEFT JOIN resolves the emergency slug in the same query (no N+1); LEFT so
+    // an orphaned resource still appears (slug → null) instead of vanishing.
+    const rows = await this.db
+      .select({
+        resource: resourcesTable,
+        emergencySlug: emergenciesTable.slug,
+      })
+      .from(resourcesTable)
+      .leftJoin(
+        emergenciesTable,
+        eq(resourcesTable.emergencyId, emergenciesTable.id),
+      )
+      .where(whereClause)
+      .orderBy(asc(resourcesTable.name), asc(resourcesTable.id));
+
+    return rows.map((r) => ({
+      resource: Resource.fromSnapshot(rowToSnapshot(r.resource)),
+      emergencySlug: r.emergencySlug ?? null,
+    }));
   }
 
   async findAllPaged(q: {

--- a/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
@@ -33,6 +33,10 @@ import { PublishResource } from '../../application/publish-resource';
 import { UpdateResourcePublicStatus } from '../../application/update-resource-public-status';
 import { GetMyResources } from '../../application/get-my-resources';
 import {
+  GetMyManagedResources,
+  MyManagedResourceView,
+} from '../../application/get-my-managed-resources';
+import {
   EditResource,
   EditResourceCommand,
 } from '../../application/edit-resource';
@@ -65,6 +69,7 @@ import { setAuditContext } from '../../../audit/infrastructure/http/audit-contex
 import {
   RegisterResourceResponseDto,
   ResourceViewDto,
+  MyManagedResourceDto,
   ReportResourceValidityResponseDto,
   ValidityReportDto,
 } from './response.dto';
@@ -88,6 +93,7 @@ export class ResourcesController {
     private readonly publish: PublishResource,
     private readonly updateStatus: UpdateResourcePublicStatus,
     private readonly getMyResources: GetMyResources,
+    private readonly getMyManagedResources: GetMyManagedResources,
     private readonly editResource: EditResource,
     private readonly discardResource: DiscardResource,
     private readonly recordInventoryEntry: RecordInventoryEntry,
@@ -410,6 +416,39 @@ export class ResourcesController {
       targetStatus: statusMap[dto.status],
       requesterUserId: req.user!.id,
     });
+  }
+
+  @Get('resources/mine')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'List the resources the authenticated principal manages, across every emergency',
+    description:
+      'Union of the resources the principal owns and the ones reached through ' +
+      'an entity-scoped grant (e.g. `point_manager`). Unlike ' +
+      '`/emergencies/{emergencyId}/resources/mine`, this needs no emergency in ' +
+      'the path, so it also serves principals whose only grant is ' +
+      'entity-scoped (#285). Each row carries its emergency id and slug.',
+  })
+  @ApiOkResponse({
+    description: 'Resources the principal manages',
+    type: MyManagedResourceDto,
+    isArray: true,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  async listMineAcrossEmergencies(
+    @Req() req: Request & { user?: AuthenticatedUser },
+  ): Promise<MyManagedResourceView[]> {
+    const user = req.user!;
+    return this.getMyManagedResources.execute(
+      user.id,
+      user.grants.map((g) => ({
+        roleId: g.roleId,
+        scope: g.scope,
+        expiresAt: g.expiresAt,
+      })),
+    );
   }
 
   @Get('emergencies/:emergencyId/resources/mine')

--- a/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/response.dto.ts
@@ -18,6 +18,35 @@ export class RegisterResourceResponseDto {
   id!: string;
 }
 
+/**
+ * One resource the authenticated principal manages (owner or entity-scoped
+ * grant), reduced to what a navigation surface needs (issue #285).
+ */
+export class MyManagedResourceDto {
+  @ApiProperty({
+    format: 'uuid',
+    example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+  })
+  id!: string;
+
+  @ApiProperty({ enum: ResourceType, example: ResourceType.CollectionPoint })
+  type!: ResourceType;
+
+  @ApiProperty({ example: 'Cruz Roja Madrid' })
+  name!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  emergencyId!: string;
+
+  @ApiProperty({
+    example: 'terremoto-venezuela-2026',
+    nullable: true,
+    type: String,
+    description: 'Slug of the owning emergency; null if its row is missing.',
+  })
+  emergencySlug!: string | null;
+}
+
 export class LocationViewDto {
   @ApiProperty({ example: 'Calle Mayor 1, Valencia' })
   address!: string;

--- a/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
@@ -1,6 +1,7 @@
 import {
   ResourceRepository,
   ResourceWithEmergency,
+  ResourceWithEmergencySlug,
 } from '../domain/ports/resource.repository';
 import { Resource } from '../domain/resource';
 import { ResourceId } from '../domain/resource-id';
@@ -146,6 +147,22 @@ export class InMemoryResourceRepository implements ResourceRepository {
           s.emergencyId === emergencyId.value && s.ownerUserId === ownerUserId,
       )
       .map((s) => Resource.fromSnapshot(s));
+    return Promise.resolve(result);
+  }
+
+  findOwnedOrGranted(
+    ownerUserId: string,
+    grantedResourceIds: string[],
+  ): Promise<ResourceWithEmergencySlug[]> {
+    // This store holds no emergencies, so the slug is always null here; the
+    // slug join is covered by the Drizzle integration spec.
+    const granted = new Set(grantedResourceIds);
+    const result = [...this.store.values()]
+      .filter((s) => s.ownerUserId === ownerUserId || granted.has(s.id))
+      .map((s) => ({
+        resource: Resource.fromSnapshot(s),
+        emergencySlug: null,
+      }));
     return Promise.resolve(result);
   }
 

--- a/apps/api/src/contexts/resources/infrastructure/resources.module.ts
+++ b/apps/api/src/contexts/resources/infrastructure/resources.module.ts
@@ -17,6 +17,7 @@ import { GetNearbyResources } from '../application/get-nearby-resources';
 import { GetResourcesInBounds } from '../application/get-resources-in-bounds';
 import { GetPublicResource } from '../application/get-public-resource';
 import { GetMyResources } from '../application/get-my-resources';
+import { GetMyManagedResources } from '../application/get-my-managed-resources';
 import { VerifyResource } from '../application/verify-resource';
 import { PublishResource } from '../application/publish-resource';
 import { EditResource } from '../application/edit-resource';
@@ -239,6 +240,12 @@ const getMyResourcesProvider = {
   useFactory: (repo: ResourceRepository) => new GetMyResources(repo),
 };
 
+const getMyManagedResourcesProvider = {
+  provide: GetMyManagedResources,
+  inject: [RESOURCE_REPOSITORY],
+  useFactory: (repo: ResourceRepository) => new GetMyManagedResources(repo),
+};
+
 const getResourcesInBoundsProvider = {
   provide: GetResourcesInBounds,
   inject: [RESOURCE_REPOSITORY],
@@ -406,6 +413,7 @@ const recordInventoryEntryProvider = {
     getMyInventoryProvider,
     updateMyInventoryProvider,
     getMyResourcesProvider,
+    getMyManagedResourcesProvider,
     getResourcesInBoundsProvider,
     getPublicResourceProvider,
     recipientTypeRepositoryProvider,

--- a/apps/api/test/resources-mine.e2e-spec.ts
+++ b/apps/api/test/resources-mine.e2e-spec.ts
@@ -1,0 +1,261 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import type { Server } from 'node:http';
+import request from 'supertest';
+import { inArray } from 'drizzle-orm';
+import * as bcrypt from 'bcryptjs';
+import { AppModule } from '../src/app.module';
+import { DomainExceptionFilter } from '../src/contexts/resources/infrastructure/http/domain-exception.filter';
+import { createDb } from '../src/shared/db';
+import {
+  usersTable,
+  grantsTable,
+} from '../src/contexts/identity/infrastructure/drizzle/schema';
+import { emergenciesTable } from '../src/contexts/emergencies/infrastructure/drizzle/schema';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+
+// UUIDs distinct from the other resource e2e files.
+const OWNER_ID = '28500000-0000-4000-8000-000000000001';
+const MANAGER_ID = '28500000-0000-4000-8000-000000000002';
+const STRANGER_ID = '28500000-0000-4000-8000-000000000003';
+const GRANT_ID = '28500000-0000-4000-8000-000000000004';
+
+const baseLocation = {
+  address: 'Av. Urdaneta 10, Caracas',
+  latitude: 10.5061,
+  longitude: -66.9146,
+};
+
+interface MineRow {
+  id: string;
+  type: string;
+  name: string;
+  emergencyId: string;
+  emergencySlug: string | null;
+}
+
+/**
+ * `GET /resources/mine` (#285): the panel of a `point_manager` whose ONLY
+ * grant is entity-scoped to their resource. Such a principal holds no
+ * emergency-scoped grant, so `/emergencies/mine` is empty and the per-emergency
+ * `/emergencies/{id}/resources/mine` can never be reached — this cross-emergency
+ * endpoint is what surfaces their point.
+ */
+describe('GET /resources/mine (e2e, #285)', () => {
+  let app: INestApplication;
+  let server: Server;
+  let ownerToken: string;
+  let managerToken: string;
+  let strangerToken: string;
+  let ownedResourceId: string;
+  let managedResourceId: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new DomainExceptionFilter());
+    await app.init();
+    server = app.getHttpServer() as Server;
+
+    const { db, pool } = createDb(
+      process.env.DATABASE_URL ??
+        'postgres://reliefhub:reliefhub@localhost:5433/reliefhub_test',
+    );
+    try {
+      await db
+        .delete(grantsTable)
+        .where(inArray(grantsTable.principalId, [MANAGER_ID]));
+      await db
+        .delete(usersTable)
+        .where(inArray(usersTable.id, [OWNER_ID, MANAGER_ID, STRANGER_ID]));
+
+      // Upsert the shared emergency: this spec asserts the canonical slug, so
+      // force it in case another e2e file inserted the id with other values.
+      await db
+        .insert(emergenciesTable)
+        .values({
+          id: EM,
+          name: 'Terremoto Venezuela 2026',
+          slug: 'terremoto-venezuela-2026',
+          country: 'VE',
+          status: 'active',
+          createdAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: emergenciesTable.id,
+          set: {
+            name: 'Terremoto Venezuela 2026',
+            slug: 'terremoto-venezuela-2026',
+            country: 'VE',
+            status: 'active',
+          },
+        });
+
+      const hash = await bcrypt.hash('Password1!', 10);
+      await db
+        .insert(usersTable)
+        .values([
+          {
+            id: OWNER_ID,
+            email: 'owner-mine285@reliefhub.org',
+            passwordHash: hash,
+            name: 'Mine Owner',
+            isAdmin: false,
+          },
+          {
+            id: MANAGER_ID,
+            email: 'manager-mine285@reliefhub.org',
+            passwordHash: hash,
+            name: 'Mine Manager',
+            isAdmin: false,
+          },
+          {
+            id: STRANGER_ID,
+            email: 'stranger-mine285@reliefhub.org',
+            passwordHash: hash,
+            name: 'Mine Stranger',
+            isAdmin: false,
+          },
+        ])
+        .onConflictDoNothing();
+    } finally {
+      await pool.end();
+    }
+
+    const [ownerRes, managerRes, strangerRes] = await Promise.all([
+      request(server)
+        .post('/auth/login')
+        .send({ email: 'owner-mine285@reliefhub.org', password: 'Password1!' })
+        .expect(200),
+      request(server)
+        .post('/auth/login')
+        .send({
+          email: 'manager-mine285@reliefhub.org',
+          password: 'Password1!',
+        })
+        .expect(200),
+      request(server)
+        .post('/auth/login')
+        .send({
+          email: 'stranger-mine285@reliefhub.org',
+          password: 'Password1!',
+        })
+        .expect(200),
+    ]);
+    ownerToken = (ownerRes.body as { accessToken: string }).accessToken;
+    managerToken = (managerRes.body as { accessToken: string }).accessToken;
+    strangerToken = (strangerRes.body as { accessToken: string }).accessToken;
+
+    // The owner registers two points; the second is run by MANAGER via an
+    // entity-scoped grant (the acopiove.org-import shape: imported points get a
+    // point_manager, not an owner).
+    const created1 = await request(server)
+      .post(`/emergencies/${EM}/resources`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({
+        type: 'collection_point',
+        name: 'Acopio propio 285',
+        location: baseLocation,
+      })
+      .expect(201);
+    ownedResourceId = (created1.body as { id: string }).id;
+
+    const created2 = await request(server)
+      .post(`/emergencies/${EM}/resources`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({
+        type: 'collection_point',
+        name: 'Acopio gestionado 285',
+        location: baseLocation,
+      })
+      .expect(201);
+    managedResourceId = (created2.body as { id: string }).id;
+
+    const { db: db2, pool: pool2 } = createDb(
+      process.env.DATABASE_URL ??
+        'postgres://reliefhub:reliefhub@localhost:5433/reliefhub_test',
+    );
+    try {
+      await db2
+        .insert(grantsTable)
+        .values({
+          id: GRANT_ID,
+          principalId: MANAGER_ID,
+          principalType: 'user',
+          roleId: 'point_manager',
+          scopeType: 'entity',
+          scopeEntityType: 'resource',
+          scopeId: managedResourceId,
+          grantedAt: new Date(),
+        })
+        .onConflictDoNothing();
+    } finally {
+      await pool2.end();
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('rejects anonymous callers', async () => {
+    await request(server).get('/resources/mine').expect(401);
+  });
+
+  it('surfaces the point of a manager whose ONLY grant is entity-scoped (#285)', async () => {
+    const res = await request(server)
+      .get('/resources/mine')
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200);
+
+    const rows = res.body as MineRow[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      id: managedResourceId,
+      type: 'collection_point',
+      name: 'Acopio gestionado 285',
+      emergencyId: EM,
+      emergencySlug: 'terremoto-venezuela-2026',
+    });
+
+    // The failing precondition of #285: no emergency-scoped grant, so the old
+    // per-emergency aggregation had nothing to iterate.
+    const mine = await request(server)
+      .get('/emergencies/mine')
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200);
+    expect(mine.body).toEqual([]);
+  });
+
+  it('returns every resource the owner owns, including grant-managed ones, without duplicates', async () => {
+    const res = await request(server)
+      .get('/resources/mine')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .expect(200);
+
+    const rows = res.body as MineRow[];
+    const ids = rows.map((r) => r.id);
+    expect(ids).toHaveLength(2);
+    expect(ids).toEqual(
+      expect.arrayContaining([ownedResourceId, managedResourceId]),
+    );
+  });
+
+  it('returns an empty list for a principal with nothing to manage', async () => {
+    const res = await request(server)
+      .get('/resources/mine')
+      .set('Authorization', `Bearer ${strangerToken}`)
+      .expect(200);
+    expect(res.body).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/navigation-data.ts
+++ b/apps/web/src/lib/navigation-data.ts
@@ -99,24 +99,20 @@ export const getMyGroups = cache(async () => {
   return (data ?? []).map((g) => ({ id: g.id, name: g.name }));
 });
 
-/** Resources are emergency-scoped: aggregate `resources/mine` across the principal's
- *  emergencies. Carries every resource type (collection points, warehouses, transport,
- *  suppliers, venues, …) — the principal manages all of it, not just collection points.
- *  N+1 cached calls (see Global Constraints ceiling). */
+/** The resources the principal manages — owned plus entity-granted — in one call
+ *  to `/resources/mine`. Cross-emergency by design: a `point_manager` whose only
+ *  grant is entity-scoped holds no emergency grant, so the old per-emergency
+ *  aggregation over `getMyEmergencies()` never surfaced their point (#285).
+ *  Carries every resource type (collection points, warehouses, transport,
+ *  suppliers, venues, …) — the principal manages all of it, not just collection
+ *  points. */
 export const getMyResources = cache(async () => {
   const token = await getToken();
   if (token == null) return [];
-  const emergencies = await getMyEmergencies();
-  const perEmergency = await Promise.all(
-    emergencies.map(async (e) => {
-      const { data } = await api.GET('/emergencies/{emergencyId}/resources/mine', {
-        headers: authHeaders(token),
-        params: { path: { emergencyId: e.id } },
-      });
-      return (data ?? []).map((r) => ({ id: r.id, name: r.name, resourceType: r.type }));
-    }),
-  );
-  return perEmergency.flat();
+  const { data } = await api.GET('/resources/mine', {
+    headers: authHeaders(token),
+  });
+  return (data ?? []).map((r) => ({ id: r.id, name: r.name, resourceType: r.type }));
 });
 
 export const getPrincipalContexts = cache(async (): Promise<PrincipalContext[]> => {

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -471,6 +471,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/resources/mine": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the resources the authenticated principal manages, across every emergency
+         * @description Union of the resources the principal owns and the ones reached through an entity-scoped grant (e.g. `point_manager`). Unlike `/emergencies/{emergencyId}/resources/mine`, this needs no emergency in the path, so it also serves principals whose only grant is entity-scoped (#285). Each row carries its emergency id and slug.
+         */
+        get: operations["ResourcesController_listMineAcrossEmergencies"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/emergencies/{emergencyId}/resources/mine": {
         parameters: {
             query?: never;
@@ -3159,6 +3179,27 @@ export interface components {
              * @enum {string}
              */
             status: "active" | "saturated" | "paused" | "closed";
+        };
+        MyManagedResourceDto: {
+            /**
+             * Format: uuid
+             * @example 3fa85f64-5717-4562-b3fc-2c963f66afa6
+             */
+            id: string;
+            /**
+             * @example collection_point
+             * @enum {string}
+             */
+            type: "collection_point" | "delivery_point" | "collection_and_delivery" | "warehouse" | "transport" | "supplier" | "venue";
+            /** @example Cruz Roja Madrid */
+            name: string;
+            /** Format: uuid */
+            emergencyId: string;
+            /**
+             * @description Slug of the owning emergency; null if its row is missing.
+             * @example terremoto-venezuela-2026
+             */
+            emergencySlug: string | null;
         };
         LocationViewDto: {
             /** @example Calle Mayor 1, Valencia */
@@ -7006,6 +7047,33 @@ export interface operations {
             };
             /** @description Resource not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ResourcesController_listMineAcrossEmergencies: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Resources the principal manages */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MyManagedResourceDto"][];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Resumen

El panel no mostraba los recursos de un `point_manager` cuyo único grant es **entity-scoped** (#285): `getMyResources` en el web agregaba `/emergencies/{id}/resources/mine` iterando `/emergencies/mine`, que solo devuelve emergencias con grant emergency-scoped, así que la emergencia del punto nunca se consultaba y el recurso no aparecía en la barra lateral ni en "Tus recursos".

Implementa la **opción (a)** propuesta en la issue:

- **Nuevo `GET /resources/mine`** (JWT, sin `@RequirePermission`: cada principal lista solo lo suyo): unión de los recursos en propiedad (`ownerUserId`) y los alcanzados por grants `entity`-scoped activos (`scope.entityType === 'resource'`, ignorando caducados), con `{ id, type, name, emergencyId, emergencySlug }`. El slug se resuelve con un `LEFT JOIN` a `emergencies` en la misma query (sin N+1).
- **Caso de uso `GetMyManagedResources`** (patrón de `ListMyEmergencies`: el controller le pasa los grants ya resueltos de `req.user`) + método `findOwnedOrGranted` en el puerto `ResourceRepository` y en ambos adapters (Drizzle e in-memory).
- **Web**: `getMyResources` (`apps/web/src/lib/navigation-data.ts`) pasa a una única llamada a `/resources/mine`, eliminando el N+1 por emergencia. Las páginas emergency-scoped que usan el endpoint antiguo no cambian (ahí el contexto de emergencia es correcto).
- Sin colisión de rutas: no existe ningún `GET resources/:id` plano en la API.

## Validación

- [x] Pasé el gate que toca para esta zona del repo (`api build` + eslint + prettier + suite completa 234/234 suites y 1494 tests, `api-client build`, `web build`, `web lint`)
- [x] Verifiqué el comportamiento con un e2e nuevo (`test/resources-mine.e2e-spec.ts`) que reproduce el escenario de la issue: gestor con solo grant `entity` → `/emergencies/mine` vacío pero `/resources/mine` devuelve su punto con slug; además unit spec del caso de uso e int-spec del repositorio Drizzle (join del slug, unión sin duplicados, lista de grants vacía)
- [x] Actualicé el cliente API (`pnpm gen:api`: `openapi.json` + `packages/api-client/src/schema.ts` con `/resources/mine`)

## Cierre

- Closes #285