### PR TITLE
refactor(supplies): protección de slug núcleo en el caso de uso + fix 404 en admin de categorías (#326)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -6270,9 +6270,6 @@
           "204": {
             "description": "Category archived"
           },
-          "400": {
-            "description": "Core category slug cannot be archived by delete"
-          },
           "401": {
             "description": "Missing or invalid token"
           },
@@ -6281,6 +6278,9 @@
           },
           "404": {
             "description": "Category not found"
+          },
+          "409": {
+            "description": "Core category slug is protected and cannot be archived"
           }
         },
         "security": [

--- a/apps/api/src/contexts/supplies/application/category-admin.errors.ts
+++ b/apps/api/src/contexts/supplies/application/category-admin.errors.ts
@@ -25,3 +25,16 @@ export class CategoryValidationError extends Error {
     this.name = 'CategoryValidationError';
   }
 }
+
+/**
+ * Una categoría núcleo (slug del enum {@link Category}, referenciado por el
+ * código y por otras tablas) está protegida: no se puede borrar ni archivar.
+ * Error de negocio propio para que el mapeo HTTP (409) viva en el filtro y no
+ * en el controller.
+ */
+export class CategoryProtectedError extends Error {
+  constructor(slug: string) {
+    super(`Core category is protected and cannot be deleted: ${slug}`);
+    this.name = 'CategoryProtectedError';
+  }
+}

--- a/apps/api/src/contexts/supplies/application/update-category.spec.ts
+++ b/apps/api/src/contexts/supplies/application/update-category.spec.ts
@@ -1,5 +1,5 @@
 import { UpdateCategory } from './update-category';
-import { CategoryValidationError } from './category-admin.errors';
+import { CategoryProtectedError } from './category-admin.errors';
 import { Category } from '../domain/category';
 import { CategoryDefinition } from '../domain/category-definition';
 import { CategoryRepository } from '../domain/ports/category.repository';
@@ -79,6 +79,6 @@ describe('UpdateCategory — archive / restore', () => {
 
     await expect(
       new UpdateCategory(repo).execute(Category.Food, { archived: true }),
-    ).rejects.toBeInstanceOf(CategoryValidationError);
+    ).rejects.toBeInstanceOf(CategoryProtectedError);
   });
 });

--- a/apps/api/src/contexts/supplies/application/update-category.ts
+++ b/apps/api/src/contexts/supplies/application/update-category.ts
@@ -1,6 +1,7 @@
 import {
   CategoryNotFoundError,
   CategoryParentNotFoundError,
+  CategoryProtectedError,
   CategoryValidationError,
 } from './category-admin.errors';
 import { isCoreCategory } from '../domain/category';
