### PR TITLE
fix(resources): el gestor (grant entity) puede operar su punto desde la web (#323)

### DIFF
--- a/apps/api/src/contexts/resources/application/get-my-resources.spec.ts
+++ b/apps/api/src/contexts/resources/application/get-my-resources.spec.ts
@@ -1,0 +1,143 @@
+import { GetMyResources } from './get-my-resources';
+import { RegisterResource } from './register-resource';
+import { InMemoryResourceRepository } from '../infrastructure/in-memory-resource.repository';
+import { FakeEventBus } from '../infrastructure/fake-event-bus';
+import { ResourceType } from '../domain/resource-enums';
+import { ResourceEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
+import { PrincipalGrant } from './principal-grant';
+
+const EM = '11111111-1111-4111-8111-111111111111';
+const EM_2 = '22222222-2222-4222-8222-222222222222';
+const OWNER_ID = 'owner-user-0000-0000-000000000000';
+const MANAGER_ID = 'manager-user-0000-0000-000000000000';
+const baseLocation = {
+  address: 'Calle Test 1, Madrid',
+  latitude: 40.4168,
+  longitude: -3.7038,
+};
+
+const activeReader: ResourceEmergencyStatusReader = {
+  getStatus: () => Promise.resolve('active'),
+};
+
+const NOW = new Date('2026-07-02T12:00:00Z');
+
+function entityGrant(
+  resourceId: string,
+  overrides: Partial<PrincipalGrant> = {},
+): PrincipalGrant {
+  return {
+    roleId: 'point_manager',
+    scope: { type: 'entity', entityType: 'resource', id: resourceId },
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+async function makeResource(
+  repo: InMemoryResourceRepository,
+  bus: FakeEventBus,
+  q: { name: string; ownerUserId: string; emergencyId?: string },
+): Promise<string> {
+  const { id } = await new RegisterResource(repo, bus, activeReader).execute({
+    emergencyId: q.emergencyId ?? EM,
+    type: ResourceType.CollectionPoint,
+    name: q.name,
+    location: baseLocation,
+    ownerUserId: q.ownerUserId,
+  });
+  return id;
+}
+
+describe('GetMyResources', () => {
+  it('returns the resources the user owns in the emergency', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    await makeResource(repo, bus, { name: 'Propio A', ownerUserId: OWNER_ID });
+    await makeResource(repo, bus, {
+      name: 'Ajeno',
+      ownerUserId: 'someone-else',
+    });
+
+    const views = await new GetMyResources(repo).execute({
+      emergencyId: EM,
+      userId: OWNER_ID,
+    });
+
+    expect(views.map((v) => v.name)).toEqual(['Propio A']);
+  });
+
+  it('includes a resource reached only through an entity-scoped grant (#323)', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, {
+      name: 'Gestionado',
+      ownerUserId: OWNER_ID,
+    });
+
+    const views = await new GetMyResources(repo).execute({
+      emergencyId: EM,
+      userId: MANAGER_ID,
+      grants: [entityGrant(id)],
+      now: NOW,
+    });
+
+    expect(views.map((v) => v.name)).toEqual(['Gestionado']);
+  });
+
+  it('excludes a granted resource that belongs to another emergency', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const otherEmId = await makeResource(repo, bus, {
+      name: 'En otra emergencia',
+      ownerUserId: OWNER_ID,
+      emergencyId: EM_2,
+    });
+
+    const views = await new GetMyResources(repo).execute({
+      emergencyId: EM,
+      userId: MANAGER_ID,
+      grants: [entityGrant(otherEmId)],
+      now: NOW,
+    });
+
+    expect(views).toEqual([]);
+  });
+
+  it('does not duplicate a resource that is both owned and granted', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, {
+      name: 'Propio y gestionado',
+      ownerUserId: OWNER_ID,
+    });
+
+    const views = await new GetMyResources(repo).execute({
+      emergencyId: EM,
+      userId: OWNER_ID,
+      grants: [entityGrant(id)],
+      now: NOW,
+    });
+
+    expect(views).toHaveLength(1);
+    expect(views[0].name).toBe('Propio y gestionado');
+  });
+
+  it('ignores expired grants', async () => {
+    const repo = new InMemoryResourceRepository();
+    const bus = new FakeEventBus();
+    const id = await makeResource(repo, bus, {
+      name: 'Caducado',
+      ownerUserId: OWNER_ID,
+    });
+
+    const views = await new GetMyResources(repo).execute({
+      emergencyId: EM,
+      userId: MANAGER_ID,
+      grants: [entityGrant(id, { expiresAt: '2026-07-01T00:00:00Z' })],
+      now: NOW,
+    });
+
+    expect(views).toEqual([]);
+  });
+});

