### PR TITLE
perf(resources): índice en owner_user_id y proyección ligera en GET /resources/mine

### DIFF
--- a/apps/api/drizzle/0052_resources_owner_idx.sql
+++ b/apps/api/drizzle/0052_resources_owner_idx.sql
@@ -1,0 +1,4 @@
+-- #318: GET /resources/mine (panel) filtra WHERE owner_user_id = $1 OR id IN (...)
+-- en cada render autenticado del shell; sin este índice el OR fuerza un seq scan
+-- de resources. Con él, Postgres resuelve con BitmapOr (owner idx + PK).
+CREATE INDEX IF NOT EXISTS resources_owner_user_id_idx ON resources (owner_user_id);

--- a/apps/api/src/contexts/resources/application/get-my-managed-resources.ts
+++ b/apps/api/src/contexts/resources/application/get-my-managed-resources.ts
@@ -1,19 +1,16 @@
-import { ResourceRepository } from '../domain/ports/resource.repository';
-import { ResourceType } from '../domain/resource-enums';
+import {
+  ManagedResourceRow,
+  ResourceRepository,
+} from '../domain/ports/resource.repository';
 
 /**
  * One resource the principal manages, reduced to what the app shell needs to
  * list and link it (issue #285). Deliberately NOT the full ResourceView: this
  * backs a navigation surface, so it carries no address/contact/inventory.
+ * Same shape the repository already projects (#318) — aliased so the HTTP
+ * layer keeps depending on an application type, not on the port directly.
  */
-export interface MyManagedResourceView {
-  id: string;
-  type: ResourceType;
-  name: string;
-  emergencyId: string;
-  /** Null when the owning emergency row is missing. */
-  emergencySlug: string | null;
-}
+export type MyManagedResourceView = ManagedResourceRow;
 
 /**
  * A grant as it reaches this use case — the controller passes the
@@ -59,13 +56,6 @@ export class GetMyManagedResources {
       grantedIds.add(scopeId);
     }
 
-    const rows = await this.repo.findOwnedOrGranted(userId, [...grantedIds]);
-    return rows.map(({ resource, emergencySlug }) => ({
-      id: resource.id.value,
-      type: resource.type,
-      name: resource.name,
-      emergencyId: resource.emergencyId.value,
-      emergencySlug,
-    }));
+    return this.repo.findOwnedOrGranted(userId, [...grantedIds]);
   }
 }

--- a/apps/api/src/contexts/resources/domain/ports/resource.repository.ts
+++ b/apps/api/src/contexts/resources/domain/ports/resource.repository.ts
@@ -21,14 +21,21 @@ export interface ResourceWithEmergency {
 }
 
 /**
- * A resource the principal manages, labelled with its emergency slug so the
- * caller can build per-emergency links without an extra lookup. Cross-emergency
- * by design: it backs `GET /resources/mine`, which must surface a point whose
- * manager holds only an entity-scoped grant (no emergency grant, issue #285).
- * `emergencySlug` is null when the emergency row is missing.
+ * A resource the principal manages, reduced to the fields the navigation
+ * surface needs and labelled with its emergency slug so the caller can build
+ * per-emergency links without an extra lookup. Cross-emergency by design: it
+ * backs `GET /resources/mine`, which must surface a point whose manager holds
+ * only an entity-scoped grant (no emergency grant, issue #285). A flat
+ * projection — NOT the full aggregate — because the read runs on every
+ * authenticated page render (#318): hydrating `Resource` (Location validation,
+ * value objects, jsonb columns) per row was pure waste. `emergencySlug` is
+ * null when the emergency row is missing.
  */
