### PR TITLE
feat(supplies): CRUD admin de categorías con API pública/privada separada (#221)

### DIFF
--- a/apps/api/drizzle/0039_categories_archived_at.sql
+++ b/apps/api/drizzle/0039_categories_archived_at.sql
@@ -1,0 +1,12 @@
+-- #221: soft-archive de categorías del catálogo. Permite ocultar una categoría
+-- sin perder la taxonomía compartida ni romper los ~12 slugs núcleo (enum
+-- Category), referenciados por el código y por otras tablas. Campo INTERNO: el
+-- GET /categories público filtra por archived_at IS NULL y no lo proyecta.
+
+ALTER TABLE categories
+  ADD COLUMN IF NOT EXISTS archived_at timestamp with time zone;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS categories_archived_at_idx
+  ON categories (archived_at);
+--> statement-breakpoint

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5653,7 +5653,7 @@
           {
             "name": "Accept-Language",
             "in": "header",
-            "description": "Fallback locale header (es or en)",
+            "description": "Fallback locale header (es, en o cualquier idioma traducido)",
             "required": false,
             "schema": {
               "type": "string"
@@ -5678,6 +5678,223 @@
         "summary": "List the shared category taxonomy (slug + labels + hierarchy)",
         "tags": [
           "categories"
+        ]
+      }
+    },
+    "/admin/categories": {
+      "get": {
+        "operationId": "CategoriesAdminController_list",
+        "parameters": [
+          {
+            "name": "locale",
+            "required": false,
+            "in": "query",
+            "description": "Preferred locale",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Accept-Language",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CategoryAdminDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing catalogue:manage permission"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List the full category taxonomy for admin (archived included)",
+        "tags": [
+          "categories-admin"
+        ]
+      },
+      "post": {
+        "operationId": "CategoriesAdminController_create",
+        "parameters": [
+          {
+            "name": "locale",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCategoryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryAdminDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid category payload"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing catalogue:manage permission"
+          },
+          "409": {
+            "description": "Category slug already exists"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Create a category or subcategory",
+        "tags": [
+          "categories-admin"
+        ]
+      }
+    },
+    "/admin/categories/{slug}": {
+      "patch": {
+        "operationId": "CategoriesAdminController_update",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "description": "Category slug (immutable)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locale",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCategoryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryAdminDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid category payload"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing catalogue:manage permission"
+          },
+          "404": {
+            "description": "Category not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Update a category (labels, order, parent, translations, archive)",
+        "tags": [
+          "categories-admin"
+        ]
+      },
+      "delete": {
+        "operationId": "CategoriesAdminController_remove",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "description": "Category slug to archive",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Category archived"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "403": {
+            "description": "Missing catalogue:manage permission"
+          },
+          "404": {
+            "description": "Category not found"
+          },
+          "409": {
+            "description": "Core category slug cannot be deleted"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Archive a category (core slugs are protected → 4xx)",
+        "tags": [
+          "categories-admin"
         ]
       }
     },
@@ -13140,6 +13357,166 @@
           "vertical",
           "sort"
         ]
+      },
+      "CategoryTranslationDto": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string",
+            "example": "fr"
+          },
+          "label": {
+            "type": "string",
+            "example": "Nourriture"
+          }
+        },
+        "required": [
+          "locale",
+          "label"
+        ]
+      },
+      "CategoryAdminDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "baby_food"
+          },
+          "label": {
+            "type": "string",
+            "example": "Alimentos para bebé",
+            "description": "Localized label"
+          },
+          "labelEs": {
+            "type": "string",
+            "example": "Alimentos para bebé"
+          },
+          "labelEn": {
+            "type": "string",
+            "example": "Baby food"
+          },
+          "parentSlug": {
+            "type": "string",
+            "example": "food",
+            "nullable": true,
+            "description": "Parent category slug, or null for a top-level category"
+          },
+          "vertical": {
+            "type": "string",
+            "example": "general"
+          },
+          "sort": {
+            "type": "number",
+            "example": 140
+          },
+          "archivedAt": {
+            "type": "string",
+            "example": null,
+            "nullable": true,
+            "description": "Soft-archive timestamp (ISO-8601), or null if active"
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CategoryTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "slug",
+          "label",
+          "labelEs",
+          "labelEn",
+          "parentSlug",
+          "vertical",
+          "sort",
+          "archivedAt",
+          "translations"
+        ]
+      },
+      "CreateCategoryDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "baby_food"
+          },
+          "labelEs": {
+            "type": "string",
+            "example": "Alimentos para bebé"
+          },
+          "labelEn": {
+            "type": "string",
+            "example": "Baby food"
+          },
+          "parentSlug": {
+            "type": "object",
+            "example": "food",
+            "nullable": true,
+            "description": "Parent category slug, or null for a top-level category"
+          },
+          "vertical": {
+            "type": "string",
+            "example": "general"
+          },
+          "sort": {
+            "type": "number",
+            "example": 140
+          },
+          "translations": {
+            "description": "Additional locale labels (beyond es/en) for category_translations",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CategoryTranslationDto"
+            }
+          }
+        },
+        "required": [
+          "slug",
+          "labelEs",
+          "labelEn",
+          "vertical",
+          "sort"
+        ]
+      },
+      "UpdateCategoryDto": {
+        "type": "object",
+        "properties": {
+          "labelEs": {
+            "type": "string",
+            "example": "Alimentos para bebé"
+          },
+          "labelEn": {
+            "type": "string",
+            "example": "Baby food"
+          },
+          "parentSlug": {
+            "type": "object",
+            "example": "food",
+            "nullable": true,
+            "description": "Parent category slug, or null for a top-level category"
+          },
+          "vertical": {
+            "type": "string",
+            "example": "general"
+          },
+          "sort": {
+            "type": "number",
+            "example": 140
+          },
+          "translations": {
+            "description": "Replace the category_translations rows with this set",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CategoryTranslationDto"
+            }
+          },
+          "archived": {
+            "type": "boolean",
+            "example": false,
+            "description": "True to hide/archive the category, false to restore it"
+          }
+        }
       },
       "SupplyDto": {
         "type": "object",

--- a/apps/api/src/contexts/identity/domain/authorization/permission.spec.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/permission.spec.ts
@@ -12,10 +12,12 @@ describe('permission catalog', () => {
       'role:grant',
       'group:manage_members',
       'apikey:create',
+      'catalogue:manage',
     ];
     for (const p of known) {
       expect(ALL_PERMISSIONS).toContain(p);
     }
+    expect(isPermission('catalogue:manage')).toBe(true);
   });
 
   it('includes the transport logistics permissions (EPIC #103)', () => {

--- a/apps/api/src/contexts/identity/domain/authorization/permission.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/permission.ts
@@ -34,6 +34,11 @@ export const PERMISSION_CATALOG = {
   role: ['grant', 'revoke', 'create_custom'],
   apikey: ['create', 'revoke'],
   audit: ['read'],
+  // Catálogo compartido de insumos (#221): gestión de la taxonomía de
+  // categorías (alta/edición/archivado de categorías y subcategorías, orden,
+  // jerarquía e idiomas). Dato global de plataforma → normalmente scope
+  // plataforma (platform_admin). El `GET /categories` público NO lo requiere.
+  catalogue: ['manage'],
   // Logística de transporte (EPIC #103). 'create'/'read' existían como data
   // antes del enforcement; #106 añade 'assign' (coordinador asigna capacidad y
   // transportista) y 'update' (cambios de estado por el coordinador). 'track'

--- a/apps/api/src/contexts/supplies/application/create-category.spec.ts
+++ b/apps/api/src/contexts/supplies/application/create-category.spec.ts
@@ -1,0 +1,99 @@
+import { CreateCategory } from './create-category';
+import { InMemoryCategoryAdminRepository } from './in-memory-category-admin.repository';
+import { CategoryRecord } from '../domain/category-record';
+import {
+  CategoryAlreadyExistsError,
+  CategoryParentNotFoundError,
+  CategoryValidationError,
+} from '../domain/category-errors';
+
+function food(): CategoryRecord {
+  return {
+    slug: 'food',
+    labelEs: 'Alimentos',
+    labelEn: 'Food',
+    parentSlug: null,
+    vertical: 'general',
+    sort: 1,
+    archivedAt: null,
+    translations: [],
+  };
+}
+
+describe('CreateCategory', () => {
+  it('crea una subcategoría con padre válido y persiste traducciones', async () => {
+    const repo = new InMemoryCategoryAdminRepository([food()]);
+    const created = await new CreateCategory(repo).execute({
+      slug: 'baby_food',
+      labelEs: 'Alimentos para bebé',
+      labelEn: 'Baby food',
+      parentSlug: 'food',
+      vertical: 'general',
+      sort: 140,
+      translations: [{ locale: 'fr', label: 'Nourriture pour bébé' }],
+    });
+
+    expect(created.slug).toBe('baby_food');
+    expect(created.parentSlug).toBe('food');
+    expect(created.translations).toEqual([
+      { locale: 'fr', label: 'Nourriture pour bébé' },
+    ]);
+    expect(await repo.findBySlug('baby_food')).not.toBeNull();
+  });
+
+  it('rechaza un slug duplicado', async () => {
+    const repo = new InMemoryCategoryAdminRepository([food()]);
+    await expect(
+      new CreateCategory(repo).execute({
+        slug: 'food',
+        labelEs: 'X',
+        labelEn: 'X',
+        parentSlug: null,
+        vertical: 'general',
+        sort: 1,
+      }),
+    ).rejects.toBeInstanceOf(CategoryAlreadyExistsError);
+  });
+
+  it('rechaza un padre inexistente', async () => {
+    const repo = new InMemoryCategoryAdminRepository([food()]);
+    await expect(
+      new CreateCategory(repo).execute({
+        slug: 'baby_food',
+        labelEs: 'A',
+        labelEn: 'B',
+        parentSlug: 'nope',
+        vertical: 'general',
+        sort: 1,
+      }),
+    ).rejects.toBeInstanceOf(CategoryParentNotFoundError);
+  });
+
+  it('rechaza etiquetas vacías', async () => {
+    const repo = new InMemoryCategoryAdminRepository();
+    await expect(
+      new CreateCategory(repo).execute({
+        slug: 'x',
+        labelEs: '   ',
+        labelEn: 'B',
+        parentSlug: null,
+        vertical: 'general',
+        sort: 1,
+      }),
+    ).rejects.toBeInstanceOf(CategoryValidationError);
+  });
+
+  it('rechaza que una categoría sea su propio padre', async () => {
+    const repo = new InMemoryCategoryAdminRepository();
+    await expect(
+      new CreateCategory(repo).execute({
+        slug: 'x',
+        labelEs: 'A',
+        labelEn: 'B',
+        parentSlug: 'x',
+        vertical: 'general',
+        sort: 1,
+      }),
+    ).rejects.toBeInstanceOf(CategoryValidationError);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/create-category.ts
+++ b/apps/api/src/contexts/supplies/application/create-category.ts
@@ -1,0 +1,73 @@
+import {
+  CategoryAlreadyExistsError,
+  CategoryParentNotFoundError,
+  CategoryValidationError,
+} from '../domain/category-errors';
+import { CategoryRecord } from '../domain/category-record';
+import {
+  CategoryAdminRepository,
+  CategoryTranslationInput,
+} from '../domain/ports/category-admin.repository';
+
+export interface CreateCategoryCommand {
+  slug: string;
+  labelEs: string;
+  labelEn: string;
+  parentSlug: string | null;
+  vertical: string;
+  sort: number;
+  translations?: readonly CategoryTranslationInput[] | undefined;
+}
+
+/**
+ * Alta de categoría/subcategoría (#221). Todas las invariantes viven aquí; el
+ * adaptador solo persiste. El slug lo valida en formato el DTO HTTP.
+ */
+export class CreateCategory {
+  constructor(private readonly repo: CategoryAdminRepository) {}
+
+  async execute(cmd: CreateCategoryCommand): Promise<CategoryRecord> {
+    const slug = cmd.slug.trim();
+    const labelEs = cmd.labelEs.trim();
+    const labelEn = cmd.labelEn.trim();
+    const vertical = cmd.vertical.trim();
+    const parentSlug = cmd.parentSlug === null ? null : cmd.parentSlug.trim();
+
+    if (slug === '') {
+      throw new CategoryValidationError(
+        'El slug de la categoría es obligatorio',
+      );
+    }
+    if (labelEs === '' || labelEn === '') {
+      throw new CategoryValidationError('Las etiquetas es/en son obligatorias');
+    }
+    if (vertical === '') {
+      throw new CategoryValidationError('El vertical es obligatorio');
+    }
+    if (parentSlug === slug) {
+      throw new CategoryValidationError(
+        'Una categoría no puede ser su propio padre',
+      );
+    }
+    if ((await this.repo.findBySlug(slug)) !== null) {
+      throw new CategoryAlreadyExistsError(slug);
+    }
+    if (
+      parentSlug !== null &&
+      (await this.repo.findBySlug(parentSlug)) === null
+    ) {
+      throw new CategoryParentNotFoundError(parentSlug);
+    }
+
+    return this.repo.create({
+      slug,
+      labelEs,
+      labelEn,
+      parentSlug,
+      vertical,
+      sort: cmd.sort,
+      archivedAt: null,
+      translations: cmd.translations ?? [],
+    });
+  }
+}

--- a/apps/api/src/contexts/supplies/application/delete-category.spec.ts
+++ b/apps/api/src/contexts/supplies/application/delete-category.spec.ts
@@ -1,0 +1,44 @@
+import { DeleteCategory } from './delete-category';
+import { InMemoryCategoryAdminRepository } from './in-memory-category-admin.repository';
+import { CategoryRecord } from '../domain/category-record';
+import {
+  CategoryNotFoundError,
+  CategoryProtectedError,
+} from '../domain/category-errors';
+
+function record(slug: string): CategoryRecord {
+  return {
+    slug,
+    labelEs: 'x',
+    labelEn: 'x',
+    parentSlug: null,
+    vertical: 'general',
+    sort: 1,
+    archivedAt: null,
+    translations: [],
+  };
+}
+
+describe('DeleteCategory', () => {
+  it('protege los slugs núcleo (no se pueden borrar)', async () => {
+    const repo = new InMemoryCategoryAdminRepository([record('food')]);
+    await expect(
+      new DeleteCategory(repo).execute('food'),
+    ).rejects.toBeInstanceOf(CategoryProtectedError);
+    // sigue activa: la protección corta antes de tocar el repo
+    expect((await repo.findBySlug('food'))?.archivedAt).toBeNull();
+  });
+
+  it('archiva una categoría no núcleo', async () => {
+    const repo = new InMemoryCategoryAdminRepository([record('baby_food')]);
+    const deleted = await new DeleteCategory(repo).execute('baby_food');
+    expect(deleted.archivedAt).toBeInstanceOf(Date);
+  });
+
+  it('falla si la categoría no existe', async () => {
+    const repo = new InMemoryCategoryAdminRepository();
+    await expect(
+      new DeleteCategory(repo).execute('nope'),
+    ).rejects.toBeInstanceOf(CategoryNotFoundError);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/delete-category.ts
+++ b/apps/api/src/contexts/supplies/application/delete-category.ts
@@ -1,0 +1,36 @@
+import { isCoreCategory } from '../domain/category';
+import {
+  CategoryNotFoundError,
+  CategoryProtectedError,
+} from '../domain/category-errors';
+import { CategoryRecord } from '../domain/category-record';
+import { CategoryAdminRepository } from '../domain/ports/category-admin.repository';
+
+/**
+ * Borrado de una categoría (#221). Las categorías núcleo (slug del enum
+ * {@link Category}) están protegidas → 4xx. El resto se archiva (soft-delete):
+ * nunca hacemos DELETE físico porque el slug lo referencian insumos/aliases.
+ */
+export class DeleteCategory {
+  constructor(private readonly repo: CategoryAdminRepository) {}
+
+  async execute(slug: string): Promise<CategoryRecord> {
+    if (isCoreCategory(slug)) {
+      throw new CategoryProtectedError(slug);
+    }
+    const current = await this.repo.findBySlug(slug);
+    if (!current) {
+      throw new CategoryNotFoundError(slug);
+    }
+    return this.repo.update(slug, {
+      slug: current.slug,
+      labelEs: current.labelEs,
+      labelEn: current.labelEn,
+      parentSlug: current.parentSlug,
+      vertical: current.vertical,
+      sort: current.sort,
+      archivedAt: current.archivedAt ?? new Date(),
+      translations: current.translations,
+    });
+  }
+}

--- a/apps/api/src/contexts/supplies/application/in-memory-category-admin.repository.ts
+++ b/apps/api/src/contexts/supplies/application/in-memory-category-admin.repository.ts
@@ -1,0 +1,59 @@
+import { CategoryRecord } from '../domain/category-record';
+import {
+  CategoryAdminRepository,
+  CategoryWriteInput,
+} from '../domain/ports/category-admin.repository';
+
+/**
+ * Repo admin en memoria para tests de los casos de uso/controller de
+ * categorías. Persistencia "tonta" (sin invariantes de negocio), igual que el
+ * adaptador real: las reglas las prueban los casos de uso.
+ */
+export class InMemoryCategoryAdminRepository implements CategoryAdminRepository {
+  private readonly bySlug = new Map<string, CategoryRecord>();
+
+  constructor(seed: CategoryRecord[] = []) {
+    for (const record of seed) {
+      this.bySlug.set(record.slug, record);
+    }
+  }
+
+  list(options: { includeArchived?: boolean } = {}): Promise<CategoryRecord[]> {
+    const all = [...this.bySlug.values()];
+    return Promise.resolve(
+      options.includeArchived ? all : all.filter((c) => c.archivedAt === null),
+    );
+  }
+
+  findBySlug(slug: string): Promise<CategoryRecord | null> {
+    return Promise.resolve(this.bySlug.get(slug) ?? null);
+  }
+
+  create(input: CategoryWriteInput): Promise<CategoryRecord> {
+    const record = this.toRecord(input);
+    this.bySlug.set(record.slug, record);
+    return Promise.resolve(record);
+  }
+
+  update(slug: string, input: CategoryWriteInput): Promise<CategoryRecord> {
+    const record = this.toRecord(input);
+    this.bySlug.set(slug, record);
+    return Promise.resolve(record);
+  }
+
+  private toRecord(input: CategoryWriteInput): CategoryRecord {
+    return {
+      slug: input.slug,
+      labelEs: input.labelEs,
+      labelEn: input.labelEn,
+      parentSlug: input.parentSlug,
+      vertical: input.vertical,
+      sort: input.sort,
+      archivedAt: input.archivedAt,
+      translations: input.translations.map((t) => ({
+        locale: t.locale,
+        label: t.label,
+      })),
+    };
+  }
+}

--- a/apps/api/src/contexts/supplies/application/list-admin-categories.ts
+++ b/apps/api/src/contexts/supplies/application/list-admin-categories.ts
@@ -1,0 +1,14 @@
+import { CategoryRecord } from '../domain/category-record';
+import { CategoryAdminRepository } from '../domain/ports/category-admin.repository';
+
+/**
+ * Lista la taxonomía completa para la API interna/admin (#221), incluyendo las
+ * categorías archivadas (la lectura pública `ListCategories` las excluye).
+ */
+export class ListAdminCategories {
+  constructor(private readonly repo: CategoryAdminRepository) {}
+
+  execute(options?: { includeArchived?: boolean }): Promise<CategoryRecord[]> {
+    return this.repo.list(options);
+  }
+}

--- a/apps/api/src/contexts/supplies/application/list-categories.spec.ts
+++ b/apps/api/src/contexts/supplies/application/list-categories.spec.ts
@@ -13,6 +13,7 @@ describe('ListCategories', () => {
         parentSlug: null,
         vertical: 'general',
         sort: 10,
+        translations: [],
       },
     ];
     const repo: CategoryRepository = {

--- a/apps/api/src/contexts/supplies/application/update-category.spec.ts
+++ b/apps/api/src/contexts/supplies/application/update-category.spec.ts
@@ -1,0 +1,69 @@
+import { UpdateCategory } from './update-category';
+import { InMemoryCategoryAdminRepository } from './in-memory-category-admin.repository';
+import { CategoryRecord } from '../domain/category-record';
+import {
+  CategoryNotFoundError,
+  CategoryValidationError,
+} from '../domain/category-errors';
+
+function food(overrides: Partial<CategoryRecord> = {}): CategoryRecord {
+  return {
+    slug: 'food',
+    labelEs: 'Alimentos',
+    labelEn: 'Food',
+    parentSlug: null,
+    vertical: 'general',
+    sort: 1,
+    archivedAt: null,
+    translations: [],
+    ...overrides,
+  };
+}
+
+describe('UpdateCategory', () => {
+  it('edita etiquetas y orden dejando el resto intacto', async () => {
+    const repo = new InMemoryCategoryAdminRepository([food()]);
+    const updated = await new UpdateCategory(repo).execute('food', {
+      labelEs: 'Comida',
+      sort: 5,
+    });
+    expect(updated.labelEs).toBe('Comida');
+    expect(updated.labelEn).toBe('Food');
+    expect(updated.sort).toBe(5);
+  });
+
+  it('archiva y restaura vía flag', async () => {
+    const repo = new InMemoryCategoryAdminRepository([food()]);
+    const uc = new UpdateCategory(repo);
+
+    const archived = await uc.execute('food', { archived: true });
+    expect(archived.archivedAt).toBeInstanceOf(Date);
+
+    const restored = await uc.execute('food', { archived: false });
+    expect(restored.archivedAt).toBeNull();
+  });
+
+  it('reemplaza las traducciones cuando se envían', async () => {
+    const repo = new InMemoryCategoryAdminRepository([
+      food({ translations: [{ locale: 'fr', label: 'Nourriture' }] }),
+    ]);
+    const updated = await new UpdateCategory(repo).execute('food', {
+      translations: [{ locale: 'pt', label: 'Comida' }],
+    });
+    expect(updated.translations).toEqual([{ locale: 'pt', label: 'Comida' }]);
+  });
+
+  it('falla si la categoría no existe', async () => {
+    const repo = new InMemoryCategoryAdminRepository();
+    await expect(
+      new UpdateCategory(repo).execute('nope', { sort: 1 }),
+    ).rejects.toBeInstanceOf(CategoryNotFoundError);
+  });
+
+  it('rechaza vaciar una etiqueta obligatoria', async () => {
+    const repo = new InMemoryCategoryAdminRepository([food()]);
+    await expect(
+      new UpdateCategory(repo).execute('food', { labelEs: '  ' }),
+    ).rejects.toBeInstanceOf(CategoryValidationError);
+  });
+});

--- a/apps/api/src/contexts/supplies/application/update-category.ts
+++ b/apps/api/src/contexts/supplies/application/update-category.ts
@@ -1,0 +1,87 @@
+import {
+  CategoryNotFoundError,
+  CategoryParentNotFoundError,
+  CategoryValidationError,
+} from '../domain/category-errors';
+import { CategoryRecord } from '../domain/category-record';
+import {
+  CategoryAdminRepository,
+  CategoryTranslationInput,
+} from '../domain/ports/category-admin.repository';
+
+export interface UpdateCategoryCommand {
+  labelEs?: string | undefined;
+  labelEn?: string | undefined;
+  parentSlug?: string | null | undefined;
+  vertical?: string | undefined;
+  sort?: number | undefined;
+  archived?: boolean | undefined;
+  translations?: readonly CategoryTranslationInput[] | undefined;
+}
+
+/**
+ * Edición de una categoría (#221): etiquetas, orden, padre, idiomas y flag de
+ * archivado. El `slug` es inmutable (es PK y lo referencian otras tablas y el
+ * enum núcleo), por eso no se expone rename. Archivar/editar vale también para
+ * categorías núcleo; borrarlas/renombrarlas no (ver DeleteCategory).
+ */
+export class UpdateCategory {
+  constructor(private readonly repo: CategoryAdminRepository) {}
+
+  async execute(
+    slug: string,
+    cmd: UpdateCategoryCommand,
+  ): Promise<CategoryRecord> {
+    const current = await this.repo.findBySlug(slug);
+    if (!current) {
+      throw new CategoryNotFoundError(slug);
+    }
+
+    const labelEs = (cmd.labelEs ?? current.labelEs).trim();
+    const labelEn = (cmd.labelEn ?? current.labelEn).trim();
+    const vertical = (cmd.vertical ?? current.vertical).trim();
+    if (labelEs === '' || labelEn === '') {
+      throw new CategoryValidationError('Las etiquetas es/en son obligatorias');
+    }
+    if (vertical === '') {
+      throw new CategoryValidationError('El vertical es obligatorio');
+    }
+
+    const parentSlug =
+      cmd.parentSlug === undefined
+        ? current.parentSlug
+        : cmd.parentSlug === null
+          ? null
+          : cmd.parentSlug.trim();
+    if (parentSlug === slug) {
+      throw new CategoryValidationError(
+        'Una categoría no puede ser su propio padre',
+      );
+    }
+    if (
+      parentSlug !== null &&
+      parentSlug !== current.parentSlug &&
+      (await this.repo.findBySlug(parentSlug)) === null
+    ) {
+      throw new CategoryParentNotFoundError(parentSlug);
+    }
+
+    const archivedAt =
+      cmd.archived === undefined
+        ? current.archivedAt
+        : cmd.archived
+          ? (current.archivedAt ?? new Date())
+          : null;
+
+    return this.repo.update(slug, {
+      slug: current.slug,
+      labelEs,
+      labelEn,
+      parentSlug,
+      vertical,
+      sort: cmd.sort ?? current.sort,
+      archivedAt,
+      translations: cmd.translations ?? current.translations,
+    });
+  }
+}

--- a/apps/api/src/contexts/supplies/domain/category-definition.ts
+++ b/apps/api/src/contexts/supplies/domain/category-definition.ts
@@ -5,9 +5,16 @@
  * the schema can carry both core categories and finer subcategories.
  *
  * Es la proyección PÚBLICA de la taxonomía (la que sirve `GET /categories`):
- * solo campos publicables. NO debe crecer con datos de gestión interna (notas,
- * flag de desactivación, etc.); esos quedan para la API interna.
+ * solo campos publicables. Incluye `translations` (etiquetas localizadas: son
+ * dato publicable, alimentan la localización multi-idioma del `label`). NO debe
+ * crecer con datos de gestión INTERNA (notas, flag de desactivación/archivado,
+ * etc.); esos viven en {@link CategoryRecord} y solo salen por la API interna.
  */
+export interface CategoryTranslation {
+  locale: string;
+  label: string;
+}
+
 export interface CategoryDefinition {
   slug: string;
   labelEs: string;
@@ -15,4 +22,6 @@ export interface CategoryDefinition {
   parentSlug: string | null;
   vertical: string;
   sort: number;
+  /** Etiquetas en idiomas adicionales a es/en (tabla category_translations). */
+  translations: readonly CategoryTranslation[];
 }

--- a/apps/api/src/contexts/supplies/domain/category-errors.ts
+++ b/apps/api/src/contexts/supplies/domain/category-errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Errores de dominio de la gestión de categorías (#221). Se lanzan desde los
+ * casos de uso y los traduce a HTTP el `SuppliesDomainExceptionFilter` global
+ * (no hay try/catch en el controller).
+ */
+export class CategoryNotFoundError extends Error {
+  constructor(slug: string) {
+    super(`Categoría no encontrada: ${slug}`);
+    this.name = 'CategoryNotFoundError';
+  }
+}
+
+export class CategoryAlreadyExistsError extends Error {
+  constructor(slug: string) {
+    super(`Ya existe una categoría con el slug: ${slug}`);
+    this.name = 'CategoryAlreadyExistsError';
+  }
+}
+
+export class CategoryParentNotFoundError extends Error {
+  constructor(slug: string) {
+    super(`La categoría padre no existe: ${slug}`);
+    this.name = 'CategoryParentNotFoundError';
+  }
+}
+
+/**
+ * Una categoría núcleo (slug del enum {@link Category}, referenciado por el
+ * código y por otras tablas) no se puede borrar ni renombrar. Sí se puede
+ * editar (etiquetas/orden/padre) y archivar vía PATCH.
+ */
+export class CategoryProtectedError extends Error {
+  constructor(slug: string) {
+    super(`La categoría núcleo no se puede borrar ni renombrar: ${slug}`);
+    this.name = 'CategoryProtectedError';
+  }
+}
+
+export class CategoryValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CategoryValidationError';
+  }
+}

--- a/apps/api/src/contexts/supplies/domain/category-record.ts
+++ b/apps/api/src/contexts/supplies/domain/category-record.ts
@@ -1,0 +1,13 @@
+import { CategoryDefinition } from './category-definition';
+
+/**
+ * CategoryRecord — la vista INTERNA/admin de una categoría: la proyección
+ * pública ({@link CategoryDefinition}) más los campos de gestión que NO deben
+ * salir por la API pública. Hoy: `archivedAt` (soft-archive). La API interna
+ * (`/admin/categories`, permiso `catalogue:manage`) trabaja con este modelo;
+ * el `GET /categories` público sigue devolviendo solo `CategoryDefinition`.
+ */
+export interface CategoryRecord extends CategoryDefinition {
+  /** Marca de archivado (ocultado). `null` = activa. Solo API interna. */
+  archivedAt: Date | null;
+}

--- a/apps/api/src/contexts/supplies/domain/category.ts
+++ b/apps/api/src/contexts/supplies/domain/category.ts
@@ -24,3 +24,17 @@ export enum Category {
   MedicalSupplies = 'medical_supplies',
   MedicalPersonnel = 'medical_personnel',
 }
+
+const CORE_CATEGORY_SLUGS: ReadonlySet<string> = new Set(
+  Object.values(Category),
+);
+
+/**
+ * ¿Es un slug núcleo? Los slugs del enum son la fuente de verdad a nivel de
+ * código y los referencian otras tablas/contextos, por lo que la gestión de
+ * catálogo (#221) los protege: no se pueden borrar ni renombrar. Regla de
+ * dominio consumida por los casos de uso (no repetida en el controller).
+ */
+export function isCoreCategory(slug: string): boolean {
+  return CORE_CATEGORY_SLUGS.has(slug);
+}

--- a/apps/api/src/contexts/supplies/domain/ports/category-admin.repository.ts
+++ b/apps/api/src/contexts/supplies/domain/ports/category-admin.repository.ts
@@ -1,0 +1,37 @@
+import { CategoryRecord } from '../category-record';
+
+export const CATEGORY_ADMIN_REPOSITORY = Symbol('CATEGORY_ADMIN_REPOSITORY');
+
+export interface CategoryTranslationInput {
+  locale: string;
+  label: string;
+}
+
+/**
+ * Estado completo con el que se persiste una categoría (incluye campos
+ * internos). Los casos de uso construyen esto tras validar sus invariantes; el
+ * adaptador es persistencia "tonta" (no revalida reglas de negocio).
+ */
+export interface CategoryWriteInput {
+  slug: string;
+  labelEs: string;
+  labelEn: string;
+  parentSlug: string | null;
+  vertical: string;
+  sort: number;
+  archivedAt: Date | null;
+  /** Idiomas adicionales (además de es/en, que viven en label_es/label_en). */
+  translations: readonly CategoryTranslationInput[];
+}
+
+/**
+ * Puerto de la API interna/admin del catálogo de categorías (#221). Separado
+ * del `CategoryRepository` de lectura pública (ISP): este ve categorías
+ * archivadas y permite escritura; aquél solo proyecta lo publicable.
+ */
+export interface CategoryAdminRepository {
+  list(options?: { includeArchived?: boolean }): Promise<CategoryRecord[]>;
+  findBySlug(slug: string): Promise<CategoryRecord | null>;
+  create(input: CategoryWriteInput): Promise<CategoryRecord>;
+  update(slug: string, input: CategoryWriteInput): Promise<CategoryRecord>;
+}

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/category-translations.query.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/category-translations.query.ts
@@ -1,0 +1,37 @@
+import { inArray } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import { CategoryTranslation } from '../../domain/category-definition';
+import { categoryTranslationsTable } from './schema';
+
+/**
+ * Carga las traducciones (idiomas adicionales a es/en) de un conjunto de
+ * categorías, agrupadas por slug y ordenadas por locale. Compartido por el
+ * repo público (localización del `label`) y el admin (evita duplicar el join).
+ */
+export async function loadTranslationsBySlug(
+  db: Db,
+  slugs: readonly string[],
+): Promise<Map<string, CategoryTranslation[]>> {
+  const map = new Map<string, CategoryTranslation[]>();
+  if (slugs.length === 0) {
+    return map;
+  }
+  const rows = await db
+    .select({
+      categorySlug: categoryTranslationsTable.categorySlug,
+      locale: categoryTranslationsTable.locale,
+      label: categoryTranslationsTable.label,
+    })
+    .from(categoryTranslationsTable)
+    .where(inArray(categoryTranslationsTable.categorySlug, [...slugs]));
+
+  for (const row of rows) {
+    const bucket = map.get(row.categorySlug) ?? [];
+    bucket.push({ locale: row.locale, label: row.label });
+    map.set(row.categorySlug, bucket);
+  }
+  for (const bucket of map.values()) {
+    bucket.sort((a, b) => a.locale.localeCompare(b.locale));
+  }
+  return map;
+}

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category-admin.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category-admin.repository.ts
@@ -1,0 +1,136 @@
+import { asc, eq, isNull } from 'drizzle-orm';
+import { Db } from '../../../../shared/db';
+import { CategoryRecord } from '../../domain/category-record';
+import {
+  CategoryAdminRepository,
+  CategoryWriteInput,
+} from '../../domain/ports/category-admin.repository';
+import { categoriesTable, categoryTranslationsTable } from './schema';
+import { loadTranslationsBySlug } from './category-translations.query';
+
+type CategoryRow = typeof categoriesTable.$inferSelect;
+
+/**
+ * Adaptador de la API interna/admin del catálogo. Persistencia "tonta": las
+ * invariantes de negocio (existe, padre válido, slug núcleo protegido) las
+ * garantizan los casos de uso; aquí solo se lee/escribe. es/en viven en
+ * label_es/label_en; category_translations guarda solo idiomas adicionales.
+ */
+export class DrizzleCategoryAdminRepository implements CategoryAdminRepository {
+  constructor(private readonly db: Db) {}
+
+  async list(
+    options: { includeArchived?: boolean } = {},
+  ): Promise<CategoryRecord[]> {
+    const base = this.db.select().from(categoriesTable);
+    const rows = await (options.includeArchived
+      ? base.orderBy(asc(categoriesTable.sort), asc(categoriesTable.slug))
+      : base
+          .where(isNull(categoriesTable.archivedAt))
+          .orderBy(asc(categoriesTable.sort), asc(categoriesTable.slug)));
+    return this.hydrate(rows);
+  }
+
+  async findBySlug(slug: string): Promise<CategoryRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(categoriesTable)
+      .where(eq(categoriesTable.slug, slug));
+    return (await this.hydrate(rows))[0] ?? null;
+  }
+
+  async create(input: CategoryWriteInput): Promise<CategoryRecord> {
+    await this.db.transaction(async (tx) => {
+      await tx.insert(categoriesTable).values({
+        slug: input.slug,
+        labelEs: input.labelEs,
+        labelEn: input.labelEn,
+        parentSlug: input.parentSlug,
+        vertical: input.vertical,
+        sort: input.sort,
+        archivedAt: input.archivedAt,
+      });
+      const translations = this.extraTranslationRows(input);
+      if (translations.length > 0) {
+        await tx.insert(categoryTranslationsTable).values(translations);
+      }
+    });
+    return this.mustFind(input.slug);
+  }
+
+  async update(
+    slug: string,
+    input: CategoryWriteInput,
+  ): Promise<CategoryRecord> {
+    await this.db.transaction(async (tx) => {
+      await tx
+        .update(categoriesTable)
+        .set({
+          labelEs: input.labelEs,
+          labelEn: input.labelEn,
+          parentSlug: input.parentSlug,
+          vertical: input.vertical,
+          sort: input.sort,
+          archivedAt: input.archivedAt,
+        })
+        .where(eq(categoriesTable.slug, slug));
+
+      await tx
+        .delete(categoryTranslationsTable)
+        .where(eq(categoryTranslationsTable.categorySlug, slug));
+      const translations = this.extraTranslationRows({ ...input, slug });
+      if (translations.length > 0) {
+        await tx.insert(categoryTranslationsTable).values(translations);
+      }
+    });
+    return this.mustFind(slug);
+  }
+
+  /** Filas de category_translations: solo idiomas ≠ es/en, sin vacíos, dedup. */
+  private extraTranslationRows(
+    input: CategoryWriteInput,
+  ): Array<{ categorySlug: string; locale: string; label: string }> {
+    const byLocale = new Map<string, string>();
+    for (const translation of input.translations) {
+      const locale = translation.locale.trim().toLowerCase();
+      const label = translation.label.trim();
+      if (locale === '' || label === '' || locale === 'es' || locale === 'en') {
+        continue;
+      }
+      byLocale.set(locale, label);
+    }
+    return [...byLocale.entries()].map(([locale, label]) => ({
+      categorySlug: input.slug,
+      locale,
+      label,
+    }));
+  }
+
+  private async mustFind(slug: string): Promise<CategoryRecord> {
+    const record = await this.findBySlug(slug);
+    if (!record) {
+      throw new Error(`Category not reloadable after write: ${slug}`);
+    }
+    return record;
+  }
+
+  private async hydrate(rows: CategoryRow[]): Promise<CategoryRecord[]> {
+    if (rows.length === 0) {
+      return [];
+    }
+    const translations = await loadTranslationsBySlug(
+      this.db,
+      rows.map((r) => r.slug),
+    );
+    return rows.map((r) => ({
+      slug: r.slug,
+      labelEs: r.labelEs,
+      labelEn: r.labelEn,
+      parentSlug: r.parentSlug ?? null,
+      vertical: r.vertical,
+      sort: r.sort,
+      archivedAt: r.archivedAt ?? null,
+      translations: translations.get(r.slug) ?? [],
+    }));
+  }
+}

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.ts
@@ -1,8 +1,9 @@
-import { asc } from 'drizzle-orm';
+import { asc, isNull } from 'drizzle-orm';
 import { Db } from '../../../../shared/db';
 import { categoriesTable, categoryAliasesTable } from './schema';
 import { CategoryRepository } from '../../domain/ports/category.repository';
 import { CategoryDefinition } from '../../domain/category-definition';
+import { loadTranslationsBySlug } from './category-translations.query';
 
 export class DrizzleCategoryRepository implements CategoryRepository {
   constructor(private readonly db: Db) {}
@@ -14,10 +15,9 @@ export class DrizzleCategoryRepository implements CategoryRepository {
 
   async listCategories(): Promise<CategoryDefinition[]> {
     // Proyección PÚBLICA de la taxonomía: allow-list explícito de columnas. NO
-    // hacemos `select()` de toda la fila para que campos internos que se añadan
-    // a `categories` en el futuro (p.ej. notas de gestión o un flag de
-    // desactivación) no se traigan ni se filtren por accidente. Cuando exista
-    // un estado de categoría, las desactivadas se excluyen aquí (`.where(...)`).
+    // hacemos `select()` de toda la fila para que campos internos (p.ej.
+    // `archived_at`, notas de gestión) no se traigan ni se filtren por
+    // accidente. Las categorías archivadas se excluyen aquí.
     const rows = await this.db
       .select({
         slug: categoriesTable.slug,
@@ -28,7 +28,13 @@ export class DrizzleCategoryRepository implements CategoryRepository {
         sort: categoriesTable.sort,
       })
       .from(categoriesTable)
+      .where(isNull(categoriesTable.archivedAt))
       .orderBy(asc(categoriesTable.sort));
+
+    const translations = await loadTranslationsBySlug(
+      this.db,
+      rows.map((r) => r.slug),
+    );
     return rows.map((r) => ({
       slug: r.slug,
       labelEs: r.labelEs,
@@ -36,6 +42,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
       parentSlug: r.parentSlug ?? null,
       vertical: r.vertical,
       sort: r.sort,
+      translations: translations.get(r.slug) ?? [],
     }));
   }
 }

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
@@ -23,6 +23,9 @@ export const categoriesTable = pgTable('categories', {
   ),
   vertical: text('vertical').notNull().default('general'),
   sort: integer('sort').notNull().default(0),
+  // Soft-archive de gestión (#221): oculta la categoría sin perder la taxonomía
+  // ni romper los slugs núcleo. Campo INTERNO: no se proyecta al público.
+  archivedAt: timestamp('archived_at', { withTimezone: true }),
 });
 
 export const categoryAliasesTable = pgTable('category_aliases', {

--- a/apps/api/src/contexts/supplies/infrastructure/http/admin-category.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/admin-category.dto.ts
@@ -1,0 +1,164 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsString,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+const CATEGORY_SLUG_PATTERN = /^[a-z0-9_]+$/;
+
+export class CategoryTranslationDto {
+  @ApiProperty({ example: 'fr' })
+  @IsString()
+  locale!: string;
+
+  @ApiProperty({ example: 'Nourriture' })
+  @IsString()
+  label!: string;
+}
+
+export class CreateCategoryDto {
+  @ApiProperty({ example: 'baby_food' })
+  @IsString()
+  @Matches(CATEGORY_SLUG_PATTERN, {
+    message: 'slug must use lowercase letters, numbers or underscores',
+  })
+  slug!: string;
+
+  @ApiProperty({ example: 'Alimentos para bebé' })
+  @IsString()
+  labelEs!: string;
+
+  @ApiProperty({ example: 'Baby food' })
+  @IsString()
+  labelEn!: string;
+
+  @ApiPropertyOptional({
+    example: 'food',
+    nullable: true,
+    description: 'Parent category slug, or null for a top-level category',
+  })
+  @IsOptional()
+  @IsString()
+  parentSlug?: string | null;
+
+  @ApiProperty({ example: 'general' })
+  @IsString()
+  vertical!: string;
+
+  @ApiProperty({ example: 140 })
+  @IsInt()
+  sort!: number;
+
+  @ApiPropertyOptional({
+    type: [CategoryTranslationDto],
+    description:
+      'Additional locale labels (beyond es/en) for category_translations',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CategoryTranslationDto)
+  translations?: CategoryTranslationDto[];
+}
+
+/**
+ * El `slug` es inmutable (PK referenciada por otras tablas y por el enum
+ * núcleo), por eso NO se puede editar aquí. Para editar etiquetas es/en se usan
+ * labelEs/labelEn; los idiomas adicionales se reemplazan con `translations`.
+ */
+export class UpdateCategoryDto {
+  @ApiPropertyOptional({ example: 'Alimentos para bebé' })
+  @IsOptional()
+  @IsString()
+  labelEs?: string;
+
+  @ApiPropertyOptional({ example: 'Baby food' })
+  @IsOptional()
+  @IsString()
+  labelEn?: string;
+
+  @ApiPropertyOptional({
+    example: 'food',
+    nullable: true,
+    description: 'Parent category slug, or null for a top-level category',
+  })
+  @IsOptional()
+  @IsString()
+  parentSlug?: string | null;
+
+  @ApiPropertyOptional({ example: 'general' })
+  @IsOptional()
+  @IsString()
+  vertical?: string;
+
+  @ApiPropertyOptional({ example: 140 })
+  @IsOptional()
+  @IsInt()
+  sort?: number;
+
+  @ApiPropertyOptional({
+    type: [CategoryTranslationDto],
+    description: 'Replace the category_translations rows with this set',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CategoryTranslationDto)
+  translations?: CategoryTranslationDto[];
+
+  @ApiPropertyOptional({
+    example: false,
+    description: 'True to hide/archive the category, false to restore it',
+  })
+  @IsOptional()
+  @IsBoolean()
+  archived?: boolean;
+}
+
+export class CategoryAdminDto {
+  @ApiProperty({ example: 'baby_food' })
+  slug!: string;
+
+  @ApiProperty({
+    example: 'Alimentos para bebé',
+    description: 'Localized label',
+  })
+  label!: string;
+
+  @ApiProperty({ example: 'Alimentos para bebé' })
+  labelEs!: string;
+
+  @ApiProperty({ example: 'Baby food' })
+  labelEn!: string;
+
+  @ApiProperty({
+    example: 'food',
+    nullable: true,
+    type: String,
+    description: 'Parent category slug, or null for a top-level category',
+  })
+  parentSlug!: string | null;
+
+  @ApiProperty({ example: 'general' })
+  vertical!: string;
+
+  @ApiProperty({ example: 140 })
+  sort!: number;
+
+  @ApiProperty({
+    example: null,
+    nullable: true,
+    type: String,
+    description: 'Soft-archive timestamp (ISO-8601), or null if active',
+  })
+  archivedAt!: string | null;
+
+  @ApiProperty({ type: [CategoryTranslationDto] })
+  translations!: CategoryTranslationDto[];
+}

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
@@ -1,0 +1,78 @@
+import { CategoriesAdminController } from './categories-admin.controller';
+import { CreateCategory } from '../../application/create-category';
+import { UpdateCategory } from '../../application/update-category';
+import { DeleteCategory } from '../../application/delete-category';
+import { ListAdminCategories } from '../../application/list-admin-categories';
+import { InMemoryCategoryAdminRepository } from '../../application/in-memory-category-admin.repository';
+import { CategoryRecord } from '../../domain/category-record';
+import { CategoryProtectedError } from '../../domain/category-errors';
+
+function controllerWith(seed: CategoryRecord[]): {
+  controller: CategoriesAdminController;
+  repo: InMemoryCategoryAdminRepository;
+} {
+  const repo = new InMemoryCategoryAdminRepository(seed);
+  const controller = new CategoriesAdminController(
+    new ListAdminCategories(repo),
+    new CreateCategory(repo),
+    new UpdateCategory(repo),
+    new DeleteCategory(repo),
+  );
+  return { controller, repo };
+}
+
+const food: CategoryRecord = {
+  slug: 'food',
+  labelEs: 'Alimentos',
+  labelEn: 'Food',
+  parentSlug: null,
+  vertical: 'general',
+  sort: 1,
+  archivedAt: null,
+  translations: [{ locale: 'fr', label: 'Nourriture' }],
+};
+
+describe('CategoriesAdminController', () => {
+  it('lista incluyendo archivadas y localiza el label', async () => {
+    const archived: CategoryRecord = {
+      ...food,
+      slug: 'legacy',
+      archivedAt: new Date(),
+      translations: [],
+    };
+    const { controller } = controllerWith([food, archived]);
+
+    const result = await controller.list('fr', {
+      'accept-language': 'fr-FR,fr;q=0.9',
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.find((c) => c.slug === 'food')?.label).toBe('Nourriture');
+    expect(result.find((c) => c.slug === 'legacy')?.archivedAt).not.toBeNull();
+  });
+
+  it('crea una categoría y mapea el payload', async () => {
+    const { controller, repo } = controllerWith([food]);
+
+    const created = await controller.create({
+      slug: 'baby_food',
+      labelEs: 'Alimentos para bebé',
+      labelEn: 'Baby food',
+      parentSlug: 'food',
+      vertical: 'general',
+      sort: 140,
+      translations: [{ locale: 'fr', label: 'Nourriture pour bébé' }],
+    });
+
+    expect(created.slug).toBe('baby_food');
+    expect(created.label).toBe('Alimentos para bebé'); // locale por defecto: es
+    expect(await repo.findBySlug('baby_food')).not.toBeNull();
+  });
+
+  it('propaga la protección de slug núcleo en delete (lo mapea el filtro global)', async () => {
+    const { controller } = controllerWith([food]);
+    await expect(controller.remove('food')).rejects.toBeInstanceOf(
+      CategoryProtectedError,
+    );
+  });
+});

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.ts
@@ -1,0 +1,180 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiHeader,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
+import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
+import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
+import { CategoryRecord } from '../../domain/category-record';
+import { CreateCategory } from '../../application/create-category';
+import { UpdateCategory } from '../../application/update-category';
+import { DeleteCategory } from '../../application/delete-category';
+import { ListAdminCategories } from '../../application/list-admin-categories';
+import {
+  CategoryAdminDto,
+  CreateCategoryDto,
+  UpdateCategoryDto,
+} from './admin-category.dto';
+import { localizeCategory, parseLocale } from './locale';
+
+/**
+ * API INTERNA/admin del catálogo de categorías (#221). Superficie privada:
+ * separada del `GET /categories` público (tag `categories-admin`, ruta
+ * `/admin/categories`) y protegida por `catalogue:manage`. Los errores de
+ * dominio los traduce el `SuppliesDomainExceptionFilter` global (sin try/catch).
+ */
+@ApiTags('categories-admin')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionGuard)
+@Controller('admin/categories')
+export class CategoriesAdminController {
+  constructor(
+    private readonly listAdminCategories: ListAdminCategories,
+    private readonly createCategory: CreateCategory,
+    private readonly updateCategory: UpdateCategory,
+    private readonly deleteCategory: DeleteCategory,
+  ) {}
+
+  @Get()
+  @RequirePermission('catalogue:manage')
+  @ApiOperation({
+    summary: 'List the full category taxonomy for admin (archived included)',
+  })
+  @ApiHeader({ name: 'Accept-Language', required: false })
+  @ApiQuery({
+    name: 'locale',
+    required: false,
+    description: 'Preferred locale',
+  })
+  @ApiOkResponse({ type: [CategoryAdminDto] })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing catalogue:manage permission' })
+  async list(
+    @Query('locale') localeParam?: string,
+    @Headers() headers: Record<string, string> = {},
+  ): Promise<CategoryAdminDto[]> {
+    const locale = parseLocale(localeParam, headers['accept-language']);
+    const records = await this.listAdminCategories.execute({
+      includeArchived: true,
+    });
+    return records.map((record) => this.toDto(record, locale));
+  }
+
+  @Post()
+  @RequirePermission('catalogue:manage')
+  @ApiOperation({ summary: 'Create a category or subcategory' })
+  @ApiCreatedResponse({ type: CategoryAdminDto })
+  @ApiBadRequestResponse({ description: 'Invalid category payload' })
+  @ApiConflictResponse({ description: 'Category slug already exists' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing catalogue:manage permission' })
+  async create(
+    @Body() dto: CreateCategoryDto,
+    @Query('locale') localeParam?: string,
+    @Headers() headers: Record<string, string> = {},
+  ): Promise<CategoryAdminDto> {
+    const record = await this.createCategory.execute({
+      slug: dto.slug,
+      labelEs: dto.labelEs,
+      labelEn: dto.labelEn,
+      parentSlug: dto.parentSlug ?? null,
+      vertical: dto.vertical,
+      sort: dto.sort,
+      translations: dto.translations,
+    });
+    return this.toDto(
+      record,
+      parseLocale(localeParam, headers['accept-language']),
+    );
+  }
+
+  @Patch(':slug')
+  @RequirePermission('catalogue:manage')
+  @ApiOperation({
+    summary: 'Update a category (labels, order, parent, translations, archive)',
+  })
+  @ApiParam({ name: 'slug', description: 'Category slug (immutable)' })
+  @ApiOkResponse({ type: CategoryAdminDto })
+  @ApiBadRequestResponse({ description: 'Invalid category payload' })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing catalogue:manage permission' })
+  async update(
+    @Param('slug') slug: string,
+    @Body() dto: UpdateCategoryDto,
+    @Query('locale') localeParam?: string,
+    @Headers() headers: Record<string, string> = {},
+  ): Promise<CategoryAdminDto> {
+    const record = await this.updateCategory.execute(slug, {
+      labelEs: dto.labelEs,
+      labelEn: dto.labelEn,
+      parentSlug: dto.parentSlug,
+      vertical: dto.vertical,
+      sort: dto.sort,
+      archived: dto.archived,
+      translations: dto.translations,
+    });
+    return this.toDto(
+      record,
+      parseLocale(localeParam, headers['accept-language']),
+    );
+  }
+
+  @Delete(':slug')
+  @HttpCode(204)
+  @RequirePermission('catalogue:manage')
+  @ApiOperation({
+    summary: 'Archive a category (core slugs are protected → 4xx)',
+  })
+  @ApiParam({ name: 'slug', description: 'Category slug to archive' })
+  @ApiNoContentResponse({ description: 'Category archived' })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiConflictResponse({ description: 'Core category slug cannot be deleted' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
+  @ApiForbiddenResponse({ description: 'Missing catalogue:manage permission' })
+  async remove(@Param('slug') slug: string): Promise<void> {
+    await this.deleteCategory.execute(slug);
+  }
+
+  private toDto(record: CategoryRecord, locale: string): CategoryAdminDto {
+    return {
+      slug: record.slug,
+      label: localizeCategory(record, locale),
+      labelEs: record.labelEs,
+      labelEn: record.labelEn,
+      parentSlug: record.parentSlug,
+      vertical: record.vertical,
+      sort: record.sort,
+      archivedAt: record.archivedAt ? record.archivedAt.toISOString() : null,
+      translations: record.translations.map((t) => ({
+        locale: t.locale,
+        label: t.label,
+      })),
+    };
+  }
+}

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.spec.ts
@@ -10,21 +10,24 @@ describe('CategoriesController', () => {
       parentSlug: null,
       vertical: 'general',
       sort: 1,
+      translations: [{ locale: 'fr', label: 'Nourriture' }],
     },
   ];
 
-  it('localiza la etiqueta y mantiene las bases', async () => {
+  it('localiza la etiqueta (es/en/idioma traducido) y mantiene las bases', async () => {
     const controller = new CategoriesController({
       execute: () => Promise.resolve(categories),
     });
 
-    const [en, es] = await Promise.all([
+    const [en, es, fr] = await Promise.all([
       controller.list('en', { 'accept-language': 'en-US,en;q=0.9' }),
       controller.list('es', { 'accept-language': 'es-VE,es;q=0.9' }),
+      controller.list('fr', { 'accept-language': 'fr-FR,fr;q=0.9' }),
     ]);
 
     expect(en[0]?.label).toBe('Food');
     expect(en[0]?.labelEs).toBe('Alimentos');
     expect(es[0]?.label).toBe('Alimentos');
+    expect(fr[0]?.label).toBe('Nourriture');
   });
 });

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/swagger';
 import { ListCategories } from '../../application/list-categories';
 import { CategoryDto } from './category-response.dto';
-import { localizedText, resolveLocale } from './locale';
+import { localizeCategory, parseLocale } from './locale';
 
 @ApiTags('categories')
 @Controller()
@@ -22,7 +22,7 @@ export class CategoriesController {
   @ApiHeader({
     name: 'Accept-Language',
     required: false,
-    description: 'Fallback locale header (es or en)',
+    description: 'Fallback locale header (es, en o cualquier idioma traducido)',
   })
   @ApiQuery({
     name: 'locale',
@@ -34,11 +34,11 @@ export class CategoriesController {
     @Query('locale') localeParam?: string,
     @Headers() headers: Record<string, string> = {},
   ): Promise<CategoryDto[]> {
-    const locale = resolveLocale(localeParam, headers['accept-language']);
+    const locale = parseLocale(localeParam, headers['accept-language']);
     const categories = await this.listCategories.execute();
     return categories.map((category) => ({
       slug: category.slug,
-      label: localizedText(category.labelEs, category.labelEn, locale),
+      label: localizeCategory(category, locale),
       labelEs: category.labelEs,
       labelEn: category.labelEn,
       parentSlug: category.parentSlug,

--- a/apps/api/src/contexts/supplies/infrastructure/http/locale.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/locale.ts
@@ -31,3 +31,52 @@ export function localizedText(
   }
   return baseEs;
 }
+
+/**
+ * Localización multi-idioma de la taxonomía de categorías (#221). A diferencia
+ * de `resolveLocale` (limitada a es/en para supplies), aquí NO restringimos el
+ * conjunto: `category_translations` puede tener cualquier idioma. Devuelve el
+ * subtag primario en minúsculas; por defecto 'es'.
+ */
+export function parseLocale(
+  locale?: string | null,
+  acceptLanguage?: string | null,
+): string {
+  const candidates = [locale, acceptLanguage?.split(',')[0], 'es'];
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+    const normalized = candidate
+      .trim()
+      .toLowerCase()
+      .split(';')[0]
+      .split('-')[0];
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return 'es';
+}
+
+/**
+ * Etiqueta localizada de una categoría: gana una traducción explícita del
+ * idioma pedido; si no, en→labelEn; en cualquier otro caso, labelEs.
+ */
+export function localizeCategory(
+  category: {
+    labelEs: string;
+    labelEn: string;
+    translations: readonly { locale: string; label: string }[];
+  },
+  locale: string,
+): string {
+  const match = category.translations.find((t) => t.locale === locale);
+  if (match && match.label.trim().length > 0) {
+    return match.label;
+  }
+  if (locale === 'en') {
+    return category.labelEn;
+  }
+  return category.labelEs;
+}

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
@@ -13,6 +13,13 @@ import {
   ContainerValidationError,
 } from '../../domain/container-errors';
 import { SupplyLineValidationError } from '../../domain/supply-line';
+import {
+  CategoryAlreadyExistsError,
+  CategoryNotFoundError,
+  CategoryParentNotFoundError,
+  CategoryProtectedError,
+  CategoryValidationError,
+} from '../../domain/category-errors';
 
 type DomainError =
   | ContainerNotFoundError
@@ -20,7 +27,12 @@ type DomainError =
   | ContainerCycleError
   | ContainerEmergencyMismatchError
   | ContainerValidationError
-  | SupplyLineValidationError;
+  | SupplyLineValidationError
+  | CategoryNotFoundError
+  | CategoryAlreadyExistsError
+  | CategoryParentNotFoundError
+  | CategoryProtectedError
+  | CategoryValidationError;
 
 /**
  * Maps supplies domain errors to HTTP codes. The supplies context owns the
@@ -33,6 +45,12 @@ type DomainError =
  *   (matches how the codebase maps "wrong emergency", e.g. offers'
  *   TargetNeedWrongEmergencyError → 422)
  * - SupplyLineValidationError (e.g. a whitespace-only line name) → 400
+ *
+ * Category admin (#221):
+ * - CategoryNotFoundError → 404
+ * - CategoryAlreadyExistsError / CategoryProtectedError (core slug) → 409
+ * - CategoryValidationError (empty label/vertical, own-parent) → 400
+ * - CategoryParentNotFoundError → 422 (bad reference; default bucket)
  */
 @Catch(
   ContainerNotFoundError,
@@ -41,6 +59,11 @@ type DomainError =
   ContainerEmergencyMismatchError,
   ContainerValidationError,
   SupplyLineValidationError,
+  CategoryNotFoundError,
+  CategoryAlreadyExistsError,
+  CategoryParentNotFoundError,
+  CategoryProtectedError,
+  CategoryValidationError,
 )
 export class SuppliesDomainExceptionFilter implements ExceptionFilter {
   catch(exception: DomainError, host: ArgumentsHost): void {
@@ -52,13 +75,23 @@ export class SuppliesDomainExceptionFilter implements ExceptionFilter {
   }
 
   private statusFor(exception: DomainError): HttpStatus {
-    if (exception instanceof ContainerNotFoundError) {
+    if (
+      exception instanceof ContainerNotFoundError ||
+      exception instanceof CategoryNotFoundError
+    ) {
       return HttpStatus.NOT_FOUND;
     }
-    if (exception instanceof ContainerSealedError) {
+    if (
+      exception instanceof ContainerSealedError ||
+      exception instanceof CategoryAlreadyExistsError ||
+      exception instanceof CategoryProtectedError
+    ) {
       return HttpStatus.CONFLICT;
     }
-    if (exception instanceof SupplyLineValidationError) {
+    if (
+      exception instanceof SupplyLineValidationError ||
+      exception instanceof CategoryValidationError
+    ) {
       return HttpStatus.BAD_REQUEST;
     }
     return HttpStatus.UNPROCESSABLE_ENTITY;

--- a/apps/api/src/contexts/supplies/supplies.module.ts
+++ b/apps/api/src/contexts/supplies/supplies.module.ts
@@ -6,6 +6,10 @@ import {
   CategoryRepository,
 } from './domain/ports/category.repository';
 import {
+  CATEGORY_ADMIN_REPOSITORY,
+  CategoryAdminRepository,
+} from './domain/ports/category-admin.repository';
+import {
   SUPPLY_REPOSITORY,
   SupplyRepository,
 } from './domain/ports/supply.repository';
@@ -22,12 +26,17 @@ import {
   ContainerAuthorizationLookup,
 } from './domain/ports/container-authorization-lookup';
 import { DrizzleCategoryRepository } from './infrastructure/drizzle/drizzle-category.repository';
+import { DrizzleCategoryAdminRepository } from './infrastructure/drizzle/drizzle-category-admin.repository';
 import { DrizzleSupplyRepository } from './infrastructure/drizzle/drizzle-supply.repository';
 import { DrizzleSupplyCatalogReadModel } from './infrastructure/drizzle/drizzle-supply-catalog.read-model';
 import { CachingSupplyCatalogReadModel } from './infrastructure/caching-supply-catalog.read-model';
 import { DrizzleContainerRepository } from './infrastructure/drizzle/drizzle-container.repository';
 import { DrizzleContainerAuthorizationLookup } from './infrastructure/drizzle/drizzle-container-authorization-lookup';
 import { ListCategories } from './application/list-categories';
+import { ListAdminCategories } from './application/list-admin-categories';
+import { CreateCategory } from './application/create-category';
+import { UpdateCategory } from './application/update-category';
+import { DeleteCategory } from './application/delete-category';
 import { ListSupplies } from './application/list-supplies';
 import { GetSupply } from './application/get-supply';
 import { CreateContainer } from './application/create-container';
@@ -39,6 +48,7 @@ import { MoveContainer } from './application/move-container';
 import { GetContainer } from './application/get-container';
 import { ListContainers } from './application/list-containers';
 import { CategoriesController } from './infrastructure/http/categories.controller';
+import { CategoriesAdminController } from './infrastructure/http/categories-admin.controller';
 import { SuppliesController } from './infrastructure/http/supplies.controller';
 import { ContainerController } from './infrastructure/http/containers.controller';
 import { IdentityModule } from '../identity/infrastructure/identity.module';
@@ -81,6 +91,41 @@ const listCategoriesProvider = {
   inject: [CATEGORY_REPOSITORY],
   useFactory: (repo: CategoryRepository): ListCategories =>
     new ListCategories(repo),
+};
+
+const categoryAdminRepositoryProvider = {
+  provide: CATEGORY_ADMIN_REPOSITORY,
+  inject: [DB],
+  useFactory: (db: Db): CategoryAdminRepository =>
+    new DrizzleCategoryAdminRepository(db),
+};
+
+const listAdminCategoriesProvider = {
+  provide: ListAdminCategories,
+  inject: [CATEGORY_ADMIN_REPOSITORY],
+  useFactory: (repo: CategoryAdminRepository): ListAdminCategories =>
+    new ListAdminCategories(repo),
+};
+
+const createCategoryProvider = {
+  provide: CreateCategory,
+  inject: [CATEGORY_ADMIN_REPOSITORY],
+  useFactory: (repo: CategoryAdminRepository): CreateCategory =>
+    new CreateCategory(repo),
+};
+
+const updateCategoryProvider = {
+  provide: UpdateCategory,
+  inject: [CATEGORY_ADMIN_REPOSITORY],
+  useFactory: (repo: CategoryAdminRepository): UpdateCategory =>
+    new UpdateCategory(repo),
+};
+
+const deleteCategoryProvider = {
+  provide: DeleteCategory,
+  inject: [CATEGORY_ADMIN_REPOSITORY],
+  useFactory: (repo: CategoryAdminRepository): DeleteCategory =>
+    new DeleteCategory(repo),
 };
 
 const listSuppliesProvider = {
@@ -152,14 +197,24 @@ const listContainersProvider = {
  */
 @Module({
   imports: [DatabaseModule, IdentityModule],
-  controllers: [CategoriesController, SuppliesController, ContainerController],
+  controllers: [
+    CategoriesController,
+    CategoriesAdminController,
+    SuppliesController,
+    ContainerController,
+  ],
   providers: [
     categoryRepositoryProvider,
+    categoryAdminRepositoryProvider,
     supplyRepositoryProvider,
     supplyCatalogReadModelProvider,
     containerRepositoryProvider,
     containerAuthorizationLookupProvider,
     listCategoriesProvider,
+    listAdminCategoriesProvider,
+    createCategoryProvider,
+    updateCategoryProvider,
+    deleteCategoryProvider,
     listSuppliesProvider,
     getSupplyProvider,
     createContainerProvider,

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -81,6 +81,14 @@ async function bootstrap(): Promise<void> {
     // `X-API-Key: rh_live_…` header (issue #96).
     .addApiKey({ type: 'apiKey', name: 'X-API-Key', in: 'header' }, 'api-key')
     .addTag('resources')
+    // Superficie interna/admin separada de la API pública. `categories` es la
+    // taxonomía pública (GET /categories); `categories-admin` es el CRUD
+    // privilegiado (catalogue:manage), documentado como grupo aparte.
+    .addTag('categories', 'Taxonomía pública compartida (solo lectura)')
+    .addTag(
+      'categories-admin',
+      'Gestión interna del catálogo (catalogue:manage)',
+    )
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -1803,6 +1803,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the full category taxonomy for admin (archived included) */
+        get: operations["CategoriesAdminController_list"];
+        put?: never;
+        /** Create a category or subcategory */
+        post: operations["CategoriesAdminController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/categories/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Archive a category (core slugs are protected → 4xx) */
+        delete: operations["CategoriesAdminController_remove"];
+        options?: never;
+        head?: never;
+        /** Update a category (labels, order, parent, translations, archive) */
+        patch: operations["CategoriesAdminController_update"];
+        trace?: never;
+    };
     "/supplies": {
         parameters: {
             query?: never;
@@ -4716,6 +4752,81 @@ export interface components {
              * @example 41
              */
             sort: number;
+        };
+        CategoryTranslationDto: {
+            /** @example fr */
+            locale: string;
+            /** @example Nourriture */
+            label: string;
+        };
+        CategoryAdminDto: {
+            /** @example baby_food */
+            slug: string;
+            /**
+             * @description Localized label
+             * @example Alimentos para bebé
+             */
+            label: string;
+            /** @example Alimentos para bebé */
+            labelEs: string;
+            /** @example Baby food */
+            labelEn: string;
+            /**
+             * @description Parent category slug, or null for a top-level category
+             * @example food
+             */
+            parentSlug: string | null;
+            /** @example general */
+            vertical: string;
+            /** @example 140 */
+            sort: number;
+            /**
+             * @description Soft-archive timestamp (ISO-8601), or null if active
+             * @example null
+             */
+            archivedAt: string | null;
+            translations: components["schemas"]["CategoryTranslationDto"][];
+        };
+        CreateCategoryDto: {
+            /** @example baby_food */
+            slug: string;
+            /** @example Alimentos para bebé */
+            labelEs: string;
+            /** @example Baby food */
+            labelEn: string;
+            /**
+             * @description Parent category slug, or null for a top-level category
+             * @example food
+             */
+            parentSlug?: Record<string, never> | null;
+            /** @example general */
+            vertical: string;
+            /** @example 140 */
+            sort: number;
+            /** @description Additional locale labels (beyond es/en) for category_translations */
+            translations?: components["schemas"]["CategoryTranslationDto"][];
+        };
+        UpdateCategoryDto: {
+            /** @example Alimentos para bebé */
+            labelEs?: string;
+            /** @example Baby food */
+            labelEn?: string;
+            /**
+             * @description Parent category slug, or null for a top-level category
+             * @example food
+             */
+            parentSlug?: Record<string, never> | null;
+            /** @example general */
+            vertical?: string;
+            /** @example 140 */
+            sort?: number;
+            /** @description Replace the category_translations rows with this set */
+            translations?: components["schemas"]["CategoryTranslationDto"][];
+            /**
+             * @description True to hide/archive the category, false to restore it
+             * @example false
+             */
+            archived?: boolean;
         };
         SupplyDto: {
             /**
@@ -9944,7 +10055,7 @@ export interface operations {
                 locale?: string;
             };
             header?: {
-                /** @description Fallback locale header (es or en) */
+                /** @description Fallback locale header (es, en o cualquier idioma traducido) */
                 "Accept-Language"?: string;
             };
             path?: never;
@@ -9960,6 +10071,202 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["CategoryDto"][];
                 };
+            };
+        };
+    };
+    CategoriesAdminController_list: {
+        parameters: {
+            query?: {
+                /** @description Preferred locale */
+                locale?: string;
+            };
+            header?: {
+                "Accept-Language"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CategoryAdminDto"][];
+                };
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing catalogue:manage permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CategoriesAdminController_create: {
+        parameters: {
+            query: {
+                locale: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateCategoryDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CategoryAdminDto"];
+                };
+            };
+            /** @description Invalid category payload */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing catalogue:manage permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Category slug already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CategoriesAdminController_remove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Category slug to archive */
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Category archived */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing catalogue:manage permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Category not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Core category slug cannot be deleted */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CategoriesAdminController_update: {
+        parameters: {
+            query: {
+                locale: string;
+            };
+            header?: never;
+            path: {
+                /** @description Category slug (immutable) */
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateCategoryDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CategoryAdminDto"];
+                };
+            };
+            /** @description Invalid category payload */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing catalogue:manage permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Category not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
## Resumen

Implementa la gestión de catálogo de categorías (#221) **reconstruida sobre el `main` actual (post-#245)**, con foco en la separación de superficie **pública** e **interna** que veníamos discutiendo. Sustituye a #246 (basada en un `main` previo a #245, con conflictos y solapamientos).

**Separación pública/privada**
- API interna `/admin/categories` (GET/POST/PATCH/DELETE) con **tag propio `categories-admin`** y permiso **`catalogue:manage`**, separada del `GET /categories` público (documentada como grupo aparte en Swagger).
- **Modelo interno `CategoryRecord`** (con `archivedAt`) distinto de la **proyección pública `CategoryDefinition`**; **puerto de escritura `CategoryAdminRepository` separado** del de lectura pública (ISP). El público nunca ve `archivedAt`.

**DDD / Clean Code (aplicando la propia review de #246)**
- Invariantes solo en los casos de uso (`CreateCategory`/`UpdateCategory`/`DeleteCategory`); el adaptador Drizzle es persistencia "tonta".
- Regla de slug núcleo centralizada en el dominio (`isCoreCategory`), consumida por el caso de uso (no repetida en el controller).
- Errores de **dominio** mapeados por el `SuppliesDomainExceptionFilter` **global** (sin `try/catch` ni mapeo a mano en el controller).
- Slug **inmutable** (es PK referenciada): no se expone rename → sin lógica muerta. Núcleo no se borra (409); sí archivar/editar. DELETE archiva (soft) las no núcleo.

**i18n**
- Multi-idioma vía `category_translations` también en el `GET /categories` público (localiza `label` a cualquier idioma), reutilizando la localización existente sin romper la firma que usa `supplies`.

**Otros**
- Permiso `catalogue:manage` en el catálogo de autorización (lo tiene `platform_admin`).
- Migración `0039_categories_archived_at.sql` (columna + índice).

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `api build`, `eslint {src,test} --max-warnings=0`, `prettier --check`, **suite completa 1301 tests** ✅; `@reliefhub/api-client build` + `web build` + `web lint` ✅.
- [x] Verifiqué el comportamiento con tests unitarios de casos de uso y controllers (create/update/delete, protección de slug núcleo, localización multi-idioma, archivado/restauración).
- [x] Actualicé migraciones (`0039`) y **regeneré el cliente API** (`openapi.json` + `schema.ts`, con las rutas `/admin/categories`).

## Cierre

- Closes #221

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyQ4dgwc1HffL8wKv18gk2)_