### PR TITLE
fix(web): AppBar usa el pathname exacto para el next del login (#278)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ apps/api/uploads/
 
 # Entorno local personal (scripts, seeds, docker extra) — no subir al repo
 .local/
+
+# Local git worktrees for parallel agent work — never commit
+.worktrees/

--- a/apps/web/src/app/auth/onboarding/page.tsx
+++ b/apps/web/src/app/auth/onboarding/page.tsx
@@ -23,7 +23,7 @@ export default async function OnboardingPage({ searchParams }: Props) {
 
   return (
     <main className="flex-1 bg-surface">
-      <AppBar variant="content" />
+      <AppBar variant="content" currentPath="/auth/onboarding" />
 
       <div className="mx-auto w-full max-w-3xl">
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">

--- a/apps/web/src/app/como-funciona/page.tsx
+++ b/apps/web/src/app/como-funciona/page.tsx
@@ -44,6 +44,7 @@ export default async function HowItWorksPage() {
       lead={h.lead}
       illustration={<StepsIllustration className="w-full" />}
       cta={{ heading: h.cta_heading, body: h.cta_body, label: h.cta_button, href: '/#emergencias' }}
+      currentPath="/como-funciona"
     >
       <ol className="grid gap-4 sm:grid-cols-3">
         {steps.map((s) => (

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -342,7 +342,7 @@ for (const p of items) {
 
   return (
     <main className="flex-1 bg-surface">
-      <AppBar variant="content" />
+      <AppBar variant="content" currentPath="/docs" />
 
       <div className="mx-auto w-full max-w-md bg-surface lg:max-w-6xl">
         <div className="px-5 pb-16 pt-8 lg:px-8 lg:pt-10">

--- a/apps/web/src/app/e/[slug]/donacion/[code]/page.tsx
+++ b/apps/web/src/app/e/[slug]/donacion/[code]/page.tsx
@@ -50,7 +50,7 @@ export default async function DonacionTrackingPage({ params }: Props) {
   const shell = (children: React.ReactNode) => (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-md">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/donacion/${code}`} />
         <PageHeading title={td.page_title} subtitle={td.page_subtitle} />
         <div className="flex flex-col gap-6 px-4 pb-12 pt-6">{children}</div>
       </div>

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/page.tsx
@@ -73,7 +73,7 @@ export default async function DonarPage({ params, searchParams }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/donar/ofrecer`} />
         <PageHeading
           title={t.donar.page_title}
           subtitle={t.donar.page_subtitle.replace('{emergencyName}', emergency.name)}

--- a/apps/web/src/app/e/[slug]/donar/page.tsx
+++ b/apps/web/src/app/e/[slug]/donar/page.tsx
@@ -50,7 +50,7 @@ export default async function DonarSelectorPage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/donar`} />
         <PageHeading title={td.choose_title} subtitle={td.choose_subtitle} />
         <div className="flex flex-col gap-3 px-4 pb-12 pt-6">
           <HelpActionRow

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
@@ -77,7 +77,7 @@ export default async function MiVoluntariadoPage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/mi-voluntariado`} />
         <PageHeading title={ta.vol_title} subtitle={ta.vol_subtitle} />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
 

--- a/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-expediciones/page.tsx
@@ -70,7 +70,7 @@ export default async function MisExpedicionesPage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/mis-expediciones`} />
         <PageHeading title={ta.ship_title} subtitle={ta.ship_subtitle} />
         <div className="flex flex-col gap-6 px-5 pb-12 pt-6 lg:px-8">
           <ShipmentsList

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/page.tsx
@@ -45,7 +45,12 @@ export default async function InventarioPage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}/mis-puntos`} />
+        <AppBar
+          variant="action"
+          slug={slug}
+          backHref={`/e/${slug}/mis-puntos`}
+          currentPath={`/e/${slug}/mis-puntos/${resourceId}/inventario`}
+        />
         <PageHeading
           title={t.account.inventory_page_title}
           subtitle={t.account.inventory_page_subtitle}

--- a/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
@@ -54,7 +54,7 @@ export default async function MisPuntosPage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/mis-puntos`} />
         <PageHeading title={ta.points_title} subtitle={ta.points_subtitle} />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
 

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/page.tsx
@@ -57,7 +57,7 @@ export default async function OfrecerTransportePage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/ofrecer-transporte`} />
         <PageHeading
           title={t.ofrecerTransporte.page_title}
           subtitle={t.ofrecerTransporte.page_subtitle.replace(

--- a/apps/web/src/app/e/[slug]/peticion/page.tsx
+++ b/apps/web/src/app/e/[slug]/peticion/page.tsx
@@ -64,7 +64,7 @@ export default async function PeticionPage({ params, searchParams }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/peticion`} />
         <PageHeading
           title={t.peticion.page_title}
           subtitle={t.peticion.page_subtitle.replace('{emergencyName}', emergency.name)}

--- a/apps/web/src/app/e/[slug]/pre-registro/page.tsx
+++ b/apps/web/src/app/e/[slug]/pre-registro/page.tsx
@@ -77,7 +77,7 @@ export default async function PreRegistroPage({ params, searchParams }: Props) {
     return (
       <main className="flex-1 bg-surface">
         <div className="mx-auto w-full max-w-3xl">
-          <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+          <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/pre-registro`} />
           <PageHeading title={tp.pick_title} subtitle={tp.pick_hint} />
           <div className="flex flex-col gap-5 px-4 pb-12 pt-6">
             <form method="get" role="search" className="flex gap-2">
@@ -160,6 +160,7 @@ export default async function PreRegistroPage({ params, searchParams }: Props) {
           variant="action"
           slug={slug}
           backHref={`/e/${slug}/pre-registro`}
+          currentPath={`/e/${slug}/pre-registro?resourceId=${resourceId}`}
         />
         <PageHeading
           title={tp.page_title}

--- a/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/[intakeId]/page.tsx
@@ -115,6 +115,7 @@ export default async function IntakeDetailPage({ params }: Props) {
           variant="action"
           slug={slug}
           backHref={`/e/${slug}/recepcion`}
+          currentPath={`/e/${slug}/recepcion/${intakeId}`}
         />
         <PageHeading title={tr.detail_subtitle.replace('{code}', intake.intakeCode)} />
         <div className="flex flex-col gap-6 px-4 pb-12 pt-6">

--- a/apps/web/src/app/e/[slug]/recepcion/page.tsx
+++ b/apps/web/src/app/e/[slug]/recepcion/page.tsx
@@ -144,6 +144,7 @@ export default async function RecepcionPage({ params, searchParams }: Props) {
           variant="action"
           slug={slug}
           backHref={`/emergencies/${slug}/manage`}
+          currentPath={`/e/${slug}/recepcion`}
         />
         <PageHeading title={tr.page_title} subtitle={tr.page_subtitle} />
         <div className="flex flex-col gap-5 px-4 pb-12 pt-6">

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/page.tsx
@@ -94,7 +94,7 @@ export default async function RecipientResourcePage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl bg-surface">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/recursos/${resourceId}`} />
         <PageHeading title={resource.name} />
         <div className="flex flex-col gap-5 px-4 pb-12 pt-5 lg:gap-6 lg:px-8">
           <PublicResourceCard

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/page.tsx
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/page.tsx
@@ -49,6 +49,7 @@ export default async function ReportarEstadoPage({ params }: Props) {
           variant="action"
           slug={slug}
           backHref={`/e/${slug}/recursos/${resourceId}`}
+          currentPath={`/e/${slug}/recursos/${resourceId}/reportar-estado`}
         />
         <PageHeading title={t.reportar_validez.page_title} subtitle={emergency.name} />
         <div className="flex flex-col gap-6 px-5 pb-12 pt-6 lg:px-8">

--- a/apps/web/src/app/e/[slug]/registrar/page.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/page.tsx
@@ -48,7 +48,7 @@ export default async function RegistrarPage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/registrar`} />
         <PageHeading
           title={t.registrar.page_title}
           subtitle={t.registrar.page_subtitle.replace('{emergencyName}', emergency.name)}

--- a/apps/web/src/app/e/[slug]/reportar/page.tsx
+++ b/apps/web/src/app/e/[slug]/reportar/page.tsx
@@ -72,7 +72,7 @@ export default async function ReportarPage({ params, searchParams }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/reportar`} />
         <PageHeading title={t.reportar.page_title} subtitle={emergency.name} />
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">
           <Card className="p-5 lg:p-7">

--- a/apps/web/src/app/e/[slug]/voluntario/page.tsx
+++ b/apps/web/src/app/e/[slug]/voluntario/page.tsx
@@ -63,7 +63,7 @@ export default async function VoluntarioPage({ params }: Props) {
   return (
     <main className="flex-1 bg-surface">
       <div className="mx-auto w-full max-w-3xl">
-        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} />
+        <AppBar variant="action" slug={slug} backHref={`/e/${slug}`} currentPath={`/e/${slug}/voluntario`} />
         <PageHeading
           title={t.voluntario.page_title}
           subtitle={t.voluntario.page_subtitle.replace('{emergencyName}', emergency.name)}

--- a/apps/web/src/app/funcionalidades/page.tsx
+++ b/apps/web/src/app/funcionalidades/page.tsx
@@ -42,6 +42,7 @@ export default async function FeaturesPage() {
         lead={f.lead}
         illustration={<CoordinationIllustration className="w-full" />}
         cta={{ heading: f.cta_heading, body: f.cta_body, label: f.cta_button, href: '/#emergencias' }}
+        currentPath="/funcionalidades"
       >
         {f.sections.map((s) => (
           <ContentSection key={s.heading} heading={s.heading}>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -24,7 +24,7 @@ export default async function LoginPage({ searchParams }: Props) {
 
   return (
     <main className="flex-1 bg-surface">
-      <AppBar variant="content" />
+      <AppBar variant="content" currentPath="/login" />
 
       <div className="mx-auto w-full max-w-3xl">
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -23,7 +23,7 @@ export default async function SignupPage({ searchParams }: Props) {
 
   return (
     <main className="flex-1 bg-surface">
-      <AppBar variant="content" />
+      <AppBar variant="content" currentPath="/signup" />
 
       <div className="mx-auto w-full max-w-3xl">
         <div className="flex flex-col gap-8 px-5 pb-12 pt-6 lg:px-8">

--- a/apps/web/src/app/sobre/page.tsx
+++ b/apps/web/src/app/sobre/page.tsx
@@ -39,6 +39,7 @@ export default async function AboutPage() {
       lead={a.lead}
       illustration={<CoordinationIllustration className="w-full" />}
       cta={{ heading: a.cta_heading, body: a.cta_body, label: a.cta_button, href: '/#emergencias' }}
+      currentPath="/sobre"
     >
       <div className="grid grid-cols-3 gap-3">
         {stats.map((s) => (

--- a/apps/web/src/app/transparencia/page.tsx
+++ b/apps/web/src/app/transparencia/page.tsx
@@ -39,6 +39,7 @@ export default async function TransparencyPage() {
       lead={tr.lead}
       illustration={<ShieldIllustration className="w-full" />}
       cta={{ heading: tr.cta_heading, body: tr.cta_body, label: tr.cta_button, href: GITHUB, external: true }}
+      currentPath="/transparencia"
     >
       <ContentSection heading={tr.verify_heading}>{tr.verify_body}</ContentSection>
       <ContentSection heading={tr.data_heading}>{tr.data_body}</ContentSection>

--- a/apps/web/src/app/verificar/page.tsx
+++ b/apps/web/src/app/verificar/page.tsx
@@ -40,6 +40,7 @@ export default async function VerifyPage() {
       lead={v.lead}
       illustration={<VerifyIllustration className="w-full" />}
       cta={{ heading: v.cta_heading, body: v.cta_body, label: v.cta_button, href: '/#emergencias' }}
+      currentPath="/verificar"
     >
       <ContentSection heading={v.levels_heading}>
         <div className="mt-1 grid gap-3 sm:grid-cols-3">

--- a/apps/web/src/components/organisms/app-bar.tsx
+++ b/apps/web/src/components/organisms/app-bar.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { api } from '@/lib/api';
 import { getToken, authHeaders, loginHref as buildLoginHref } from '@/lib/auth';
+import { resolveAppBarCurrentPath } from '@/lib/app-bar-context';
 import { getT } from '@/i18n/server';
 import { BrandLogo } from '@/components/molecules/brand-logo';
 import { LanguageSwitcher } from '@/components/molecules/language-switcher';
@@ -17,6 +18,13 @@ interface AppBarProps {
   slug?: string;
   emergency?: { name: string; status: 'active' | 'paused' | 'closed' };
   backHref?: string;
+  /**
+   * Exact route the page is rendered at, used to build the login `next`
+   * param so "Iniciar sesión" returns here instead of collapsing to the
+   * emergency/site root (#278). Optional for backward compatibility; pages
+   * that don't pass it keep the previous (imprecise) fallback behavior.
+   */
+  currentPath?: string;
 }
 
 const STATUS_DOT: Record<'active' | 'paused' | 'closed', string> = {
@@ -25,7 +33,7 @@ const STATUS_DOT: Record<'active' | 'paused' | 'closed', string> = {
   closed: 'bg-white/50',
 };
 
-export async function AppBar({ variant, slug, emergency, backHref }: AppBarProps) {
+export async function AppBar({ variant, slug, emergency, backHref, currentPath }: AppBarProps) {
   const { t } = await getT();
   const ta = t.appbar;
   const token = await getToken();
@@ -43,8 +51,7 @@ export async function AppBar({ variant, slug, emergency, backHref }: AppBarProps
     if (notifRes.data != null) unreadCount = notifRes.data.unreadCount;
   }
 
-  const currentPath = slug != null ? `/e/${slug}` : '/';
-  const loginHref = buildLoginHref(currentPath);
+  const loginHref = buildLoginHref(resolveAppBarCurrentPath(slug, currentPath));
 
   const infoLinks: PublicLink[] = [
     { href: '/como-funciona', label: ta.how_it_works },

--- a/apps/web/src/components/organisms/content-page.tsx
+++ b/apps/web/src/components/organisms/content-page.tsx
@@ -17,12 +17,14 @@ interface ContentPageProps {
   illustration: ReactNode;
   children: ReactNode;
   cta: Cta;
+  /** Exact route this page is rendered at — see AppBarProps.currentPath (#278). */
+  currentPath?: string;
 }
 
-export async function ContentPage({ overline, h1, lead, illustration, children, cta }: ContentPageProps) {
+export async function ContentPage({ overline, h1, lead, illustration, children, cta, currentPath }: ContentPageProps) {
   return (
     <main className="flex-1 bg-surface">
-      <AppBar variant="content" />
+      <AppBar variant="content" currentPath={currentPath} />
 
       <div className="mx-auto w-full max-w-3xl bg-surface">
         <article className="px-5 pb-16 pt-8 lg:px-8 lg:pt-10">

--- a/apps/web/src/lib/app-bar-context.test.ts
+++ b/apps/web/src/lib/app-bar-context.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { emergencyAccountLinks } from './app-bar-context.ts';
+import { emergencyAccountLinks, resolveAppBarCurrentPath } from './app-bar-context.ts';
 
 test('sin slug no hay enlaces de emergencia', () => {
   assert.deepEqual(emergencyAccountLinks(undefined), []);
@@ -21,4 +21,21 @@ test('con slug devuelve los 3 enlaces contextuales', () => {
     links.map((l) => l.labelKey),
     ['my_points', 'my_volunteering', 'my_shipments'],
   );
+});
+
+// #278: el `next` del login desde sub-páginas (ej. `/e/:slug/registrar`) debe
+// apuntar a la página exacta, no colapsar a la raíz de la emergencia.
+test('con currentPath explícito, se usa tal cual (página exacta)', () => {
+  assert.equal(
+    resolveAppBarCurrentPath('terremoto-venezuela-2026', '/e/terremoto-venezuela-2026/registrar'),
+    '/e/terremoto-venezuela-2026/registrar',
+  );
+});
+
+test('sin currentPath pero con slug, cae a la raíz de la emergencia', () => {
+  assert.equal(resolveAppBarCurrentPath('terremoto-venezuela-2026', undefined), '/e/terremoto-venezuela-2026');
+});
+
+test('sin currentPath ni slug, cae a la raíz del sitio', () => {
+  assert.equal(resolveAppBarCurrentPath(undefined, undefined), '/');
 });

--- a/apps/web/src/lib/app-bar-context.ts
+++ b/apps/web/src/lib/app-bar-context.ts
@@ -11,3 +11,19 @@ export function emergencyAccountLinks(slug: string | undefined): AccountLink[] {
     { href: `/e/${slug}/mis-expediciones`, labelKey: 'my_shipments' },
   ];
 }
+
+/**
+ * Resolves the exact path AppBar's login link should send the user back to
+ * (built into `?next=` via `loginHref`). Pages on an emergency subpage (e.g.
+ * `/e/:slug/registrar`) must pass their own `currentPath` explicitly; without
+ * it, this falls back to the emergency root (`/e/:slug`) or the site root
+ * (`/`) — imprecise but not wrong, so it stays a safe default for callers that
+ * don't (yet) pass one.
+ *
+ * Fixes #278: clicking "Iniciar sesión" from a sub-página used to always land
+ * back on the emergency home instead of the exact page the user was on.
+ */
+export function resolveAppBarCurrentPath(slug: string | undefined, currentPath: string | undefined): string {
+  if (currentPath !== undefined) return currentPath;
+  return slug !== undefined ? `/e/${slug}` : '/';
+}


### PR DESCRIPTION
Closes #278

## Problema
`AppBar` construía el `next` del login como `/e/{slug}` o `/`, perdiendo la sub-página exacta (`/registrar`, `/peticion`, `/como-funciona`, etc.).

## Solución
Se evaluó exponer el pathname vía `proxy.ts`, pero su matcher está deliberadamente acotado a segmentos totalmente protegidos (`/dashboard`, `/admin`, `/organizations`, `/panel`, `/emergencies/:slug/manage`) — ampliarlo solo para este caso mezclaría responsabilidades y añadiría overhead de edge function a cada request. En su lugar: `AppBar` acepta un prop opcional `currentPath`; cada página que lo requiere lo pasa explícitamente (nuevo helper puro `resolveAppBarCurrentPath` en `app-bar-context.ts`). Sin el prop, se mantiene el comportamiento anterior (fallback), por lo que no hay regresión silenciosa.

Se actualizaron ~24 páginas para pasar su ruta exacta.

## Tests
TDD: casos añadidos primero en `app-bar-context.test.ts`. `pnpm --filter web test`: 92/92. Build y lint limpios.