-export interface ResourceWithEmergencySlug {
-  resource: Resource;
+export interface ManagedResourceRow {
+  id: string;
+  type: ResourceType;
+  name: string;
+  emergencyId: string;
   emergencySlug: string | null;
 }
 
@@ -65,12 +72,12 @@ export interface ResourceRepository {
    * Resources the principal manages, across ALL emergencies (any status):
    * the ones they own (`ownerUserId`) plus the ones reached through an
    * entity-scoped grant (`grantedResourceIds`). Each row carries its emergency
-   * slug (see {@link ResourceWithEmergencySlug}).
+   * slug (see {@link ManagedResourceRow}).
    */
   findOwnedOrGranted(
     ownerUserId: string,
     grantedResourceIds: string[],
-  ): Promise<ResourceWithEmergencySlug[]>;
+  ): Promise<ManagedResourceRow[]>;
   /** Visible public resources: Active, Saturated, Paused (excludes Hidden and Closed). */
   findVisibleByEmergency(emergencyId: EmergencyId): Promise<Resource[]>;
   /** Resources currently flagged `disputed` (citizen reports pending review). */

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.int-spec.ts
@@ -1776,9 +1776,11 @@ describe('DrizzleResourceRepository (integration)', () => {
       const rows = await repo.findOwnedOrGranted(OWNER_ID, [granted, owned]);
 
       expect(rows).toHaveLength(2);
-      const byId = new Map(rows.map((r) => [r.resource.id.value, r]));
+      const byId = new Map(rows.map((r) => [r.id, r]));
       expect(byId.get(owned)?.emergencySlug).toBe('terremoto-test-285');
-      expect(byId.get(granted)?.resource.name).toBe('Acopio gestionado');
+      expect(byId.get(owned)?.emergencyId).toBe(EM3);
+      expect(byId.get(granted)?.name).toBe('Acopio gestionado');
+      expect(byId.get(granted)?.type).toBe(ResourceType.CollectionPoint);
     });
 
     it('with no granted ids returns only the owned resources', async () => {
@@ -1796,7 +1798,7 @@ describe('DrizzleResourceRepository (integration)', () => {
       const rows = await repo.findOwnedOrGranted(OWNER_ID, []);
 
       expect(rows).toHaveLength(1);
-      expect(rows[0]?.resource.name).toBe('Solo propio');
+      expect(rows[0]?.name).toBe('Solo propio');
     });
   });
 });

--- a/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/drizzle/drizzle-resource.repository.ts
@@ -6,7 +6,7 @@ import { emergenciesTable } from '../../../emergencies/infrastructure/drizzle/sc
 import {
   ResourceRepository,
   ResourceWithEmergency,
-  ResourceWithEmergencySlug,
+  ManagedResourceRow,
 } from '../../domain/ports/resource.repository';
 import { Resource, ResourceSnapshot, Provenance } from '../../domain/resource';
 import { AuthorSnapshot } from '../../../../shared/domain/author';