@@ -52,7 +53,7 @@ export class UpdateCategory {
       }
     }
     if (cmd.archived === true && isCoreCategory(current.slug)) {
-      throw new CategoryValidationError('Core categories cannot be archived');
+      throw new CategoryProtectedError(current.slug);
     }
 
     return await this.repo.updateCategory(currentSlug, {

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
@@ -1,4 +1,3 @@
-import { BadRequestException } from '@nestjs/common';
 import { CategoriesAdminController } from './categories-admin.controller';
 import { CategoryDefinition } from '../../domain/category-definition';
 
@@ -70,19 +69,9 @@ describe('CategoriesAdminController', () => {
     expect(result.label).toBe('Nourriture pour bébé');
   });
 
-  it('rejects delete for core slugs', async () => {
-    const controller = new CategoriesAdminController(
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-    );
-
-    await expect(controller.delete('food')).rejects.toBeInstanceOf(
-      BadRequestException,
-    );
-  });
-
-  it('archiva una categoría no-núcleo vía DELETE', async () => {
+  // La protección de slugs núcleo ya NO vive en el controller (que solo
+  // delega): la aplica el caso de uso UpdateCategory (ver update-category.spec).
+  it('archiva vía DELETE delegando en el caso de uso (sin regla en el controller)', async () => {
     const archived = { ...category, archivedAt: new Date().toISOString() };
     const updateCategory = { execute: jest.fn().mockResolvedValue(archived) };
     const controller = new CategoriesAdminController(

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Controller,
   Body,
   Delete,
@@ -31,7 +30,6 @@ import {
 import { JwtAuthGuard } from '../../../identity/infrastructure/http/jwt-auth.guard';
 import { PermissionGuard } from '../../../identity/infrastructure/http/permission.guard';
 import { RequirePermission } from '../../../identity/infrastructure/http/require-permission.decorator';
-import { isCoreCategory } from '../../domain/category';
 import { CategoryDefinition } from '../../domain/category-definition';
 import { CreateCategory } from '../../application/create-category';
 import { ListCategories } from '../../application/list-categories';
@@ -139,17 +137,14 @@ export class CategoriesAdminController {
   @ApiParam({ name: 'slug', description: 'Category slug to archive' })
   @ApiNoContentResponse({ description: 'Category archived' })
   @ApiNotFoundResponse({ description: 'Category not found' })
-  @ApiBadRequestResponse({
-    description: 'Core category slug cannot be archived by delete',
+  @ApiConflictResponse({
+    description: 'Core category slug is protected and cannot be archived',
   })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid token' })
   @ApiForbiddenResponse({ description: 'Missing catalogue:manage permission' })
   async delete(@Param('slug') slug: string): Promise<void> {
-    if (isCoreCategory(slug)) {
-      throw new BadRequestException(
-        `Core category slug cannot be deleted: ${slug}`,
-      );
-    }
+    // La protección de slugs núcleo vive en el caso de uso (regla de dominio),
+    // que lanza CategoryProtectedError → 409 vía el filtro global.
     await this.updateCategory.execute(slug, { archived: true });
   }
 

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.spec.ts
@@ -1,0 +1,51 @@
+import { ArgumentsHost, HttpStatus } from '@nestjs/common';
+import { SuppliesDomainExceptionFilter } from './supplies-domain-exception.filter';
+import {
+  CategoryNotFoundError,
+  CategoryProtectedError,
+  CategoryValidationError,
+} from '../../application/category-admin.errors';
+
+function statusFor(
+  exception:
+    | CategoryNotFoundError
+    | CategoryProtectedError
+    | CategoryValidationError,
+): number {
+  const filter = new SuppliesDomainExceptionFilter();
+  let statusCode = 0;
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return this;
+    },
+    json() {
+      return this;
+    },
+  };
+  const host = {
+    switchToHttp: () => ({ getResponse: () => res }),
+  } as unknown as ArgumentsHost;
+  filter.catch(exception, host);
+  return statusCode;
+}
+
+describe('SuppliesDomainExceptionFilter — categorías admin', () => {
+  it('mapea el CategoryNotFoundError de application a 404 (regresión: antes 500)', () => {
+    expect(statusFor(new CategoryNotFoundError('missing'))).toBe(
+      HttpStatus.NOT_FOUND,
+    );
+  });
+
+  it('mapea CategoryProtectedError (slug núcleo) a 409', () => {
+    expect(statusFor(new CategoryProtectedError('food'))).toBe(
+      HttpStatus.CONFLICT,
+    );
+  });
+
+  it('mapea CategoryValidationError a 422', () => {
+    expect(statusFor(new CategoryValidationError('bad'))).toBe(
+      HttpStatus.UNPROCESSABLE_ENTITY,
+    );
+  });
+});

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
@@ -25,7 +25,9 @@ import {
 } from '../../domain/supply-errors';
 import {
   CategoryAlreadyExistsError,
+  CategoryNotFoundError as CategoryAdminNotFoundError,
   CategoryParentNotFoundError,
+  CategoryProtectedError,
   CategoryValidationError,
 } from '../../application/category-admin.errors';
 
@@ -45,7 +47,9 @@ type DomainError =
   | MergeIntoSelfError
   | AliasConflictError
   | CategoryAlreadyExistsError
+  | CategoryAdminNotFoundError
   | CategoryParentNotFoundError
+  | CategoryProtectedError
   | CategoryValidationError;
 
 /**
@@ -74,7 +78,9 @@ type DomainError =
   MergeIntoSelfError,
   AliasConflictError,
   CategoryAlreadyExistsError,
+  CategoryAdminNotFoundError,
   CategoryParentNotFoundError,
+  CategoryProtectedError,
   CategoryValidationError,
 )
 export class SuppliesDomainExceptionFilter implements ExceptionFilter {
@@ -92,6 +98,7 @@ export class SuppliesDomainExceptionFilter implements ExceptionFilter {
       exception instanceof SupplyNotFoundError ||
       exception instanceof VariantTargetNotFoundError ||
       exception instanceof CategoryNotFoundError ||
+      exception instanceof CategoryAdminNotFoundError ||
       exception instanceof CategoryParentNotFoundError
     ) {
       return HttpStatus.NOT_FOUND;
@@ -100,7 +107,8 @@ export class SuppliesDomainExceptionFilter implements ExceptionFilter {
       exception instanceof ContainerSealedError ||
       exception instanceof SupplyCodeConflictError ||
       exception instanceof AliasConflictError ||
-      exception instanceof CategoryAlreadyExistsError
+      exception instanceof CategoryAlreadyExistsError ||
+      exception instanceof CategoryProtectedError
     ) {
       return HttpStatus.CONFLICT;
     }

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -11168,13 +11168,6 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Core category slug cannot be archived by delete */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
             /** @description Missing or invalid token */
             401: {
                 headers: {
@@ -11191,6 +11184,13 @@ export interface operations {
             };
             /** @description Category not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Core category slug is protected and cannot be archived */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Resumen

Salda **parte** de la deuda técnica de #326 (heredada del merge de #246), quedándome en lo de **bajo riesgo y alto valor**. Sin cambios funcionales salvo dos correcciones de código HTTP:

- **Regla de dominio fuera del controller (punto 3 de #326):** la protección "no archivar/borrar una categoría núcleo" ya no vive en `CategoriesAdminController.delete()` (que lanzaba `BadRequestException`). Ahora es una regla del caso de uso `UpdateCategory`, que lanza el error de negocio `CategoryProtectedError`, mapeado a **409** por el `SuppliesDomainExceptionFilter` global. El controller admin ya no conoce la regla ni lanza `HttpException`.
- **Fix de regresión latente (404):** `PATCH`/`DELETE /admin/categories/:slug` sobre una categoría **inexistente** devolvía **500**, porque el filtro capturaba el `CategoryNotFoundError` de `domain/supply-errors` mientras el caso de uso lanza el homónimo de `application/category-admin.errors` (dos clases distintas con el mismo nombre). El filtro ahora captura ambos → **404**.

### Deliberadamente fuera de alcance (queda en #326)
Los puntos 1 (modelo interno vs proyección pública) y 2 (ISP: separar puerto de lectura pública y de escritura admin) resultaron **más transversales de lo previsto**: `CategoryRepository.findBySlug` lo comparten también `create-supply`/`edit-supply` para validar la categoría, así que la separación correcta es reads/writes y toca otros casos de uso de `supplies`. Lo dejo documentado en #326 para un esfuerzo deliberado aparte, en vez de meter un cambio grande y arriesgado sobre código recién mergeado.

## Validación

- [x] Gate de la zona: `api build`, `eslint {src,test} --max-warnings=0`, `prettier --check`, **suite completa 1561 tests** ✅; `@reliefhub/api-client build` + `web build` + `web lint` ✅.
- [x] Tests: nuevo `supplies-domain-exception.filter.spec.ts` (404 admin-not-found — regresión, 409 protected, 422 validation); `update-category.spec` ahora espera `CategoryProtectedError` al archivar núcleo; `categories-admin.controller.spec` refleja que el controller solo delega.
- [x] Regeneré el cliente API (`openapi.json` + `schema.ts`): único cambio, la respuesta del DELETE 400 → 409.

## Cierre

- Refs #326

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyQ4dgwc1HffL8wKv18gk2)_