### PR TITLE
refactor(web): redirectToLogin() centralizado + limpieza real de la cookie caducada vía /api/session/clear

### DIFF
--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -1,9 +1,7 @@
 'use server';
 
-import { redirect } from 'next/navigation';
-import { clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 
 export async function logoutAction(): Promise<void> {
-  await clearToken();
-  redirect('/login');
+  return redirectToLogin();
 }

--- a/apps/web/src/app/admin/accreditations/actions.ts
+++ b/apps/web/src/app/admin/accreditations/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
-import { redirect } from 'next/navigation';
+import { requireSession, getToken, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 
@@ -79,8 +78,7 @@ export async function grantAccreditationAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/accreditations'));
+      return redirectToLogin('/admin/accreditations');
     }
     if (response.status === 403) {
       return { status: 'error', message: ta.acc_err_grant_forbidden };
@@ -110,8 +108,7 @@ export async function revokeAccreditationAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/accreditations'));
+      return redirectToLogin('/admin/accreditations');
     }
     if (response.status === 403) {
       return { status: 'error', message: ta.acc_err_revoke_forbidden };

--- a/apps/web/src/app/admin/accreditations/page.tsx
+++ b/apps/web/src/app/admin/accreditations/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchAccreditations } from './actions';
 import { GrantAccreditationForm } from './grant-form';
@@ -29,7 +29,7 @@ export default async function AcreditacionesPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect(loginHref('/admin/accreditations'));
+    return redirectToLogin('/admin/accreditations');
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/admin/api-keys/[id]/page.tsx
+++ b/apps/web/src/app/admin/api-keys/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchServiceAccounts, fetchApiKeys } from '../actions';
 import { IssueKeyButton } from '../issue-key-button';
@@ -26,7 +26,7 @@ export default async function ServiceAccountDetailPage({ params }: Props) {
   const { data: me, response: meRes } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
-  if (meRes.status === 401 || !me) redirect(loginHref(`/admin/api-keys/${id}`));
+  if (meRes.status === 401 || !me) return redirectToLogin(`/admin/api-keys/${id}`);
   if (!me.isAdmin) redirect('/');
 
   const [accounts, keys] = await Promise.all([

--- a/apps/web/src/app/admin/api-keys/actions.ts
+++ b/apps/web/src/app/admin/api-keys/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
-import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, getToken, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 
 export type ApiKeyActionResult =
@@ -82,8 +81,7 @@ export async function createServiceAccountAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/api-keys'));
+      return redirectToLogin('/admin/api-keys');
     }
     if (response.status === 403) {
       return {

--- a/apps/web/src/app/admin/api-keys/page.tsx
+++ b/apps/web/src/app/admin/api-keys/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchServiceAccounts } from './actions';
 import { CreateServiceAccountForm } from './create-sa-form';
@@ -22,7 +22,7 @@ export default async function ApiKeysPage() {
   const { data: me, response: meRes } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
-  if (meRes.status === 401 || !me) redirect(loginHref('/admin/api-keys'));
+  if (meRes.status === 401 || !me) return redirectToLogin('/admin/api-keys');
   if (!me.isAdmin) redirect('/');
 
   const accounts = await fetchServiceAccounts();

--- a/apps/web/src/app/admin/audit/page.tsx
+++ b/apps/web/src/app/admin/audit/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchAuditEntries } from './actions';
 import { AuditFilter } from './audit-filter';
@@ -38,7 +38,7 @@ export default async function AuditoriaPage({ searchParams }: PageProps) {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect(loginHref('/admin/audit'));
+    return redirectToLogin('/admin/audit');
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
-import { redirect } from 'next/navigation';
-import { loginHref } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { getMe } from '@/lib/navigation-data';
 import { DashboardLayout } from '@/lib/dashboard-layout';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -22,7 +21,7 @@ export default async function AdminLayout({
   children: ReactNode;
 }) {
   const me = await getMe();
-  if (me == null) redirect(loginHref('/admin'));
+  if (me == null) return redirectToLogin('/admin');
 
   return (
     <DashboardLayout>

--- a/apps/web/src/app/admin/organizations/[id]/page.tsx
+++ b/apps/web/src/app/admin/organizations/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -36,7 +36,7 @@ export default async function OrganizacionDetailPage({ params }: Props) {
     headers: authHeaders(token),
   });
   if (meResponse.status === 401 || !me) {
-    redirect(loginHref(`/admin/organizations/${id}`));
+    return redirectToLogin(`/admin/organizations/${id}`);
   }
   if (!me.isAdmin) redirect('/');
 

--- a/apps/web/src/app/admin/organizations/actions.ts
+++ b/apps/web/src/app/admin/organizations/actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
-import { redirect } from 'next/navigation';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 
 export type AccreditationStatus = 'global' | 'emergency' | 'none';
@@ -66,8 +65,7 @@ export async function fetchOrganizations(): Promise<OrganizationListItem[]> {
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/organizations'));
+      return redirectToLogin('/admin/organizations');
     }
     return [];
   }
@@ -88,8 +86,7 @@ export async function fetchOrganizationDetail(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/admin/organizations/${id}`));
+      return redirectToLogin(`/admin/organizations/${id}`);
     }
     if (response.status === 404) return null;
     return null;

--- a/apps/web/src/app/admin/organizations/page.tsx
+++ b/apps/web/src/app/admin/organizations/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { getT } from '@/i18n/server';
@@ -25,7 +25,7 @@ export default async function OrganizacionesPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect(loginHref('/admin/organizations'));
+    return redirectToLogin('/admin/organizations');
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { Card } from '@/components/atoms/card';
@@ -39,7 +39,7 @@ export default async function AdministracionPage() {
   ]);
 
   const me = meRes.data;
-  if (meRes.response.status === 401 || !me) redirect(loginHref('/admin'));
+  if (meRes.response.status === 401 || !me) return redirectToLogin('/admin');
 
   const roles = (rolesRes.data ?? []) as { id: string; permissions: string[] }[];
   const scopes = sortAdminScopes(administrableScopes(me.grants ?? [], roles));

--- a/apps/web/src/app/admin/permissions/actions.ts
+++ b/apps/web/src/app/admin/permissions/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
-import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, getToken, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { parseDateInput } from '@/lib/parse-date-input';
 
@@ -123,8 +122,7 @@ export async function grantRoleAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/permissions'));
+      return redirectToLogin('/admin/permissions');
     }
     if (response.status === 403) {
       return {

--- a/apps/web/src/app/admin/permissions/page.tsx
+++ b/apps/web/src/app/admin/permissions/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchRoles, fetchGrants, resolvePrincipal } from './actions';
 import { GrantRoleForm } from './grant-role-form';
@@ -25,7 +25,7 @@ export default async function PermisosPage({ searchParams }: Props) {
   const { data: me, response: meRes } = await api.GET('/auth/me', {
     headers: authHeaders(token),
   });
-  if (meRes.status === 401 || !me) redirect(loginHref('/admin/permissions'));
+  if (meRes.status === 401 || !me) return redirectToLogin('/admin/permissions');
   if (!me.isAdmin) redirect('/');
 
   const { principalId } = await searchParams;

--- a/apps/web/src/app/admin/points/[id]/page.tsx
+++ b/apps/web/src/app/admin/points/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -39,7 +39,7 @@ export default async function CentroDetailPage({ params }: Props) {
     headers: authHeaders(token),
   });
   if (meResponse.status === 401 || !me) {
-    redirect(loginHref(`/admin/points/${id}`));
+    return redirectToLogin(`/admin/points/${id}`);
   }
   if (!me.isAdmin) redirect('/');
 

--- a/apps/web/src/app/admin/points/actions.ts
+++ b/apps/web/src/app/admin/points/actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
-import { redirect } from 'next/navigation';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { revalidatePath } from 'next/cache';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
@@ -32,8 +31,7 @@ export async function fetchAdminResources(): Promise<ResourceAdminListItem[]> {
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/points'));
+      return redirectToLogin('/admin/points');
     }
     return [];
   }
@@ -54,8 +52,7 @@ export async function fetchAdminResourceDetail(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/admin/points/${id}`));
+      return redirectToLogin(`/admin/points/${id}`);
     }
     if (response.status === 404) return null;
     return null;
@@ -91,8 +88,7 @@ export async function recordInventoryEntry(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/admin/points/${resourceId}`));
+      return redirectToLogin(`/admin/points/${resourceId}`);
     }
     if (response.status === 403) {
       return { status: 'error', message: ta.centros_detail_inv_err_forbidden };

--- a/apps/web/src/app/admin/points/page.tsx
+++ b/apps/web/src/app/admin/points/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { getT } from '@/i18n/server';
@@ -25,7 +25,7 @@ export default async function CentrosPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect(loginHref('/admin/points'));
+    return redirectToLogin('/admin/points');
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/admin/scope/[scopeType]/[id]/actions.ts
+++ b/apps/web/src/app/admin/scope/[scopeType]/[id]/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
-import { getToken, requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { getToken, requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { parseDateInput } from '@/lib/parse-date-input';
 
@@ -134,8 +133,7 @@ export async function grantRoleAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(path(scopeType, scopeId)));
+      return redirectToLogin(path(scopeType, scopeId));
     }
     if (response.status === 403) {
       return {
@@ -168,8 +166,7 @@ export async function revokeGrantAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(path(scopeType, scopeId)));
+      return redirectToLogin(path(scopeType, scopeId));
     }
     if (response.status === 403) {
       return { status: 'error', message: 'No tienes permiso para revocar este rol.' };

--- a/apps/web/src/app/admin/scope/[scopeType]/[id]/page.tsx
+++ b/apps/web/src/app/admin/scope/[scopeType]/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect, notFound } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -51,7 +51,7 @@ export default async function ScopeAdminPage({ params }: PageProps) {
     fetchRoles(),
   ]);
   const me = meRes.data;
-  if (meRes.response.status === 401 || !me) redirect(loginHref(next));
+  if (meRes.response.status === 401 || !me) return redirectToLogin(next);
 
   // Authorize: the caller must actually administer THIS scope.
   const scope = administrableScopes(me.grants ?? [], roles).find(

--- a/apps/web/src/app/admin/templates/actions.ts
+++ b/apps/web/src/app/admin/templates/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
-import { redirect } from 'next/navigation';
+import { requireSession, getToken, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
@@ -67,8 +66,7 @@ export async function createTemplateAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/templates'));
+      return redirectToLogin('/admin/templates');
     }
     if (response.status === 403) {
       return { status: 'error', message: t.templates.err_no_permission_create };
@@ -95,8 +93,7 @@ export async function deleteTemplateAction(id: string): Promise<TemplateActionRe
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/templates'));
+      return redirectToLogin('/admin/templates');
     }
     if (response.status === 403) {
       return { status: 'error', message: t.templates.err_no_permission_delete };
@@ -149,8 +146,7 @@ export async function createFromTemplateAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/templates'));
+      return redirectToLogin('/admin/templates');
     }
     if (response.status === 403) {
       return { status: 'error', message: t.templates.err_no_permission_create_emergency };

--- a/apps/web/src/app/admin/templates/page.tsx
+++ b/apps/web/src/app/admin/templates/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import { fetchTemplates } from './actions';
@@ -29,7 +29,7 @@ export default async function TemplatesPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect(loginHref('/admin/templates'));
+    return redirectToLogin('/admin/templates');
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/admin/users/[id]/page.tsx
+++ b/apps/web/src/app/admin/users/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { EmptyState } from '@/components/molecules/empty-state';
@@ -30,7 +30,7 @@ export default async function UsuarioDetailPage({ params }: Props) {
     headers: authHeaders(token),
   });
   if (meResponse.status === 401 || !me) {
-    redirect(loginHref(`/admin/users/${id}`));
+    return redirectToLogin(`/admin/users/${id}`);
   }
   if (!me.isAdmin) redirect('/');
 

--- a/apps/web/src/app/admin/users/actions.ts
+++ b/apps/web/src/app/admin/users/actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
-import { redirect } from 'next/navigation';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 
 export interface UserListItem {
@@ -65,8 +64,7 @@ export async function fetchUsers(): Promise<UserListItem[]> {
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/admin/users'));
+      return redirectToLogin('/admin/users');
     }
     return [];
   }
@@ -85,8 +83,7 @@ export async function fetchUserDetail(id: string): Promise<UserDetail | null> {
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/admin/users/${id}`));
+      return redirectToLogin(`/admin/users/${id}`);
     }
     if (response.status === 404) return null;
     return null;

