### PR TITLE
feat(supplies): backfill best-effort de supplyId en líneas legacy + informe de no-casados

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -6396,6 +6396,64 @@
         ]
       }
     },
+    "/admin/supplies/backfill": {
+      "get": {
+        "operationId": "SuppliesAdminController_backfillReport",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupplyLinkReportDto"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Falta el permiso catalogue:manage"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Informe de líneas legacy sin enlazar al catálogo (no-casadas)",
+        "tags": [
+          "supplies-admin"
+        ]
+      },
+      "post": {
+        "operationId": "SuppliesAdminController_backfill",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupplyLinkBackfillResultDto"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Falta el permiso catalogue:manage"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Backfill best-effort del supplyId de las líneas legacy (idempotente)",
+        "tags": [
+          "supplies-admin"
+        ]
+      }
+    },
     "/admin/supplies/{id}": {
       "get": {
         "operationId": "SuppliesAdminController_get",
@@ -14684,6 +14742,105 @@
           "attributes",
           "status",
           "aliases"
+        ]
+      },
+      "UnmatchedSupplyLineGroupDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "Harina PAN"
+          },
+          "lines": {
+            "type": "number",
+            "example": 12,
+            "description": "Líneas sin enlazar con ese texto"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "need_items",
+                "offer_items",
+                "resource_items",
+                "donation_intake_lines",
+                "container_lines"
+              ]
+            }
+          },
+          "ambiguous": {
+            "type": "boolean",
+            "example": false,
+            "description": "true = el texto casa con varios insumos activos: fusionar duplicados en vez de crear un alias"
+          }
+        },
+        "required": [
+          "name",
+          "lines",
+          "sources",
+          "ambiguous"
+        ]
+      },
+      "SupplyLinkReportDto": {
+        "type": "object",
+        "properties": {
+          "unmatchedLines": {
+            "type": "number",
+            "example": 27
+          },
+          "unmatched": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UnmatchedSupplyLineGroupDto"
+            }
+          },
+          "pendingNames": {
+            "type": "number",
+            "example": 34,
+            "description": "Textos distintos que un backfill enlazaría ahora"
+          },
+          "pendingLines": {
+            "type": "number",
+            "example": 120
+          }
+        },
+        "required": [
+          "unmatchedLines",
+          "unmatched",
+          "pendingNames",
+          "pendingLines"
+        ]
+      },
+      "SupplyLinkBackfillResultDto": {
+        "type": "object",
+        "properties": {
+          "unmatchedLines": {
+            "type": "number",
+            "example": 27
+          },
+          "unmatched": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UnmatchedSupplyLineGroupDto"
+            }
+          },
+          "linkedNames": {
+            "type": "number",
+            "example": 34,
+            "description": "Textos distintos que casaron contra el catálogo"
+          },
+          "linkedLines": {
+            "type": "number",
+            "example": 120,
+            "description": "Líneas realmente actualizadas en esta ejecución (0 al re-correr o si otra ejecución concurrente las enlazó antes)"
+          }
+        },
+        "required": [
+          "unmatchedLines",
+          "unmatched",
+          "linkedNames",
+          "linkedLines"
         ]
       },
       "EditSupplyDto": {

--- a/apps/api/src/contexts/supplies/application/backfill-supply-links.spec.ts
+++ b/apps/api/src/contexts/supplies/application/backfill-supply-links.spec.ts
@@ -1,0 +1,170 @@
+import { BackfillSupplyLinks } from './backfill-supply-links';
+import { PublicSupplyRecord } from '../domain/ports/supply-catalog.read-model';
+import { UnlinkedLineGroup } from '../domain/ports/supply-link-backfill.repository';
+
+function makeRecord(
+  overrides: Partial<PublicSupplyRecord> & { id: string; nameEs: string },
+): PublicSupplyRecord {
+  return {
+    code: 'INS-9999',
+    nameEn: null,
+    categorySlug: 'food',
+    categoryLabelEs: 'Alimentos',
+    categoryLabelEn: null,
+    defaultUnit: null,
+    attributes: {},
+    variantOfId: null,
+    aliases: [],
+    ...overrides,
+  };
+}
+
+function makeUseCase(
+  records: PublicSupplyRecord[],
+  groups: UnlinkedLineGroup[],
+  linkedLines = 0,
+) {
+  const catalog = { listActive: jest.fn().mockResolvedValue(records) };
+  const repo = {
+    listUnlinked: jest.fn().mockResolvedValue(groups),
+    applyLinks: jest.fn().mockResolvedValue(linkedLines),
+  };
+  return { useCase: new BackfillSupplyLinks(catalog, repo), catalog, repo };
+}
+
+const water = makeRecord({
+  id: 'sup-water',
+  code: 'INS-0001',
+  nameEs: 'Agua potable',
+  nameEn: 'Drinking water',
+  categorySlug: 'water',
+  aliases: ['agua embotellada'],
+});
+
+describe('BackfillSupplyLinks', () => {
+  it('enlaza por nombre y alias (normalización de mayúsculas/tildes) y deja el resto como no-casado', async () => {
+    const { useCase, repo } = makeUseCase(
+      [water],
+      [
+        { source: 'need_items', name: 'AGUA   Potable', lines: 3 },
+        { source: 'offer_items', name: 'Agua embotellada', lines: 2 },
+        { source: 'resource_items', name: 'Harina PAN', lines: 5 },
+      ],
+      5,
+    );
+
+    const result = await useCase.execute();
+
+    expect(repo.applyLinks).toHaveBeenCalledWith([
+      { source: 'need_items', name: 'AGUA   Potable', supplyId: 'sup-water' },
+      {
+        source: 'offer_items',
+        name: 'Agua embotellada',
+        supplyId: 'sup-water',
+      },
+    ]);
+    expect(result.linkedNames).toBe(2);
+    expect(result.linkedLines).toBe(5);
+    expect(result.unmatched).toEqual([
+      {
+        name: 'Harina PAN',
+        lines: 5,
+        sources: ['resource_items'],
+        ambiguous: false,
+      },
+    ]);
+    expect(result.unmatchedLines).toBe(5);
+  });
+
+  it('es idempotente: sin grupos resolubles no escribe nada', async () => {
+    const { useCase, repo } = makeUseCase(
+      [water],
+      [{ source: 'container_lines', name: 'Harina PAN', lines: 1 }],
+    );
+
+    const result = await useCase.execute();
+
+    expect(repo.applyLinks).not.toHaveBeenCalled();
+    expect(result.linkedLines).toBe(0);
+    expect(result.linkedNames).toBe(0);
+  });
+
+  it('agrega los no-casados por texto normalizado sumando líneas y fuentes, ordenado por volumen', async () => {
+    const { useCase } = makeUseCase(
+      [water],
+      [
+        { source: 'need_items', name: 'Harina PAN', lines: 2 },
+        { source: 'container_lines', name: 'harina  pan', lines: 3 },
+        { source: 'offer_items', name: 'Pañales', lines: 1 },
+      ],
+    );
+
+    const report = await useCase.report();
+
+    expect(report.unmatched).toEqual([
+      {
+        name: 'Harina PAN',
+        lines: 5,
+        sources: ['need_items', 'container_lines'],
+        ambiguous: false,
+      },
+      { name: 'Pañales', lines: 1, sources: ['offer_items'], ambiguous: false },
+    ]);
+    expect(report.unmatchedLines).toBe(6);
+  });
+
+  it('una etiqueta ambigua (misma forma normalizada en dos insumos) no se enlaza', async () => {
+    const gloves = makeRecord({
+      id: 'sup-gloves-a',
+      code: 'INS-0002',
+      nameEs: 'Guantes',
+    });
+    const glovesDupe = makeRecord({
+      id: 'sup-gloves-b',
+      code: 'INS-0003',
+      nameEs: 'GUANTES',
+    });
+    const { useCase, repo } = makeUseCase(
+      [gloves, glovesDupe],
+      [{ source: 'resource_items', name: 'guantes', lines: 4 }],
+    );
+
+    const result = await useCase.execute();
+
+    expect(repo.applyLinks).not.toHaveBeenCalled();
+    // ambiguous=true distingue el remedio: fusionar duplicados, no crear alias.
+    expect(result.unmatched).toEqual([
+      {
+        name: 'guantes',
+        lines: 4,
+        sources: ['resource_items'],
+        ambiguous: true,
+      },
+    ]);
+  });
+
+  it('report() calcula lo que casaría sin ejecutar el backfill', async () => {
+    const { useCase, repo } = makeUseCase(
+      [water],
+      [
+        { source: 'need_items', name: 'agua potable', lines: 3 },
+        { source: 'donation_intake_lines', name: 'INS-0001', lines: 1 },
+        { source: 'offer_items', name: 'Leche en polvo', lines: 2 },
+      ],
+    );
+
+    const report = await useCase.report();
+
+    expect(repo.applyLinks).not.toHaveBeenCalled();
+    expect(report.pendingNames).toBe(2);
+    expect(report.pendingLines).toBe(4);
+    expect(report.unmatched).toEqual([
+      {
+        name: 'Leche en polvo',
+        lines: 2,
+        sources: ['offer_items'],
+        ambiguous: false,
+      },
+    ]);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/backfill-supply-links.ts
+++ b/apps/api/src/contexts/supplies/application/backfill-supply-links.ts
@@ -1,0 +1,138 @@
+import { SupplyCatalogReadModel } from '../domain/ports/supply-catalog.read-model';
+import {
+  SupplyLineSource,
+  SupplyLinkBackfillRepository,
+  SupplyLinkPatch,
+} from '../domain/ports/supply-link-backfill.repository';
+import { normalizeSupplyText } from '../domain/supply-normalize';
+import { supplyResolverFromCatalog } from '../domain/supply-resolver';
+
+/** Texto que no casa con el catálogo, agregado por forma normalizada. */
+export interface UnmatchedSupplyLineGroup {
+  /** Primera variante cruda vista de ese texto (para mostrar al admin). */
+  name: string;
+  /** Total de líneas sin casar con ese texto (todas las fuentes). */
+  lines: number;
+  sources: SupplyLineSource[];
+  /**
+   * true = el texto casa con MÁS de un insumo activo. El remedio no es un
+   * alias (nunca desambigua) sino fusionar/renombrar los insumos en conflicto.
+   */
+  ambiguous: boolean;
+}
+
+/** Informe de solo lectura: qué casaría y qué no, sin escribir nada. */
+export interface SupplyLinkReport {
+  /** Textos distintos que un backfill enlazaría ahora mismo. */
+  pendingNames: number;
+  pendingLines: number;
+  unmatchedLines: number;
+  unmatched: UnmatchedSupplyLineGroup[];
+}
+
+/** Resultado de una ejecución del backfill. */
+export interface SupplyLinkBackfillResult {
+  /** Textos distintos que casaron contra el catálogo en esta ejecución. */
+  linkedNames: number;
+  /** Líneas realmente actualizadas en esta ejecución (0 al re-correr). */
+  linkedLines: number;
+  unmatchedLines: number;
+  unmatched: UnmatchedSupplyLineGroup[];
+}
+
+interface Classification {
+  patches: SupplyLinkPatch[];
+  resolvedNames: number;
+  resolvedLines: number;
+  unmatched: UnmatchedSupplyLineGroup[];
+  unmatchedLines: number;
+}
+
+/**
+ * Backfill best-effort de los soft-links `supplyId` (#226): resuelve el texto
+ * libre de las líneas legacy contra el catálogo maestro activo (nombre es/en,
+ * código y alias, vía `SupplyResolver`) y enlaza solo lo que casa sin
+ * ambigüedad. Lo no-casado queda como informe para revisión admin — el remedio
+ * es dar de alta un alias (o fusionar duplicados si `ambiguous`) y
+ * re-ejecutar, nunca forzar el enlace.
+ */
+export class BackfillSupplyLinks {
+  constructor(
+    private readonly catalog: SupplyCatalogReadModel,
+    private readonly repo: SupplyLinkBackfillRepository,
+  ) {}
+
+  /** Informe sin efectos: qué enlazaría un backfill y qué queda sin casar. */
+  async report(): Promise<SupplyLinkReport> {
+    const c = await this.classify();
+    return {
+      pendingNames: c.resolvedNames,
+      pendingLines: c.resolvedLines,
+      unmatchedLines: c.unmatchedLines,
+      unmatched: c.unmatched,
+    };
+  }
+
+  /** Ejecuta el backfill y devuelve el resultado + informe de no-casados. */
+  async execute(): Promise<SupplyLinkBackfillResult> {
+    const c = await this.classify();
+    const linkedLines =
+      c.patches.length > 0 ? await this.repo.applyLinks(c.patches) : 0;
+    return {
+      linkedNames: c.resolvedNames,
+      linkedLines,
+      unmatchedLines: c.unmatchedLines,
+      unmatched: c.unmatched,
+    };
+  }
+
+  private async classify(): Promise<Classification> {
+    const [groups, records] = await Promise.all([
+      this.repo.listUnlinked(),
+      this.catalog.listActive(),
+    ]);
+    const resolver = supplyResolverFromCatalog(records);
+
+    const patches: SupplyLinkPatch[] = [];
+    const resolvedKeys = new Set<string>();
+    let resolvedLines = 0;
+    const unmatchedByKey = new Map<string, UnmatchedSupplyLineGroup>();
+
+    for (const group of groups) {
+      const supplyId = resolver.resolve(group.name);
+      const key = normalizeSupplyText(group.name);
+      if (supplyId !== null) {
+        patches.push({ source: group.source, name: group.name, supplyId });
+        resolvedKeys.add(key);
+        resolvedLines += group.lines;
+        continue;
+      }
+      const current = unmatchedByKey.get(key);
+      if (current) {
+        current.lines += group.lines;
+        if (!current.sources.includes(group.source)) {
+          current.sources.push(group.source);
+        }
+      } else {
+        unmatchedByKey.set(key, {
+          name: group.name,
+          lines: group.lines,
+          sources: [group.source],
+          ambiguous: resolver.isAmbiguous(group.name),
+        });
+      }
+    }
+
+    const unmatched = [...unmatchedByKey.values()].sort(
+      (a, b) => b.lines - a.lines || a.name.localeCompare(b.name),
+    );
+    const unmatchedLines = unmatched.reduce((sum, g) => sum + g.lines, 0);
+    return {
+      patches,
+      resolvedNames: resolvedKeys.size,
+      resolvedLines,
+      unmatched,
+      unmatchedLines,
+    };
+  }
+}

--- a/apps/api/src/contexts/supplies/application/list-supplies.ts
+++ b/apps/api/src/contexts/supplies/application/list-supplies.ts
@@ -1,7 +1,5 @@
-import { Supply } from '../domain/supply';
-import { SupplyAlias } from '../domain/supply-alias';
 import { normalizeSupplyText } from '../domain/supply-normalize';
-import { SupplyResolver } from '../domain/supply-resolver';
+import { supplyResolverFromCatalog } from '../domain/supply-resolver';
 import {
   PublicSupplyRecord,
   SupplyCatalogReadModel,
@@ -91,40 +89,6 @@ function getMatchScore(
   return score;
 }
 
-/**
- * Índice de resolución exacta (nombre canónico es/en, código y alias). Los
- * registros ya son `active`, así que los campos de gestión del agregado se
- * rellenan con placeholders neutros: el resolver solo lee id/nombre/código.
- */
-function toSupplyResolver(
-  records: readonly PublicSupplyRecord[],
-): SupplyResolver {
-  const make = (record: PublicSupplyRecord, name: string): Supply =>
-    Supply.fromSnapshot({
-      id: record.id,
-      code: record.code,
-      name,
-      categorySlug: record.categorySlug,
-      defaultUnit: record.defaultUnit,
-      attributes: record.attributes,
-      variantOfId: record.variantOfId,
-      status: 'active',
-      registrationNotes: null,
-    });
-
-  const supplies = records.flatMap((record) =>
-    record.nameEn
-      ? [make(record, record.nameEs), make(record, record.nameEn)]
-      : [make(record, record.nameEs)],
-  );
-  const aliases = records.flatMap((record) =>
-    record.aliases.map((alias) =>
-      SupplyAlias.create({ alias, supplyId: record.id }),
-    ),
-  );
-  return new SupplyResolver(supplies, aliases);
-}
-
 export class ListSupplies {
   constructor(private readonly catalog: SupplyCatalogReadModel) {}
 
@@ -133,7 +97,7 @@ export class ListSupplies {
     const resolvedLocale = query.locale === 'en' ? 'en' : 'es';
     const normalizedQuery = query.q ? normalizeSupplyText(query.q) : '';
     const exactMatchId = query.q
-      ? toSupplyResolver(records).resolve(query.q)
+      ? supplyResolverFromCatalog(records).resolve(query.q)
       : null;
 
     if (!normalizedQuery) {

--- a/apps/api/src/contexts/supplies/domain/ports/supply-link-backfill.repository.ts
+++ b/apps/api/src/contexts/supplies/domain/ports/supply-link-backfill.repository.ts
@@ -1,0 +1,43 @@
+export const SUPPLY_LINK_BACKFILL_REPOSITORY = Symbol(
+  'SUPPLY_LINK_BACKFILL_REPOSITORY',
+);
+
+/**
+ * De dónde sale una línea de material sin enlazar. Las cuatro primeras son las
+ * tablas `*_items`/`*_lines` con columna `supply_id` (migración 0045); la
+ * quinta son las líneas jsonb embebidas en `containers.lines`.
+ */
+export type SupplyLineSource =
+  | 'need_items'
+  | 'offer_items'
+  | 'resource_items'
+  | 'donation_intake_lines'
+  | 'container_lines';
+
+/** Texto libre de líneas con `supplyId` nulo, agrupado por fuente + nombre. */
+export interface UnlinkedLineGroup {
+  source: SupplyLineSource;
+  /** El `name` crudo tal y como está persistido (sin normalizar). */
+  name: string;
+  /** Cuántas líneas sin enlazar comparten exactamente ese texto. */
+  lines: number;
+}
+
+/** Orden de enlace: fija `supplyId` en las líneas de `source` cuyo `name` crudo coincida. */
+export interface SupplyLinkPatch {
+  source: SupplyLineSource;
+  name: string;
+  supplyId: string;
+}
+
+/**
+ * Puerto del backfill de soft-links (#226). El contrato garantiza la
+ * idempotencia: `applyLinks` SOLO escribe donde `supplyId` sigue nulo, así que
+ * re-ejecutar no duplica ni revierte enlaces manuales previos.
+ */
+export interface SupplyLinkBackfillRepository {
+  /** Grupos (fuente, texto) de líneas aún sin enlazar al catálogo. */
+  listUnlinked(): Promise<UnlinkedLineGroup[]>;
+  /** Aplica los enlaces resueltos y devuelve cuántas líneas se actualizaron. */
+  applyLinks(patches: readonly SupplyLinkPatch[]): Promise<number>;
+}

--- a/apps/api/src/contexts/supplies/domain/supply-resolver.spec.ts
+++ b/apps/api/src/contexts/supplies/domain/supply-resolver.spec.ts
@@ -68,6 +68,20 @@ describe('SupplyResolver', () => {
     expect(resolver.resolve('insumo generico')).toBeNull();
   });
 
+  it('isAmbiguous distingue etiqueta ambigua de etiqueta desconocida', () => {
+    const resolver = new SupplyResolver(
+      [water, diapers],
+      [
+        SupplyAlias.create({ alias: 'insumo generico', supplyId: water.id }),
+        SupplyAlias.create({ alias: 'insumo generico', supplyId: diapers.id }),
+      ],
+    );
+
+    expect(resolver.isAmbiguous('INSUMO Generico')).toBe(true);
+    expect(resolver.isAmbiguous('arbol raro')).toBe(false);
+    expect(resolver.isAmbiguous('agua potable')).toBe(false);
+  });
+
   it('resolveMany deduplica resultados', () => {
     const resolver = new SupplyResolver(
       [water, diapers],

--- a/apps/api/src/contexts/supplies/domain/supply-resolver.ts
+++ b/apps/api/src/contexts/supplies/domain/supply-resolver.ts
@@ -1,5 +1,6 @@
 import { Supply } from './supply';
 import { SupplyAlias } from './supply-alias';
+import { PublicSupplyRecord } from './ports/supply-catalog.read-model';
 
 export class SupplyResolver {
   private readonly index = new Map<string, string | null>();
@@ -35,10 +36,57 @@ export class SupplyResolver {
     return resolved ?? null;
   }
 
+  /**
+   * Una etiqueta es ambigua cuando su forma normalizada apunta a más de un
+   * insumo. `resolve()` la devuelve como null igual que una desconocida, pero
+   * el remedio operativo es distinto: un alias nuevo nunca la desambigua —
+   * hay que fusionar (o renombrar) los insumos en conflicto.
+   */
+  isAmbiguous(label: string): boolean {
+    return this.index.get(SupplyAlias.normalize(label)) === null;
+  }
+
   resolveMany(labels: string[]): string[] {
     const resolved = labels
       .map((label) => this.resolve(label))
       .filter((s): s is string => s !== null);
     return [...new Set(resolved)];
   }
+}
+
+/**
+ * Índice de resolución exacta sobre el catálogo activo (nombre canónico
+ * es/en, código y alias). Los registros ya son `active`, así que los campos
+ * de gestión del agregado se rellenan con placeholders neutros: el resolver
+ * solo lee id/nombre/código. Resolver contra el catálogo activo es deliberado
+ * — un insumo fusionado/archivado no debe captar líneas nuevas; su texto sale
+ * en el informe de no-casados (#226) para dar de alta un alias.
+ */
+export function supplyResolverFromCatalog(
+  records: readonly PublicSupplyRecord[],
+): SupplyResolver {
+  const make = (record: PublicSupplyRecord, name: string): Supply =>
+    Supply.fromSnapshot({
+      id: record.id,
+      code: record.code,
+      name,
+      categorySlug: record.categorySlug,
+      defaultUnit: record.defaultUnit,
+      attributes: record.attributes,
+      variantOfId: record.variantOfId,
+      status: 'active',
+      registrationNotes: null,
+    });
+
+  const supplies = records.flatMap((record) =>
+    record.nameEn
+      ? [make(record, record.nameEs), make(record, record.nameEn)]
+      : [make(record, record.nameEs)],
+  );
+  const aliases = records.flatMap((record) =>
+    record.aliases.map((alias) =>
+      SupplyAlias.create({ alias, supplyId: record.id }),
+    ),
+  );
+  return new SupplyResolver(supplies, aliases);
 }

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.int-spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.int-spec.ts
@@ -1,0 +1,296 @@
+import { eq } from 'drizzle-orm';
+import { createDb, Db } from '../../../../shared/db';
+import { containersTable, suppliesTable } from './schema';
+import {
+  needItemsTable,
+  needsTable,
+} from '../../../needs/infrastructure/drizzle/schema';
+import {
+  offerItemsTable,
+  offersTable,
+} from '../../../offers/infrastructure/drizzle/schema';
+import {
+  donationIntakeLinesTable,
+  donationIntakesTable,
+} from '../../../offers/infrastructure/drizzle/donation-intake-schema';
+import {
+  resourceItemsTable,
+  resourcesTable,
+} from '../../../resources/infrastructure/drizzle/schema';
+import { DrizzleSupplyLinkBackfillRepository } from './drizzle-supply-link-backfill.repository';
+import type { SupplyLineSnapshot } from '../../domain/supply-line';
+import type { Category } from '../../domain/category';
+import type { Pool } from 'pg';
+
+const URL =
+  process.env.DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub';
+
+const EM = '55555555-5555-4555-8555-555555555555';
+const USER = '77777777-7777-4777-8777-777777777777';
+const SUPPLY_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SUPPLY_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const NEED = '11111111-2222-4333-8444-555555555501';
+const OFFER = '11111111-2222-4333-8444-555555555502';
+const RESOURCE = '11111111-2222-4333-8444-555555555503';
+const INTAKE = '11111111-2222-4333-8444-555555555504';
+const CONTAINER = '11111111-2222-4333-8444-555555555505';
+
+const NOW = new Date('2026-07-01T00:00:00.000Z');
+
+function containerLine(
+  name: string,
+  supplyId: string | null,
+): SupplyLineSnapshot {
+  return {
+    name,
+    quantity: 1,
+    unit: null,
+    category: 'water' as Category,
+    supplyId,
+    presentation: null,
+    expiresAt: null,
+  };
+}
+
+describe('DrizzleSupplyLinkBackfillRepository (integration)', () => {
+  let db: Db;
+  let pool: Pool;
+  let repo: DrizzleSupplyLinkBackfillRepository;
+
+  beforeAll(() => {
+    ({ db, pool } = createDb(URL));
+    repo = new DrizzleSupplyLinkBackfillRepository(db);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await db.delete(needItemsTable);
+    await db.delete(needsTable);
+    await db.delete(offerItemsTable);
+    await db.delete(offersTable);
+    await db.delete(donationIntakeLinesTable);
+    await db.delete(donationIntakesTable);
+    await db.delete(resourceItemsTable);
+    await db.delete(resourcesTable);
+    await db.delete(containersTable);
+    await db.delete(suppliesTable);
+
+    await db.insert(suppliesTable).values([
+      {
+        id: SUPPLY_A,
+        code: 'INS-9001',
+        name: 'Agua potable',
+        categorySlug: 'water',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+      {
+        id: SUPPLY_B,
+        code: 'INS-9002',
+        name: 'Harina de maíz',
+        categorySlug: 'food',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+
+    await db.insert(needsTable).values({
+      id: NEED,
+      emergencyId: EM,
+      title: 'Necesidad test',
+      address: 'Calle 1',
+      latitude: 0,
+      longitude: 0,
+      priority: 'high',
+      requesterUserId: USER,
+      status: 'published',
+      createdAt: NOW,
+    });
+    await db.insert(needItemsTable).values([
+      {
+        id: '21111111-2222-4333-8444-555555555511',
+        needId: NEED,
+        name: 'AGUA Potable',
+        quantity: 3,
+        category: 'water',
+      },
+      {
+        id: '21111111-2222-4333-8444-555555555512',
+        needId: NEED,
+        name: 'AGUA Potable',
+        quantity: 1,
+        category: 'water',
+      },
+      // Enlace manual previo: el backfill NUNCA debe tocarlo.
+      {
+        id: '21111111-2222-4333-8444-555555555513',
+        needId: NEED,
+        name: 'AGUA Potable',
+        quantity: 2,
+        category: 'water',
+        supplyId: SUPPLY_B,
+      },
+    ]);
+
+    await db.insert(offersTable).values({
+      id: OFFER,
+      emergencyId: EM,
+      donorUserId: USER,
+      address: 'Calle 2',
+      latitude: 0,
+      longitude: 0,
+      status: 'pending',
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    await db.insert(offerItemsTable).values({
+      id: '21111111-2222-4333-8444-555555555521',
+      offerId: OFFER,
+      name: 'agua embotellada',
+      quantity: 5,
+      category: 'water',
+    });
+
+    await db.insert(resourcesTable).values({
+      id: RESOURCE,
+      emergencyId: EM,
+      type: 'collection_point',
+      name: 'Punto test',
+      address: 'Calle 3',
+      latitude: 0,
+      longitude: 0,
+      ownerUserId: USER,
+      verificationLevel: 'unverified',
+      publicStatus: 'published',
+      createdAt: NOW,
+    });
+    await db.insert(resourceItemsTable).values({
+      id: '21111111-2222-4333-8444-555555555531',
+      resourceId: RESOURCE,
+      name: 'Harina PAN',
+      quantity: 7,
+      category: 'food',
+    });
+
+    await db.insert(donationIntakesTable).values({
+      id: INTAKE,
+      emergencyId: EM,
+      targetResourceId: RESOURCE,
+      intakeCode: 'DON-0001',
+      status: 'pending',
+      donorName: 'Donante test',
+      donorPhone: '+58 412 0000000',
+      contactNormalized: 'donante-test',
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    await db.insert(donationIntakeLinesTable).values({
+      id: '21111111-2222-4333-8444-555555555541',
+      intakeId: INTAKE,
+      name: 'AGUA Potable',
+      quantity: 2,
+      category: 'water',
+    });
+
+    await db.insert(containersTable).values({
+      id: CONTAINER,
+      emergencyId: EM,
+      code: 'CAJ-0001',
+      type: 'box',
+      lines: [
+        containerLine('AGUA Potable', null),
+        containerLine('Harina PAN', null),
+        containerLine('Pañales', SUPPLY_B),
+      ],
+      status: 'open',
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+  });
+
+  it('listUnlinked agrupa por texto crudo y fuente, ignorando las líneas ya enlazadas', async () => {
+    const groups = await repo.listUnlinked();
+
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        { source: 'need_items', name: 'AGUA Potable', lines: 2 },
+        { source: 'offer_items', name: 'agua embotellada', lines: 1 },
+        { source: 'resource_items', name: 'Harina PAN', lines: 1 },
+        { source: 'donation_intake_lines', name: 'AGUA Potable', lines: 1 },
+        { source: 'container_lines', name: 'AGUA Potable', lines: 1 },
+        { source: 'container_lines', name: 'Harina PAN', lines: 1 },
+      ]),
+    );
+    // La línea de contenedor ya enlazada y la need_item manual no aparecen.
+    expect(groups).toHaveLength(6);
+  });
+
+  it('applyLinks enlaza solo supply_id nulos por (fuente, texto exacto), incluidas las líneas jsonb', async () => {
+    const updated = await repo.applyLinks([
+      { source: 'need_items', name: 'AGUA Potable', supplyId: SUPPLY_A },
+      { source: 'offer_items', name: 'agua embotellada', supplyId: SUPPLY_A },
+      {
+        source: 'donation_intake_lines',
+        name: 'AGUA Potable',
+        supplyId: SUPPLY_A,
+      },
+      { source: 'container_lines', name: 'AGUA Potable', supplyId: SUPPLY_A },
+    ]);
+
+    // 2 need_items + 1 offer_item + 1 intake_line + 1 línea de contenedor.
+    expect(updated).toBe(5);
+
+    const needLines = await db
+      .select({
+        supplyId: needItemsTable.supplyId,
+        quantity: needItemsTable.quantity,
+      })
+      .from(needItemsTable);
+    expect(
+      needLines.filter((l) => l.supplyId === SUPPLY_A).map((l) => l.quantity),
+    ).toEqual(expect.arrayContaining([3, 1]));
+    // El enlace manual a SUPPLY_B sobrevive.
+    expect(needLines.find((l) => l.quantity === 2)?.supplyId).toBe(SUPPLY_B);
+
+    // resource_items no estaba en los parches: sigue sin enlazar.
+    const [resourceLine] = await db
+      .select({ supplyId: resourceItemsTable.supplyId })
+      .from(resourceItemsTable);
+    expect(resourceLine.supplyId).toBeNull();
+
+    const [container] = await db
+      .select({ lines: containersTable.lines })
+      .from(containersTable)
+      .where(eq(containersTable.id, CONTAINER));
+    expect(container.lines).toEqual([
+      expect.objectContaining({ name: 'AGUA Potable', supplyId: SUPPLY_A }),
+      expect.objectContaining({ name: 'Harina PAN', supplyId: null }),
+      expect.objectContaining({ name: 'Pañales', supplyId: SUPPLY_B }),
+    ]);
+  });
+
+  it('re-ejecutar los mismos parches no actualiza nada (idempotencia)', async () => {
+    const patches = [
+      {
+        source: 'need_items' as const,
+        name: 'AGUA Potable',
+        supplyId: SUPPLY_A,
+      },
+      {
+        source: 'container_lines' as const,
+        name: 'AGUA Potable',
+        supplyId: SUPPLY_A,
+      },
+    ];
+
+    const first = await repo.applyLinks(patches);
+    const second = await repo.applyLinks(patches);
+
+    expect(first).toBe(3);
+    expect(second).toBe(0);
+  });
+});

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.spec.ts
@@ -1,0 +1,55 @@
+import { relinkContainerLines } from './drizzle-supply-link-backfill.repository';
+import { SupplyLineSnapshot } from '../../domain/supply-line';
+
+function line(overrides: Partial<SupplyLineSnapshot>): SupplyLineSnapshot {
+  return {
+    name: 'Agua potable',
+    quantity: 1,
+    unit: null,
+    category: 'water',
+    supplyId: null,
+    presentation: null,
+    expiresAt: null,
+    ...overrides,
+  } as SupplyLineSnapshot;
+}
+
+describe('relinkContainerLines', () => {
+  const map = new Map([['Agua potable', 'sup-water']]);
+
+  it('enlaza solo las líneas sin supplyId cuyo nombre crudo casa', () => {
+    const lines = [
+      line({}),
+      line({ name: 'Harina PAN' }),
+      line({ supplyId: 'sup-manual' }),
+    ];
+
+    const result = relinkContainerLines(lines, map);
+
+    expect(result.relinked).toBe(1);
+    expect(result.lines[0].supplyId).toBe('sup-water');
+    expect(result.lines[1].supplyId).toBeNull();
+    expect(result.lines[2].supplyId).toBe('sup-manual');
+  });
+
+  it('no muta el array original y preserva el resto de campos de la línea', () => {
+    const original = line({ quantity: 7, presentation: 'botella 1.5L' });
+
+    const result = relinkContainerLines([original], map);
+
+    expect(original.supplyId).toBeNull();
+    expect(result.lines[0]).toEqual({
+      ...original,
+      supplyId: 'sup-water',
+    });
+  });
+
+  it('devuelve relinked=0 cuando no hay nada que enlazar', () => {
+    const lines = [line({ supplyId: 'sup-water' }), line({ name: 'Otro' })];
+
+    const result = relinkContainerLines(lines, map);
+
+    expect(result.relinked).toBe(0);
+    expect(result.lines).toEqual(lines);
+  });
+});

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.ts
@@ -1,0 +1,175 @@
+import { and, inArray, isNull, sql, eq } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import { SupplyLineSnapshot } from '../../domain/supply-line';
+import {
+  SupplyLineSource,
+  SupplyLinkBackfillRepository,
+  SupplyLinkPatch,
+  UnlinkedLineGroup,
+} from '../../domain/ports/supply-link-backfill.repository';
+import { containersTable } from './schema';
+import { needItemsTable } from '../../../needs/infrastructure/drizzle/schema';
+import { offerItemsTable } from '../../../offers/infrastructure/drizzle/schema';
+import { donationIntakeLinesTable } from '../../../offers/infrastructure/drizzle/donation-intake-schema';
+import { resourceItemsTable } from '../../../resources/infrastructure/drizzle/schema';
+
+/**
+ * Las cuatro tablas relacionales con columna `supply_id` (migración 0045).
+ * Comparten estructura por construcción (factory `supplyLineColumns`), así que
+ * un único registro sirve a `listUnlinked` y `applyLinks`: añadir la próxima
+ * fuente es una entrada aquí + el literal en `SupplyLineSource`, sin clonar
+ * bloques en dos métodos.
+ */
+const LINE_TABLES = [
+  ['need_items', needItemsTable],
+  ['offer_items', offerItemsTable],
+  ['resource_items', resourceItemsTable],
+  ['donation_intake_lines', donationIntakeLinesTable],
+] as const;
+
+/** Contenedores con alguna línea jsonb aún sin enlazar (clave ausente o null). */
+const hasUnlinkedLine = sql`EXISTS (
+  SELECT 1 FROM jsonb_array_elements(${containersTable.lines}) AS l
+  WHERE (l->>'supplyId') IS NULL
+)`;
+
+/**
+ * Reenlaza las líneas jsonb de un contenedor: fija `supplyId` en las líneas
+ * aún sin enlazar cuyo `name` crudo esté en el mapa. Pura para testearla sin
+ * BD; las líneas ya enlazadas nunca se tocan (idempotencia).
+ */
+export function relinkContainerLines(
+  lines: readonly SupplyLineSnapshot[],
+  supplyIdByName: ReadonlyMap<string, string>,
+): { lines: SupplyLineSnapshot[]; relinked: number } {
+  let relinked = 0;
+  const next = lines.map((line) => {
+    if (line.supplyId != null) return line;
+    const supplyId = supplyIdByName.get(line.name);
+    if (supplyId === undefined) return line;
+    relinked += 1;
+    return { ...line, supplyId };
+  });
+  return { lines: next, relinked };
+}
+
+/**
+ * Backfill de soft-links sobre las tablas de {@link LINE_TABLES} y sobre las
+ * líneas jsonb de `containers.lines`. Las tablas de otros contextos se
+ * importan directamente (mismo patrón que identity/metrics): esto es una
+ * operación de gobernanza del catálogo que corre por debajo de los agregados,
+ * y el guard `supply_id IS NULL` garantiza que nunca pisa un enlace ya hecho.
+ * También enlaza líneas de contenedores sellados/expedidos a propósito: el
+ * soft-link es metadato de catálogo, no altera el contenido declarado
+ * (name/quantity) que congela el sellado.
+ */
+export class DrizzleSupplyLinkBackfillRepository implements SupplyLinkBackfillRepository {
+  constructor(private readonly db: Db) {}
+
+  async listUnlinked(): Promise<UnlinkedLineGroup[]> {
+    const perTable = await Promise.all(
+      LINE_TABLES.map(async ([source, table]) => {
+        const rows = await this.db
+          .select({
+            name: table.name,
+            lines: sql<number>`count(*)::int`,
+          })
+          .from(table)
+          .where(isNull(table.supplyId))
+          .groupBy(table.name);
+        return rows.map(
+          (row): UnlinkedLineGroup => ({
+            source,
+            name: row.name,
+            lines: row.lines,
+          }),
+        );
+      }),
+    );
+
+    const containerRows = await this.db
+      .select({ lines: containersTable.lines })
+      .from(containersTable)
+      .where(hasUnlinkedLine);
+
+    const containerCounts = new Map<string, number>();
+    for (const row of containerRows) {
+      for (const line of row.lines) {
+        if (line.supplyId != null) continue;
+        containerCounts.set(
+          line.name,
+          (containerCounts.get(line.name) ?? 0) + 1,
+        );
+      }
+    }
+
+    const groups = perTable.flat();
+    for (const [name, lines] of containerCounts) {
+      groups.push({ source: 'container_lines', name, lines });
+    }
+    return groups;
+  }
+
+  async applyLinks(patches: readonly SupplyLinkPatch[]): Promise<number> {
+    // source -> supplyId -> names: un solo UPDATE por (tabla, insumo) en vez
+    // de un round-trip por cada texto distinto.
+    const grouped = new Map<SupplyLineSource, Map<string, string[]>>();
+    for (const patch of patches) {
+      const perSupply =
+        grouped.get(patch.source) ?? new Map<string, string[]>();
+      const names = perSupply.get(patch.supplyId) ?? [];
+      names.push(patch.name);
+      perSupply.set(patch.supplyId, names);
+      grouped.set(patch.source, perSupply);
+    }
+
+    let updated = 0;
+    await this.db.transaction(async (tx) => {
+      for (const [source, table] of LINE_TABLES) {
+        for (const [supplyId, names] of grouped.get(source) ?? []) {
+          const result = await tx
+            .update(table)
+            .set({ supplyId })
+            .where(and(inArray(table.name, names), isNull(table.supplyId)));
+          updated += result.rowCount ?? 0;
+        }
+      }
+
+      const containerPatches = grouped.get('container_lines');
+      if (containerPatches !== undefined) {
+        const supplyIdByName = new Map<string, string>();
+        for (const [supplyId, names] of containerPatches) {
+          for (const name of names) supplyIdByName.set(name, supplyId);
+        }
+        // FOR UPDATE: el relink es read-modify-write del jsonb completo; sin
+        // bloqueo, un save() concurrente del agregado Container (que también
+        // sobrescribe `lines` entero) perdería líneas en silencio. Solo se
+        // bloquean los contenedores que de verdad tienen algo que enlazar.
+        const nameList = sql.join(
+          [...supplyIdByName.keys()].map((name) => sql`${name}`),
+          sql`, `,
+        );
+        const rows = await tx
+          .select({ id: containersTable.id, lines: containersTable.lines })
+          .from(containersTable)
+          .where(
+            sql`EXISTS (
+              SELECT 1 FROM jsonb_array_elements(${containersTable.lines}) AS l
+              WHERE (l->>'supplyId') IS NULL AND (l->>'name') IN (${nameList})
+            )`,
+          )
+          .for('update');
+        for (const row of rows) {
+          const result = relinkContainerLines(row.lines, supplyIdByName);
+          if (result.relinked === 0) continue;
+          await tx
+            .update(containersTable)
+            .set({ lines: result.lines, updatedAt: new Date() })
+            .where(eq(containersTable.id, row.id));
+          updated += result.relinked;
+        }
+      }
+    });
+    return updated;
+  }
+}

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.controller.spec.ts
@@ -15,6 +15,10 @@ function makeController(overrides: Record<string, { execute: jest.Mock }>) {
     getSupplyAdmin: { execute: jest.fn().mockResolvedValue({ id: 'i' }) },
     ...overrides,
   };
+  const backfillSupplyLinks = {
+    execute: jest.fn().mockResolvedValue({ linkedLines: 3 }),
+    report: jest.fn().mockResolvedValue({ unmatched: [] }),
+  };
   const cache = { invalidate: jest.fn() };
   const controller = new SuppliesAdminController(
     useCases.createSupply as never,
@@ -26,9 +30,10 @@ function makeController(overrides: Record<string, { execute: jest.Mock }>) {
     useCases.mergeSupplies as never,
     useCases.listSuppliesAdmin as never,
     useCases.getSupplyAdmin as never,
+    backfillSupplyLinks as never,
     cache as never,
   );
-  return { controller, useCases, cache };
+  return { controller, useCases, backfillSupplyLinks, cache };
 }
 
 describe('SuppliesAdminController', () => {
@@ -77,6 +82,21 @@ describe('SuppliesAdminController', () => {
       sourceId: 's',
       targetId: 't',
     });
+  });
+
+  it('backfill ejecuta el caso de uso y devuelve su resultado', async () => {
+    const { controller, backfillSupplyLinks } = makeController({});
+    const result = await controller.backfill();
+    expect(backfillSupplyLinks.execute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ linkedLines: 3 });
+  });
+
+  it('backfillReport devuelve el informe sin ejecutar el backfill', async () => {
+    const { controller, backfillSupplyLinks } = makeController({});
+    const report = await controller.backfillReport();
+    expect(backfillSupplyLinks.report).toHaveBeenCalledTimes(1);
+    expect(backfillSupplyLinks.execute).not.toHaveBeenCalled();
+    expect(report).toEqual({ unmatched: [] });
   });
 
   it('archive/restore delegan el id', async () => {

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.controller.ts
@@ -30,6 +30,11 @@ import { RemoveSupplyAlias } from '../../application/remove-supply-alias';
 import { MergeSupplies } from '../../application/merge-supplies';
 import { ListSuppliesAdmin } from '../../application/list-supplies-admin';
 import { GetSupplyAdmin } from '../../application/get-supply-admin';
+import {
+  BackfillSupplyLinks,
+  SupplyLinkBackfillResult,
+  SupplyLinkReport,
+} from '../../application/backfill-supply-links';
 import { AdminSupplyView } from '../../application/admin-supply-view';
 import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
 import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
@@ -47,6 +52,10 @@ import {
   AdminSupplyDto,
   CreateSupplyResponseDto,
 } from './admin-supply-response.dto';
+import {
+  SupplyLinkBackfillResultDto,
+  SupplyLinkReportDto,
+} from './supply-link-backfill.dto';
 
 /**
  * API de gestión del catálogo maestro de insumos (#222). Cerrada a admins
@@ -73,6 +82,7 @@ export class SuppliesAdminController {
     private readonly mergeSupplies: MergeSupplies,
     private readonly listSuppliesAdmin: ListSuppliesAdmin,
     private readonly getSupplyAdmin: GetSupplyAdmin,
+    private readonly backfillSupplyLinks: BackfillSupplyLinks,
     private readonly cache: CachingSupplyCatalogReadModel,
   ) {}
 
@@ -103,6 +113,28 @@ export class SuppliesAdminController {
     // tal cual para no introducir claves con `undefined` explícito
     // (exactOptionalPropertyTypes).
     return this.listSuppliesAdmin.execute(query);
+  }
+
+  // Rutas literales ANTES de `:id`: Nest resuelve en orden de declaración y
+  // el ParseUUIDPipe de `:id` respondería 400 a `GET backfill`.
+  @Get('backfill')
+  @ApiOperation({
+    summary: 'Informe de líneas legacy sin enlazar al catálogo (no-casadas)',
+  })
+  @ApiOkResponse({ type: SupplyLinkReportDto })
+  async backfillReport(): Promise<SupplyLinkReport> {
+    return this.backfillSupplyLinks.report();
+  }
+
+  @Post('backfill')
+  @HttpCode(200)
+  @ApiOperation({
+    summary:
+      'Backfill best-effort del supplyId de las líneas legacy (idempotente)',
+  })
+  @ApiOkResponse({ type: SupplyLinkBackfillResultDto })
+  async backfill(): Promise<SupplyLinkBackfillResult> {
+    return this.backfillSupplyLinks.execute();
   }
 
   @Get(':id')

--- a/apps/api/src/contexts/supplies/infrastructure/http/supply-link-backfill.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supply-link-backfill.dto.ts
@@ -1,0 +1,65 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+const LINE_SOURCES = [
+  'need_items',
+  'offer_items',
+  'resource_items',
+  'donation_intake_lines',
+  'container_lines',
+] as const;
+
+/** Un texto de línea que no casa con el catálogo (agregado por forma normalizada). */
+export class UnmatchedSupplyLineGroupDto {
+  @ApiProperty({ example: 'Harina PAN' })
+  name!: string;
+
+  @ApiProperty({ example: 12, description: 'Líneas sin enlazar con ese texto' })
+  lines!: number;
+
+  @ApiProperty({ enum: LINE_SOURCES, isArray: true })
+  sources!: string[];
+
+  @ApiProperty({
+    example: false,
+    description:
+      'true = el texto casa con varios insumos activos: fusionar duplicados en vez de crear un alias',
+  })
+  ambiguous!: boolean;
+}
+
+/** Bloque común de no-casados de ambas respuestas del backfill. */
+class SupplyLinkUnmatchedDto {
+  @ApiProperty({ example: 27 })
+  unmatchedLines!: number;
+
+  @ApiProperty({ type: [UnmatchedSupplyLineGroupDto] })
+  unmatched!: UnmatchedSupplyLineGroupDto[];
+}
+
+/** Informe de solo lectura del estado de enlace (`GET admin/supplies/backfill`). */
+export class SupplyLinkReportDto extends SupplyLinkUnmatchedDto {
+  @ApiProperty({
+    example: 34,
+    description: 'Textos distintos que un backfill enlazaría ahora',
+  })
+  pendingNames!: number;
+
+  @ApiProperty({ example: 120 })
+  pendingLines!: number;
+}
+
+/** Resultado de una ejecución del backfill (`POST admin/supplies/backfill`). */
+export class SupplyLinkBackfillResultDto extends SupplyLinkUnmatchedDto {
+  @ApiProperty({
+    example: 34,
+    description: 'Textos distintos que casaron contra el catálogo',
+  })
+  linkedNames!: number;
+
+  @ApiProperty({
+    example: 120,
+    description:
+      'Líneas realmente actualizadas en esta ejecución (0 al re-correr o si otra ejecución concurrente las enlazó antes)',
+  })
+  linkedLines!: number;
+}

--- a/apps/api/src/contexts/supplies/supplies.module.ts
+++ b/apps/api/src/contexts/supplies/supplies.module.ts
@@ -21,11 +21,16 @@ import {
   CONTAINER_AUTHORIZATION_LOOKUP,
   ContainerAuthorizationLookup,
 } from './domain/ports/container-authorization-lookup';
+import {
+  SUPPLY_LINK_BACKFILL_REPOSITORY,
+  SupplyLinkBackfillRepository,
+} from './domain/ports/supply-link-backfill.repository';
 import { DrizzleCategoryRepository } from './infrastructure/drizzle/drizzle-category.repository';
 import { DrizzleSupplyRepository } from './infrastructure/drizzle/drizzle-supply.repository';
 import { DrizzleSupplyCatalogReadModel } from './infrastructure/drizzle/drizzle-supply-catalog.read-model';
 import { CachingSupplyCatalogReadModel } from './infrastructure/caching-supply-catalog.read-model';
 import { DrizzleContainerRepository } from './infrastructure/drizzle/drizzle-container.repository';
+import { DrizzleSupplyLinkBackfillRepository } from './infrastructure/drizzle/drizzle-supply-link-backfill.repository';
 import { DrizzleContainerAuthorizationLookup } from './infrastructure/drizzle/drizzle-container-authorization-lookup';
 import { ListCategories } from './application/list-categories';
 import { CreateCategory } from './application/create-category';
@@ -41,6 +46,7 @@ import { RemoveSupplyAlias } from './application/remove-supply-alias';
 import { MergeSupplies } from './application/merge-supplies';
 import { ListSuppliesAdmin } from './application/list-supplies-admin';
 import { GetSupplyAdmin } from './application/get-supply-admin';
+import { BackfillSupplyLinks } from './application/backfill-supply-links';
 import { CreateContainer } from './application/create-container';
 import { AddLineToContainer } from './application/add-line-to-container';
 import { RemoveLineFromContainer } from './application/remove-line-from-container';
@@ -187,6 +193,22 @@ const getSupplyAdminProvider = {
   useFactory: (repo: SupplyRepository) => new GetSupplyAdmin(repo),
 };
 
+const supplyLinkBackfillRepositoryProvider = {
+  provide: SUPPLY_LINK_BACKFILL_REPOSITORY,
+  inject: [DB],
+  useFactory: (db: Db): SupplyLinkBackfillRepository =>
+    new DrizzleSupplyLinkBackfillRepository(db),
+};
+
+const backfillSupplyLinksProvider = {
+  provide: BackfillSupplyLinks,
+  inject: [SUPPLY_CATALOG_READ_MODEL, SUPPLY_LINK_BACKFILL_REPOSITORY],
+  useFactory: (
+    catalog: SupplyCatalogReadModel,
+    repo: SupplyLinkBackfillRepository,
+  ) => new BackfillSupplyLinks(catalog, repo),
+};
+
 const createContainerProvider = {
   provide: CreateContainer,
   inject: [CONTAINER_REPOSITORY],
@@ -271,6 +293,8 @@ const listContainersProvider = {
     mergeSuppliesProvider,
     listSuppliesAdminProvider,
     getSupplyAdminProvider,
+    supplyLinkBackfillRepositoryProvider,
+    backfillSupplyLinksProvider,
     createContainerProvider,
     addLineToContainerProvider,
     removeLineFromContainerProvider,

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -1952,6 +1952,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/supplies/backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Informe de líneas legacy sin enlazar al catálogo (no-casadas) */
+        get: operations["SuppliesAdminController_backfillReport"];
+        put?: never;
+        /** Backfill best-effort del supplyId de las líneas legacy (idempotente) */
+        post: operations["SuppliesAdminController_backfill"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/supplies/{id}": {
         parameters: {
             query?: never;
@@ -5284,6 +5302,48 @@ export interface components {
              *     ]
              */
             aliases: string[];
+        };
+        UnmatchedSupplyLineGroupDto: {
+            /** @example Harina PAN */
+            name: string;
+            /**
+             * @description Líneas sin enlazar con ese texto
+             * @example 12
+             */
+            lines: number;
+            sources: ("need_items" | "offer_items" | "resource_items" | "donation_intake_lines" | "container_lines")[];
+            /**
+             * @description true = el texto casa con varios insumos activos: fusionar duplicados en vez de crear un alias
+             * @example false
+             */
+            ambiguous: boolean;
+        };
+        SupplyLinkReportDto: {
+            /** @example 27 */
+            unmatchedLines: number;
+            unmatched: components["schemas"]["UnmatchedSupplyLineGroupDto"][];
+            /**
+             * @description Textos distintos que un backfill enlazaría ahora
+             * @example 34
+             */
+            pendingNames: number;
+            /** @example 120 */
+            pendingLines: number;
+        };
+        SupplyLinkBackfillResultDto: {
+            /** @example 27 */
+            unmatchedLines: number;
+            unmatched: components["schemas"]["UnmatchedSupplyLineGroupDto"][];
+            /**
+             * @description Textos distintos que casaron contra el catálogo
+             * @example 34
+             */
+            linkedNames: number;
+            /**
+             * @description Líneas realmente actualizadas en esta ejecución (0 al re-correr o si otra ejecución concurrente las enlazó antes)
+             * @example 120
+             */
+            linkedLines: number;
         };
         EditSupplyDto: {
             /** @example Agua mineral */
@@ -11055,6 +11115,58 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CreateSupplyResponseDto"];
+                };
+            };
+            /** @description Falta el permiso catalogue:manage */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    SuppliesAdminController_backfillReport: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupplyLinkReportDto"];
+                };
+            };
+            /** @description Falta el permiso catalogue:manage */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    SuppliesAdminController_backfill: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupplyLinkBackfillResultDto"];
                 };
             };
             /** @description Falta el permiso catalogue:manage */


### PR DESCRIPTION
## Resumen

Implementa el backfill best-effort de los soft-links `supplyId` (#226): tras activar el soft-link (migración `0045`), las líneas históricas seguían con `supplyId=null`; este PR las enlaza contra el catálogo maestro y deja lo que no casa como informe para revisión admin.

- **Caso de uso `BackfillSupplyLinks`** (`supplies/application`): resuelve el texto libre de las líneas legacy contra el catálogo **activo** (nombre es/en, código y alias, vía `SupplyResolver`) y enlaza solo lo que casa sin ambigüedad. Resolver contra el catálogo activo es deliberado: un insumo fusionado/archivado no capta líneas nuevas — su texto sale en el informe para dar de alta un alias y re-ejecutar.
- **Fuentes cubiertas**: `need_items`, `offer_items`, `resource_items`, `donation_intake_lines` (columna `supply_id`, migración `0045`) y las líneas jsonb de `containers.lines`.
- **Endpoints admin** (`catalogue:manage`):
  - `POST /admin/supplies/backfill` — ejecuta el enlace y devuelve el resultado (`linkedNames`/`linkedLines` + no-casados).
  - `GET /admin/supplies/backfill` — informe en vivo sin efectos: qué casaría (`pendingNames`/`pendingLines`) y qué queda sin casar (texto + recuento + fuentes). Cada grupo no-casado lleva `ambiguous`: `true` significa que el texto casa con varios insumos activos y el remedio es **fusionar** duplicados, no crear un alias (un alias nunca desambigua).
- **Idempotencia por contrato**: el adapter solo escribe donde `supply_id IS NULL` — re-correr no duplica ni revierte enlaces manuales.
- **Concurrencia/eficiencia en el adapter Drizzle**: UPDATEs agrupados por (tabla, insumo) con `inArray` y conteo por `rowCount`; la reescritura del jsonb de contenedores usa `SELECT … FOR UPDATE` filtrado por `EXISTS` (solo contenedores con líneas enlazables), para no pisar escrituras concurrentes del agregado `Container` ni bloquear filas de más.
- **Refactor de dominio**: `supplyResolverFromCatalog` (antes privada en `list-supplies.ts`) e `isAmbiguous` suben a `domain/supply-resolver.ts` y se reutilizan desde el autocomplete público y el backfill.

## Validación

- [x] Pasé el gate que toca para esta zona del repo (`api build` + eslint `--max-warnings=0` + prettier + `api test` completo: 236 suites / 1500 tests en verde; `api-client build`, `web build`, `web lint`)
- [x] Verifiqué el comportamiento con tests de integración contra Postgres real (`drizzle-supply-link-backfill.repository.int-spec.ts`): agrupación por fuente/texto, enlace solo de `supply_id` nulos incluidas líneas jsonb, preservación de enlaces manuales e idempotencia al re-correr
- [x] Actualicé el cliente API (`pnpm gen:api`, rutas `/admin/supplies/backfill` en `packages/api-client/src/schema.ts`); sin migraciones (reusa el schema de `0045`)

## Cierre

- Closes #226

---
_Generated by [Claude Code](https://claude.ai/code/session_0153TVSNnae6XREdGVKdtfUj)_