### PR TITLE
feat(auth): login/alta confiable por teléfono desde bots autorizados (#315)

### DIFF
--- a/apps/api/drizzle/0054_user_consents_service_account.sql
+++ b/apps/api/drizzle/0054_user_consents_service_account.sql
@@ -1,0 +1,6 @@
+-- #315: origen de Service Account en el consentimiento registrado por un canal
+-- de confianza (bot de Telegram/WhatsApp) en el alta por teléfono. Aditiva y
+-- nullable — los flujos web normales (register/onboarding) lo dejan a NULL y
+-- siguen anotando ip/user_agent. Sin FK: el consentimiento se conserva aunque
+-- la Service Account se elimine (trazabilidad histórica).
+ALTER TABLE user_consents ADD COLUMN IF NOT EXISTS service_account_id uuid;

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -194,6 +194,107 @@
         ]
       }
     },
+    "/auth/trusted/login-by-phone": {
+      "post": {
+        "operationId": "TrustedAuthController_loginByPhoneRoute",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginByPhoneDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Login correcto",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrustedAuthResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Falta o es inválida la API key"
+          },
+          "403": {
+            "description": "La Service Account no tiene el permiso auth:trusted_phone_login"
+          },
+          "404": {
+            "description": "No existe usuario con ese teléfono"
+          },
+          "429": {
+            "description": "Límite de peticiones excedido"
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "summary": "Emitir un JWT de usuario a partir de su teléfono verificado (bot de confianza)",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/auth/trusted/register-by-phone": {
+      "post": {
+        "operationId": "TrustedAuthController_registerByPhoneRoute",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterByPhoneDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Usuario creado (auto-login)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrustedAuthResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Falta la aceptación de términos/privacidad o un campo inválido"
+          },
+          "401": {
+            "description": "Falta o es inválida la API key"
+          },
+          "403": {
+            "description": "La Service Account no tiene el permiso auth:trusted_phone_login"
+          },
+          "409": {
+            "description": "Ya existe una cuenta con ese email"
+          },
+          "429": {
+            "description": "Límite de peticiones excedido"
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "summary": "Alta passwordless de un usuario por teléfono verificado (bot de confianza)",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
     "/grants/at-scope": {
       "get": {
         "operationId": "GrantsController_listAtScope",
@@ -9073,6 +9174,91 @@
             "example": "Nuevo Nombre"
           }
         }
+      },
+      "LoginByPhoneDto": {
+        "type": "object",
+        "properties": {
+          "phone": {
+            "type": "string",
+            "example": "+58 412 555 0101",
+            "description": "Teléfono verificado por el canal de confianza (bot). Se normaliza (espacios, guiones, prefijo +) antes de buscar la cuenta."
+          }
+        },
+        "required": [
+          "phone"
+        ]
+      },
+      "TrustedAuthUserDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "User UUID"
+          },
+          "name": {
+            "type": "string",
+            "example": "Jane Doe"
+          },
+          "email": {
+            "type": "string",
+            "example": "jane@example.com"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "email"
+        ]
+      },
+      "TrustedAuthResponseDto": {
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string",
+            "description": "JWT del usuario — mismos claims que /auth/login; nunca confiere más permisos que los del propio usuario."
+          },
+          "user": {
+            "$ref": "#/components/schemas/TrustedAuthUserDto"
+          }
+        },
+        "required": [
+          "accessToken",
+          "user"
+        ]
+      },
+      "RegisterByPhoneDto": {
+        "type": "object",
+        "properties": {
+          "phone": {
+            "type": "string",
+            "example": "+58 412 555 0101"
+          },
+          "name": {
+            "type": "string",
+            "example": "Jane Doe"
+          },
+          "email": {
+            "type": "string",
+            "example": "jane@example.com"
+          },
+          "acceptedTerms": {
+            "type": "boolean",
+            "example": true,
+            "description": "Aceptación de las condiciones del servicio (debe ser true; el bot la recogió en la conversación)."
+          },
+          "acceptedPrivacy": {
+            "type": "boolean",
+            "example": true,
+            "description": "Aceptación de la política de privacidad (debe ser true)."
+          }
+        },
+        "required": [
+          "phone",
+          "name",
+          "email",
+          "acceptedTerms",
+          "acceptedPrivacy"
+        ]
       },
       "GrantListItemDto": {
         "type": "object",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { ApiKeyAwareThrottlerGuard } from './contexts/identity/infrastructure/http/api-key-aware-throttler.guard';
 import { DatabaseModule } from './shared/database.module';
 import { ResourcesModule } from './contexts/resources/infrastructure/resources.module';
 import { EmergenciesModule } from './contexts/emergencies/infrastructure/emergencies.module';
@@ -52,6 +53,13 @@ const isTestEnv = process.env.NODE_ENV === 'test';
               ttl: 60_000,
               limit: 5,
             },
+            {
+              // trusted-channel bot auth (#315): 20 req / 60 s, keyed per
+              // API-key prefix (not IP) by ApiKeyAwareThrottlerGuard.
+              name: 'trusted-auth',
+              ttl: 60_000,
+              limit: 20,
+            },
           ],
     ),
     DatabaseModule,
@@ -77,9 +85,10 @@ const isTestEnv = process.env.NODE_ENV === 'test';
   ],
   providers: [
     // Apply rate limiting to EVERY route by default. Individual routes tighten
-    // it with @Throttle (auth, intake, geocode…). In test env the throttler is
+    // it with @Throttle (auth, intake, trusted-auth…). Keys API-key traffic by
+    // key prefix and everything else by IP (#315). In test env the throttler is
     // configured with an empty ruleset, so this guard is a no-op there.
-    { provide: APP_GUARD, useClass: ThrottlerGuard },
+    { provide: APP_GUARD, useClass: ApiKeyAwareThrottlerGuard },
   ],
 })
 export class AppModule {}

--- a/apps/api/src/contexts/identity/application/login-by-phone.spec.ts
+++ b/apps/api/src/contexts/identity/application/login-by-phone.spec.ts
@@ -1,0 +1,134 @@
+import { LoginByPhone } from './login-by-phone';
+import { InMemoryUserRepository } from '../infrastructure/in-memory-user.repository';
+import { User } from '../domain/user';
+import { UserId } from '../domain/user-id';
+import { Email } from '../domain/email';
+import { UserNotFoundByPhoneError } from '../domain/user-not-found-by-phone.error';
+import type { TokenService, TokenPayload } from '../domain/ports/token.service';
+
+class FakeTokenService implements TokenService {
+  sign(p: TokenPayload): string {
+    return `token:${p.sub}:${p.email}:${p.isAdmin}`;
+  }
+  verify(): TokenPayload {
+    throw new Error('not used');
+  }
+}
+
+const A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+async function seed(
+  repo: InMemoryUserRepository,
+  u: {
+    id: string;
+    email: string;
+    phone: string | null;
+    isAdmin?: boolean;
+    name?: string;
+  },
+): Promise<void> {
+  await repo.save(
+    User.create({
+      id: UserId.fromString(u.id),
+      email: Email.fromString(u.email),
+      passwordHash: null,
+      name: u.name ?? 'User',
+      isAdmin: u.isAdmin ?? false,
+      phone: u.phone,
+    }),
+  );
+}
+
+describe('LoginByPhone', () => {
+  const tokenService = new FakeTokenService();
+
+  it('issues a token for the user matching the phone, format-insensitively', async () => {
+    const repo = new InMemoryUserRepository();
+    await seed(repo, {
+      id: A,
+      email: 'ana@reliefhub.org',
+      phone: '+58 412-555.0101',
+      name: 'Ana',
+    });
+
+    const result = await new LoginByPhone(repo, tokenService).execute({
+      phone: '+584125550101',
+    });
+
+    expect(result.user).toEqual({
+      id: A,
+      name: 'Ana',
+      email: 'ana@reliefhub.org',
+    });
+    expect(result.accessToken).toContain('ana@reliefhub.org');
+    expect(result.ambiguous).toBe(false);
+  });
+
+  it('propagates isAdmin into the token claims (no privilege escalation)', async () => {
+    const repo = new InMemoryUserRepository();
+    await seed(repo, {
+      id: A,
+      email: 'plain@reliefhub.org',
+      phone: '0412 555 0101',
+      isAdmin: false,
+    });
+
+    const result = await new LoginByPhone(repo, tokenService).execute({
+      phone: '04125550101',
+    });
+
+    // The JWT carries the user's own isAdmin=false — the bot never elevates.
+    expect(result.accessToken.endsWith(':false')).toBe(true);
+  });
+
+  it('throws UserNotFoundByPhoneError when no user matches (→ 404)', async () => {
+    const repo = new InMemoryUserRepository();
+    await seed(repo, {
+      id: A,
+      email: 'ana@reliefhub.org',
+      phone: '+584125550101',
+    });
+
+    await expect(
+      new LoginByPhone(repo, tokenService).execute({ phone: '+34600000000' }),
+    ).rejects.toBeInstanceOf(UserNotFoundByPhoneError);
+  });
+
+  it('a phone with no digits never matches → not found', async () => {
+    const repo = new InMemoryUserRepository();
+    await seed(repo, {
+      id: A,
+      email: 'ana@reliefhub.org',
+      phone: '+584125550101',
+    });
+
+    await expect(
+      new LoginByPhone(repo, tokenService).execute({ phone: '   ' }),
+    ).rejects.toBeInstanceOf(UserNotFoundByPhoneError);
+  });
+
+  it('picks the most recent and flags ambiguous when several accounts share the phone', async () => {
+    const repo = new InMemoryUserRepository();
+    // Both accounts carry the SAME number in different formats.
+    await seed(repo, {
+      id: A,
+      email: 'old@reliefhub.org',
+      phone: '+58 412 555 0101',
+      name: 'Old',
+    });
+    await seed(repo, {
+      id: B,
+      email: 'new@reliefhub.org',
+      phone: '(58) 412.555.0101',
+      name: 'New',
+    });
+
+    const result = await new LoginByPhone(repo, tokenService).execute({
+      phone: '+584125550101',
+    });
+
+    expect(result.user.id).toBe(B); // most recent
+    expect(result.ambiguous).toBe(true);
+  });
+});

