### PR TITLE
fix(auth): pedir el scope email en el login de Facebook

### DIFF
--- a/apps/api/src/contexts/identity/infrastructure/http/facebook.strategy.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/facebook.strategy.ts
@@ -23,7 +23,14 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
       clientID: clientID || PLACEHOLDER,
       clientSecret: clientSecret || PLACEHOLDER,
       callbackURL: `${process.env.OAUTH_CALLBACK_BASE ?? 'http://localhost:3000'}/auth/facebook/callback`,
+      // Request the `email` permission — passport-facebook does NOT ask for it by
+      // default, so without this the Graph profile has no email and validate()
+      // throws. Mirrors GoogleStrategy's scope.
+      scope: ['email'],
       profileFields: ['id', 'emails', 'name', 'displayName'],
+      // Sign Graph API calls with appsecret_proof so a stolen user token cannot
+      // be replayed without the app secret (Facebook-recommended hardening).
+      enableProof: true,
     };
 
     super(options);


### PR DESCRIPTION
## Contexto

El login social de Facebook ya está implementado de punta a punta (estrategia + rutas `/auth/facebook[/callback]` + CSRF state + botón en el frontend). Al habilitarlo faltaba un detalle que lo habría roto en runtime.

## Bug

`GoogleStrategy` pide `scope: ['email', 'profile']`, pero `FacebookStrategy` **no pedía ningún scope**. `passport-facebook` no solicita `email` por defecto → el perfil del Graph llega sin email → `validate()` lanza `Facebook profile did not return an email address` y el callback redirige a `/login?error=oauth_failed`.

## Fix

`facebook.strategy.ts`:
- `scope: ['email']` (espejo de Google) — sin esto el flujo no completa.
- `enableProof: true` — firma las llamadas al Graph con `appsecret_proof` (hardening recomendado por Facebook; un token robado no se puede reutilizar sin el app secret).

## Nota (config, fuera de código)

Para activarlo en prod hacen falta las env vars `FACEBOOK_APP_ID` / `FACEBOOK_APP_SECRET` en `/opt/responsegrid/deploy/.env` y el redirect URI `https://api.responsegrid.app/auth/facebook/callback` en el dashboard de Facebook. (Ver comentario en la issue.)

Gate local: build + eslint + prettier + tests oauth (24).