@@ -408,7 +408,7 @@ export class DrizzleResourceRepository implements ResourceRepository {
   async findOwnedOrGranted(
     ownerUserId: string,
     grantedResourceIds: string[],
-  ): Promise<ResourceWithEmergencySlug[]> {
+  ): Promise<ManagedResourceRow[]> {
     // A single OR keeps a resource that is both owned and granted as one row.
     // Guard the inArray: drizzle rejects an empty id list.
     const whereClause =
@@ -421,9 +421,14 @@ export class DrizzleResourceRepository implements ResourceRepository {
 
     // LEFT JOIN resolves the emergency slug in the same query (no N+1); LEFT so
     // an orphaned resource still appears (slug → null) instead of vanishing.
+    // Projection only — this read runs on every authenticated page render, so
+    // it must not drag the wide columns (raw/author jsonb) over the wire (#318).
     const rows = await this.db
       .select({
-        resource: resourcesTable,
+        id: resourcesTable.id,
+        type: resourcesTable.type,
+        name: resourcesTable.name,
+        emergencyId: resourcesTable.emergencyId,
         emergencySlug: emergenciesTable.slug,
       })
       .from(resourcesTable)
@@ -435,7 +440,10 @@ export class DrizzleResourceRepository implements ResourceRepository {
       .orderBy(asc(resourcesTable.name), asc(resourcesTable.id));
 
     return rows.map((r) => ({
-      resource: Resource.fromSnapshot(rowToSnapshot(r.resource)),
+      id: r.id,
+      type: r.type as ResourceType,
+      name: r.name,
+      emergencyId: r.emergencyId,
       emergencySlug: r.emergencySlug ?? null,
     }));
   }

--- a/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
+++ b/apps/api/src/contexts/resources/infrastructure/in-memory-resource.repository.ts
@@ -1,7 +1,7 @@
 import {
   ResourceRepository,
   ResourceWithEmergency,
-  ResourceWithEmergencySlug,
+  ManagedResourceRow,
 } from '../domain/ports/resource.repository';
 import { Resource } from '../domain/resource';
 import { ResourceId } from '../domain/resource-id';
@@ -153,14 +153,17 @@ export class InMemoryResourceRepository implements ResourceRepository {
   findOwnedOrGranted(
     ownerUserId: string,
     grantedResourceIds: string[],
-  ): Promise<ResourceWithEmergencySlug[]> {
+  ): Promise<ManagedResourceRow[]> {
     // This store holds no emergencies, so the slug is always null here; the
     // slug join is covered by the Drizzle integration spec.
     const granted = new Set(grantedResourceIds);
     const result = [...this.store.values()]
       .filter((s) => s.ownerUserId === ownerUserId || granted.has(s.id))
       .map((s) => ({
-        resource: Resource.fromSnapshot(s),
+        id: s.id,
+        type: s.type,
+        name: s.name,
+        emergencyId: s.emergencyId,
         emergencySlug: null,
       }));
     return Promise.resolve(result);

--- a/apps/api/src/contexts/resources/infrastructure/resources.module.ts
+++ b/apps/api/src/contexts/resources/infrastructure/resources.module.ts
@@ -386,6 +386,10 @@ const recordInventoryEntryProvider = {
 @Module({
   imports: [DatabaseModule, IdentityModule, NotificationsModule],
   controllers: [
+    // ORDER MATTERS: ResourcesController declares the static GET /resources/mine
+    // and must register before AdminResourcesController's GET /resources/:id, or
+    // Express matches the param route first and "mine" 400s in ParseUUIDPipe
+    // (#318; pinned by test/resources-mine.e2e-spec.ts).
     ResourcesController,
     CoordinationController,
     PublicController,


### PR DESCRIPTION
## Resumen

Seguimiento de rendimiento de la revisión de la PR #310 (#285). `GET /resources/mine` corre en cada render autenticado del shell (`getNavContext`) y era innecesariamente caro:

- **Migración `0052_resources_owner_idx.sql`**: `CREATE INDEX IF NOT EXISTS resources_owner_user_id_idx ON resources(owner_user_id)`. El `WHERE owner_user_id = ? OR id IN (…)` resolvía con **seq scan** (no existía ningún índice sobre `owner_user_id`); con el índice Postgres usa **BitmapOr** (owner idx + PK), verificado con `EXPLAIN` en local.
- **Proyección ligera en `findOwnedOrGranted`**: selecciona solo las 5 columnas necesarias (`id, type, name, emergency_id, emergencies.slug`) y devuelve un shape plano (`ManagedResourceRow` en el puerto) en vez de traer la fila completa (~28 columnas, jsonb `raw`/`author` incluidos) e hidratar el agregado `Resource` (validación de `Location`, value objects) para luego leer 4 campos. `MyManagedResourceView` pasa a ser un alias del row — una única fuente de verdad del shape. **Sin cambio de contrato HTTP** (el DTO ya era exactamente ese shape), por lo que no requiere `gen:api`.
- **Comentario en `resources.module.ts`** documentando que el orden del array `controllers` es significativo: `/resources/mine` (estático) debe registrarse antes que el `/resources/:id` del admin; hoy además lo pina el e2e `resources-mine.e2e-spec.ts`.

El `LIMIT`/paginación del listado queda deliberadamente fuera (ver #318): recortar en silencio sería peor sin una decisión de producto sobre el affordance «N más».

## Validación

- [x] Gate completo: `api build` + eslint `--max-warnings=0` + prettier + suite completa (1508 tests, migración 0052 aplicada por el global-setup) + e2e `resources-mine` (4/4) + build de api-client y web + lint web
- [x] `EXPLAIN` confirma `Bitmap Index Scan on resources_owner_user_id_idx` + `BitmapOr` con el PK para la rama `id IN (…)`
- [x] Sin cambio de DTOs/endpoints → cliente API sin cambios (verificado: `schema.ts` intacto)

## Cierre

- Closes #318