--- a/apps/api/src/contexts/identity/application/login-by-phone.ts
+++ b/apps/api/src/contexts/identity/application/login-by-phone.ts
@@ -1,0 +1,63 @@
+import { UserRepository } from '../domain/ports/user.repository';
+import { TokenService } from '../domain/ports/token.service';
+import { UserNotFoundByPhoneError } from '../domain/user-not-found-by-phone.error';
+
+export interface LoginByPhoneCommand {
+  /** The verified phone number the trusted channel (bot) shared. */
+  phone: string;
+}
+
+/** The public identity the trusted endpoints hand back with the token. */
+export interface TrustedAuthUser {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface TrustedAuthResult {
+  accessToken: string;
+  user: TrustedAuthUser;
+  /**
+   * True when more than one account matched the phone (historical duplicates,
+   * no unique index on `phone`). The most recent was picked; the caller audits
+   * the ambiguity for manual review (#315). Never a 500, never a silent guess.
+   */
+  ambiguous: boolean;
+}
+
+/**
+ * Issues a user JWT from a phone number verified by a trusted messaging channel
+ * (Telegram/WhatsApp bot). Called ONLY behind the `auth:trusted_phone_login`
+ * service-account gate — this use case assumes the caller was already
+ * authorised. The emitted token follows the normal rules (same claims as
+ * `/auth/login`): it never confers more than the found user's own permissions,
+ * so a leak of the bot's API key means "log in as any user who shared their
+ * phone", not "act with any privilege" (#315).
+ */
+export class LoginByPhone {
+  constructor(
+    private readonly userRepo: UserRepository,
+    private readonly tokenService: TokenService,
+  ) {}
+
+  async execute(cmd: LoginByPhoneCommand): Promise<TrustedAuthResult> {
+    const matches = await this.userRepo.findByPhone(cmd.phone);
+    if (matches.length === 0) {
+      throw new UserNotFoundByPhoneError();
+    }
+
+    // findByPhone returns most-recent-first; take the newest match.
+    const user = matches[0];
+    const accessToken = this.tokenService.sign({
+      sub: user.id.value,
+      email: user.email.value,
+      isAdmin: user.isAdmin,
+    });
+
+    return {
+      accessToken,
+      user: { id: user.id.value, name: user.name, email: user.email.value },
+      ambiguous: matches.length > 1,
+    };
+  }
+}

--- a/apps/api/src/contexts/identity/application/register-by-phone.spec.ts
+++ b/apps/api/src/contexts/identity/application/register-by-phone.spec.ts
@@ -1,0 +1,124 @@
+import {
+  RegisterByPhone,
+  type RegisterByPhoneCommand,
+} from './register-by-phone';
+import { InMemoryUserRepository } from '../infrastructure/in-memory-user.repository';
+import { InMemoryConsentRepository } from '../infrastructure/in-memory-consent.repository';
+import { User } from '../domain/user';
+import { UserId } from '../domain/user-id';
+import { Email } from '../domain/email';
+import { EmailAlreadyRegisteredError } from '../domain/email-already-registered.error';
+import { ConsentRequiredError } from '../domain/consent-required.error';
+import { PhoneRequiredError } from '../domain/phone-required.error';
+import type { TokenService, TokenPayload } from '../domain/ports/token.service';
+
+class FakeTokenService implements TokenService {
+  sign(p: TokenPayload): string {
+    return `token:${p.sub}:${p.email}:${p.isAdmin}`;
+  }
+  verify(): TokenPayload {
+    throw new Error('not used');
+  }
+}
+
+const SA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function validCmd(
+  overrides: Partial<RegisterByPhoneCommand> = {},
+): RegisterByPhoneCommand {
+  return {
+    phone: '+58 412 555 0101',
+    name: 'Nueva Persona',
+    email: 'nueva@reliefhub.org',
+    acceptedTerms: true,
+    acceptedPrivacy: true,
+    serviceAccountId: SA,
+    ...overrides,
+  };
+}
+
+function makeUseCase(repo: InMemoryUserRepository) {
+  const consentRepo = new InMemoryConsentRepository();
+  return {
+    useCase: new RegisterByPhone(repo, new FakeTokenService(), consentRepo),
+    consentRepo,
+  };
+}
+
+describe('RegisterByPhone', () => {
+  it('creates a passwordless account with the phone and returns a token', async () => {
+    const repo = new InMemoryUserRepository();
+    const { useCase } = makeUseCase(repo);
+
+    const result = await useCase.execute(validCmd());
+
+    expect(result.user).toMatchObject({
+      name: 'Nueva Persona',
+      email: 'nueva@reliefhub.org',
+    });
+    expect(result.accessToken).toContain('nueva@reliefhub.org');
+    expect(result.ambiguous).toBe(false);
+
+    const saved = await repo.findByEmail(
+      Email.fromString('nueva@reliefhub.org'),
+    );
+    expect(saved).not.toBeNull();
+    expect(saved!.passwordHash).toBeNull(); // social/bot alta path
+    expect(saved!.phone).toBe('+58 412 555 0101');
+    expect(saved!.isAdmin).toBe(false);
+  });
+
+  it('records consent for both legal documents', async () => {
+    const repo = new InMemoryUserRepository();
+    const { useCase, consentRepo } = makeUseCase(repo);
+
+    await useCase.execute(validCmd({ email: 'consent@reliefhub.org' }));
+
+    const saved = await repo.findByEmail(
+      Email.fromString('consent@reliefhub.org'),
+    );
+    const consents = await consentRepo.findByUser(saved!.id);
+    expect(consents).toHaveLength(2);
+  });
+
+  it('409 (EmailAlreadyRegisteredError) when the email already exists', async () => {
+    const repo = new InMemoryUserRepository();
+    await repo.save(
+      User.create({
+        id: UserId.fromString('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'),
+        email: Email.fromString('taken@reliefhub.org'),
+        passwordHash: 'x',
+        name: 'Existing',
+        isAdmin: false,
+      }),
+    );
+    const { useCase } = makeUseCase(repo);
+
+    await expect(
+      useCase.execute(validCmd({ email: 'taken@reliefhub.org' })),
+    ).rejects.toBeInstanceOf(EmailAlreadyRegisteredError);
+  });
+
+  it('400 (ConsentRequiredError) when terms or privacy are not accepted', async () => {
+    const repo = new InMemoryUserRepository();
+    const { useCase } = makeUseCase(repo);
+
+    await expect(
+      useCase.execute(validCmd({ acceptedTerms: false })),
+    ).rejects.toBeInstanceOf(ConsentRequiredError);
+    await expect(
+      useCase.execute(validCmd({ acceptedPrivacy: false })),
+    ).rejects.toBeInstanceOf(ConsentRequiredError);
+    expect(await repo.countAll()).toBe(0);
+  });
+
+  it('400 (PhoneRequiredError) when the phone is blank', async () => {
+    const repo = new InMemoryUserRepository();
+    const { useCase } = makeUseCase(repo);
+
+    await expect(
+      useCase.execute(validCmd({ phone: '   ' })),
+    ).rejects.toBeInstanceOf(PhoneRequiredError);
+    expect(await repo.countAll()).toBe(0);
+  });
+});

--- a/apps/api/src/contexts/identity/application/register-by-phone.ts
+++ b/apps/api/src/contexts/identity/application/register-by-phone.ts
@@ -1,0 +1,88 @@
+import { UserRepository } from '../domain/ports/user.repository';
+import { TokenService } from '../domain/ports/token.service';
+import { ConsentRepository } from '../domain/ports/consent.repository';
+import { Email } from '../domain/email';
+import { UserId } from '../domain/user-id';
+import { User } from '../domain/user';
+import { EmailAlreadyRegisteredError } from '../domain/email-already-registered.error';
+import { ConsentRequiredError } from '../domain/consent-required.error';
+import { PhoneRequiredError } from '../domain/phone-required.error';
+import {
+  ALL_CONSENT_DOCUMENTS,
+  CURRENT_CONSENT_VERSIONS,
+} from '../domain/consent';
+import { TrustedAuthResult } from './login-by-phone';
+
+export interface RegisterByPhoneCommand {
+  /** The verified phone number shared on the channel (the account's contact). */
+  phone: string;
+  name: string;
+  email: string;
+  /** Must be true — the bot showed the Terms and collected acceptance. */
+  acceptedTerms: boolean;
+  /** Must be true — the bot showed the Privacy Policy and collected acceptance. */
+  acceptedPrivacy: boolean;
+  /** The service account (bot) recording this alta, stamped on the consent. */
+  serviceAccountId: string;
+}
+
+/**
+ * Creates a passwordless account for a phone verified by a trusted channel, when
+ * `login-by-phone` found no existing user (the bot then collected name + email +
+ * consent in the conversation). Mirrors the social-login alta path: the user has
+ * `passwordHash: null` and must set a password via the normal reset flow to log
+ * in on the web. Consent is recorded stamped with the originating service
+ * account instead of an IP/User-Agent (#315).
+ */
+export class RegisterByPhone {
+  constructor(
+    private readonly userRepo: UserRepository,
+    private readonly tokenService: TokenService,
+    private readonly consentRepo: ConsentRepository,
+  ) {}
+
+  async execute(cmd: RegisterByPhoneCommand): Promise<TrustedAuthResult> {
+    if (!cmd.acceptedTerms || !cmd.acceptedPrivacy) {
+      throw new ConsentRequiredError();
+    }
+    const phone = cmd.phone?.trim() ?? '';
+    if (phone === '') throw new PhoneRequiredError();
+
+    const email = Email.fromString(cmd.email);
+
+    const existing = await this.userRepo.findByEmail(email);
+    if (existing) throw new EmailAlreadyRegisteredError();
+
+    const id = UserId.create();
+    const user = User.create({
+      id,
+      email,
+      passwordHash: null,
+      name: cmd.name,
+      isAdmin: false,
+      phone,
+    });
+    await this.userRepo.save(user);
+
+    await this.consentRepo.record(
+      id,
+      ALL_CONSENT_DOCUMENTS.map((document) => ({
+        document,
+        version: CURRENT_CONSENT_VERSIONS[document],
+      })),
+      { ip: null, userAgent: null, serviceAccountId: cmd.serviceAccountId },
+    );
+
+    const accessToken = this.tokenService.sign({
+      sub: id.value,
+      email: email.value,
+      isAdmin: false,
+    });
+
+    return {
+      accessToken,
+      user: { id: id.value, name: cmd.name, email: email.value },
+      ambiguous: false,
+    };
+  }
+}

--- a/apps/api/src/contexts/identity/domain/authorization/permission.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/permission.ts
@@ -54,6 +54,12 @@ export const PERMISSION_CATALOG = {
   // de categorías/subcategorías (#221) — gobernanza admins-only del catálogo
   // cerrado. 'read' queda reservado para lecturas internas del catálogo.
   catalogue: ['manage', 'read'],
+  // Login/alta confiable por teléfono desde canales de mensajería (#315). NO
+  // pertenece a ningún rol del catálogo: se concede uno-a-uno, vía Grant, a las
+  // Service Accounts de los bots (Telegram/WhatsApp) que ya verifican el número
+  // en el cliente. El JWT emitido nunca da más permisos que los del usuario
+  // encontrado — acota el blast radius de una fuga de la API key del bot.
+  auth: ['trusted-phone-login'],
 } as const;
 
 type Catalog = typeof PERMISSION_CATALOG;

--- a/apps/api/src/contexts/identity/domain/authorization/permission.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/permission.ts
@@ -59,7 +59,7 @@ export const PERMISSION_CATALOG = {
   // Service Accounts de los bots (Telegram/WhatsApp) que ya verifican el número
   // en el cliente. El JWT emitido nunca da más permisos que los del usuario
   // encontrado — acota el blast radius de una fuga de la API key del bot.
-  auth: ['trusted-phone-login'],
+  auth: ['trusted_phone_login'],
 } as const;
 
 type Catalog = typeof PERMISSION_CATALOG;

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
@@ -235,6 +235,18 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       'resource:read',
     ],
   },
