### PR TITLE
fix(resources): los grants entity-scoped autorizan la gestión del punto (#316)

### DIFF
--- a/apps/api/src/contexts/resources/application/get-my-inventory.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-my-inventory.spec.ts
@@ -14,6 +14,7 @@ const EM = '11111111-1111-4111-8111-111111111111';
 const OWNER_ID = 'owner-user-0000-0000-000000000000';
 const COORD_ID = 'coord-user-0000-0000-000000000000';
 const THIRD_ID = 'third-user-0000-0000-000000000000';
+const MANAGER_ID = 'manager-user-0000-0000-000000000000';
 const baseLocation = {
   address: 'Calle Test 1, Madrid',
   latitude: 40.4168,
@@ -75,6 +76,26 @@ describe('GetMyInventory', () => {
     const lines = await new GetMyInventory(repo, coordOnlyMembership).execute({
       resourceId: id,
       requesterUserId: COORD_ID,
+    });
+
+    expect(lines).toHaveLength(1);
+  });
+
+  it('point manager (entity-scoped grant, not owner/coordinator) can read (#316)', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+
+    const lines = await new GetMyInventory(repo, noMembership).execute({
+      resourceId: id,
+      requesterUserId: MANAGER_ID,
+      grants: [
+        {
+          roleId: 'point_manager',
+          scope: { type: 'entity', entityType: 'resource', id },
+          expiresAt: null,
+        },
+      ],
     });
 
     expect(lines).toHaveLength(1);

--- a/apps/api/src/contexts/resources/application/get-my-inventory.ts
+++ b/apps/api/src/contexts/resources/application/get-my-inventory.ts
@@ -3,10 +3,13 @@ import { ResourceMembershipReader } from '../domain/ports/membership-reader';
 import { SupplyLineSnapshot } from '../../supplies/domain/supply-line';
 import { UnauthorizedInventoryChangeError } from './unauthorized-inventory-change.error';
 import { loadResourceForManagement } from './load-resource-for-management';
+import { PrincipalGrant } from './principal-grant';
 
 export interface GetMyInventoryQuery {
   resourceId: string;
   requesterUserId: string;
+  /** Request grants, so an entity-scoped point manager is authorized (#316). */
+  grants?: PrincipalGrant[];
 }
 
 export class GetMyInventory {
@@ -21,6 +24,7 @@ export class GetMyInventory {
       membershipReader: this.membershipReader,
       resourceId: q.resourceId,
       requesterUserId: q.requesterUserId,
+      grants: q.grants ?? [],
       makeForbidden: () => new UnauthorizedInventoryChangeError(),
     });
 

--- a/apps/api/src/contexts/resources/application/get-my-managed-resources.ts
+++ b/apps/api/src/contexts/resources/application/get-my-managed-resources.ts
@@ -2,6 +2,7 @@ import {
   ManagedResourceRow,
   ResourceRepository,
 } from '../domain/ports/resource.repository';
+import { PrincipalGrant, grantedResourceIds } from './principal-grant';
 
 /**
  * One resource the principal manages, reduced to what the app shell needs to
@@ -12,16 +13,10 @@ import {
  */
 export type MyManagedResourceView = ManagedResourceRow;
 
-/**
- * A grant as it reaches this use case — the controller passes the
- * already-resolved request grants (see {@link AuthenticatedUser}). Only the
- * fields needed to resolve resource entity scope are required.
- */
-export interface PrincipalGrant {
-  roleId: string;
-  scope: { type: string; entityType?: string; id?: string };
-  expiresAt: string | null;
-}
+// Re-exported so existing importers keep resolving `PrincipalGrant` from here;
+// the type and its resource-scope filter now live in ./principal-grant, shared
+// with the inventory/status gate (issue #316).
+export type { PrincipalGrant } from './principal-grant';
 
 /**
  * Lists the resources the authenticated principal manages, across every
@@ -40,22 +35,8 @@ export class GetMyManagedResources {
     grants: PrincipalGrant[],
     now: Date = new Date(),
   ): Promise<MyManagedResourceView[]> {
-    const grantedIds = new Set<string>();
-    for (const g of grants) {
-      if (g.scope.type !== 'entity' || g.scope.entityType !== 'resource') {
-        continue;
-      }
-      const scopeId = g.scope.id;
-      if (scopeId == null || scopeId === '') continue;
-      if (
-        g.expiresAt != null &&
-        new Date(g.expiresAt).getTime() <= now.getTime()
-      ) {
-        continue;
-      }
-      grantedIds.add(scopeId);
-    }
-
-    return this.repo.findOwnedOrGranted(userId, [...grantedIds]);
+    return this.repo.findOwnedOrGranted(userId, [
+      ...grantedResourceIds(grants, now),
+    ]);
   }
 }

--- a/apps/api/src/contexts/resources/application/load-resource-for-management.spec.ts
+++ b/apps/api/src/contexts/resources/application/load-resource-for-management.spec.ts
@@ -1,0 +1,198 @@
+import { loadResourceForManagement } from './load-resource-for-management';
+import { RegisterResource } from './register-resource';
+import { InMemoryResourceRepository } from '../infrastructure/in-memory-resource.repository';
+import { FakeEventBus } from '../infrastructure/fake-event-bus';
+import { ResourceType } from '../domain/resource-enums';
+import { ResourceEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+import { ResourceMembershipReader } from '../domain/ports/membership-reader';
+import { ResourceNotFoundError } from './resource-not-found.error';
+import { PrincipalGrant } from './principal-grant';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const OWNER_ID = 'owner-user-0000-0000-000000000000';
+const COORD_ID = 'coord-user-0000-0000-000000000000';
+const MANAGER_ID = 'manager-user-0000-0000-000000000000';
+const THIRD_ID = 'third-user-0000-0000-000000000000';
+const OTHER_RESOURCE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const baseLocation = {
+  address: 'Calle Test 1, Madrid',
+  latitude: 40.4168,
+  longitude: -3.7038,
+};
+
+const activeReader: ResourceEmergencyStatusReader = {
+  getStatus: () => Promise.resolve('active'),
+};
+
+class Forbidden extends Error {}
+const makeForbidden = (): Error => new Forbidden();
+
+/** Membership reader that records whether it was consulted. */
+function trackingReader(isCoord: boolean): {
+  reader: ResourceMembershipReader;
+  queried: () => boolean;
+} {
+  let queried = false;
+  return {
+    reader: {
+      isCoordinator: (userId) => {
+        queried = true;
+        return Promise.resolve(isCoord && userId === COORD_ID);
+      },
+    },
+    queried: () => queried,
+  };
+}
+
+function entityGrant(
+  resourceId: string,
+  overrides: Partial<PrincipalGrant> = {},
+): PrincipalGrant {
+  return {
+    roleId: 'point_manager',
+    scope: { type: 'entity', entityType: 'resource', id: resourceId },
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+async function makeResource(
+  repo: InMemoryResourceRepository,
+  bus: FakeEventBus,
+): Promise<string> {
+  const { id } = await new RegisterResource(repo, bus, activeReader).execute({
+    emergencyId: EM,
+    type: ResourceType.CollectionPoint,
+    name: 'Punto Test',
+    location: baseLocation,
+    ownerUserId: OWNER_ID,
+  });
+  return id;
+}
+
+describe('loadResourceForManagement', () => {
+  it('owner is authorized without consulting membership', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+    const { reader, queried } = trackingReader(false);
+
+    const resource = await loadResourceForManagement({
+      repo,
+      membershipReader: reader,
+      resourceId: id,
+      requesterUserId: OWNER_ID,
+      makeForbidden,
+    });
+
+    expect(resource.id.value).toBe(id);
+    expect(queried()).toBe(false);
+  });
+
+  it('an active entity-scoped grant on the resource authorizes without consulting membership (#316)', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+    const { reader, queried } = trackingReader(false);
+
+    const resource = await loadResourceForManagement({
+      repo,
+      membershipReader: reader,
+      resourceId: id,
+      requesterUserId: MANAGER_ID,
+      grants: [entityGrant(id)],
+      makeForbidden,
+    });
+
+    expect(resource.id.value).toBe(id);
+    expect(queried()).toBe(false);
+  });
+
+  it('an expired entity grant does not authorize', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+    const { reader } = trackingReader(false);
+
+    await expect(
+      loadResourceForManagement({
+        repo,
+        membershipReader: reader,
+        resourceId: id,
+        requesterUserId: MANAGER_ID,
+        grants: [entityGrant(id, { expiresAt: '2026-07-01T00:00:00Z' })],
+        now: new Date('2026-07-02T12:00:00Z'),
+        makeForbidden,
+      }),
+    ).rejects.toBeInstanceOf(Forbidden);
+  });
+
+  it('an entity grant on a different resource does not authorize', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+    const { reader } = trackingReader(false);
+
+    await expect(
+      loadResourceForManagement({
+        repo,
+        membershipReader: reader,
+        resourceId: id,
+        requesterUserId: MANAGER_ID,
+        grants: [entityGrant(OTHER_RESOURCE)],
+        makeForbidden,
+      }),
+    ).rejects.toBeInstanceOf(Forbidden);
+  });
+
+  it('a coordinator with no grant is authorized (falls through to membership)', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+    const { reader, queried } = trackingReader(true);
+
+    const resource = await loadResourceForManagement({
+      repo,
+      membershipReader: reader,
+      resourceId: id,
+      requesterUserId: COORD_ID,
+      makeForbidden,
+    });
+
+    expect(resource.id.value).toBe(id);
+    expect(queried()).toBe(true);
+  });
+
+  it('a third party with no owner/grant/coordinator is rejected', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus);
+    const { reader } = trackingReader(false);
+
+    await expect(
+      loadResourceForManagement({
+        repo,
+        membershipReader: reader,
+        resourceId: id,
+        requesterUserId: THIRD_ID,
+        grants: [],
+        makeForbidden,
+      }),
+    ).rejects.toBeInstanceOf(Forbidden);
+  });
+
+  it('an unknown resource id maps to ResourceNotFoundError before any authz check', async () => {
+    const repo = new InMemoryResourceRepository();
+    const { reader } = trackingReader(false);
+
+    await expect(
+      loadResourceForManagement({
+        repo,
+        membershipReader: reader,
+        resourceId: '99999999-9999-4999-8999-999999999999',
+        requesterUserId: OWNER_ID,
+        makeForbidden,
+      }),
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+});

--- a/apps/api/src/contexts/resources/application/load-resource-for-management.ts
+++ b/apps/api/src/contexts/resources/application/load-resource-for-management.ts
@@ -3,23 +3,30 @@ import { ResourceRepository } from '../domain/ports/resource.repository';
 import { ResourceMembershipReader } from '../domain/ports/membership-reader';
 import { ResourceId } from '../domain/resource-id';
 import { ResourceNotFoundError } from './resource-not-found.error';
+import { PrincipalGrant, grantedResourceIds } from './principal-grant';
 
 /**
- * Shared owner-or-coordinator gate for the resource self-management use cases
- * (public status, declared inventory). Loads the resource — absent id maps to
- * 404 — and returns it when the requester is its owner or a coordinator of its
- * emergency; otherwise throws the caller's `makeForbidden` error, so each
+ * Shared management gate for the resource self-management use cases (public
+ * status, declared inventory). Loads the resource — absent id maps to 404 — and
+ * returns it when the requester (in priority order) owns it, holds an active
+ * entity-scoped grant on it (e.g. `point_manager`, #316) or is a coordinator of
+ * its emergency; otherwise throws the caller's `makeForbidden` error, so each
  * feature keeps its own 403 type in the HTTP exception mapping.
  *
- * The coordinator membership lookup only runs for NON-owners: the owner is the
- * dominant self-service path and needs no extra query. An owner who is also a
- * member of the ownerOrganization satisfies `isOwner`.
+ * The entity-grant check uses the SAME definition the `/resources/mine` panel
+ * lists by ({@link grantedResourceIds}), so a point that shows in the panel is a
+ * point its manager can actually operate. It runs before the coordinator lookup
+ * because the grants already travel on the request (no I/O), so the dominant
+ * owner and point-manager paths never hit the membership table. An owner who is
+ * also a member of the ownerOrganization satisfies `isOwner`.
  */
 export async function loadResourceForManagement(params: {
   repo: ResourceRepository;
   membershipReader: ResourceMembershipReader;
   resourceId: string;
   requesterUserId: string;
+  grants?: PrincipalGrant[];
+  now?: Date;
   makeForbidden: () => Error;
 }): Promise<Resource> {
   const resource = await params.repo.findById(
@@ -27,13 +34,18 @@ export async function loadResourceForManagement(params: {
   );
   if (!resource) throw new ResourceNotFoundError(params.resourceId);
 
-  const isOwner = resource.ownerUserId === params.requesterUserId;
-  if (!isOwner) {
-    const isCoordinator = await params.membershipReader.isCoordinator(
-      params.requesterUserId,
-      resource.emergencyId.value,
-    );
-    if (!isCoordinator) throw params.makeForbidden();
-  }
+  if (resource.ownerUserId === params.requesterUserId) return resource;
+
+  const granted = grantedResourceIds(
+    params.grants ?? [],
+    params.now ?? new Date(),
+  );
+  if (granted.has(resource.id.value)) return resource;
+
+  const isCoordinator = await params.membershipReader.isCoordinator(
+    params.requesterUserId,
+    resource.emergencyId.value,
+  );
+  if (!isCoordinator) throw params.makeForbidden();
   return resource;
 }

--- a/apps/api/src/contexts/resources/application/principal-grant.spec.ts
+++ b/apps/api/src/contexts/resources/application/principal-grant.spec.ts
@@ -1,0 +1,63 @@
+import { grantedResourceIds, PrincipalGrant } from './principal-grant';
+
+const R1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const R2 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const NOW = new Date('2026-07-02T12:00:00Z');
+
+function grant(overrides: Partial<PrincipalGrant> = {}): PrincipalGrant {
+  return {
+    roleId: 'point_manager',
+    scope: { type: 'entity', entityType: 'resource', id: R1 },
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+describe('grantedResourceIds', () => {
+  it('collects the ids of active entity-scoped resource grants', () => {
+    const ids = grantedResourceIds(
+      [
+        grant({ scope: { type: 'entity', entityType: 'resource', id: R1 } }),
+        grant({ scope: { type: 'entity', entityType: 'resource', id: R2 } }),
+      ],
+      NOW,
+    );
+    expect([...ids].sort()).toEqual([R1, R2].sort());
+  });
+
+  it('treats a null expiry as always active', () => {
+    expect(grantedResourceIds([grant({ expiresAt: null })], NOW).has(R1)).toBe(
+      true,
+    );
+  });
+
+  it('ignores grants expired at or before now', () => {
+    expect(
+      grantedResourceIds([grant({ expiresAt: '2026-07-01T00:00:00Z' })], NOW)
+        .size,
+    ).toBe(0);
+  });
+
+  it('ignores grants that are not entity-scoped to a resource', () => {
+    const ids = grantedResourceIds(
+      [
+        grant({ scope: { type: 'emergency', id: R1 } }),
+        grant({ scope: { type: 'entity', entityType: 'group', id: R1 } }),
+      ],
+      NOW,
+    );
+    expect(ids.size).toBe(0);
+  });
+
+  it('ignores an entity resource grant with no id', () => {
+    const ids = grantedResourceIds(
+      [grant({ scope: { type: 'entity', entityType: 'resource' } })],
+      NOW,
+    );
+    expect(ids.size).toBe(0);
+  });
+
+  it('returns an empty set when there are no grants', () => {
+    expect(grantedResourceIds([], NOW).size).toBe(0);
+  });
+});

--- a/apps/api/src/contexts/resources/application/principal-grant.ts
+++ b/apps/api/src/contexts/resources/application/principal-grant.ts
@@ -1,0 +1,47 @@
+/**
+ * A grant as it reaches the resource use cases. The controller maps identity's
+ * `GrantSnapshot` down to this minimal shape so the application layer never
+ * imports the identity context — only the fields needed to resolve resource
+ * entity scope are kept.
+ */
+export interface PrincipalGrant {
+  roleId: string;
+  scope: { type: string; entityType?: string; id?: string };
+  expiresAt: string | null;
+}
+
+/**
+ * The single reusable definition of "which resources this principal manages
+ * through a grant": the ids of every ACTIVE entity-scoped grant whose entity
+ * is a resource. Shared by {@link GetMyManagedResources} (panel visibility,
+ * #285) and `loadResourceForManagement` (the inventory/status gate, #316) so a
+ * point that lists in the panel is exactly a point the principal can operate.
+ *
+ * Ownership and emergency-coordinator authority are NOT part of this set — each
+ * caller checks those separately. The role is irrelevant here: any entity grant
+ * on the resource surfaces it. Today the only role that emits such grants
+ * (`point_manager`) also carries `resource:edit`, so an entity grant implies
+ * full management; the day a read-only entity role appears, split read vs write
+ * HERE — this is the one place the three surfaces agree on (issue #316, note c).
+ */
+export function grantedResourceIds(
+  grants: PrincipalGrant[],
+  now: Date,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const g of grants) {
+    if (g.scope.type !== 'entity' || g.scope.entityType !== 'resource') {
+      continue;
+    }
+    const scopeId = g.scope.id;
+    if (scopeId == null || scopeId === '') continue;
+    if (
+      g.expiresAt != null &&
+      new Date(g.expiresAt).getTime() <= now.getTime()
+    ) {
+      continue;
+    }
+    ids.add(scopeId);
+  }
+  return ids;
+}

--- a/apps/api/src/contexts/resources/application/update-my-inventory.spec.ts
+++ b/apps/api/src/contexts/resources/application/update-my-inventory.spec.ts
@@ -16,6 +16,7 @@ const EM = '11111111-1111-4111-8111-111111111111';
 const OWNER_ID = 'owner-user-0000-0000-000000000000';
 const COORD_ID = 'coord-user-0000-0000-000000000000';
 const THIRD_ID = 'third-user-0000-0000-000000000000';
+const MANAGER_ID = 'manager-user-0000-0000-000000000000';
 const baseLocation = {
   address: 'Calle Test 1, Madrid',
   latitude: 40.4168,
@@ -84,6 +85,28 @@ describe('UpdateMyInventory', () => {
 
     const found = await repo.findById(ResourceId.fromString(id));
     expect(found?.items.map((i) => i.name)).toEqual(['Mantas']);
+  });
+
+  it('point manager (entity-scoped grant, not owner/coordinator) can replace inventory (#316)', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, [line('Agua', 10)]);
+
+    await new UpdateMyInventory(repo, noMembership).execute({
+      resourceId: id,
+      requesterUserId: MANAGER_ID,
+      lines: [line('Kits', 7)],
+      grants: [
+        {
+          roleId: 'point_manager',
+          scope: { type: 'entity', entityType: 'resource', id },
+          expiresAt: null,
+        },
+      ],
+    });
+
+    const found = await repo.findById(ResourceId.fromString(id));
+    expect(found?.items.map((i) => i.name)).toEqual(['Kits']);
   });
 
   it('owner path does not query coordinator membership', async () => {

--- a/apps/api/src/contexts/resources/application/update-my-inventory.ts
+++ b/apps/api/src/contexts/resources/application/update-my-inventory.ts
@@ -3,11 +3,14 @@ import { ResourceMembershipReader } from '../domain/ports/membership-reader';
 import { SupplyLine, SupplyLineProps } from '../../supplies/domain/supply-line';
 import { UnauthorizedInventoryChangeError } from './unauthorized-inventory-change.error';
 import { loadResourceForManagement } from './load-resource-for-management';
+import { PrincipalGrant } from './principal-grant';
 
 export interface UpdateMyInventoryCommand {
   resourceId: string;
   requesterUserId: string;
   lines: SupplyLineProps[];
+  /** Request grants, so an entity-scoped point manager is authorized (#316). */
+  grants?: PrincipalGrant[];
 }
 
 export class UpdateMyInventory {
@@ -22,6 +25,7 @@ export class UpdateMyInventory {
       membershipReader: this.membershipReader,
       resourceId: cmd.resourceId,
       requesterUserId: cmd.requesterUserId,
+      grants: cmd.grants ?? [],
       makeForbidden: () => new UnauthorizedInventoryChangeError(),
     });
 

--- a/apps/api/src/contexts/resources/application/update-resource-public-status.spec.ts
+++ b/apps/api/src/contexts/resources/application/update-resource-public-status.spec.ts
@@ -19,6 +19,7 @@ const EM = '11111111-1111-4111-8111-111111111111';
 const OWNER_ID = 'owner-user-0000-0000-000000000000';
 const COORD_ID = 'coord-user-0000-0000-000000000000';
 const THIRD_ID = 'third-user-0000-0000-000000000000';
+const MANAGER_ID = 'manager-user-0000-0000-000000000000';
 const baseLocation = {
   address: 'Calle Test 1, Madrid',
   latitude: 40.4168,
@@ -92,6 +93,28 @@ describe('UpdateResourcePublicStatus', () => {
 
     const found = await repo.findById(ResourceId.fromString(id));
     expect(found?.publicStatus).toBe(PublicStatus.Paused);
+  });
+
+  it('point manager (entity-scoped grant, not owner/coordinator) can change status (#316)', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makePublishedResource(repo, bus);
+
+    await new UpdateResourcePublicStatus(repo, noMembership).execute({
+      resourceId: id,
+      targetStatus: PublicStatus.Saturated,
+      requesterUserId: MANAGER_ID,
+      grants: [
+        {
+          roleId: 'point_manager',
+          scope: { type: 'entity', entityType: 'resource', id },
+          expiresAt: null,
+        },
+      ],
+    });
+
+    const found = await repo.findById(ResourceId.fromString(id));
+    expect(found?.publicStatus).toBe(PublicStatus.Saturated);
   });
 
   it('third-party user (not owner, not coordinator) → UnauthorizedStatusChangeError (→ 403)', async () => {

--- a/apps/api/src/contexts/resources/application/update-resource-public-status.ts
+++ b/apps/api/src/contexts/resources/application/update-resource-public-status.ts
@@ -3,11 +3,14 @@ import { ResourceMembershipReader } from '../domain/ports/membership-reader';
 import { PublicStatus } from '../domain/resource-enums';
 import { UnauthorizedStatusChangeError } from './unauthorized-status-change.error';
 import { loadResourceForManagement } from './load-resource-for-management';
+import { PrincipalGrant } from './principal-grant';
 
 export interface UpdateResourcePublicStatusCommand {
   resourceId: string;
   targetStatus: PublicStatus;
   requesterUserId: string;
+  /** Request grants, so an entity-scoped point manager is authorized (#316). */
+  grants?: PrincipalGrant[];
 }
 
 export class UpdateResourcePublicStatus {
@@ -22,6 +25,7 @@ export class UpdateResourcePublicStatus {
       membershipReader: this.membershipReader,
       resourceId: cmd.resourceId,
       requesterUserId: cmd.requesterUserId,
+      grants: cmd.grants ?? [],
       makeForbidden: () => new UnauthorizedStatusChangeError(),
     });
 

--- a/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
@@ -36,6 +36,7 @@ import {
   GetMyManagedResources,
   MyManagedResourceView,
 } from '../../application/get-my-managed-resources';
+import { PrincipalGrant } from '../../application/principal-grant';
 import {
   EditResource,
   EditResourceCommand,
@@ -103,6 +104,20 @@ export class ResourcesController {
     private readonly resolveDispute: ResolveResourceDispute,
     private readonly validityReports: GetResourceValidityReports,
   ) {}
+
+  /**
+   * Maps the request's identity grants to the minimal application shape the
+   * resource use cases consume, so an entity-scoped point manager is authorized
+   * on the management surfaces without the application layer importing identity
+   * (issue #316).
+   */
+  private principalGrants(user: AuthenticatedUser): PrincipalGrant[] {
+    return user.grants.map((g) => ({
+      roleId: g.roleId,
+      scope: g.scope,
+      expiresAt: g.expiresAt,
+    }));
+  }
 
   @Post('emergencies/:emergencyId/resources')
   @HttpCode(201)
@@ -218,6 +233,7 @@ export class ResourcesController {
     const lines = await this.getMyInventory.execute({
       resourceId,
       requesterUserId: req.user!.id,
+      grants: this.principalGrants(req.user!),
     });
     return lines.map(toSupplyLineResponse);
   }
@@ -248,6 +264,7 @@ export class ResourcesController {
       resourceId,
       requesterUserId: req.user!.id,
       lines: dto.items.map(toSupplyLineProps),
+      grants: this.principalGrants(req.user!),
     });
   }
 
@@ -415,6 +432,7 @@ export class ResourcesController {
       resourceId,
       targetStatus: statusMap[dto.status],
       requesterUserId: req.user!.id,
+      grants: this.principalGrants(req.user!),
     });
   }
 
@@ -443,11 +461,7 @@ export class ResourcesController {
     const user = req.user!;
     return this.getMyManagedResources.execute(
       user.id,
-      user.grants.map((g) => ({
-        roleId: g.roleId,
-        scope: g.scope,
-        expiresAt: g.expiresAt,
-      })),
+      this.principalGrants(user),
     );
   }
 

--- a/apps/api/test/resources-manage-grant.e2e-spec.ts
+++ b/apps/api/test/resources-manage-grant.e2e-spec.ts
@@ -1,0 +1,296 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import type { Server } from 'node:http';
+import request from 'supertest';
+import { inArray } from 'drizzle-orm';
+import * as bcrypt from 'bcryptjs';
+import { AppModule } from '../src/app.module';
+import { DomainExceptionFilter } from '../src/contexts/resources/infrastructure/http/domain-exception.filter';
+import { createDb } from '../src/shared/db';
+import {
+  usersTable,
+  grantsTable,
+  membershipsTable,
+} from '../src/contexts/identity/infrastructure/drizzle/schema';
+import { emergenciesTable } from '../src/contexts/emergencies/infrastructure/drizzle/schema';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+
+// UUIDs distinct from the other resource e2e files.
+const OWNER_ID = '31600000-0000-4000-8000-000000000001';
+const COORD_ID = '31600000-0000-4000-8000-000000000002';
+const MANAGER_ID = '31600000-0000-4000-8000-000000000003';
+const STRANGER_ID = '31600000-0000-4000-8000-000000000004';
+const GRANT_ID = '31600000-0000-4000-8000-000000000005';
+const COORD_MEMBERSHIP_ID = '31600000-0000-4000-8000-000000000006';
+
+const baseLocation = {
+  address: 'Av. Urdaneta 20, Caracas',
+  latitude: 10.5061,
+  longitude: -66.9146,
+};
+
+interface Line {
+  name: string;
+  quantity: number;
+  unit: string | null;
+  category: string;
+}
+
+/**
+ * The gestor journey (#316): a `point_manager` whose ONLY grant is
+ * entity-scoped to their resource must be able to OPERATE it — read and replace
+ * its declared inventory and change its public status — not merely see it in the
+ * panel (#285). Exercises the real HTTP stack so the shared
+ * `loadResourceForManagement` gate is proven to honour entity grants.
+ */
+describe('Resource management by entity-scoped grant (e2e, #316)', () => {
+  let app: INestApplication;
+  let server: Server;
+  let ownerToken: string;
+  let coordToken: string;
+  let managerToken: string;
+  let strangerToken: string;
+  let managedResourceId: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new DomainExceptionFilter());
+    await app.init();
+    server = app.getHttpServer() as Server;
+
+    const dbUrl =
+      process.env.DATABASE_URL ??
+      'postgres://reliefhub:reliefhub@localhost:5433/reliefhub_test';
+
+    const { db, pool } = createDb(dbUrl);
+    try {
+      await db
+        .delete(grantsTable)
+        .where(inArray(grantsTable.principalId, [MANAGER_ID]));
+      await db
+        .delete(membershipsTable)
+        .where(inArray(membershipsTable.userId, [COORD_ID]));
+      await db
+        .delete(usersTable)
+        .where(
+          inArray(usersTable.id, [OWNER_ID, COORD_ID, MANAGER_ID, STRANGER_ID]),
+        );
+
+      await db
+        .insert(emergenciesTable)
+        .values({
+          id: EM,
+          name: 'Terremoto Venezuela 2026',
+          slug: 'terremoto-venezuela-2026',
+          country: 'VE',
+          status: 'active',
+          createdAt: new Date(),
+        })
+        .onConflictDoNothing();
+
+      const hash = await bcrypt.hash('Password1!', 10);
+      await db
+        .insert(usersTable)
+        .values([
+          {
+            id: OWNER_ID,
+            email: 'owner-manage316@reliefhub.org',
+            passwordHash: hash,
+            name: 'Manage Owner',
+            isAdmin: false,
+          },
+          {
+            id: COORD_ID,
+            email: 'coord-manage316@reliefhub.org',
+            passwordHash: hash,
+            name: 'Manage Coordinator',
+            isAdmin: false,
+          },
+          {
+            id: MANAGER_ID,
+            email: 'manager-manage316@reliefhub.org',
+            passwordHash: hash,
+            name: 'Manage Manager',
+            isAdmin: false,
+          },
+          {
+            id: STRANGER_ID,
+            email: 'stranger-manage316@reliefhub.org',
+            passwordHash: hash,
+            name: 'Manage Stranger',
+            isAdmin: false,
+          },
+        ])
+        .onConflictDoNothing();
+
+      await db
+        .insert(membershipsTable)
+        .values({
+          id: COORD_MEMBERSHIP_ID,
+          userId: COORD_ID,
+          emergencyId: EM,
+          role: 'coordinator',
+        })
+        .onConflictDoNothing();
+    } finally {
+      await pool.end();
+    }
+
+    const [ownerRes, coordRes, managerRes, strangerRes] = await Promise.all([
+      request(server)
+        .post('/auth/login')
+        .send({
+          email: 'owner-manage316@reliefhub.org',
+          password: 'Password1!',
+        })
+        .expect(200),
+      request(server)
+        .post('/auth/login')
+        .send({
+          email: 'coord-manage316@reliefhub.org',
+          password: 'Password1!',
+        })
+        .expect(200),
+      request(server)
+        .post('/auth/login')
+        .send({
+          email: 'manager-manage316@reliefhub.org',
+          password: 'Password1!',
+        })
+        .expect(200),
+      request(server)
+        .post('/auth/login')
+        .send({
+          email: 'stranger-manage316@reliefhub.org',
+          password: 'Password1!',
+        })
+        .expect(200),
+    ]);
+    ownerToken = (ownerRes.body as { accessToken: string }).accessToken;
+    coordToken = (coordRes.body as { accessToken: string }).accessToken;
+    managerToken = (managerRes.body as { accessToken: string }).accessToken;
+    strangerToken = (strangerRes.body as { accessToken: string }).accessToken;
+
+    // Owner registers the point with one declared line; MANAGER will run it via
+    // an entity-scoped grant (the acopiove.org-import shape: imported points get
+    // a point_manager, not an owner).
+    const created = await request(server)
+      .post(`/emergencies/${EM}/resources`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({
+        type: 'collection_point',
+        name: 'Acopio gestionado 316',
+        location: baseLocation,
+        items: [{ name: 'Agua', quantity: 10, unit: 'l', category: 'water' }],
+      })
+      .expect(201);
+    managedResourceId = (created.body as { id: string }).id;
+
+    const { db: db2, pool: pool2 } = createDb(dbUrl);
+    try {
+      await db2
+        .insert(grantsTable)
+        .values({
+          id: GRANT_ID,
+          principalId: MANAGER_ID,
+          principalType: 'user',
+          roleId: 'point_manager',
+          scopeType: 'entity',
+          scopeEntityType: 'resource',
+          scopeId: managedResourceId,
+          grantedAt: new Date(),
+        })
+        .onConflictDoNothing();
+    } finally {
+      await pool2.end();
+    }
+
+    // Publish it (coordinator) so the public-status transition is legal.
+    await request(server)
+      .post(`/resources/${managedResourceId}/verify`)
+      .set('Authorization', `Bearer ${coordToken}`)
+      .send({})
+      .expect(204);
+    await request(server)
+      .post(`/resources/${managedResourceId}/publish`)
+      .set('Authorization', `Bearer ${coordToken}`)
+      .expect(204);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('the manager reads the full declared inventory of their point', async () => {
+    const res = await request(server)
+      .get(`/resources/${managedResourceId}/inventory`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200);
+
+    const lines = res.body as Line[];
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ name: 'Agua', quantity: 10 });
+  });
+
+  it('the manager replaces the declared inventory of their point', async () => {
+    await request(server)
+      .put(`/resources/${managedResourceId}/inventory`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send({
+        items: [{ name: 'Arroz', quantity: 3, unit: 'kg', category: 'food' }],
+      })
+      .expect(204);
+
+    const res = await request(server)
+      .get(`/resources/${managedResourceId}/inventory`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200);
+    const lines = res.body as Line[];
+    expect(lines.map((l) => l.name)).toEqual(['Arroz']);
+  });
+
+  it('the manager changes the public status of their point', async () => {
+    await request(server)
+      .post(`/resources/${managedResourceId}/status`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send({ status: 'saturated' })
+      .expect(204);
+
+    const publicList = await request(server)
+      .get(`/emergencies/${EM}/public/resources`)
+      .expect(200);
+    const found = (
+      publicList.body as { items: Array<{ id: string; publicStatus: string }> }
+    ).items.find((r) => r.id === managedResourceId);
+    expect(found?.publicStatus).toBe('saturated');
+  });
+
+  it('a stranger (no owner/grant/coordinator) cannot replace the inventory → 403', async () => {
+    await request(server)
+      .put(`/resources/${managedResourceId}/inventory`)
+      .set('Authorization', `Bearer ${strangerToken}`)
+      .send({
+        items: [{ name: 'Nada', quantity: 1, unit: 'u', category: 'other' }],
+      })
+      .expect(403);
+  });
+
+  it('a stranger (no owner/grant/coordinator) cannot change the status → 403', async () => {
+    await request(server)
+      .post(`/resources/${managedResourceId}/status`)
+      .set('Authorization', `Bearer ${strangerToken}`)
+      .send({ status: 'paused' })
+      .expect(403);
+  });
+});


### PR DESCRIPTION
## Resumen

Continuación de #285. El panel ya mostraba los puntos alcanzados por grants `entity`-scoped (`GET /resources/mine`), pero el gestor recibía **403** al operar el punto: `loadResourceForManagement` —el gate compartido de inventario (`GET/PUT /resources/:id/inventory`) y estado público (`POST /resources/:id/status`)— solo autorizaba `owner || coordinator` e ignoraba los grants `entity`.

Cambios:
- **Definición única y reutilizable** de «recursos que este principal gestiona por grant» extraída a `grantedResourceIds()` (application), compartida por `GetMyManagedResources` (panel, #285) y el gate — así un punto que **lista** es exactamente un punto **operable** (criterio de aceptación 3).
- El gate ahora autoriza **`owner || grant entity activo sobre el recurso || coordinator`**. El grant se evalúa antes que la pertenencia (viaja en la request, sin I/O), por lo que las rutas de owner y de `point_manager` no consultan la tabla de memberships.
- Los grants de la request se propagan a `GetMyInventory` / `UpdateMyInventory` / `UpdateResourcePublicStatus` mediante un mapper privado del controller, reutilizado también por `/resources/mine`.

Nota (propuesta **c** del issue): hoy el único rol que emite grants `entity` sobre `resource` es `point_manager`, que ya porta `resource:edit`; por eso «cualquier grant entity» equivale a gestión plena. El día que aparezca un rol entity de solo lectura, el único punto donde separar lectura/escritura es `grantedResourceIds()` — queda documentado ahí.

Alcance: sólo **backend (parte a)**. Las superficies web (workspace `/resources/[id]/manage` y la fuente de datos de `mis-puntos`, partes **b** / **2** del issue) quedan como seguimiento. No se tocan DTOs/paths/tipos ni descripciones OpenAPI, así que `packages/api-client/src/schema.ts` no cambia (sin `gen:api`).

## Validación

- [x] Pasé el gate que toca para esta zona del repo: `pnpm --filter api build`, eslint `--max-warnings=0`, prettier `--check`, y los 152 unit/in-memory de `resources/application`. Los specs con Postgres (`*.int-spec`, `*.e2e`) corren en CI.
- [x] Verifiqué el comportamiento con tests: unit de las tres use cases + del gate `loadResourceForManagement` + del filtro puro `grantedResourceIds`, y e2e del journey del gestor (leer y reemplazar inventario y cambiar estado mediante grant entity, más los 403 del tercero).
- [x] Sin migraciones ni cambios de cliente API (no cambian DTOs/endpoints); descripciones OpenAPI sin tocar a propósito para no desincronizar `schema.ts`.

## Cierre

- Closes #316