--- a/apps/web/src/app/admin/users/page.tsx
+++ b/apps/web/src/app/admin/users/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/molecules/page-header';
 import { getT } from '@/i18n/server';
@@ -25,7 +25,7 @@ export default async function UsuariosPage() {
   });
 
   if (meResponse.status === 401 || !me) {
-    redirect(loginHref('/admin/users'));
+    return redirectToLogin('/admin/users');
   }
 
   if (!me.isAdmin) {

--- a/apps/web/src/app/api/session/clear/route.ts
+++ b/apps/web/src/app/api/session/clear/route.ts
@@ -5,19 +5,25 @@ import { SESSION_COOKIE } from '@/lib/session-cookie';
 /**
  * GET /api/session/clear?next=<ruta>
  *
- * Deletes the stale session cookie and forwards to login. Server Component
- * render paths cannot mutate cookies, so when they detect an expired session
- * (401 with a token present) they redirect here — the one place besides a
- * Server Action where deletion is legal — instead of leaving the dead cookie
- * alive until its maxAge (#312). `next` is sanitised by loginHref, so an
- * attacker-crafted link through this handler cannot open-redirect; the only
- * other thing it can do is delete the visitor's own already-invalid cookie.
+ * Deletes the session cookie and forwards to login. Server Component render
+ * paths cannot mutate cookies, so when they detect an expired session (401
+ * with a token present) they redirect here — the one place besides a Server
+ * Action where deletion is legal — instead of leaving the dead cookie alive
+ * until its maxAge (#312).
+ *
+ * This is, by design, an unauthenticated logout endpoint: it deletes the
+ * cookie without validating the token (a pre-check against the API would
+ * fail open or closed during an outage — the very moment this path fires).
+ * A crafted cross-site link here can therefore force-log-out a user with a
+ * valid session; accepted as low impact (nuisance, no data exposure). The
+ * guarded risk is open redirect, prevented by loginHref/safeNextPath — which
+ * also reject /api/* as `next`, so this handler cannot be chained into a
+ * login loop.
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const next = request.nextUrl.searchParams.get('next');
-  const response = NextResponse.redirect(
-    new URL(loginHref(next), request.nextUrl),
-  );
+  // Base on request.url (as proxy.ts does) so both redirect builders agree.
+  const response = NextResponse.redirect(new URL(loginHref(next), request.url));
   response.cookies.delete(SESSION_COOKIE);
   return response;
 }

--- a/apps/web/src/app/api/session/clear/route.ts
+++ b/apps/web/src/app/api/session/clear/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { loginHref } from '@/lib/safe-next';
+import { SESSION_COOKIE } from '@/lib/session-cookie';
+
+/**
+ * GET /api/session/clear?next=<ruta>
+ *
+ * Deletes the stale session cookie and forwards to login. Server Component
+ * render paths cannot mutate cookies, so when they detect an expired session
+ * (401 with a token present) they redirect here — the one place besides a
+ * Server Action where deletion is legal — instead of leaving the dead cookie
+ * alive until its maxAge (#312). `next` is sanitised by loginHref, so an
+ * attacker-crafted link through this handler cannot open-redirect; the only
+ * other thing it can do is delete the visitor's own already-invalid cookie.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const next = request.nextUrl.searchParams.get('next');
+  const response = NextResponse.redirect(
+    new URL(loginHref(next), request.nextUrl),
+  );
+  response.cookies.delete(SESSION_COOKIE);
+  return response;
+}

--- a/apps/web/src/app/dashboard/donations/page.tsx
+++ b/apps/web/src/app/dashboard/donations/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -36,8 +35,7 @@ export default async function MisDonacionesPage() {
     headers: authHeaders(token),
   });
   if (res.response.status === 401) {
-    await clearToken();
-    redirect(loginHref('/dashboard/donations'));
+    return redirectToLogin('/dashboard/donations');
   }
   const donations = res.data ?? [];
 

--- a/apps/web/src/app/dashboard/notifications/actions.ts
+++ b/apps/web/src/app/dashboard/notifications/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type NotificationActionResult =
@@ -28,7 +27,7 @@ export async function markNotificationReadAction(
   });
 
   if (error !== undefined) {
-    if (response.status === 401) redirect(loginHref('/dashboard/notifications'));
+    if (response.status === 401) return redirectToLogin('/dashboard/notifications');
     if (response.status === 403) {
       return { status: 'error', message: t.notificaciones.err_mark_read_forbidden };
     }
@@ -53,7 +52,7 @@ export async function markAllNotificationsReadAction(): Promise<NotificationActi
   });
 
   if (error !== undefined) {
-    if (response.status === 401) redirect(loginHref('/dashboard/notifications'));
+    if (response.status === 401) return redirectToLogin('/dashboard/notifications');
     return { status: 'error', message: t.notificaciones.err_mark_all_read_failed };
   }
 

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
-import { requireSession, loginHref } from '@/lib/auth';
+import { requireSession, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { getMe, getRoles, getPrincipalContexts } from '@/lib/navigation-data';
 import { contextHref, type PrincipalContext } from '@/lib/navigation';
@@ -26,7 +25,7 @@ export default async function DashboardHomePage() {
   await requireSession('/dashboard');
 
   const me = await getMe();
-  if (me == null) redirect(loginHref('/dashboard'));
+  if (me == null) return redirectToLogin('/dashboard');
 
   const { t } = await getT();
   const tp = t.panel;

--- a/apps/web/src/app/dashboard/permissions/page.tsx
+++ b/apps/web/src/app/dashboard/permissions/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { scopeLabel } from '@/lib/permissions';
 import { formatDate } from '@/lib/format-date';
@@ -24,7 +23,7 @@ export default async function MisPermisosPage() {
   ]);
 
   if (meRes.status === 401 || !me) {
-    redirect(loginHref('/dashboard/permissions'));
+    return redirectToLogin('/dashboard/permissions');
   }
 
   const roleMap = new Map((roles ?? []).map((r) => [r.id, r]));

--- a/apps/web/src/app/dashboard/profile/page.tsx
+++ b/apps/web/src/app/dashboard/profile/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import { PageContainer } from '@/components/molecules/page-container';
@@ -27,7 +26,7 @@ export default async function MiPerfilPage() {
     headers: authHeaders(token),
   });
 
-  if (me === undefined) redirect(loginHref('/dashboard/profile'));
+  if (me === undefined) return redirectToLogin('/dashboard/profile');
 
   return (
     <main className="flex-1 bg-surface">

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { getCategories } from '@/adapters/get-categories';
 import { isMaterialCategory } from '@/domain/supplies/category';
@@ -131,8 +130,7 @@ export async function submitOffer(
   );
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/donar/ofrecer`));
+    return redirectToLogin(`/e/${slug}/donar/ofrecer`);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
@@ -30,8 +29,7 @@ export async function fetchMyVolunteerProfile(
   );
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
+    return redirectToLogin(`/e/${slug}/mi-voluntariado`);
   }
 
   if (response.status === 404 || data === undefined) {
@@ -56,8 +54,7 @@ export async function fetchMyTasks(
   );
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
+    return redirectToLogin(`/e/${slug}/mi-voluntariado`);
   }
 
   return data ?? [];
@@ -77,8 +74,7 @@ export async function checkInTask(
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
+    return redirectToLogin(`/e/${slug}/mi-voluntariado`);
   }
 
   if (response.status === 403) {
@@ -109,8 +105,7 @@ export async function checkOutTask(
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/mi-voluntariado`));
+    return redirectToLogin(`/e/${slug}/mi-voluntariado`);
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { notFound } from 'next/navigation';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { ShipmentsList } from '@/components/organisms/shipments-list';
@@ -50,8 +50,7 @@ export default async function MisExpedicionesPage({ params }: Props) {
       })
       .then(async (r) => {
         if (r.response.status === 401) {
-          await clearToken();
-          redirect(loginHref(`/e/${slug}/mis-expediciones`));
+          return redirectToLogin(`/e/${slug}/mis-expediciones`);
         }
         return r.data ?? [];
       }),

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/actions.ts
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { getT } from '@/i18n/server';
 import { getCategories } from '@/adapters/get-categories';
@@ -29,8 +29,7 @@ export async function fetchMyInventory(
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/mis-puntos/${resourceId}/inventario`));
+    return redirectToLogin(`/e/${slug}/mis-puntos/${resourceId}/inventario`);
   }
   // Not the owner/coordinator of this point → back to the caller's own list
   // (same pattern as the intake detail page), never a misleading 404.
@@ -79,8 +78,7 @@ export async function saveMyInventory(
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/mis-puntos/${resourceId}/inventario`));
+    return redirectToLogin(`/e/${slug}/mis-puntos/${resourceId}/inventario`);
   }
   if (response.status === 403) {
     return { status: 'error', message: t.account.inventory_update_forbidden };

--- a/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
+++ b/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
@@ -29,8 +28,7 @@ export async function fetchMyResources(
   );
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/mis-puntos`));
+    return redirectToLogin(`/e/${slug}/mis-puntos`);
   }
 
   if (!response.ok || data == null) {
@@ -55,8 +53,7 @@ export async function updateResourceStatus(
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/mis-puntos`));
+    return redirectToLogin(`/e/${slug}/mis-puntos`);
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 type CapacityMode = components['schemas']['PublishCapacityDto']['mode'];
@@ -132,8 +131,7 @@ export async function submitCapacity(
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/ofrecer-transporte`));
+    return redirectToLogin(`/e/${slug}/ofrecer-transporte`);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { requireSession, loginHref } from '@/lib/auth';
+import { requireSession, redirectToLogin } from '@/lib/auth';
 import { getMe } from '@/lib/navigation-data';
 import { submitCapacity } from './actions';
 import { OfrecerTransporteForm } from './ofrecer-transporte-form';
@@ -42,7 +42,7 @@ export default async function OfrecerTransportePage({ params }: Props) {
   // Resolve the current user — they are the provider (type: volunteer).
   const me = await getMe();
   if (me == null) {
-    redirect(loginHref(`/e/${slug}/ofrecer-transporte`));
+    return redirectToLogin(`/e/${slug}/ofrecer-transporte`);
   }
 
   const emergency = await getEmergencyBySlug(slug);

--- a/apps/web/src/app/e/[slug]/peticion/actions.ts
+++ b/apps/web/src/app/e/[slug]/peticion/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { getT } from '@/i18n/server';
 import { getCategories } from '@/adapters/get-categories';
@@ -124,8 +123,7 @@ export async function submitPeticion(
   );
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(peticionPath));
+    return redirectToLogin(peticionPath);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -49,8 +49,7 @@ export default async function IntakeDetailPage({ params }: Props) {
 
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
-    await clearToken();
-    redirect(loginHref(next));
+    return redirectToLogin(next);
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -67,8 +66,7 @@ export default async function IntakeDetailPage({ params }: Props) {
     headers,
   });
   if (res.response.status === 401) {
-    await clearToken();
-    redirect(loginHref(next));
+    return redirectToLogin(next);
   }
   if (res.response.status === 403) {
     redirect(`/e/${slug}/recepcion`);

--- a/apps/web/src/app/e/[slug]/recepcion/actions.ts
+++ b/apps/web/src/app/e/[slug]/recepcion/actions.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { getCategories } from '@/adapters/get-categories';
@@ -103,8 +103,7 @@ export async function submitReception(
           });
 
   if (result.response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/recepcion`));
+    return redirectToLogin(`/e/${slug}/recepcion`);
   }
   if (result.response.status === 409) {
     return { status: 'error', message: tr.err_already_processed };

--- a/apps/web/src/app/e/[slug]/recepcion/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
@@ -55,8 +55,7 @@ export default async function RecepcionPage({ params, searchParams }: Props) {
 
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/recepcion`));
+    return redirectToLogin(`/e/${slug}/recepcion`);
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(
@@ -81,8 +80,7 @@ export default async function RecepcionPage({ params, searchParams }: Props) {
     headers,
   });
   if (mineRes.response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/recepcion`));
+    return redirectToLogin(`/e/${slug}/recepcion`);
   }
   const myPoints = (mineRes.data ?? []).filter((r) =>
     COLLECTION_TYPES.has(r.type),

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/actions.ts
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/actions.ts
@@ -1,9 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
 import { api } from "@/lib/api";
-import { authHeaders, clearToken, getToken, requireSession, loginHref } from "@/lib/auth";
+import { authHeaders, getToken, requireSession, redirectToLogin } from "@/lib/auth";
 
 export interface ResourceGrantView {
   id: string;
@@ -120,8 +119,7 @@ export async function grantResourceRoleAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(resourcePath(slug, resourceId)));
+      return redirectToLogin(resourcePath(slug, resourceId));
     }
     if (response.status === 403) {
       return {
@@ -157,8 +155,7 @@ export async function revokeResourceGrantAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(resourcePath(slug, resourceId)));
+      return redirectToLogin(resourcePath(slug, resourceId));
     }
     if (response.status === 403) {
       return {

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { authHeaders, clearToken, getToken } from "@/lib/auth";
+import { authHeaders, getToken } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { getEmergencyBySlug } from "@/lib/emergencies";
 import { getMe, getRoles } from "@/lib/navigation-data";
@@ -39,13 +39,17 @@ export default async function RecipientResourcePage({ params }: Props) {
 
   const emergencyId = emergency.id;
   const isActive = emergency.status === "active";
-  const token = await getToken();
+  let token = await getToken();
   let access: EmergencyAccess | null = null;
 
   if (token !== null) {
     const [me, roles] = await Promise.all([getMe(), getRoles()]);
     if (me === null) {
-      await clearToken();
+      // Expired/invalid session on a public page: degrade to the anonymous
+      // view. The cookie can't be deleted from render (it goes away on the
+      // next login or via /api/session/clear from a protected page), so just
+      // stop forwarding the dead token to the fetches below.
+      token = null;
     } else {
       access = resolveEmergencyAccess(
         emergencyId,

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/actions.ts
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
-import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
-import { getToken, redirectToLogin, authHeaders, loginHref } from '@/lib/auth';
+import { requireSession, redirectToLogin, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { getT } from '@/i18n/server';
@@ -32,10 +31,7 @@ export async function reportValidity(
   formData: FormData,
 ): Promise<ReportValidityState> {
   const next = `/e/${slug}/recursos/${resourceId}/reportar-estado`;
-  const token = await getToken();
-  if (token === null) {
-    redirect(loginHref(next));
-  }
+  const token = await requireSession(next);
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/actions.ts
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/actions.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
-import { getToken, clearToken, authHeaders, loginHref } from '@/lib/auth';
+import { getToken, redirectToLogin, authHeaders, loginHref } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { getT } from '@/i18n/server';
@@ -31,10 +31,10 @@ export async function reportValidity(
   _prev: ReportValidityState,
   formData: FormData,
 ): Promise<ReportValidityState> {
-  const loginNext = loginHref(`/e/${slug}/recursos/${resourceId}/reportar-estado`);
+  const next = `/e/${slug}/recursos/${resourceId}/reportar-estado`;
   const token = await getToken();
   if (token === null) {
-    redirect(loginNext);
+    redirect(loginHref(next));
   }
 
   const { t } = await getT();
@@ -77,8 +77,7 @@ export async function reportValidity(
   );
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginNext);
+    return redirectToLogin(next);
   }
   if (response.status === 403) {
     return { status: 'error', message: t.reportar_validez.err_owner };

--- a/apps/web/src/app/e/[slug]/registrar/actions.ts
+++ b/apps/web/src/app/e/[slug]/registrar/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { getT } from '@/i18n/server';
 import { getCategories } from '@/adapters/get-categories';
@@ -110,8 +109,7 @@ export async function registerResource(
   );
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/registrar`));
+    return redirectToLogin(`/e/${slug}/registrar`);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/e/[slug]/reportar/actions.ts
+++ b/apps/web/src/app/e/[slug]/reportar/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, getToken, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { getT } from '@/i18n/server';
@@ -83,8 +83,7 @@ export async function submitReport(
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(`/login`);
+    return redirectToLogin();
   }
 
   if (response.status === 403) {
@@ -117,8 +116,7 @@ export async function reviewReport(
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/emergencies/${slug}/manage/reports`));
+    return redirectToLogin(`/emergencies/${slug}/manage/reports`);
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/e/[slug]/reportar/actions.ts
+++ b/apps/web/src/app/e/[slug]/reportar/actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
-import { redirect } from 'next/navigation';
-import { requireSession, getToken, authHeaders, redirectToLogin } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { getT } from '@/i18n/server';
@@ -30,10 +29,7 @@ export async function submitReport(
   _prev: SubmitReportState,
   formData: FormData,
 ): Promise<SubmitReportState> {
-  const token = await getToken();
-  if (token === null) {
-    redirect(`/login`);
-  }
+  const token = await requireSession();
 
   const { t } = await getT();
 

--- a/apps/web/src/app/e/[slug]/voluntario/actions.ts
+++ b/apps/web/src/app/e/[slug]/voluntario/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
-import { requireSession, loginHref, authHeaders, clearToken } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 type Skill = components['schemas']['RegisterVolunteerDto']['skills'][number];
@@ -104,8 +103,7 @@ export async function registerVolunteer(
   );
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/e/${slug}/voluntario`));
+    return redirectToLogin(`/e/${slug}/voluntario`);
   }
 
   if (response.status === 409) {

--- a/apps/web/src/app/emergencies/[slug]/manage/actions.ts
+++ b/apps/web/src/app/emergencies/[slug]/manage/actions.ts
@@ -1,10 +1,9 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
 import type { components } from '@reliefhub/api-client';
 import { api } from '@/lib/api';
-import { requireSession, clearToken, authHeaders, redirectToLogin } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 /** A reason is mandatory for every edit/discard; mirror the API's min length. */
@@ -262,8 +261,7 @@ export async function renewNeed(
 }
 
 export async function logout(): Promise<never> {
-  await clearToken();
-  redirect('/login');
+  return redirectToLogin();
 }
 
 /**

--- a/apps/web/src/app/emergencies/[slug]/manage/actions.ts
+++ b/apps/web/src/app/emergencies/[slug]/manage/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import type { components } from '@reliefhub/api-client';
 import { api } from '@/lib/api';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, clearToken, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 /** A reason is mandatory for every edit/discard; mirror the API's min length. */
@@ -57,8 +57,7 @@ export async function matchOffer(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_match };
@@ -91,8 +90,7 @@ export async function fulfillOffer(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_fulfill };
@@ -122,8 +120,7 @@ export async function cancelOffer(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_cancel };
@@ -168,8 +165,7 @@ export async function verifyAndPublish(
 
   if (!verifyResponse.ok) {
     if (verifyResponse.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return {
       status: 'error',
@@ -187,8 +183,7 @@ export async function verifyAndPublish(
 
   if (publishError !== undefined) {
     if (publishResponse.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     // The verify step already persisted; refresh so the queue/badge reflect the
     // now-verified state even though publishing failed (avoids a stale "Sin
@@ -221,8 +216,7 @@ export async function validateNeed(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return {
       status: 'error',
@@ -252,8 +246,7 @@ export async function renewNeed(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_renew };
@@ -292,8 +285,7 @@ export async function pauseEmergency(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_pause };
@@ -324,8 +316,7 @@ export async function resumeEmergency(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_resume };
@@ -372,8 +363,7 @@ export async function editNeed(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return { status: 'error', message: t.coord.err_edit_failed };
   }
@@ -402,8 +392,7 @@ export async function discardNeed(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return { status: 'error', message: t.coord.err_discard_failed };
   }
@@ -440,8 +429,7 @@ export async function editResource(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return { status: 'error', message: t.coord.err_edit_failed };
   }
@@ -470,8 +458,7 @@ export async function discardResource(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return { status: 'error', message: t.coord.err_discard_failed };
   }
@@ -515,8 +502,7 @@ export async function resolveDispute(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/resources/disputes`));
+      return redirectToLogin(`/emergencies/${slug}/manage/resources/disputes`);
     }
     return { status: 'error', message: t.coord.err_resolve_dispute_failed };
   }
@@ -558,8 +544,7 @@ export async function getValidityReports(
 
   if (error !== undefined || data === undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/resources/disputes`));
+      return redirectToLogin(`/emergencies/${slug}/manage/resources/disputes`);
     }
     return { status: 'error', message: t.coord.err_load_reports_failed };
   }
@@ -590,8 +575,7 @@ export async function editOffer(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return { status: 'error', message: t.coord.err_edit_failed };
   }
@@ -620,8 +604,7 @@ export async function discardOffer(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return { status: 'error', message: t.coord.err_discard_failed };
   }
@@ -654,8 +637,7 @@ export async function editReport(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return { status: 'error', message: t.coord.err_edit_failed };
   }
@@ -684,8 +666,7 @@ export async function discardReport(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     return { status: 'error', message: t.coord.err_discard_failed };
   }
@@ -711,8 +692,7 @@ export async function publishAnnouncement(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.err_no_permission_announce };

--- a/apps/web/src/app/emergencies/[slug]/manage/activity/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/activity/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
@@ -52,8 +52,7 @@ export default async function ManageActivityPage({ params }: Props) {
     })
     .then(async (r) => {
       if (r.response.status === 401) {
-        await clearToken();
-        redirect(loginHref(`/emergencies/${slug}/manage/activity`));
+        return redirectToLogin(`/emergencies/${slug}/manage/activity`);
       }
       if (r.response.status === 403) redirect(`/emergencies/${slug}/manage`);
       return r.data?.entries ?? [];

--- a/apps/web/src/app/emergencies/[slug]/manage/logistics/actions.ts
+++ b/apps/web/src/app/emergencies/[slug]/manage/logistics/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import type { components } from '@reliefhub/api-client';
 
@@ -63,8 +62,7 @@ export async function createShipment(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/logistics`));
+      return redirectToLogin(`/emergencies/${slug}/manage/logistics`);
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_create };
@@ -110,8 +108,7 @@ export async function assignCapacity(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/logistics`));
+      return redirectToLogin(`/emergencies/${slug}/manage/logistics`);
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_assign };
@@ -153,8 +150,7 @@ export async function getCapacitySuggestions(
 
   if (error !== undefined || data === undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/logistics`));
+      return redirectToLogin(`/emergencies/${slug}/manage/logistics`);
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_assign };
@@ -191,8 +187,7 @@ export async function markInTransit(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(loginNext));
+      return redirectToLogin(loginNext);
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_act };
@@ -231,8 +226,7 @@ export async function confirmDelivery(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(loginNext));
+      return redirectToLogin(loginNext);
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_act };
@@ -269,8 +263,7 @@ export async function cancelShipment(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/logistics`));
+      return redirectToLogin(`/emergencies/${slug}/manage/logistics`);
     }
     if (response.status === 403) {
       return { status: 'error', message: ts.ship_err_no_permission_cancel };

--- a/apps/web/src/app/emergencies/[slug]/manage/logistics/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/logistics/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
@@ -105,8 +105,7 @@ export default async function ManageLogisticsPage({
 
   const onUnauthorized = async (statusCode: number): Promise<void> => {
     if (statusCode === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/logistics`));
+      return redirectToLogin(`/emergencies/${slug}/manage/logistics`);
     }
   };
 

--- a/apps/web/src/app/emergencies/[slug]/manage/needs/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/needs/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
@@ -82,8 +82,7 @@ export default async function ManageNeedsPage({
 
   const onUnauthorized = async (status: number): Promise<void> => {
     if (status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/needs`));
+      return redirectToLogin(`/emergencies/${slug}/manage/needs`);
     }
   };
 

--- a/apps/web/src/app/emergencies/[slug]/manage/offers/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/offers/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
@@ -77,8 +77,7 @@ export default async function ManageOffersPage({
 
   const onUnauthorized = async (statusCode: number): Promise<void> => {
     if (statusCode === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/offers`));
+      return redirectToLogin(`/emergencies/${slug}/manage/offers`);
     }
   };
 

--- a/apps/web/src/app/emergencies/[slug]/manage/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
@@ -38,8 +37,7 @@ export default async function ManageOverviewPage({ params }: Props) {
 
   const onUnauthorized = async (status: number): Promise<void> => {
     if (status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage`));
+      return redirectToLogin(`/emergencies/${slug}/manage`);
     }
   };
 

--- a/apps/web/src/app/emergencies/[slug]/manage/personnel-actions.ts
+++ b/apps/web/src/app/emergencies/[slug]/manage/personnel-actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type PersonnelActionResult =
@@ -31,8 +30,7 @@ export async function createTaskFromNeed(
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/emergencies/${slug}/manage`));
+    return redirectToLogin(`/emergencies/${slug}/manage`);
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/emergencies/[slug]/manage/reports/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/reports/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
@@ -87,8 +87,7 @@ export default async function ManageReportsPage({ params, searchParams }: Props)
   });
 
   if (response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/emergencies/${slug}/manage/reports`));
+    return redirectToLogin(`/emergencies/${slug}/manage/reports`);
   }
 
   if (response.status === 403) {

--- a/apps/web/src/app/emergencies/[slug]/manage/resources/disputes/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/resources/disputes/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
@@ -46,8 +46,7 @@ export default async function ManageResourcesDisputesPage({ params }: Props) {
   );
 
   if (result.response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/emergencies/${slug}/manage/resources/disputes`));
+    return redirectToLogin(`/emergencies/${slug}/manage/resources/disputes`);
   }
   if (result.response.status === 403) {
     redirect(`/emergencies/${slug}/manage`);

--- a/apps/web/src/app/emergencies/[slug]/manage/resources/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/resources/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
@@ -92,8 +92,7 @@ export default async function ManageResourcesPage({ params, searchParams }: Prop
   });
 
   if (result.response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/emergencies/${slug}/manage/resources`));
+    return redirectToLogin(`/emergencies/${slug}/manage/resources`);
   }
   if (result.response.status === 403) {
     redirect(`/emergencies/${slug}/manage`);

--- a/apps/web/src/app/emergencies/[slug]/manage/volunteers/actions.ts
+++ b/apps/web/src/app/emergencies/[slug]/manage/volunteers/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { VALID_SKILLS, type VolunteerSkill } from './skills';
 
@@ -29,8 +28,7 @@ export async function updateVolunteerStatus(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/volunteers`));
+      return redirectToLogin(`/emergencies/${slug}/manage/volunteers`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_status };
@@ -94,8 +92,7 @@ export async function createTask(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/volunteers`));
+      return redirectToLogin(`/emergencies/${slug}/manage/volunteers`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_create };
@@ -124,8 +121,7 @@ export async function assignVolunteer(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/volunteers`));
+      return redirectToLogin(`/emergencies/${slug}/manage/volunteers`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_assign };
@@ -160,8 +156,7 @@ export async function unassignVolunteer(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/volunteers`));
+      return redirectToLogin(`/emergencies/${slug}/manage/volunteers`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_unassign };
@@ -194,8 +189,7 @@ export async function completeTask(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/volunteers`));
+      return redirectToLogin(`/emergencies/${slug}/manage/volunteers`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_complete };
@@ -225,8 +219,7 @@ export async function cancelTask(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref(`/emergencies/${slug}/manage/volunteers`));
+      return redirectToLogin(`/emergencies/${slug}/manage/volunteers`);
     }
     if (response.status === 403) {
       return { status: 'error', message: t.coord.vol_err_no_permission_cancel };

--- a/apps/web/src/app/emergencies/[slug]/manage/volunteers/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/volunteers/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
@@ -84,8 +84,7 @@ export default async function ManageVolunteersPage({ params, searchParams }: Pro
   ]);
 
   if (rosterResult.response.status === 401 || tasksResult.response.status === 401) {
-    await clearToken();
-    redirect(loginHref(`/emergencies/${slug}/manage/volunteers`));
+    return redirectToLogin(`/emergencies/${slug}/manage/volunteers`);
   }
 
   if (rosterResult.response.status === 403 || tasksResult.response.status === 403) {

--- a/apps/web/src/app/organizations/[id]/manage/actions.ts
+++ b/apps/web/src/app/organizations/[id]/manage/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type OrgActionResult =
@@ -32,7 +31,7 @@ export async function addMemberAction(
   });
 
   if (error !== undefined) {
-    if (response.status === 401) redirect(loginHref(`/organizations/${orgId}/manage`));
+    if (response.status === 401) return redirectToLogin(`/organizations/${orgId}/manage`);
     if (response.status === 403) {
       return { status: 'error', message: t.organizaciones.err_owner_only };
     }
@@ -63,7 +62,7 @@ export async function removeMemberAction(
   });
 
   if (error !== undefined) {
-    if (response.status === 401) redirect(loginHref(`/organizations/${orgId}/manage`));
+    if (response.status === 401) return redirectToLogin(`/organizations/${orgId}/manage`);
     if (response.status === 403) {
       return { status: 'error', message: t.organizaciones.err_owner_only };
     }

--- a/apps/web/src/app/organizations/[id]/manage/layout.tsx
+++ b/apps/web/src/app/organizations/[id]/manage/layout.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
-import { redirect } from 'next/navigation';
-import { loginHref, clearToken } from '@/lib/auth';
+import { redirectToLogin } from '@/lib/auth';
 import { getMe } from '@/lib/navigation-data';
 import { DashboardLayout } from '@/lib/dashboard-layout';
 
@@ -21,8 +20,7 @@ export default async function OrganizationManageLayout({
 
   const me = await getMe();
   if (me == null) {
-    await clearToken();
-    redirect(loginHref(`/organizations/${id}/manage`));
+    return redirectToLogin(`/organizations/${id}/manage`);
   }
 
   return (

--- a/apps/web/src/app/panel/grupos/actions.ts
+++ b/apps/web/src/app/panel/grupos/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { requireSession, loginHref, getToken, clearToken, authHeaders } from '@/lib/auth';
+import { requireSession, loginHref, getToken, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 
 export type GroupActionResult =
@@ -106,8 +106,7 @@ export async function createGroupAction(
 
   if (error !== undefined) {
     if (response.status === 401) {
-      await clearToken();
-      redirect(loginHref('/panel/grupos'));
+      return redirectToLogin('/panel/grupos');
     }
     if (response.status === 403) {
       return {

--- a/apps/web/src/app/panel/grupos/page.tsx
+++ b/apps/web/src/app/panel/grupos/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { fetchMyGroups } from './actions';
 import { CreateGroupForm } from './create-group-form';
@@ -28,7 +27,7 @@ export default async function GruposPage() {
     ]);
 
   if (meRes.status === 401 || !me) {
-    redirect(loginHref('/panel/grupos'));
+    return redirectToLogin('/panel/grupos');
   }
 
   const roleMap = new Map((roles ?? []).map((r) => [r.id, r]));

--- a/apps/web/src/app/panel/organizaciones/actions.ts
+++ b/apps/web/src/app/panel/organizaciones/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import { requireSession, loginHref, authHeaders } from '@/lib/auth';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 
 export type OrgActionResult =
@@ -38,7 +38,7 @@ export async function createOrganizationAction(
   });
 
   if (error !== undefined || data === undefined) {
-    if (response.status === 401) redirect(loginHref('/panel/organizaciones'));
+    if (response.status === 401) return redirectToLogin('/panel/organizaciones');
     return { status: 'error', message: t.organizaciones.err_create_failed };
   }
 

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { loginHref } from './safe-next';
+import { loginHref, sessionClearHref } from './safe-next';
 import { SESSION_COOKIE } from './session-cookie';
 
 // Re-exported so server callers can pull the login-redirect contract and the
@@ -50,17 +50,36 @@ export async function setToken(token: string): Promise<void> {
  * Removes the auth token cookie (logout). Best-effort: Next.js only allows
  * cookie mutation in Server Actions and Route Handlers, so when this runs
  * during Server Component render (a fetch helper reacting to a 401 from an
- * expired token) the deletion is skipped instead of crashing the render —
- * callers redirect to login right after, and the stale cookie is overwritten
- * by the next successful login.
+ * expired token) the deletion is skipped instead of crashing the render.
+ *
+ * Returns whether the cookie was actually deleted, so callers can route the
+ * real cleanup elsewhere when it wasn't — {@link redirectToLogin} sends those
+ * through `GET /api/session/clear`, the Route Handler that CAN delete it.
  */
-export async function clearToken(): Promise<void> {
+export async function clearToken(): Promise<boolean> {
   const jar = await cookies();
   try {
     jar.delete(COOKIE_NAME);
+    return true;
   } catch {
     // Server Component render: cookies are read-only here.
+    return false;
   }
+}
+
+/**
+ * Single owner of the "session is invalid → go to login" move, safe from both
+ * Server Actions and Server Component render. Deletes the session cookie when
+ * the runtime allows it and redirects to login preserving `next`; when it
+ * can't (render), it redirects through `GET /api/session/clear` so the stale
+ * cookie is deleted for real instead of lingering until its maxAge.
+ *
+ * Use this instead of hand-writing `await clearToken(); redirect(loginHref(…))`
+ * (issue #312 centralised that pattern).
+ */
+export async function redirectToLogin(next?: string | null): Promise<never> {
+  const cleared = await clearToken();
+  redirect(cleared ? loginHref(next) : sessionClearHref(next));
 }
 
 /**

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -47,16 +47,16 @@ export async function setToken(token: string): Promise<void> {
 }
 
 /**
- * Removes the auth token cookie (logout). Best-effort: Next.js only allows
- * cookie mutation in Server Actions and Route Handlers, so when this runs
- * during Server Component render (a fetch helper reacting to a 401 from an
- * expired token) the deletion is skipped instead of crashing the render.
+ * Removes the auth token cookie. Best-effort: Next.js only allows cookie
+ * mutation in Server Actions and Route Handlers, so when this runs during
+ * Server Component render (a fetch helper reacting to a 401 from an expired
+ * token) the deletion is skipped instead of crashing the render.
  *
- * Returns whether the cookie was actually deleted, so callers can route the
- * real cleanup elsewhere when it wasn't — {@link redirectToLogin} sends those
- * through `GET /api/session/clear`, the Route Handler that CAN delete it.
+ * Returns whether the cookie was actually deleted, so {@link redirectToLogin}
+ * — the only consumer, including logout — can route the real cleanup through
+ * `GET /api/session/clear` (the Route Handler that CAN delete it) when not.
  */
-export async function clearToken(): Promise<boolean> {
+async function clearToken(): Promise<boolean> {
   const jar = await cookies();
   try {
     jar.delete(COOKIE_NAME);
@@ -96,7 +96,8 @@ export function authHeaders(token: string): { Authorization: string } {
  *
  * It only checks for the presence of the cookie; it does NOT validate the token
  * against the API. Callers that additionally call `/auth/me` still handle a 401
- * from that call and redirect via {@link loginHref}.
+ * from that call — via {@link redirectToLogin}, so the stale cookie is also
+ * cleaned up.
  */
 export async function requireSession(next?: string | null): Promise<string> {
   const token = await getToken();

--- a/apps/web/src/lib/dashboard-layout.tsx
+++ b/apps/web/src/lib/dashboard-layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
+import { redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { getNavContext } from '@/lib/navigation-data';
 import { buildNavModel, type NavItem } from '@/lib/navigation';
@@ -17,7 +18,7 @@ export async function DashboardLayout({
   emergencyContext?: ReactNode;
 }) {
   const { me, roles, notificationUnread, contexts } = await getNavContext();
-  if (me == null) redirect('/login');
+  if (me == null) return redirectToLogin();
   // Force onboarding for any incomplete profile (missing phone/consent or an
   // outdated consent version) before granting access to the panel.
   if (me.profileComplete === false) redirect('/auth/onboarding?next=/dashboard');

--- a/apps/web/src/lib/manage-access.ts
+++ b/apps/web/src/lib/manage-access.ts
@@ -1,5 +1,5 @@
-import { notFound, redirect } from 'next/navigation';
-import { requireSession, loginHref, clearToken, authHeaders } from '@/lib/auth';
+import { notFound } from 'next/navigation';
+import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { getMe, getRoles } from '@/lib/navigation-data';
 import {
@@ -36,8 +36,7 @@ export async function resolveManageAccess(
 
   const [me, roles] = await Promise.all([getMe(), getRoles()]);
   if (me == null) {
-    await clearToken();
-    redirect(loginHref(returnPath));
+    return redirectToLogin(returnPath);
   }
 
   const access: EmergencyAccess = resolveEmergencyAccess(

--- a/apps/web/src/lib/safe-next.test.ts
+++ b/apps/web/src/lib/safe-next.test.ts
@@ -22,6 +22,20 @@ test('rejects open-redirect targets', () => {
 });
 
 /**
+ * `next` must land on a page, never on an API route: /api/session/clear
+ * deletes the session cookie, so /login?next=%2Fapi%2Fsession%2Fclear would
+ * log the user straight back out after every successful login (login-loop
+ * trap found in the #312 review).
+ */
+test('rejects API routes as next targets', () => {
+  assert.equal(safeNextPath('/api/session/clear'), null);
+  assert.equal(safeNextPath('/api'), null);
+  assert.equal(safeNextPath('/API/session/clear'), null); // case-insensitive
+  assert.equal(loginHref('/api/session/clear'), '/login');
+  assert.equal(sessionClearHref('/api/session/clear'), '/api/session/clear');
+});
+
+/**
  * loginHref is the single source of truth for the `?next=` contract: every
  * login redirect goes through it, so a safe origin round-trips and an unsafe or
  * absent one collapses to a plain `/login` (never an open redirect).

--- a/apps/web/src/lib/safe-next.test.ts
+++ b/apps/web/src/lib/safe-next.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { safeNextPath, loginHref } from './safe-next.ts';
+import { safeNextPath, loginHref, sessionClearHref } from './safe-next.ts';
 
 /**
  * #258: post-login redirect must return the user to the internal page they came
@@ -38,4 +38,24 @@ test('loginHref falls back to plain /login for unsafe or missing next', () => {
   assert.equal(loginHref('//evil.com'), '/login');
   assert.equal(loginHref(undefined), '/login');
   assert.equal(loginHref(null), '/login');
+});
+
+/**
+ * sessionClearHref routes an expired-session redirect through the route handler
+ * that CAN delete the cookie (render paths cannot). Same `next` contract as
+ * loginHref: safe origins round-trip, unsafe/absent ones are dropped.
+ */
+test('sessionClearHref embeds a safe origin as an encoded next param', () => {
+  assert.equal(
+    sessionClearHref('/e/terremoto-venezuela-2026/mis-puntos'),
+    '/api/session/clear?next=%2Fe%2Fterremoto-venezuela-2026%2Fmis-puntos',
+  );
+});
+
+test('sessionClearHref drops unsafe or missing next', () => {
+  assert.equal(sessionClearHref('https://evil.com'), '/api/session/clear');
+  assert.equal(sessionClearHref('//evil.com'), '/api/session/clear');
+  assert.equal(sessionClearHref('/\\evil.com'), '/api/session/clear');
+  assert.equal(sessionClearHref(undefined), '/api/session/clear');
+  assert.equal(sessionClearHref(null), '/api/session/clear');
 });

--- a/apps/web/src/lib/safe-next.ts
+++ b/apps/web/src/lib/safe-next.ts
@@ -30,3 +30,17 @@ export function loginHref(next?: string | null): string {
   const safe = safeNextPath(next);
   return safe ? `/login?next=${encodeURIComponent(safe)}` : '/login';
 }
+
+/**
+ * Login redirect for callers that could NOT delete the stale session cookie
+ * (Server Component render, where Next.js forbids cookie mutation): routes
+ * through `GET /api/session/clear`, a Route Handler that deletes the cookie
+ * and then forwards to {@link loginHref} with the same sanitised `next`.
+ * Prefer {@link loginHref} directly when the cookie is already gone.
+ */
+export function sessionClearHref(next?: string | null): string {
+  const safe = safeNextPath(next);
+  return safe
+    ? `/api/session/clear?next=${encodeURIComponent(safe)}`
+    : '/api/session/clear';
+}

--- a/apps/web/src/lib/safe-next.ts
+++ b/apps/web/src/lib/safe-next.ts
@@ -11,6 +11,11 @@ export function safeNextPath(value: unknown): string | null {
   if (!value.startsWith('/')) return null;
   if (value.startsWith('//')) return null;
   if (value.includes('\\')) return null;
+  // Only pages are valid return targets. API routes are state-changing GETs
+  // (e.g. /api/session/clear deletes the session cookie, so a crafted
+  // /login?next=%2Fapi%2Fsession%2Fclear would undo every successful login).
+  const lower = value.toLowerCase();
+  if (lower === '/api' || lower.startsWith('/api/')) return null;
   return value;
 }
 


### PR DESCRIPTION
## Resumen

Seguimiento de la revisión de la PR #309 (issue #295). Cierra los tres flecos que quedaron:

1. **Dueño único del "sesión inválida → login".** `clearToken()` ahora devuelve si pudo borrar la cookie, y el nuevo helper **`redirectToLogin(next)`** (`apps/web/src/lib/auth.ts`) encapsula el movimiento completo: borra la cookie cuando el runtime lo permite (Server Actions) y redirige a `loginHref(next)`; cuando no puede (render de Server Components), redirige a través del nuevo **route handler `GET /api/session/clear?next=…`**, que borra la cookie de verdad (ahí sí es legal) y reenvía a login.
2. **La cookie caducada ya no es inmortal.** Antes, en caminos de render la cookie vencida sobrevivía hasta su `maxAge` (8h) y cada navegación protegida pagaba SSR completo + llamadas API condenadas al 401 (los gates de `proxy.ts` y `requireSession` son de solo-presencia). Ahora el primer 401 la elimina vía el route handler. El `next` va saneado por `safeNextPath` en ambos saltos (mismo contrato anti open-redirect de #258).
3. **Migración del patrón copiado.** Los **86 call sites** del par `await clearToken(); redirect(loginHref(next))` (43 ficheros) pasan a `return redirectToLogin(next)`. En `recursos/[resourceId]/page.tsx` se elimina la llamada muerta a `clearToken()` (no-op garantizado en render, sin redirect posterior) y se deja de reenviar el Bearer inválido al endpoint público cuando `/auth/me` devolvió 401.

**Segundo commit (`21c2207`) — hallazgos de la revisión en detalle de esta misma PR:**

- **Fix de bucle de login:** `safeNextPath` rechaza `/api/*` como `next`. Sin esto, `/login?next=%2Fapi%2Fsession%2Fclear` hacía que la redirección post-login entrara al endpoint que borra la cookie recién emitida (afectaba a login, signup, OAuth y onboarding). Test nuevo que lo fija.
- **Comentario honesto en el route handler** (es un logout no autenticado; el forced-logout cross-site queda aceptado como impacto bajo) y base del redirect con `request.url`, consistente con `proxy.ts`.
- **Sweep semántico completo:** 25 sitios más que manejaban el mismo caso (401 o `getMe()==null` con token presente) con `redirect(loginHref(…))` sin limpieza — toda la capa `/admin`, dashboard, panel y varias actions — migran a `redirectToLogin`; `dashboard-layout.tsx` además hacía `redirect('/login')` a mano perdiendo el `next`.
- Los dos `logout` pasan a `redirectToLogin()` y **`clearToken` deja de exportarse** (un solo dueño del contrato); `reportar` y `reportar-estado` usan `requireSession` en vez de su gate artesanal; el docstring de `requireSession` deja de recomendar el patrón antiguo.

## Validación

- [x] Gate de la zona: `pnpm --filter @reliefhub/api-client build`, `pnpm --filter web build` (tsc estricto — valida el narrowing de los ~111 call sites migrados), `pnpm --filter web lint` (solo la warning preexistente de `opengraph-image.tsx`) y `pnpm --filter web test` (**89 pass**, incluye los tests de `sessionClearHref` y del rechazo de `/api/*` en `next`). Cambio web-only.
- [x] Verificado manualmente en build de producción (`next start`) contra un stub de API que responde 401, con cookie `rh_token` caducada:
  - Página protegida (p. ej. `/admin`) → **307** a `/api/session/clear?next=…`.
  - El route handler responde **`Set-Cookie: rh_token=; Expires=Thu, 01 Jan 1970`** (borrado real) + **307** a `/login?next=<página exacta>`.
  - `?next=https%3A%2F%2Fevil.com` y `?next=%2Fapi%2Fsession%2Fclear` colapsan a `/login` (sin open redirect, sin bucle).
  - Cero errores en el log del servidor.
- [x] Docs/migraciones/cliente API: no aplica (sin cambios de API ni de esquema); el contrato queda en los docstrings de `redirectToLogin`/`sessionClearHref` y el route handler.

## Cierre

- Closes #312