+  trusted_channel_bot: {
+    id: 'trusted_channel_bot',
+    description:
+      'Cuenta de servicio de un canal de mensajería de confianza (bot de ' +
+      'Telegram/WhatsApp) que ya verifica el teléfono en el cliente. Rol de un ' +
+      'solo permiso: emitir un JWT de usuario por teléfono verificado ' +
+      '(login/alta). Se concede uno-a-uno vía Grant explícito por Service ' +
+      'Account; NO se hereda de integration_partner ni de ningún rol general — ' +
+      'el vehículo del permiso `auth:trusted-phone-login` (#315).',
+    defaultScopeType: 'platform',
+    permissions: ['auth:trusted-phone-login'],
+  },
   citizen: {
     id: 'citizen',
     description:

--- a/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
+++ b/apps/api/src/contexts/identity/domain/authorization/role-catalog.ts
@@ -243,9 +243,9 @@ export const ROLE_CATALOG: Record<string, RoleDefinition> = {
       'solo permiso: emitir un JWT de usuario por teléfono verificado ' +
       '(login/alta). Se concede uno-a-uno vía Grant explícito por Service ' +
       'Account; NO se hereda de integration_partner ni de ningún rol general — ' +
-      'el vehículo del permiso `auth:trusted-phone-login` (#315).',
+      'el vehículo del permiso `auth:trusted_phone_login` (#315).',
     defaultScopeType: 'platform',
-    permissions: ['auth:trusted-phone-login'],
+    permissions: ['auth:trusted_phone_login'],
   },
   citizen: {
     id: 'citizen',

--- a/apps/api/src/contexts/identity/domain/phone-normalization.spec.ts
+++ b/apps/api/src/contexts/identity/domain/phone-normalization.spec.ts
@@ -1,0 +1,23 @@
+import { normalizePhone } from './phone-normalization';
+
+describe('normalizePhone', () => {
+  it('strips spaces, dashes, parentheses, dots and the leading +', () => {
+    expect(normalizePhone('+58 412-555.0101')).toBe('584125550101');
+    expect(normalizePhone('(0412) 555 0101')).toBe('04125550101');
+  });
+
+  it('is idempotent on an already-clean number', () => {
+    expect(normalizePhone('584125550101')).toBe('584125550101');
+  });
+
+  it('makes two differently-formatted equal numbers compare equal', () => {
+    expect(normalizePhone('+58 412 555 0101')).toBe(
+      normalizePhone('+584125550101'),
+    );
+  });
+
+  it('returns an empty string for input with no digits', () => {
+    expect(normalizePhone('   ')).toBe('');
+    expect(normalizePhone('+-()')).toBe('');
+  });
+});

--- a/apps/api/src/contexts/identity/domain/phone-normalization.ts
+++ b/apps/api/src/contexts/identity/domain/phone-normalization.ts
@@ -1,0 +1,11 @@
+/**
+ * Normalises a phone number for matching by stripping every non-digit character
+ * (spaces, dashes, parentheses, dots and the leading `+`). Deliberately simple —
+ * NOT full E.164 parsing: it covers the "clean common formats" scope of #315 so
+ * a number stored as `+58 412 555 0101` matches an input `+584125550101` or
+ * `0412-555-0101`. Two numbers are considered the same iff their digit strings
+ * are equal.
+ */
+export function normalizePhone(raw: string): string {
+  return raw.replace(/[^0-9]/g, '');
+}

--- a/apps/api/src/contexts/identity/domain/ports/consent.repository.ts
+++ b/apps/api/src/contexts/identity/domain/ports/consent.repository.ts
@@ -12,6 +12,12 @@ export interface ConsentEntry {
 export interface ConsentContext {
   ip: string | null;
   userAgent: string | null;
+  /**
+   * The service account that recorded this consent on the user's behalf, when
+   * the acceptance came through a trusted channel (bot) rather than a browser
+   * (#315). Null/absent for the normal web flows.
+   */
+  serviceAccountId?: string | null;
 }
 
 export interface ConsentRepository {

--- a/apps/api/src/contexts/identity/domain/ports/user.repository.ts
+++ b/apps/api/src/contexts/identity/domain/ports/user.repository.ts
@@ -7,6 +7,15 @@ export const USER_REPOSITORY = Symbol('UserRepository');
 export interface UserRepository {
   findByEmail(email: Email): Promise<User | null>;
   findById(id: UserId): Promise<User | null>;
+  /**
+   * Users whose phone matches `phone` after normalisation (see
+   * {@link normalizePhone}), ordered MOST RECENT FIRST. Returns `[]` when none
+   * match or the normalised input is empty. A list — not a single user —
+   * because `phone` is not unique: a historically shared/duplicated number can
+   * match several accounts, and the trusted-phone login must pick the most
+   * recent and flag the ambiguity rather than fail or guess silently (#315).
+   */
+  findByPhone(phone: string): Promise<User[]>;
   save(user: User): Promise<void>;
   /**
    * Stamp the user's last successful login (issue #176). Kept off {@link save}

--- a/apps/api/src/contexts/identity/domain/user-not-found-by-phone.error.ts
+++ b/apps/api/src/contexts/identity/domain/user-not-found-by-phone.error.ts
@@ -1,0 +1,12 @@
+/**
+ * No user matches the (normalised) phone number presented on the trusted
+ * channel login (#315). Maps to HTTP 404 so the bot can fall back to the
+ * register-by-phone flow. Carries no phone number in the message — it must not
+ * leak into logs.
+ */
+export class UserNotFoundByPhoneError extends Error {
+  constructor() {
+    super('No user found for the given phone number');
+    this.name = 'UserNotFoundByPhoneError';
+  }
+}

--- a/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-consent.repository.ts
+++ b/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-consent.repository.ts
@@ -39,6 +39,7 @@ export class DrizzleConsentRepository implements ConsentRepository {
         version: e.version,
         ip: context.ip,
         userAgent: context.userAgent,
+        serviceAccountId: context.serviceAccountId ?? null,
       })),
     );
   }

--- a/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-user.repository.int-spec.ts
+++ b/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-user.repository.int-spec.ts
@@ -79,6 +79,76 @@ describe('DrizzleUserRepository (integration)', () => {
     expect(result).toBeNull();
   });
 
+  it('findByPhone matches after normalisation, format-insensitively (#315)', async () => {
+    await repo.save(
+      User.create({
+        id: UserId.fromString(USER_ID),
+        email: Email.fromString('ana@reliefhub.org'),
+        passwordHash: null,
+        name: 'Ana',
+        isAdmin: false,
+        phone: '+58 412 555 0101',
+      }),
+    );
+
+    for (const input of [
+      '584125550101',
+      '+58-412-555.0101',
+      '(58)4125550101',
+    ]) {
+      const found = await repo.findByPhone(input);
+      expect(found.map((u) => u.email.value)).toEqual(['ana@reliefhub.org']);
+    }
+  });
+
+  it('findByPhone returns [] for no match, null phones, or empty input', async () => {
+    await repo.save(
+      User.create({
+        id: UserId.fromString(USER_ID),
+        email: Email.fromString('nophone@reliefhub.org'),
+        passwordHash: null,
+        name: 'No Phone',
+        isAdmin: false,
+        // phone omitted → null
+      }),
+    );
+
+    expect(await repo.findByPhone('584125550101')).toEqual([]);
+    expect(await repo.findByPhone('   ')).toEqual([]);
+  });
+
+  it('findByPhone returns the most recent first when several accounts share a phone (#315)', async () => {
+    const OLD = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const NEW = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    // Explicit createdAt so recency ordering is deterministic.
+    await db.insert(usersTable).values([
+      {
+        id: OLD,
+        email: 'old@reliefhub.org',
+        passwordHash: null,
+        name: 'Old',
+        isAdmin: false,
+        phone: '+58 412 555 0101',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+      },
+      {
+        id: NEW,
+        email: 'new@reliefhub.org',
+        passwordHash: null,
+        name: 'New',
+        isAdmin: false,
+        phone: '(58) 412.555.0101',
+        createdAt: new Date('2026-06-01T00:00:00Z'),
+      },
+    ]);
+
+    const found = await repo.findByPhone('+584125550101');
+    expect(found.map((u) => u.email.value)).toEqual([
+      'new@reliefhub.org',
+      'old@reliefhub.org',
+    ]);
+  });
+
   it('upserts on duplicate id (updates name)', async () => {
     const user = User.create({
       id: UserId.fromString(USER_ID),

--- a/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-user.repository.ts
+++ b/apps/api/src/contexts/identity/infrastructure/drizzle/drizzle-user.repository.ts
@@ -1,10 +1,11 @@
-import { eq } from 'drizzle-orm';
+import { desc, eq, sql } from 'drizzle-orm';
 import { Db } from '../../../../shared/db';
 import { usersTable } from './schema';
 import { UserRepository } from '../../domain/ports/user.repository';
 import { User, UserSnapshot } from '../../domain/user';
 import { UserId } from '../../domain/user-id';
 import { Email } from '../../domain/email';
+import { normalizePhone } from '../../domain/phone-normalization';
 
 type Row = typeof usersTable.$inferSelect;
 
@@ -47,6 +48,24 @@ export class DrizzleUserRepository implements UserRepository {
       .from(usersTable)
       .where(eq(usersTable.id, id.value));
     return rows[0] ? User.fromSnapshot(rowToSnapshot(rows[0])) : null;
+  }
+
+  async findByPhone(phone: string): Promise<User[]> {
+    const digits = normalizePhone(phone);
+    if (digits === '') return [];
+    // Compare STORED phone stripped of every non-digit against the normalised
+    // input, so `+58 412 555 0101`, `(58) 412.555.0101` and `+584125550101` all
+    // match. `digits` is bound as a parameter and only ever contains [0-9], so
+    // there is no injection surface. Null phones drop out (regexp_replace(NULL)
+    // is NULL). Most recent first for the ambiguous-match tie-break (#315).
+    const rows = await this.db
+      .select()
+      .from(usersTable)
+      .where(
+        sql`regexp_replace(${usersTable.phone}, '[^0-9]', '', 'g') = ${digits}`,
+      )
+      .orderBy(desc(usersTable.createdAt));
+    return rows.map((r) => User.fromSnapshot(rowToSnapshot(r)));
   }
 
   async recordLogin(id: UserId, at: Date): Promise<void> {

--- a/apps/api/src/contexts/identity/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/identity/infrastructure/drizzle/schema.ts
@@ -45,6 +45,13 @@ export const userConsentsTable = pgTable(
     ip: text('ip'),
     /** Request User-Agent at the moment of acceptance (audit). Nullable. */
     userAgent: text('user_agent'),
+    /**
+     * Service account that recorded this acceptance on the user's behalf when it
+     * came through a trusted channel/bot instead of a browser (#315, migration
+     * 0054). Null for the normal web flows. No FK — historical trace survives SA
+     * deletion.
+     */
+    serviceAccountId: uuid('service_account_id'),
     acceptedAt: timestamp('accepted_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/api/src/contexts/identity/infrastructure/http/api-key-aware-throttler.guard.spec.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/api-key-aware-throttler.guard.spec.ts
@@ -1,0 +1,36 @@
+import { apiKeyThrottleTracker } from './api-key-aware-throttler.guard';
+
+const KEY = `rh_live_${'a'.repeat(48)}`; // valid: rh_live_ + 48 hex
+
+describe('apiKeyThrottleTracker', () => {
+  it('keys API-key traffic by the key prefix, not the IP', () => {
+    expect(
+      apiKeyThrottleTracker({ headers: { 'x-api-key': KEY }, ip: '1.2.3.4' }),
+    ).toBe('rh_live_aaaaaaaa');
+  });
+
+  it('uses the first value when the header is an array', () => {
+    expect(
+      apiKeyThrottleTracker({ headers: { 'x-api-key': [KEY] }, ip: '1.2.3.4' }),
+    ).toBe('rh_live_aaaaaaaa');
+  });
+
+  it('falls back to the IP when there is no API key', () => {
+    expect(apiKeyThrottleTracker({ headers: {}, ip: '9.9.9.9' })).toBe(
+      '9.9.9.9',
+    );
+  });
+
+  it('falls back to the IP when the API key is malformed', () => {
+    expect(
+      apiKeyThrottleTracker({
+        headers: { 'x-api-key': 'not-a-key' },
+        ip: '9.9.9.9',
+      }),
+    ).toBe('9.9.9.9');
+  });
+
+  it('returns an empty string when neither a key nor an IP is present', () => {
+    expect(apiKeyThrottleTracker({ headers: {} })).toBe('');
+  });
+});

--- a/apps/api/src/contexts/identity/infrastructure/http/api-key-aware-throttler.guard.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/api-key-aware-throttler.guard.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { prefixOf } from '../../domain/api-key-generator';
+
+/**
+ * Derives the throttle key for a request. For API-key (service-account) traffic
+ * it keys by the KEY PREFIX rather than the source IP: a bot's requests all come
+ * from one server, so per-IP would lump every trusted channel together and let
+ * one noisy bot starve the others. The prefix identifies the credential (a
+ * finer, safer grain than per-IP); everything else keeps the stock per-IP
+ * tracker. Extracted as a pure function so it can be unit-tested without the
+ * throttler runtime (#315).
+ */
+export function apiKeyThrottleTracker(req: {
+  headers: Record<string, string | string[] | undefined>;
+  ip?: string;
+}): string {
+  const header = req.headers['x-api-key'];
+  const presented = Array.isArray(header) ? header[0] : header;
+  const prefix = typeof presented === 'string' ? prefixOf(presented) : null;
+  return prefix ?? req.ip ?? '';
+}
+
+/**
+ * Global rate-limit guard that keys trusted-channel (API-key) traffic by the
+ * API-key prefix instead of the client IP (#315). A drop-in replacement for the
+ * stock {@link ThrottlerGuard}: identical behaviour for every non-API-key
+ * request (still per-IP).
+ */
+@Injectable()
+export class ApiKeyAwareThrottlerGuard extends ThrottlerGuard {
+  protected getTracker(req: Record<string, unknown>): Promise<string> {
+    return Promise.resolve(
+      apiKeyThrottleTracker(
+        req as unknown as {
+          headers: Record<string, string | string[] | undefined>;
+          ip?: string;
+        },
+      ),
+    );
+  }
+}

--- a/apps/api/src/contexts/identity/infrastructure/http/dto.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/dto.ts
@@ -169,6 +169,75 @@ export class MeResponseDto {
   grants!: MeGrantDto[];
 }
 
+export class LoginByPhoneDto {
+  @ApiProperty({
+    example: '+58 412 555 0101',
+    description:
+      'Teléfono verificado por el canal de confianza (bot). Se normaliza ' +
+      '(espacios, guiones, prefijo +) antes de buscar la cuenta.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  phone!: string;
+}
+
+export class RegisterByPhoneDto {
+  @ApiProperty({ example: '+58 412 555 0101' })
+  @IsString()
+  @IsNotEmpty()
+  phone!: string;
+
+  @ApiProperty({ example: 'Jane Doe' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({ example: 'jane@example.com' })
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty({
+    example: true,
+    description:
+      'Aceptación de las condiciones del servicio (debe ser true; el bot la ' +
+      'recogió en la conversación).',
+  })
+  @IsBoolean()
+  @Equals(true)
+  acceptedTerms!: boolean;
+
+  @ApiProperty({
+    example: true,
+    description: 'Aceptación de la política de privacidad (debe ser true).',
+  })
+  @IsBoolean()
+  @Equals(true)
+  acceptedPrivacy!: boolean;
+}
+
+export class TrustedAuthUserDto {
+  @ApiProperty({ description: 'User UUID' })
+  id!: string;
+
+  @ApiProperty({ example: 'Jane Doe' })
+  name!: string;
+
+  @ApiProperty({ example: 'jane@example.com' })
+  email!: string;
+}
+
+export class TrustedAuthResponseDto {
+  @ApiProperty({
+    description:
+      'JWT del usuario — mismos claims que /auth/login; nunca confiere más ' +
+      'permisos que los del propio usuario.',
+  })
+  accessToken!: string;
+
+  @ApiProperty({ type: TrustedAuthUserDto })
+  user!: TrustedAuthUserDto;
+}
+
 export class UpdateProfileDto {
   @ApiProperty({
     example: '+58 412 555 0101',

--- a/apps/api/src/contexts/identity/infrastructure/http/identity-exception.filter.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/identity-exception.filter.ts
@@ -10,13 +10,15 @@ import { EmailAlreadyRegisteredError } from '../../domain/email-already-register
 import { AccountLinkRequiresAuthError } from '../../domain/account-link-requires-auth.error';
 import { ConsentRequiredError } from '../../domain/consent-required.error';
 import { PhoneRequiredError } from '../../domain/phone-required.error';
+import { UserNotFoundByPhoneError } from '../../domain/user-not-found-by-phone.error';
 
 type IdentityError =
   | InvalidCredentialsError
   | EmailAlreadyRegisteredError
   | AccountLinkRequiresAuthError
   | ConsentRequiredError
-  | PhoneRequiredError;
+  | PhoneRequiredError
+  | UserNotFoundByPhoneError;
 
 @Catch(
   InvalidCredentialsError,
@@ -24,6 +26,7 @@ type IdentityError =
   AccountLinkRequiresAuthError,
   ConsentRequiredError,
   PhoneRequiredError,
+  UserNotFoundByPhoneError,
 )
 export class IdentityExceptionFilter implements ExceptionFilter {
   catch(exception: IdentityError, host: ArgumentsHost): void {
@@ -40,6 +43,9 @@ export class IdentityExceptionFilter implements ExceptionFilter {
       exception instanceof PhoneRequiredError
     ) {
       status = HttpStatus.BAD_REQUEST;
+    } else if (exception instanceof UserNotFoundByPhoneError) {
+      // 404: no account for that phone → the bot falls back to register-by-phone.
+      status = HttpStatus.NOT_FOUND;
     } else {
       status = HttpStatus.UNAUTHORIZED;
     }

--- a/apps/api/src/contexts/identity/infrastructure/http/trusted-auth.controller.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/trusted-auth.controller.ts
@@ -1,0 +1,139 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Request,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiConflictResponse,
+  ApiForbiddenResponse,
+  ApiUnauthorizedResponse,
+  ApiTooManyRequestsResponse,
+  ApiSecurity,
+} from '@nestjs/swagger';
+import type { Request as ExpressRequest } from 'express';
+import { LoginByPhone } from '../../application/login-by-phone';
+import { RegisterByPhone } from '../../application/register-by-phone';
+import {
+  LoginByPhoneDto,
+  RegisterByPhoneDto,
+  TrustedAuthResponseDto,
+} from './dto';
+import { IdentityExceptionFilter } from './identity-exception.filter';
+import { ApiKeyAuthGuard } from './api-key-auth.guard';
+import { ServiceAccountPermissionGuard } from './service-account-permission.guard';
+import { RequirePermission } from './require-permission.decorator';
+import type { AuthenticatedUser } from './jwt-auth.guard';
+import { setAuditContext } from '../../../audit/infrastructure/http/audit-context';
+
+type AuthedRequest = ExpressRequest & { user: AuthenticatedUser };
+
+// 20 requests / 60 s. Keyed per API-key prefix (not IP) by
+// ApiKeyAwareThrottlerGuard, since all of a bot's traffic shares one server.
+const TRUSTED_THROTTLE = { 'trusted-auth': { ttl: 60_000, limit: 20 } };
+
+/**
+ * Trusted-channel authentication for messaging bots (Telegram/WhatsApp) that
+ * already verify the user's phone in the client (#315). Service-account only:
+ * `ApiKeyAuthGuard` forces `X-API-Key` (so `isServiceAccount` is true and the
+ * permission is actually enforced), and `auth:trusted_phone_login` — a
+ * platform-scoped grant on the bot's Service Account — is required. The emitted
+ * JWT follows the normal rules: it never confers more than the target user's own
+ * permissions, so a leaked bot key means "log in as a user who shared their
+ * phone", not "act with any privilege".
+ */
+@ApiTags('auth')
+@Controller('auth/trusted')
+@UseFilters(IdentityExceptionFilter)
+@UseGuards(ApiKeyAuthGuard, ServiceAccountPermissionGuard)
+@ApiSecurity('api-key')
+export class TrustedAuthController {
+  constructor(
+    private readonly loginByPhone: LoginByPhone,
+    private readonly registerByPhone: RegisterByPhone,
+  ) {}
+
+  @Post('login-by-phone')
+  @HttpCode(HttpStatus.OK)
+  @RequirePermission('auth:trusted_phone_login')
+  @Throttle(TRUSTED_THROTTLE)
+  @ApiOperation({
+    summary:
+      'Emitir un JWT de usuario a partir de su teléfono verificado (bot de confianza)',
+  })
+  @ApiOkResponse({
+    description: 'Login correcto',
+    type: TrustedAuthResponseDto,
+  })
+  @ApiNotFoundResponse({ description: 'No existe usuario con ese teléfono' })
+  @ApiForbiddenResponse({
+    description:
+      'La Service Account no tiene el permiso auth:trusted_phone_login',
+  })
+  @ApiUnauthorizedResponse({ description: 'Falta o es inválida la API key' })
+  @ApiTooManyRequestsResponse({ description: 'Límite de peticiones excedido' })
+  async loginByPhoneRoute(
+    @Body() dto: LoginByPhoneDto,
+    @Request() req: AuthedRequest,
+  ): Promise<TrustedAuthResponseDto> {
+    const result = await this.loginByPhone.execute({ phone: dto.phone });
+    setAuditContext(req, {
+      reason:
+        `trusted-channel login-by-phone via service_account ${req.user.id}` +
+        (result.ambiguous ? ' [ambiguous phone match]' : ''),
+    });
+    return { accessToken: result.accessToken, user: result.user };
+  }
+
+  @Post('register-by-phone')
+  @HttpCode(HttpStatus.CREATED)
+  @RequirePermission('auth:trusted_phone_login')
+  @Throttle(TRUSTED_THROTTLE)
+  @ApiOperation({
+    summary:
+      'Alta passwordless de un usuario por teléfono verificado (bot de confianza)',
+  })
+  @ApiCreatedResponse({
+    description: 'Usuario creado (auto-login)',
+    type: TrustedAuthResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description:
+      'Falta la aceptación de términos/privacidad o un campo inválido',
+  })
+  @ApiConflictResponse({ description: 'Ya existe una cuenta con ese email' })
+  @ApiForbiddenResponse({
+    description:
+      'La Service Account no tiene el permiso auth:trusted_phone_login',
+  })
+  @ApiUnauthorizedResponse({ description: 'Falta o es inválida la API key' })
+  @ApiTooManyRequestsResponse({ description: 'Límite de peticiones excedido' })
+  async registerByPhoneRoute(
+    @Body() dto: RegisterByPhoneDto,
+    @Request() req: AuthedRequest,
+  ): Promise<TrustedAuthResponseDto> {
+    const result = await this.registerByPhone.execute({
+      phone: dto.phone,
+      name: dto.name,
+      email: dto.email,
+      acceptedTerms: dto.acceptedTerms,
+      acceptedPrivacy: dto.acceptedPrivacy,
+      serviceAccountId: req.user.id,
+    });
+    setAuditContext(req, {
+      reason: `trusted-channel register-by-phone via service_account ${req.user.id}`,
+    });
+    return { accessToken: result.accessToken, user: result.user };
+  }
+}

--- a/apps/api/src/contexts/identity/infrastructure/identity.module.ts
+++ b/apps/api/src/contexts/identity/infrastructure/identity.module.ts
@@ -4,6 +4,7 @@ import { PassportModule } from '@nestjs/passport';
 import { DB, DatabaseModule } from '../../../shared/database.module';
 import { Db } from '../../../shared/db';
 import { AuthController } from './http/auth.controller';
+import { TrustedAuthController } from './http/trusted-auth.controller';
 import { OAuthController } from './http/oauth.controller';
 import { GrantsController } from './http/grants.controller';
 import { ApiKeysController } from './http/api-keys.controller';
@@ -12,6 +13,8 @@ import { RolesController } from './http/roles.controller';
 import { UsersController } from './http/users.controller';
 import { Login } from '../application/login';
 import { RegisterUser } from '../application/register-user';
+import { LoginByPhone } from '../application/login-by-phone';
+import { RegisterByPhone } from '../application/register-by-phone';
 import { CompleteRegistration } from '../application/complete-registration';
 import { AuthenticateWithProvider } from '../application/authenticate-with-provider';
 import { GrantRole } from '../application/grant-role';
@@ -417,6 +420,23 @@ const registerUserProvider = {
   ) => new RegisterUser(userRepo, hasher, tokenService, consentRepo),
 };
 
+const loginByPhoneProvider = {
+  provide: LoginByPhone,
+  inject: [USER_REPOSITORY, TOKEN_SERVICE],
+  useFactory: (userRepo: UserRepository, tokenService: JwtTokenService) =>
+    new LoginByPhone(userRepo, tokenService),
+};
+
+const registerByPhoneProvider = {
+  provide: RegisterByPhone,
+  inject: [USER_REPOSITORY, TOKEN_SERVICE, CONSENT_REPOSITORY],
+  useFactory: (
+    userRepo: UserRepository,
+    tokenService: JwtTokenService,
+    consentRepo: ConsentRepository,
+  ) => new RegisterByPhone(userRepo, tokenService, consentRepo),
+};
+
 const completeRegistrationProvider = {
   provide: CompleteRegistration,
   inject: [USER_REPOSITORY, CONSENT_REPOSITORY],
@@ -473,6 +493,7 @@ const updateProfileProvider = {
   ],
   controllers: [
     AuthController,
+    TrustedAuthController,
     OAuthController,
     GrantsController,
     ApiKeysController,
@@ -490,6 +511,8 @@ const updateProfileProvider = {
     tokenServiceProvider,
     loginProvider,
     registerUserProvider,
+    loginByPhoneProvider,
+    registerByPhoneProvider,
     completeRegistrationProvider,
     authenticateWithProviderProvider,
     setPasswordInviterProvider,

--- a/apps/api/src/contexts/identity/infrastructure/in-memory-user.repository.ts
+++ b/apps/api/src/contexts/identity/infrastructure/in-memory-user.repository.ts
@@ -2,6 +2,7 @@ import { UserRepository } from '../domain/ports/user.repository';
 import { User } from '../domain/user';
 import { UserId } from '../domain/user-id';
 import { Email } from '../domain/email';
+import { normalizePhone } from '../domain/phone-normalization';
 
 export class InMemoryUserRepository implements UserRepository {
   private store = new Map<string, ReturnType<User['toSnapshot']>>();
@@ -15,6 +16,17 @@ export class InMemoryUserRepository implements UserRepository {
   findByEmail(email: Email): Promise<User | null> {
     const snap = [...this.store.values()].find((s) => s.email === email.value);
     return Promise.resolve(snap ? User.fromSnapshot(snap) : null);
+  }
+
+  findByPhone(phone: string): Promise<User[]> {
+    const digits = normalizePhone(phone);
+    if (digits === '') return Promise.resolve([]);
+    // Insertion order approximates recency; reverse → most recent first.
+    const matches = [...this.store.values()]
+      .filter((s) => s.phone !== null && normalizePhone(s.phone) === digits)
+      .reverse()
+      .map((s) => User.fromSnapshot(s));
+    return Promise.resolve(matches);
   }
 
   findById(id: UserId): Promise<User | null> {

--- a/apps/api/test/trusted-phone-auth.e2e-spec.ts
+++ b/apps/api/test/trusted-phone-auth.e2e-spec.ts
@@ -1,0 +1,323 @@
+/**
+ * E2E: trusted-channel phone auth via a service-account API key (#315).
+ *
+ * A messaging bot (Telegram/WhatsApp) that already verified the user's phone
+ * exchanges it for a user JWT — but ONLY when its Service Account holds the
+ * dedicated `auth:trusted_phone_login` grant. Proves end to end:
+ *   - no API key                                   → 401
+ *   - API key WITHOUT the grant                     → 403
+ *   - login: existing phone → 200 { accessToken, user }, and the token is a
+ *       real user JWT (works on /auth/me); unknown phone → 404
+ *   - register: new phone → 201, user persisted passwordless, consent stamped
+ *       with the originating service account; existing email → 409; no consent → 400
+ *   - the emitted JWT carries the USER's own isAdmin (no privilege escalation)
+ */
+import { Test } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import type { Server } from 'node:http';
+import request from 'supertest';
+import { and, eq } from 'drizzle-orm';
+import * as bcrypt from 'bcryptjs';
+import { AppModule } from '../src/app.module';
+import { createDb } from '../src/shared/db';
+import {
+  usersTable,
+  grantsTable,
+  serviceAccountsTable,
+  apiKeysTable,
+  userConsentsTable,
+} from '../src/contexts/identity/infrastructure/drizzle/schema';
+
+const ORG = '31500000-0000-4000-8000-0000000000b1';
+const ADMIN_ID = '31500000-0000-4000-8000-0000000000a1';
+const USER_ID = '31500000-0000-4000-8000-0000000000c1';
+const GRANT_ADMIN = '31500000-0000-4000-8000-0000000000f1';
+const GRANT_BOT = '31500000-0000-4000-8000-0000000000f2';
+
+const USER_PHONE = '+58 412 555 0101';
+
+const DB_URL =
+  process.env.DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5433/reliefhub_test';
+
+describe('Trusted-channel phone auth via API key (e2e, #315)', () => {
+  let app: INestApplication;
+  let server: Server;
+  let adminToken: string;
+  let botKey: string;
+  let ungrantedKey: string;
+  let botSaId: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+    server = app.getHttpServer() as Server;
+
+    const { db, pool } = createDb(DB_URL);
+    try {
+      await db.delete(apiKeysTable);
+      await db.delete(serviceAccountsTable);
+      await db.delete(grantsTable).where(eq(grantsTable.id, GRANT_ADMIN));
+      await db.delete(usersTable).where(eq(usersTable.id, ADMIN_ID));
+      await db.delete(usersTable).where(eq(usersTable.id, USER_ID));
+
+      const hash = await bcrypt.hash('Password1!', 10);
+      await db
+        .insert(usersTable)
+        .values([
+          {
+            id: ADMIN_ID,
+            email: 'trusted-admin@example.com',
+            passwordHash: hash,
+            name: 'Trusted Admin',
+            isAdmin: false,
+          },
+          {
+            id: USER_ID,
+            email: 'ana-trusted@example.com',
+            passwordHash: hash,
+            name: 'Ana Trusted',
+            isAdmin: false,
+            phone: USER_PHONE,
+          },
+        ])
+        .onConflictDoNothing();
+
+      // Admin administers ORG → apikey:create/revoke, so it can mint the bot's
+      // service account and keys.
+      await db
+        .insert(grantsTable)
+        .values({
+          id: GRANT_ADMIN,
+          principalId: ADMIN_ID,
+          principalType: 'user',
+          roleId: 'org_admin',
+          scopeType: 'organization',
+          scopeId: ORG,
+          grantedAt: new Date(),
+        })
+        .onConflictDoNothing();
+    } finally {
+      await pool.end();
+    }
+
+    const adminLogin = await request(server)
+      .post('/auth/login')
+      .send({ email: 'trusted-admin@example.com', password: 'Password1!' })
+      .expect(200);
+    adminToken = (adminLogin.body as { accessToken: string }).accessToken;
+
+    // The bot's service account.
+    const saRes = await request(server)
+      .post('/service-accounts')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'telegram-bot', ownerOrganizationId: ORG })
+      .expect(201);
+    botSaId = (saRes.body as { id: string }).id;
+
+    // The dedicated platform-scoped trusted_channel_bot grant (the only thing
+    // that unlocks the endpoints).
+    const grantDb = createDb(DB_URL);
+    try {
+      await grantDb.db
+        .insert(grantsTable)
+        .values({
+          id: GRANT_BOT,
+          principalId: botSaId,
+          principalType: 'service_account',
+          roleId: 'trusted_channel_bot',
+          scopeType: 'platform',
+          scopeId: null,
+          grantedAt: new Date(),
+        })
+        .onConflictDoNothing();
+    } finally {
+      await grantDb.pool.end();
+    }
+
+    const keyRes = await request(server)
+      .post(`/service-accounts/${botSaId}/api-keys`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({})
+      .expect(201);
+    botKey = (keyRes.body as { apiKey: string }).apiKey;
+
+    // A second service account with NO trusted grant — proves the grant is required.
+    const sa2 = await request(server)
+      .post('/service-accounts')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'ungranted-bot', ownerOrganizationId: ORG })
+      .expect(201);
+    const key2 = await request(server)
+      .post(`/service-accounts/${(sa2.body as { id: string }).id}/api-keys`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({})
+      .expect(201);
+    ungrantedKey = (key2.body as { apiKey: string }).apiKey;
+  });
+
+  afterAll(async () => {
+    const { db, pool } = createDb(DB_URL);
+    try {
+      await db.delete(apiKeysTable);
+      await db.delete(serviceAccountsTable);
+    } finally {
+      await pool.end();
+    }
+    await app.close();
+  });
+
+  describe('login-by-phone', () => {
+    it('401 without an API key', async () => {
+      await request(server)
+        .post('/auth/trusted/login-by-phone')
+        .send({ phone: USER_PHONE })
+        .expect(401);
+    });
+
+    it('403 with an API key that lacks the trusted grant', async () => {
+      await request(server)
+        .post('/auth/trusted/login-by-phone')
+        .set('X-API-Key', ungrantedKey)
+        .send({ phone: USER_PHONE })
+        .expect(403);
+    });
+
+    it('200 for an existing phone, and the token is a real user JWT', async () => {
+      const res = await request(server)
+        .post('/auth/trusted/login-by-phone')
+        .set('X-API-Key', botKey)
+        // A DIFFERENT format of the same number — normalisation must still match.
+        .send({ phone: '+584125550101' })
+        .expect(200);
+
+      const body = res.body as {
+        accessToken: string;
+        user: { id: string; name: string; email: string };
+      };
+      expect(body.user).toEqual({
+        id: USER_ID,
+        name: 'Ana Trusted',
+        email: 'ana-trusted@example.com',
+      });
+
+      // The token authenticates as that user on a normal JWT-guarded route.
+      const me = await request(server)
+        .get('/auth/me')
+        .set('Authorization', `Bearer ${body.accessToken}`)
+        .expect(200);
+      expect((me.body as { id: string; isAdmin: boolean }).id).toBe(USER_ID);
+      expect((me.body as { isAdmin: boolean }).isAdmin).toBe(false);
+    });
+
+    it('404 for a phone that belongs to no user', async () => {
+      await request(server)
+        .post('/auth/trusted/login-by-phone')
+        .set('X-API-Key', botKey)
+        .send({ phone: '+34600000000' })
+        .expect(404);
+    });
+  });
+
+  describe('register-by-phone', () => {
+    it('201 creates a passwordless user and stamps consent with the service account', async () => {
+      const res = await request(server)
+        .post('/auth/trusted/register-by-phone')
+        .set('X-API-Key', botKey)
+        .send({
+          phone: '+58 424 000 1122',
+          name: 'Nuevo Usuario',
+          email: 'nuevo-trusted@example.com',
+          acceptedTerms: true,
+          acceptedPrivacy: true,
+        })
+        .expect(201);
+
+      const body = res.body as {
+        accessToken: string;
+        user: { id: string; email: string };
+      };
+      expect(body.user.email).toBe('nuevo-trusted@example.com');
+      expect(body.accessToken).toBeTruthy();
+
+      const { db, pool } = createDb(DB_URL);
+      try {
+        const consents = await db
+          .select()
+          .from(userConsentsTable)
+          .where(eq(userConsentsTable.userId, body.user.id));
+        expect(consents.length).toBe(2); // terms + privacy
+        // Origin: the bot's service account, no browser ip/user-agent.
+        for (const c of consents) {
+          expect(c.serviceAccountId).toBe(botSaId);
+          expect(c.ip).toBeNull();
+        }
+        const created = await db
+          .select()
+          .from(usersTable)
+          .where(
+            and(
+              eq(usersTable.id, body.user.id),
+              eq(usersTable.email, 'nuevo-trusted@example.com'),
+            ),
+          );
+        expect(created[0]?.passwordHash).toBeNull(); // passwordless alta
+        expect(created[0]?.phone).toBe('+58 424 000 1122');
+      } finally {
+        await pool.end();
+      }
+    });
+
+    it('409 when the email already exists', async () => {
+      await request(server)
+        .post('/auth/trusted/register-by-phone')
+        .set('X-API-Key', botKey)
+        .send({
+          phone: '+58 424 000 3344',
+          name: 'Dup',
+          email: 'ana-trusted@example.com', // already taken by the seeded user
+          acceptedTerms: true,
+          acceptedPrivacy: true,
+        })
+        .expect(409);
+    });
+
+    it('400 when consent is not accepted', async () => {
+      await request(server)
+        .post('/auth/trusted/register-by-phone')
+        .set('X-API-Key', botKey)
+        .send({
+          phone: '+58 424 000 5566',
+          name: 'Sin Consentimiento',
+          email: 'sinconsent-trusted@example.com',
+          acceptedTerms: false,
+          acceptedPrivacy: true,
+        })
+        .expect(400);
+    });
+
+    it('403 with an API key that lacks the trusted grant', async () => {
+      await request(server)
+        .post('/auth/trusted/register-by-phone')
+        .set('X-API-Key', ungrantedKey)
+        .send({
+          phone: '+58 424 000 7788',
+          name: 'X',
+          email: 'x-trusted@example.com',
+          acceptedTerms: true,
+          acceptedPrivacy: true,
+        })
+        .expect(403);
+    });
+  });
+});

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -73,6 +73,40 @@ export interface paths {
         patch: operations["AuthController_updateMe"];
         trace?: never;
     };
+    "/auth/trusted/login-by-phone": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Emitir un JWT de usuario a partir de su teléfono verificado (bot de confianza) */
+        post: operations["TrustedAuthController_loginByPhoneRoute"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/trusted/register-by-phone": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Alta passwordless de un usuario por teléfono verificado (bot de confianza) */
+        post: operations["TrustedAuthController_registerByPhoneRoute"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/grants/at-scope": {
         parameters: {
             query?: never;
@@ -2794,6 +2828,44 @@ export interface components {
             phone?: string | null;
             /** @example Nuevo Nombre */
             name?: string;
+        };
+        LoginByPhoneDto: {
+            /**
+             * @description Teléfono verificado por el canal de confianza (bot). Se normaliza (espacios, guiones, prefijo +) antes de buscar la cuenta.
+             * @example +58 412 555 0101
+             */
+            phone: string;
+        };
+        TrustedAuthUserDto: {
+            /** @description User UUID */
+            id: string;
+            /** @example Jane Doe */
+            name: string;
+            /** @example jane@example.com */
+            email: string;
+        };
+        TrustedAuthResponseDto: {
+            /** @description JWT del usuario — mismos claims que /auth/login; nunca confiere más permisos que los del propio usuario. */
+            accessToken: string;
+            user: components["schemas"]["TrustedAuthUserDto"];
+        };
+        RegisterByPhoneDto: {
+            /** @example +58 412 555 0101 */
+            phone: string;
+            /** @example Jane Doe */
+            name: string;
+            /** @example jane@example.com */
+            email: string;
+            /**
+             * @description Aceptación de las condiciones del servicio (debe ser true; el bot la recogió en la conversación).
+             * @example true
+             */
+            acceptedTerms: boolean;
+            /**
+             * @description Aceptación de la política de privacidad (debe ser true).
+             * @example true
+             */
+            acceptedPrivacy: boolean;
         };
         GrantListItemDto: {
             /** Format: uuid */
@@ -6041,6 +6113,117 @@ export interface operations {
             };
             /** @description Token inválido o ausente */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TrustedAuthController_loginByPhoneRoute: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginByPhoneDto"];
+            };
+        };
+        responses: {
+            /** @description Login correcto */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrustedAuthResponseDto"];
+                };
+            };
+            /** @description Falta o es inválida la API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description La Service Account no tiene el permiso auth:trusted_phone_login */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No existe usuario con ese teléfono */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Límite de peticiones excedido */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TrustedAuthController_registerByPhoneRoute: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterByPhoneDto"];
+            };
+        };
+        responses: {
+            /** @description Usuario creado (auto-login) */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrustedAuthResponseDto"];
+                };
+            };
+            /** @description Falta la aceptación de términos/privacidad o un campo inválido */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Falta o es inválida la API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description La Service Account no tiene el permiso auth:trusted_phone_login */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Ya existe una cuenta con ese email */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Límite de peticiones excedido */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Resumen

Endpoints seguros para que los bots de Telegram/WhatsApp (que ya verifican el teléfono en el cliente) obtengan un JWT de usuario por teléfono, sin exponer esa confianza de forma pública (#315).

**Seguridad — el eje del diseño:**
- Permiso dedicado `auth:trusted_phone_login`, **fuera de todo rol general**, portado por un rol de un solo permiso `trusted_channel_bot` (scope `platform`) que se concede **uno-a-uno** a la Service Account del bot. Una API key nueva no lo hereda.
- El JWT emitido sigue las reglas normales: **nunca confiere más permisos que los del propio usuario** (mismos claims que `/auth/login`). Una fuga de la key del bot = «loguearse como quien comparte su teléfono con ese bot», no «actuar con cualquier permiso». Revocar la key es el kill-switch inmediato.

**Endpoints** (service-account-only vía `X-API-Key`: `ApiKeyAuthGuard` + `ServiceAccountPermissionGuard` + `@RequirePermission`):
- `POST /auth/trusted/login-by-phone` — `{ phone }` → `200 { accessToken, user }` · `404` no existe · `403` sin permiso · `401` sin key.
- `POST /auth/trusted/register-by-phone` — `{ phone, name, email, acceptedTerms, acceptedPrivacy }` → `201 { accessToken, user }` · `409` email duplicado · `400` sin consentimiento. Alta **passwordless** (mismo camino que el alta social), consentimiento sellado con el `serviceAccountId` de origen.

**Detalles:**
- `findByPhone` con **normalización** (espacios/guiones/paréntesis/prefijo `+`) en SQL; teléfono **ambiguo** (no hay índice único) → devuelve el más reciente y marca el caso en la auditoría, nunca 500 ni fallo silencioso.
- **Rate limit dedicado** `trusted-auth` (20/60s) con `ApiKeyAwareThrottlerGuard` que **clavea por prefijo de API key, no por IP** (todo el tráfico del bot sale de un servidor); fallback a IP para el resto de rutas.
- **Migración 0054** `user_consents.service_account_id` (aditiva, nullable). `gen:api` regenerado.

## Notas de diseño (ajustes sobre el spec del issue)

- **Nombre del permiso**: `auth:trusted_phone_login` (snake_case, convención del catálogo — el test `permission.spec` exige `^[a-z]+:[a-z_]+$`) en vez del `-` del issue.
- **Vehículo del grant**: los grants confieren *roles*, no permisos sueltos, así que el permiso vive en el rol dedicado `trusted_channel_bot` — que es exactamente el «explícito, nunca heredado de otro rol» que pedía el diseño.
- **Auditoría**: vía `setAuditContext` + el interceptor global (registra la acción con `actorUserId` = id de la Service Account y un `reason` que identifica el canal + el caso ambiguo), consistente con cómo el repo audita las escrituras de Service Account (#235), en vez de una escritura a medida con `actorUserId: null`.

## Validación

- [x] Gate API completo con infra (Postgres/Redis levantados en el entorno): `build`, eslint `--max-warnings=0`, prettier `--check`, **unit+int 1559** (migración 0054 aplicada, incl. int de `findByPhone`) y **e2e 345**.
- [x] **e2e `trusted-phone-auth`** (8 casos): gating 401/403, login 200 (+ el JWT vale en `/auth/me`, sin escalada de privilegios) / 404; alta 201 (usuario passwordless + consentimiento con origen de SA verificado en BD) / 409 / 400 / 403.
- [x] Gate web: `@reliefhub/api-client build` + `web build` + `web lint`.
- [x] Migración aditiva y nullable; `gen:api` regenerado y `schema.ts` commiteado (2 endpoints nuevos).

## Cierre

- Closes #315