--- a/apps/api/src/contexts/resources/application/get-my-resources.ts
+++ b/apps/api/src/contexts/resources/application/get-my-resources.ts
@@ -1,6 +1,8 @@
 import { ResourceRepository } from '../domain/ports/resource.repository';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
+import { ResourceId } from '../domain/resource-id';
 import { ResourceView, toResourceView } from './resource-view';
+import { PrincipalGrant, grantedResourceIds } from './principal-grant';
 
 export class GetMyResources {
   constructor(private readonly repo: ResourceRepository) {}
@@ -8,11 +10,35 @@ export class GetMyResources {
   async execute(q: {
     emergencyId: string;
     userId: string;
+    grants?: PrincipalGrant[];
+    now?: Date;
   }): Promise<ResourceView[]> {
-    const resources = await this.repo.findByOwnerAndEmergency(
+    const emergencyId = EmergencyId.fromString(q.emergencyId);
+    const owned = await this.repo.findByOwnerAndEmergency(
       q.userId,
-      EmergencyId.fromString(q.emergencyId),
+      emergencyId,
     );
-    return resources.map(toResourceView);
+
+    // Owner ∪ resources reached through an active entity-scoped grant on the
+    // resource (e.g. `point_manager`), restricted to THIS emergency. Same grant
+    // definition the panel (`/resources/mine`) and the management gate use
+    // (`grantedResourceIds`, #316), so `mis-puntos` stops diverging from the
+    // panel and a gestor sees — and can operate — their point here (#323).
+    // Deduped by id, owned first; the full `ResourceView` (with `publicStatus`)
+    // is preserved because the list renders the status form per point.
+    const byId = new Map(owned.map((r) => [r.id.value, r]));
+    const grantedIds = [
+      ...grantedResourceIds(q.grants ?? [], q.now ?? new Date()),
+    ].filter((id) => !byId.has(id));
+    const granted = await Promise.all(
+      grantedIds.map((id) => this.repo.findById(ResourceId.fromString(id))),
+    );
+    for (const r of granted) {
+      if (r != null && r.emergencyId.value === q.emergencyId) {
+        byId.set(r.id.value, r);
+      }
+    }
+
+    return [...byId.values()].map(toResourceView);
   }
 }

--- a/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
+++ b/apps/api/src/contexts/resources/infrastructure/http/resources.controller.ts
@@ -489,6 +489,7 @@ export class ResourcesController {
     return this.getMyResources.execute({
       emergencyId,
       userId: req.user!.id,
+      grants: this.principalGrants(req.user!),
     });
   }
 

--- a/apps/api/test/resources-manage-grant.e2e-spec.ts
+++ b/apps/api/test/resources-manage-grant.e2e-spec.ts
@@ -276,6 +276,18 @@ describe('Resource management by entity-scoped grant (e2e, #316)', () => {
     expect(found?.publicStatus).toBe('saturated');
   });
 
+  it('the manager point appears in the per-emergency mis-puntos list (#323)', async () => {
+    // Before #323 this endpoint was owner-only, so a pure point_manager saw an
+    // empty list here while the panel already showed the point (#285).
+    const res = await request(server)
+      .get(`/emergencies/${EM}/resources/mine`)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .expect(200);
+
+    const ids = (res.body as Array<{ id: string }>).map((r) => r.id);
+    expect(ids).toContain(managedResourceId);
+  });
+
   it('a stranger (no owner/grant/coordinator) cannot replace the inventory → 403', async () => {
     await request(server)
       .put(`/resources/${managedResourceId}/inventory`)

--- a/apps/web/src/lib/navigation-data.ts
+++ b/apps/web/src/lib/navigation-data.ts
@@ -112,7 +112,12 @@ export const getMyResources = cache(async () => {
   const { data } = await api.GET('/resources/mine', {
     headers: authHeaders(token),
   });
-  return (data ?? []).map((r) => ({ id: r.id, name: r.name, resourceType: r.type }));
+  return (data ?? []).map((r) => ({
+    id: r.id,
+    name: r.name,
+    resourceType: r.type,
+    emergencySlug: r.emergencySlug,
+  }));
 });
 
 export const getPrincipalContexts = cache(async (): Promise<PrincipalContext[]> => {

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -54,7 +54,8 @@ test('no permissions → just the overview', () => {
 test('contextHref points each context type at its workspace', () => {
   const cases: [PrincipalContext, string][] = [
     [{ type: 'emergency', id: 'e1', slug: 'terremoto', name: 'T', roleIds: [] }, '/emergencies/terremoto/manage'],
-    [{ type: 'resource', id: 'p1', name: 'Almacén', roleIds: [] }, '/resources/p1/manage'],
+    [{ type: 'resource', id: 'p1', name: 'Almacén', roleIds: [], emergencySlug: 'terremoto' }, '/e/terremoto/mis-puntos/p1/inventario'],
+    [{ type: 'resource', id: 'p2', name: 'Sin slug', roleIds: [], emergencySlug: null }, '/dashboard'],
     [{ type: 'organization', id: 'o1', name: 'Cruz Roja', roleIds: [] }, '/organizations/o1/manage'],
     [{ type: 'group', id: 'g1', name: 'Logística B', roleIds: [] }, '/dashboard/groups/g1'],
   ];
@@ -63,7 +64,7 @@ test('contextHref points each context type at its workspace', () => {
 
 const MARIA: PrincipalContext[] = [
   { type: 'emergency', id: 'e1', slug: 'terremoto', name: 'Terremoto Venezuela 2026', roleIds: ['emergency_verifier'] },
-  { type: 'resource', id: 'p1', name: 'Almacén Central Caracas', roleIds: ['point_manager'], resourceType: 'warehouse' },
+  { type: 'resource', id: 'p1', name: 'Almacén Central Caracas', roleIds: ['point_manager'], resourceType: 'warehouse', emergencySlug: 'terremoto' },
   { type: 'organization', id: 'o1', name: 'Cruz Roja Local', roleIds: ['org_admin'] },
 ];
 
@@ -142,7 +143,7 @@ test('admin group appears for platform admins', () => {
 test('buildPrincipalContexts maps each source to a typed context', () => {
   const ctx = buildPrincipalContexts({
     emergencies: [{ id: 'e1', slug: 'terremoto', name: 'Terremoto', roleIds: ['emergency_verifier'] }],
-    resources: [{ id: 'p1', name: 'Almacén', resourceType: 'warehouse' }],
+    resources: [{ id: 'p1', name: 'Almacén', resourceType: 'warehouse', emergencySlug: 'terremoto' }],
     organizations: [{ id: 'o1', name: 'Cruz Roja' }],
     groups: [{ id: 'g1', name: 'Logística B' }],
   });
@@ -156,6 +157,7 @@ test('buildPrincipalContexts maps each source to a typed context', () => {
   assert.equal(resource?.slug, undefined);
   assert.deepEqual(resource?.roleIds, []);
   assert.equal(resource?.resourceType, 'warehouse');
+  assert.equal(resource?.emergencySlug, 'terremoto');
 });
 
 test('empty sources produce an empty context list', () => {

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -73,6 +73,13 @@ export interface PrincipalContext {
   roleIds: string[];
   /** Only set for `resource` contexts — the `ResourceViewDto` type enum value. */
   resourceType?: ResourceType;
+  /**
+   * Only set for `resource` contexts — the slug of the resource's emergency, so
+   * the switcher can deep-link into that emergency's `mis-puntos` surface (a
+   * managed point has no standalone workspace route). Rides on the context from
+   * `/resources/mine`; null only when the emergency row is missing (#323).
+   */
+  emergencySlug?: string | null;
 }
 
 export function contextHref(c: PrincipalContext): string {
@@ -80,7 +87,15 @@ export function contextHref(c: PrincipalContext): string {
     case 'emergency':
       return `/emergencies/${c.slug}/manage`;
     case 'resource':
-      return `/resources/${c.id}/manage`;
+      // A managed point has no standalone workspace route (`/resources/:id/manage`
+      // never existed → 404). Deep-link into its emergency's `mis-puntos`
+      // inventory surface, where owner, coordinator and `point_manager` are all
+      // authorized after #316. `emergencySlug` is effectively always present
+      // (emergencies always have a slug); the `/dashboard` fallback only guards
+      // the impossible null so the switcher never emits a 404 (#323).
+      return c.emergencySlug != null
+        ? `/e/${c.emergencySlug}/mis-puntos/${c.id}/inventario`
+        : '/dashboard';
     case 'organization':
       return `/organizations/${c.id}/manage`;
     case 'group':
@@ -95,7 +110,12 @@ export function contextHref(c: PrincipalContext): string {
 
 export interface RawPrincipalContexts {
   emergencies: { id: string; slug: string; name: string; roleIds: string[] }[];
-  resources: { id: string; name: string; resourceType: ResourceType }[];
+  resources: {
+    id: string;
+    name: string;
+    resourceType: ResourceType;
+    emergencySlug: string | null;
+  }[];
   organizations: { id: string; name: string }[];
   groups: { id: string; name: string }[];
 }
@@ -107,7 +127,7 @@ export function buildPrincipalContexts(raw: RawPrincipalContexts): PrincipalCont
       type: 'emergency', id: e.id, slug: e.slug, name: e.name, roleIds: e.roleIds,
     })),
     ...raw.resources.map((r): PrincipalContext => ({
-      type: 'resource', id: r.id, name: r.name, roleIds: [], resourceType: r.resourceType,
+      type: 'resource', id: r.id, name: r.name, roleIds: [], resourceType: r.resourceType, emergencySlug: r.emergencySlug,
     })),
     ...raw.organizations.map((o): PrincipalContext => ({
       type: 'organization', id: o.id, name: o.name, roleIds: [],


### PR DESCRIPTION
## Resumen

Seguimiento de #316 (backend, ya en `main`): cierra el journey del gestor (`point_manager` con grant `entity`) en la **web**. Dos huecos que #316 dejaba abiertos:

1. **404 del switcher.** `contextHref` apuntaba a `/resources/:id/manage`, una ruta web que nunca existió. Ahora enlaza a la superficie de gestión que sí existe —`/e/{slug}/mis-puntos/{id}/inventario`— propagando el `emergencySlug` que `/resources/mine` ya devuelve, a través de `PrincipalContext` (`navigation.ts` / `navigation-data.ts`). El fallback `/dashboard` sólo cubre el `emergencySlug` nulo (imposible en la práctica) para que el switcher nunca emita un 404.
2. **`mis-puntos` owner-only.** `GetMyResources` (tras `GET /emergencies/{id}/resources/mine`) pasa de `owner` a `owner ∪ grants entity activos sobre el recurso en esa emergencia`, reutilizando la definición compartida `grantedResourceIds()` (#316). El gestor ve su punto en la lista —con su formulario de estado y el enlace a inventario— igual que en el panel. Se conserva el `ResourceViewDto` completo (la lista pinta `publicStatus`).

Con esto el journey completo funciona de punta a punta: panel → inventario (editar) → volver a `mis-puntos` (estado), todo autorizado tras #316.

## Validación

- [x] Gate API: `pnpm --filter api build`, eslint `--max-warnings=0`, prettier `--check`, y los unit/in-memory de `resources/application` (28 suites / 157 tests, con el nuevo `get-my-resources.spec`). Los specs con Postgres corren en CI.
- [x] Gate web: `@reliefhub/api-client build` + `pnpm --filter web build` + `pnpm --filter web lint` + `pnpm --filter web test` (89 pasan, incl. `navigation.test.ts`).
- [x] e2e: el punto del gestor aparece en `GET /emergencies/{id}/resources/mine` (antes owner-only) — añadido a `resources-manage-grant.e2e-spec.ts`.
- [x] Sin migraciones ni `gen:api`: no cambian DTOs/paths; `emergencySlug` ya viaja en `/resources/mine` y la lista conserva el `ResourceViewDto`.

## Cierre

- Closes #323