### PR TITLE
fix(web): errores de formulario accionables — fila inválida + mensajes 4xx localizados (#296)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ apps/api/uploads/
 
 # Entorno local personal (scripts, seeds, docker extra) — no subir al repo
 .local/
+
+# Local git worktrees for parallel agent work — never commit
+.worktrees/

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
@@ -3,6 +3,7 @@
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
+import { localizeBackendError } from '@/lib/backend-error-messages';
 import { getT } from '@/i18n/server';
 import { getCategories } from '@/adapters/get-categories';
 import { isMaterialCategory } from '@/domain/supplies/category';
@@ -141,14 +142,14 @@ export async function submitOffer(
   }
 
   if (error !== undefined || data === undefined) {
-    const msg =
-      typeof error === 'object' &&
-      error !== null &&
-      'message' in error &&
-      typeof (error as { message: unknown }).message === 'string'
-        ? (error as { message: string }).message
-        : t.donar.err_submit_failed;
-    return { status: 'error', message: msg };
+    const rawMessage =
+      typeof error === 'object' && error !== null && 'message' in error
+        ? (error as { message: unknown }).message
+        : undefined;
+    return {
+      status: 'error',
+      message: localizeBackendError(t.backendErrors, rawMessage, t.donar.err_submit_failed),
+    };
   }
 
   return { status: 'success', id: data.id };

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/actions.ts
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/actions.ts
@@ -14,7 +14,7 @@ type SupplyLineView = components['schemas']['SupplyLineResponseDto'];
 export type InventoryState =
   | { status: 'idle' }
   | { status: 'success' }
-  | { status: 'error'; message: string };
+  | { status: 'error'; message: string; invalidRow?: number };
 
 /** Owner/coordinator read of the point's full declared lines (null → notFound). */
 export async function fetchMyInventory(
@@ -63,13 +63,25 @@ export async function saveMyInventory(
   );
 
   // allowEmpty: the owner can clear the inventory (empty list is a valid save).
-  const items = parseSupplyLines(formData.get('items'), {
+  const parsedItems = parseSupplyLines(formData.get('items'), {
     isValidCategory: (c) => validCategories.has(c),
     allowEmpty: true,
   });
-  if (items === null) {
-    return { status: 'error', message: t.account.inventory_invalid_items };
+  if ('invalidRow' in parsedItems) {
+    // invalidRow >= 0 means a specific row failed validation (#296): surface
+    // its 1-based position and let the caller highlight that row instead of
+    // making the owner hunt through a long inventory for the bad line.
+    const { invalidRow } = parsedItems;
+    return {
+      status: 'error',
+      message:
+        invalidRow >= 0
+          ? t.account.inventory_invalid_row.replace('{n}', String(invalidRow + 1))
+          : t.account.inventory_invalid_items,
+      ...(invalidRow >= 0 ? { invalidRow } : {}),
+    };
   }
+  const { items } = parsedItems;
 
   const { response } = await api.PUT('/resources/{resourceId}/inventory', {
     params: { path: { resourceId } },

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/inventory-edit-form.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/inventory-edit-form.tsx
@@ -70,6 +70,7 @@ export function InventoryEditForm({
         initialLines={initial.map(toLine)}
         strict
         allowAllCategories
+        invalidRowIndex={state.status === 'error' ? state.invalidRow : undefined}
       />
 
       <Button type="submit" disabled={pending} fullWidth>

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
@@ -3,6 +3,7 @@
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
+import { localizeBackendError } from '@/lib/backend-error-messages';
 import { getT } from '@/i18n/server';
 
 type CapacityMode = components['schemas']['PublishCapacityDto']['mode'];
@@ -142,14 +143,14 @@ export async function submitCapacity(
   }
 
   if (error !== undefined || data === undefined) {
-    const msg =
-      typeof error === 'object' &&
-      error !== null &&
-      'message' in error &&
-      typeof (error as { message: unknown }).message === 'string'
-        ? (error as { message: string }).message
-        : tt.err_submit_failed;
-    return { status: 'error', message: msg };
+    const rawMessage =
+      typeof error === 'object' && error !== null && 'message' in error
+        ? (error as { message: unknown }).message
+        : undefined;
+    return {
+      status: 'error',
+      message: localizeBackendError(t.backendErrors, rawMessage, tt.err_submit_failed),
+    };
   }
 
   return { status: 'success', id: data.id };

--- a/apps/web/src/app/e/[slug]/peticion/actions.ts
+++ b/apps/web/src/app/e/[slug]/peticion/actions.ts
@@ -84,16 +84,17 @@ export async function submitPeticion(
   // medical_personnel, which getCategories returns alongside material slugs).
   const validCategories = new Set((await getCategories(locale)).map((c) => c.slug));
 
-  const items = parseSupplyLines(rawItems, {
+  const parsedItems = parseSupplyLines(rawItems, {
     isValidCategory: (c) => validCategories.has(c),
     allowEmpty: false,
   });
-  if (items === null) {
+  if ('invalidRow' in parsedItems) {
     return {
       status: 'error',
       message: t.peticion.err_invalid_items,
     };
   }
+  const { items } = parsedItems;
 
   const description =
     typeof rawDescription === 'string' && rawDescription.trim() !== ''

--- a/apps/web/src/app/e/[slug]/peticion/actions.ts
+++ b/apps/web/src/app/e/[slug]/peticion/actions.ts
@@ -4,6 +4,7 @@ import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { parseSupplyLines } from '@/lib/supply-lines';
+import { localizeBackendError } from '@/lib/backend-error-messages';
 import { getT } from '@/i18n/server';
 import { getCategories } from '@/adapters/get-categories';
 
@@ -135,14 +136,14 @@ export async function submitPeticion(
   }
 
   if (error !== undefined || data === undefined) {
-    const msg =
-      typeof error === 'object' &&
-      error !== null &&
-      'message' in error &&
-      typeof (error as { message: unknown }).message === 'string'
-        ? (error as { message: string }).message
-        : t.peticion.err_submit_failed;
-    return { status: 'error', message: msg };
+    const rawMessage =
+      typeof error === 'object' && error !== null && 'message' in error
+        ? (error as { message: unknown }).message
+        : undefined;
+    return {
+      status: 'error',
+      message: localizeBackendError(t.backendErrors, rawMessage, t.peticion.err_submit_failed),
+    };
   }
 
   return { status: 'success', id: data.id };

--- a/apps/web/src/app/e/[slug]/pre-registro/actions.ts
+++ b/apps/web/src/app/e/[slug]/pre-registro/actions.ts
@@ -70,13 +70,14 @@ export async function submitPreRegistration(
     (await getCategories(locale)).filter(isMaterialCategory).map((c) => c.slug),
   );
 
-  const items = parseSupplyLines(formData.get('items'), {
+  const parsedItems = parseSupplyLines(formData.get('items'), {
     isValidCategory: (c) => validMaterialCategories.has(c),
     allowEmpty: true,
   });
-  if (items === null) {
+  if ('invalidRow' in parsedItems) {
     return { status: 'error', message: tp.err_invalid_items };
   }
+  const { items } = parsedItems;
   if (items.length < 1) {
     return { status: 'error', message: tp.err_items_required };
   }

--- a/apps/web/src/app/e/[slug]/recepcion/actions.ts
+++ b/apps/web/src/app/e/[slug]/recepcion/actions.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
+import type { components } from '@reliefhub/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { parseSupplyLines } from '@/lib/supply-lines';
@@ -49,19 +50,20 @@ export async function submitReception(
   // Received lines edited at the desk (#129): only sent with `receive`. Reuse
   // the shared parser with material-only category validation; an empty/absent
   // list means "no edit" → keep the declared lines (items stays undefined).
-  let items: ReturnType<typeof parseSupplyLines> | undefined;
+  let items: components['schemas']['SupplyLineDto'][] | undefined;
   let adjustmentReason: string | null = null;
   if (intent === 'receive') {
     const validMaterialCategories = new Set(
       (await getCategories(locale)).filter(isMaterialCategory).map((c) => c.slug),
     );
-    items = parseSupplyLines(formData.get('items'), {
+    const parsedItems = parseSupplyLines(formData.get('items'), {
       isValidCategory: (c) => validMaterialCategories.has(c),
       allowEmpty: true,
     });
-    if (items === null) {
+    if ('invalidRow' in parsedItems) {
       return { status: 'error', message: tr.err_action_failed };
     }
+    items = parsedItems.items;
     const rawReason = formData.get('adjustmentReason');
     adjustmentReason =
       typeof rawReason === 'string' && rawReason.trim() !== ''

--- a/apps/web/src/app/e/[slug]/registrar/actions.ts
+++ b/apps/web/src/app/e/[slug]/registrar/actions.ts
@@ -84,13 +84,14 @@ export async function registerResource(
     (await getCategories(locale)).filter(isMaterialCategory).map((c) => c.slug),
   );
 
-  const items = parseSupplyLines(formData.get('items'), {
+  const parsedItems = parseSupplyLines(formData.get('items'), {
     isValidCategory: (c) => validMaterialCategories.has(c),
     allowEmpty: true,
   });
-  if (items === null) {
+  if ('invalidRow' in parsedItems) {
     return { status: 'error', message: t.registrar.err_invalid_items };
   }
+  const { items } = parsedItems;
 
   const { data, error, response } = await api.POST(
     '/emergencies/{emergencyId}/resources',

--- a/apps/web/src/app/e/[slug]/registrar/actions.ts
+++ b/apps/web/src/app/e/[slug]/registrar/actions.ts
@@ -4,6 +4,7 @@ import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { parseSupplyLines } from '@/lib/supply-lines';
+import { localizeBackendError } from '@/lib/backend-error-messages';
 import { getT } from '@/i18n/server';
 import { getCategories } from '@/adapters/get-categories';
 import { isMaterialCategory } from '@/domain/supplies/category';
@@ -121,14 +122,18 @@ export async function registerResource(
   }
 
   if (error !== undefined || data === undefined) {
-    const msg =
-      typeof error === 'object' &&
-      error !== null &&
-      'message' in error &&
-      typeof (error as { message: unknown }).message === 'string'
-        ? (error as { message: string }).message
-        : t.registrar.err_register_failed;
-    return { status: 'error', message: msg };
+    const rawMessage =
+      typeof error === 'object' && error !== null && 'message' in error
+        ? (error as { message: unknown }).message
+        : undefined;
+    return {
+      status: 'error',
+      message: localizeBackendError(
+        t.backendErrors,
+        rawMessage,
+        t.registrar.err_register_failed,
+      ),
+    };
   }
 
   return { status: 'success', id: data.id };

--- a/apps/web/src/app/e/[slug]/registrar/inventory-field.tsx
+++ b/apps/web/src/app/e/[slug]/registrar/inventory-field.tsx
@@ -61,6 +61,13 @@ interface InventoryFieldProps {
    * not create.
    */
   allowAllCategories?: boolean;
+  /**
+   * Index of the row the last submit's server-side validation error points at
+   * (#296) — surfaced by `strict` surfaces via `parseSupplyLines`' `invalidRow`
+   * so the offending row is highlighted instead of making the user scan a long
+   * inventory for it.
+   */
+  invalidRowIndex?: number;
 }
 
 /**
@@ -78,6 +85,7 @@ export function InventoryField({
   initialLines,
   strict = false,
   allowAllCategories = false,
+  invalidRowIndex,
 }: InventoryFieldProps) {
   const materialCategories = categories.filter(isMaterialCategory);
   const selectableCategories = allowAllCategories ? categories : materialCategories;
@@ -128,6 +136,7 @@ export function InventoryField({
         defaultCategory={defaultCategory}
         showExpiry
         labels={labels}
+        invalidIndex={invalidRowIndex}
       />
 
       {/* Hidden input carries serialized items to the server action */}

--- a/apps/web/src/app/e/[slug]/voluntario/actions.ts
+++ b/apps/web/src/app/e/[slug]/voluntario/actions.ts
@@ -3,6 +3,7 @@
 import { api } from '@/lib/api';
 import type { components } from '@reliefhub/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
+import { localizeBackendError } from '@/lib/backend-error-messages';
 import { getT } from '@/i18n/server';
 
 type Skill = components['schemas']['RegisterVolunteerDto']['skills'][number];
@@ -121,14 +122,18 @@ export async function registerVolunteer(
   }
 
   if (error !== undefined || data === undefined) {
-    const msg =
-      typeof error === 'object' &&
-      error !== null &&
-      'message' in error &&
-      typeof (error as { message: unknown }).message === 'string'
-        ? (error as { message: string }).message
-        : t.voluntario.err_register_failed;
-    return { status: 'error', message: msg };
+    const rawMessage =
+      typeof error === 'object' && error !== null && 'message' in error
+        ? (error as { message: unknown }).message
+        : undefined;
+    return {
+      status: 'error',
+      message: localizeBackendError(
+        t.backendErrors,
+        rawMessage,
+        t.voluntario.err_register_failed,
+      ),
+    };
   }
 
   return { status: 'success' };

--- a/apps/web/src/components/molecules/supply-line-fields.tsx
+++ b/apps/web/src/components/molecules/supply-line-fields.tsx
@@ -45,11 +45,18 @@ interface SupplyLineFieldsProps {
   labels?: Partial<Messages['supplyLine']>;
   showExpiry?: boolean;
   hideHeader?: boolean;
+  /**
+   * Marks this row as the one a server-side validation error points at (#296,
+   * e.g. `parseSupplyLines`' `invalidRow`) so the user can find it in a long
+   * list instead of getting only a generic "something in here is wrong".
+   */
+  invalid?: boolean;
 }
 
 export function SupplyLineFields({
   idPrefix, rowId, index, required, removable, categories, locale,
   value, onChange, onRemove, labels, showExpiry = false, hideHeader = false,
+  invalid = false,
 }: SupplyLineFieldsProps) {
   const t = { ...getMessages(locale).supplyLine, ...labels };
   const n = String(index + 1);
@@ -71,7 +78,10 @@ export function SupplyLineFields({
     'w-full rounded-lg border-2 border-navy bg-white px-4 py-3 text-base text-ink focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2';
 
   return (
-    <div className="rounded-lg border-2 border-line p-4">
+    <div
+      className={`rounded-lg border-2 p-4 ${invalid ? 'border-danger' : 'border-line'}`}
+      aria-invalid={invalid || undefined}
+    >
       <div className="flex flex-col gap-3">
         {!hideHeader && (
           <div className="flex items-center justify-between">
@@ -89,6 +99,12 @@ export function SupplyLineFields({
               </button>
             )}
           </div>
+        )}
+
+        {invalid && (
+          <p role="alert" className="text-sm font-medium text-danger">
+            {t.invalidRowHint}
+          </p>
         )}
 
         <div className="flex flex-col gap-1.5">

--- a/apps/web/src/components/organisms/supply-line-list.tsx
+++ b/apps/web/src/components/organisms/supply-line-list.tsx
@@ -16,11 +16,13 @@ interface SupplyLineListProps {
   defaultCategory: string;
   showExpiry?: boolean;
   labels?: Partial<Messages['supplyLine']>;
+  /** Index of the row a server-side validation error points at (#296). */
+  invalidIndex?: number;
 }
 
 export function SupplyLineList({
   value, onChange, categories, locale, idPrefix, required,
-  defaultCategory, showExpiry = false, labels,
+  defaultCategory, showExpiry = false, labels, invalidIndex,
 }: SupplyLineListProps) {
   const t = { ...getMessages(locale).supplyLine, ...labels };
 
@@ -56,6 +58,7 @@ export function SupplyLineList({
             onRemove={() => remove(index)}
             showExpiry={showExpiry}
             labels={labels}
+            invalid={index === invalidIndex}
           />
         ))
       )}

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -53,6 +53,24 @@ export const en = {
     intake_paused: 'Intake is paused for this emergency. Please try again later.',
   },
 
+  // Localized copy for raw 4xx domain-error messages (#296) — see es.ts.
+  backendErrors: {
+    resource_not_in_emergency: 'The linked resource no longer exists in this emergency.',
+    supply_name_required: 'Every material needs a name.',
+    supply_quantity_invalid: 'Quantity must be a whole number greater than zero.',
+    supply_expiry_invalid: 'The expiry date must use the YYYY-MM-DD format.',
+    target_need_not_found: 'The selected need no longer exists.',
+    target_need_wrong_emergency: 'The selected need does not belong to this emergency.',
+    offer_items_required: 'The offer must include at least one material.',
+    capacity_weight_or_volume_required: 'State the weight or the volume of the capacity.',
+    capacity_amount_invalid: 'Weight and volume must be greater than zero.',
+    coverage_area_required: 'The coverage area cannot be empty.',
+    capacity_window_invalid_date: 'The availability window date is not valid.',
+    capacity_window_order_invalid:
+      'The window start date cannot be after the end date.',
+    generic: 'Could not complete the request. Please try again.',
+  },
+
   appbar: {
     login: 'Log in',
     offer: 'Offer help',
@@ -715,6 +733,7 @@ export const en = {
     addItem: 'Add item',
     emptyList: 'No items yet.',
     legend: 'Items',
+    invalidRowHint: 'Check this row: it is incomplete or invalid.',
   },
 
   // ── Citizen delivery pre-registration (#130) ──────────────────────────────
@@ -1711,6 +1730,8 @@ export const en = {
     inventory_update_failed: 'Could not save the inventory.',
     inventory_invalid_items:
       'Check the material: some lines are incomplete or invalid. Fill in the missing fields or remove the empty rows.',
+    inventory_invalid_row:
+      'Row {n} is incomplete or invalid. Complete it or remove it to save.',
 
     type_collection_point: 'Collection point',
     type_delivery_point: 'Delivery point',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -52,6 +52,29 @@ export const es = {
     intake_paused: 'El alta está en pausa en esta emergencia. Inténtalo más tarde.',
   },
 
+  // ── Backend error messages (#296) ───────────────────────────────────────
+  // Localized copy for raw 4xx domain-error messages the API returns as plain
+  // English text (no stable error-code contract — see the domain exception
+  // filters in apps/api). Matched by `src/lib/backend-error-messages.ts` and
+  // used as the fallback-safe replacement for `error.message` in server
+  // actions, instead of showing the backend's English text to the user.
+  backendErrors: {
+    resource_not_in_emergency: 'El punto vinculado ya no existe en esta emergencia.',
+    supply_name_required: 'Cada material necesita un nombre.',
+    supply_quantity_invalid: 'La cantidad debe ser un número entero mayor que cero.',
+    supply_expiry_invalid: 'La fecha de caducidad debe tener el formato AAAA-MM-DD.',
+    target_need_not_found: 'La necesidad seleccionada ya no existe.',
+    target_need_wrong_emergency: 'La necesidad seleccionada no pertenece a esta emergencia.',
+    offer_items_required: 'La oferta debe incluir al menos un material.',
+    capacity_weight_or_volume_required: 'Indica el peso o el volumen de la capacidad.',
+    capacity_amount_invalid: 'El peso y el volumen deben ser mayores que cero.',
+    coverage_area_required: 'El área de cobertura no puede estar vacía.',
+    capacity_window_invalid_date: 'La fecha de la ventana de disponibilidad no es válida.',
+    capacity_window_order_invalid:
+      'La fecha de inicio de la ventana no puede ser posterior a la de fin.',
+    generic: 'No se pudo completar la solicitud. Inténtalo de nuevo.',
+  },
+
   // ── AppBar ────────────────────────────────────────────────────────────────
   appbar: {
     login: 'Iniciar sesión',
@@ -742,6 +765,7 @@ export const es = {
     addItem: 'Añadir artículo',
     emptyList: 'Sin artículos todavía.',
     legend: 'Artículos',
+    invalidRowHint: 'Revisa esta fila: está incompleta o es inválida.',
   },
 
   // ── Pre-registro de entrega ciudadano (#130) ──────────────────────────────
@@ -1747,6 +1771,8 @@ export const es = {
     inventory_update_failed: 'No se pudo guardar el inventario.',
     inventory_invalid_items:
       'Revisa el material: hay líneas incompletas o inválidas. Completa los campos que falten o elimina las filas vacías.',
+    inventory_invalid_row:
+      'La fila {n} está incompleta o es inválida. Complétala o elimínala para poder guardar.',
 
     type_collection_point: 'Punto de recogida',
     type_delivery_point: 'Punto de entrega',

--- a/apps/web/src/lib/backend-error-messages.test.ts
+++ b/apps/web/src/lib/backend-error-messages.test.ts
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { localizeBackendError } from './backend-error-messages.ts';
+import { es } from '../i18n/messages/es.ts';
+
+const t = es.backendErrors;
+const FALLBACK = 'No se pudo enviar el formulario.';
+
+test('maps the "resource does not exist in this emergency" domain error (#296)', () => {
+  assert.equal(
+    localizeBackendError(
+      t,
+      'Resource 1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8 does not exist in this emergency',
+      FALLBACK,
+    ),
+    t.resource_not_in_emergency,
+  );
+});
+
+test('maps known SupplyLine validation messages', () => {
+  assert.equal(
+    localizeBackendError(t, 'SupplyLine name must not be empty', FALLBACK),
+    t.supply_name_required,
+  );
+  assert.equal(
+    localizeBackendError(t, 'SupplyLine quantity must be a positive integer', FALLBACK),
+    t.supply_quantity_invalid,
+  );
+  assert.equal(
+    localizeBackendError(
+      t,
+      'SupplyLine expiresAt must be a valid YYYY-MM-DD date',
+      FALLBACK,
+    ),
+    t.supply_expiry_invalid,
+  );
+});
+
+test('maps offer target-need domain errors', () => {
+  assert.equal(
+    localizeBackendError(
+      t,
+      'Target need not found: 1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8',
+      FALLBACK,
+    ),
+    t.target_need_not_found,
+  );
+  assert.equal(
+    localizeBackendError(
+      t,
+      "Target need '1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8' does not belong to emergency '2e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8'",
+      FALLBACK,
+    ),
+    t.target_need_wrong_emergency,
+  );
+});
+
+test('maps logistics capacity domain errors', () => {
+  assert.equal(
+    localizeBackendError(
+      t,
+      'Transport capacity must declare at least weightKg or volumeM3',
+      FALLBACK,
+    ),
+    t.capacity_weight_or_volume_required,
+  );
+  assert.equal(
+    localizeBackendError(t, 'Capacity weightKg must be greater than 0, got -3', FALLBACK),
+    t.capacity_amount_invalid,
+  );
+  assert.equal(
+    localizeBackendError(t, 'Area coverage must not be empty', FALLBACK),
+    t.coverage_area_required,
+  );
+  assert.equal(
+    localizeBackendError(
+      t,
+      "Capacity window from must be a valid ISO date, got 'nope'",
+      FALLBACK,
+    ),
+    t.capacity_window_invalid_date,
+  );
+  assert.equal(
+    localizeBackendError(
+      t,
+      "Capacity window 'from' (2026-01-02) must not be after 'to' (2026-01-01)",
+      FALLBACK,
+    ),
+    t.capacity_window_order_invalid,
+  );
+});
+
+test('falls back to the caller-provided message for anything unmapped', () => {
+  assert.equal(localizeBackendError(t, 'boom, something exploded', FALLBACK), FALLBACK);
+  assert.equal(localizeBackendError(t, undefined, FALLBACK), FALLBACK);
+  assert.equal(localizeBackendError(t, null, FALLBACK), FALLBACK);
+  assert.equal(localizeBackendError(t, '', FALLBACK), FALLBACK);
+  assert.equal(localizeBackendError(t, 42, FALLBACK), FALLBACK);
+});

--- a/apps/web/src/lib/backend-error-messages.ts
+++ b/apps/web/src/lib/backend-error-messages.ts
@@ -1,0 +1,68 @@
+import type { Messages } from '../i18n/messages/es.ts';
+
+type BackendErrorMessages = Messages['backendErrors'];
+
+/**
+ * Known backend domain-error messages (#296). The NestJS exception filters
+ * (`apps/api/src/contexts/*\/infrastructure/http/*-exception.filter.ts`) return
+ * `{ statusCode, message: exception.message }` with no stable error-code
+ * field — just the `Error`'s English text, sometimes with an id interpolated
+ * in the middle. So we match on a stable substring/prefix of each known
+ * message rather than the id-bearing parts.
+ *
+ * Order matters: the first matching pattern wins.
+ */
+const KNOWN_BACKEND_ERRORS: readonly {
+  pattern: RegExp;
+  key: keyof BackendErrorMessages;
+}[] = [
+  // needs / resources / offers — SupplyLineValidationError
+  { pattern: /^SupplyLine name must not be empty/, key: 'supply_name_required' },
+  {
+    pattern: /^SupplyLine quantity must be a positive integer/,
+    key: 'supply_quantity_invalid',
+  },
+  {
+    pattern: /^SupplyLine expiresAt must be a valid/,
+    key: 'supply_expiry_invalid',
+  },
+  // needs — NeedResourceNotInEmergencyError
+  { pattern: /does not exist in this emergency/, key: 'resource_not_in_emergency' },
+  // offers — TargetNeedNotFoundError / TargetNeedWrongEmergencyError
+  { pattern: /^Target need not found/, key: 'target_need_not_found' },
+  { pattern: /does not belong to emergency/, key: 'target_need_wrong_emergency' },
+  // offers — OfferItemsRequiredError
+  {
+    pattern: /^An offer must have at least one supply line/,
+    key: 'offer_items_required',
+  },
+  // logistics/capacities — TransportCapacity domain errors
+  {
+    pattern: /^Transport capacity must declare at least/,
+    key: 'capacity_weight_or_volume_required',
+  },
+  { pattern: /^Capacity \S+ must be greater than 0/, key: 'capacity_amount_invalid' },
+  { pattern: /^Area coverage must not be empty/, key: 'coverage_area_required' },
+  {
+    pattern: /^Capacity window \S+ must be a valid ISO date/,
+    key: 'capacity_window_invalid_date',
+  },
+  { pattern: /must not be after/, key: 'capacity_window_order_invalid' },
+];
+
+/**
+ * Map a raw backend error message to localized copy, so a form never shows
+ * English text (and stray UUIDs) straight from the API (#296). Returns
+ * `fallback` — the caller's existing generic "couldn't submit" message —
+ * for anything unmapped (including a missing/non-string message), so this
+ * is always safe to call with whatever `error.message` the typed client gives.
+ */
+export function localizeBackendError(
+  t: BackendErrorMessages,
+  message: unknown,
+  fallback: string,
+): string {
+  if (typeof message !== 'string' || message.trim() === '') return fallback;
+  const match = KNOWN_BACKEND_ERRORS.find((entry) => entry.pattern.test(message));
+  return match ? t[match.key] : fallback;
+}

--- a/apps/web/src/lib/supply-lines.test.ts
+++ b/apps/web/src/lib/supply-lines.test.ts
@@ -11,35 +11,35 @@ const isCat = (c: string) => ['food', 'water', 'hygiene'].includes(c);
 const REQUIRED = { isValidCategory: isCat, allowEmpty: false };
 const OPTIONAL = { isValidCategory: isCat, allowEmpty: true };
 
-test('absent payload: [] when allowEmpty, null when required', () => {
-  assert.deepEqual(parseSupplyLines('', OPTIONAL), []);
-  assert.deepEqual(parseSupplyLines('   ', OPTIONAL), []);
-  assert.deepEqual(parseSupplyLines(null, OPTIONAL), []);
-  assert.equal(parseSupplyLines('', REQUIRED), null);
-  assert.equal(parseSupplyLines(null, REQUIRED), null);
+test('absent payload: {items:[]} when allowEmpty, generic invalidRow when required', () => {
+  assert.deepEqual(parseSupplyLines('', OPTIONAL), { items: [] });
+  assert.deepEqual(parseSupplyLines('   ', OPTIONAL), { items: [] });
+  assert.deepEqual(parseSupplyLines(null, OPTIONAL), { items: [] });
+  assert.deepEqual(parseSupplyLines('', REQUIRED), { invalidRow: -1 });
+  assert.deepEqual(parseSupplyLines(null, REQUIRED), { invalidRow: -1 });
 });
 
 test('empty array respects allowEmpty', () => {
-  assert.deepEqual(parseSupplyLines('[]', OPTIONAL), []);
-  assert.equal(parseSupplyLines('[]', REQUIRED), null);
+  assert.deepEqual(parseSupplyLines('[]', OPTIONAL), { items: [] });
+  assert.deepEqual(parseSupplyLines('[]', REQUIRED), { invalidRow: -1 });
 });
 
 test('parses a well-formed line and trims name/unit', () => {
   const raw = JSON.stringify([
     { name: '  Agua  ', quantity: 5, unit: ' cajas ', category: 'water' },
   ]);
-  assert.deepEqual(parseSupplyLines(raw, REQUIRED), [
-    { name: 'Agua', quantity: 5, unit: 'cajas', category: 'water' },
-  ]);
+  assert.deepEqual(parseSupplyLines(raw, REQUIRED), {
+    items: [{ name: 'Agua', quantity: 5, unit: 'cajas', category: 'water' }],
+  });
 });
 
 test('omits a blank unit instead of sending an empty string', () => {
   const raw = JSON.stringify([
     { name: 'Arroz', quantity: 2, unit: '   ', category: 'food' },
   ]);
-  assert.deepEqual(parseSupplyLines(raw, REQUIRED), [
-    { name: 'Arroz', quantity: 2, category: 'food' },
-  ]);
+  assert.deepEqual(parseSupplyLines(raw, REQUIRED), {
+    items: [{ name: 'Arroz', quantity: 2, category: 'food' }],
+  });
 });
 
 test('preserves a soft supply link when present', () => {
@@ -51,71 +51,102 @@ test('preserves a soft supply link when present', () => {
       supplyId: ' 1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8 ',
     },
   ]);
-  assert.deepEqual(parseSupplyLines(raw, REQUIRED), [
-    {
-      name: 'Agua',
-      quantity: 12,
-      category: 'water',
-      supplyId: '1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8',
-    },
-  ]);
+  assert.deepEqual(parseSupplyLines(raw, REQUIRED), {
+    items: [
+      {
+        name: 'Agua',
+        quantity: 12,
+        category: 'water',
+        supplyId: '1e4b5f3b-5c9c-4f77-8f50-3d2dbdc0c7d8',
+      },
+    ],
+  });
 });
 
 test('preserves a trimmed presentation, omits it when blank (#61)', () => {
   const withPres = JSON.stringify([
     { name: 'Clindamicina', quantity: 5, category: 'food', presentation: '  EV (intravenoso)  ' },
   ]);
-  assert.deepEqual(parseSupplyLines(withPres, REQUIRED), [
-    { name: 'Clindamicina', quantity: 5, category: 'food', presentation: 'EV (intravenoso)' },
-  ]);
+  assert.deepEqual(parseSupplyLines(withPres, REQUIRED), {
+    items: [{ name: 'Clindamicina', quantity: 5, category: 'food', presentation: 'EV (intravenoso)' }],
+  });
 
   const blankPres = JSON.stringify([
     { name: 'Agua', quantity: 1, category: 'water', presentation: '   ' },
   ]);
-  assert.deepEqual(parseSupplyLines(blankPres, REQUIRED), [
-    { name: 'Agua', quantity: 1, category: 'water' },
-  ]);
+  assert.deepEqual(parseSupplyLines(blankPres, REQUIRED), {
+    items: [{ name: 'Agua', quantity: 1, category: 'water' }],
+  });
 });
 
 test('rejects a non-string presentation', () => {
-  assert.equal(
+  assert.deepEqual(
     parseSupplyLines(
       JSON.stringify([{ name: 'X', quantity: 1, category: 'food', presentation: 5 }]),
       REQUIRED,
     ),
-    null,
+    { invalidRow: 0 },
   );
 });
 
-test('returns null on malformed JSON or a non-array root', () => {
-  assert.equal(parseSupplyLines('{not json', REQUIRED), null);
-  assert.equal(parseSupplyLines('{"a":1}', REQUIRED), null);
+test('returns a generic (row-less) failure on malformed JSON or a non-array root', () => {
+  assert.deepEqual(parseSupplyLines('{not json', REQUIRED), { invalidRow: -1 });
+  assert.deepEqual(parseSupplyLines('{"a":1}', REQUIRED), { invalidRow: -1 });
 });
 
 test('rejects blank name, bad quantity, or invalid category', () => {
-  assert.equal(
+  assert.deepEqual(
     parseSupplyLines(
       JSON.stringify([{ name: ' ', quantity: 1, category: 'food' }]),
       REQUIRED,
     ),
-    null,
+    { invalidRow: 0 },
   );
   for (const q of [0, -1, 1.5, '2']) {
-    assert.equal(
+    assert.deepEqual(
       parseSupplyLines(
         JSON.stringify([{ name: 'X', quantity: q, category: 'food' }]),
         REQUIRED,
       ),
-      null,
+      { invalidRow: 0 },
       `quantity=${String(q)} should be rejected`,
     );
   }
-  assert.equal(
+  assert.deepEqual(
     parseSupplyLines(
       JSON.stringify([{ name: 'X', quantity: 1, category: 'weapons' }]),
       REQUIRED,
     ),
-    null,
+    { invalidRow: 0 },
+  );
+});
+
+test('identifies the first invalid row when it is not the only one (start, middle, end)', () => {
+  const good = { name: 'Agua', quantity: 1, category: 'water' };
+  const bad = { name: '', quantity: 1, category: 'water' };
+
+  // Invalid row is first.
+  assert.deepEqual(
+    parseSupplyLines(JSON.stringify([bad, good, good]), REQUIRED),
+    { invalidRow: 0 },
+  );
+
+  // Invalid row is in the middle.
+  assert.deepEqual(
+    parseSupplyLines(JSON.stringify([good, bad, good]), REQUIRED),
+    { invalidRow: 1 },
+  );
+
+  // Invalid row is last.
+  assert.deepEqual(
+    parseSupplyLines(JSON.stringify([good, good, bad]), REQUIRED),
+    { invalidRow: 2 },
+  );
+
+  // Only the FIRST invalid row is reported when several are bad.
+  assert.deepEqual(
+    parseSupplyLines(JSON.stringify([good, bad, bad]), REQUIRED),
+    { invalidRow: 1 },
   );
 });
 

--- a/apps/web/src/lib/supply-lines.ts
+++ b/apps/web/src/lib/supply-lines.ts
@@ -9,68 +9,78 @@ const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
+ * Result of {@link parseSupplyLines}: either the parsed items, or the index of
+ * the first invalid row so the caller can point the user at it (#296) instead
+ * of a generic "something in here is wrong". `invalidRow: -1` means the
+ * failure isn't tied to a specific row (malformed JSON, a non-array root, or
+ * a required-but-empty list) — callers should fall back to a generic message.
+ */
+export type ParsedSupplyLines = { items: SupplyLineDto[] } | { invalidRow: number };
+
+/**
  * Parse the supply lines serialized by a SupplyLine editor (a JSON array in a
- * hidden `items` input) into the typed request shape. Returns `null` on a
- * malformed/tampered payload so the caller can surface a validation error.
+ * hidden `items` input) into the typed request shape. Returns `{ invalidRow }`
+ * on a malformed/tampered payload so the caller can surface a validation error
+ * (and, when it's row-specific, highlight that row — #296).
  *
  * - `isValidCategory` narrows each category against the allowed catalogue for
  *   the caller's context (e.g. all categories for needs, material-only
  *   categories for offers/inventory) — sourced from the DB category taxonomy.
- * - `allowEmpty` decides whether an absent/empty list is valid (`[]`, e.g.
- *   optional resource inventory) or an error (`null`, e.g. a need needs ≥1 item).
+ * - `allowEmpty` decides whether an absent/empty list is valid (`{ items: [] }`,
+ *   e.g. optional resource inventory) or an error (e.g. a need needs ≥1 item).
  */
 export function parseSupplyLines(
   raw: FormDataEntryValue | null,
   opts: { isValidCategory: (c: string) => boolean; allowEmpty: boolean },
-): SupplyLineDto[] | null {
+): ParsedSupplyLines {
   if (typeof raw !== 'string' || raw.trim() === '') {
-    return opts.allowEmpty ? [] : null;
+    return opts.allowEmpty ? { items: [] } : { invalidRow: -1 };
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return null;
+    return { invalidRow: -1 };
   }
-  if (!Array.isArray(parsed)) return null;
-  if (parsed.length === 0) return opts.allowEmpty ? [] : null;
+  if (!Array.isArray(parsed)) return { invalidRow: -1 };
+  if (parsed.length === 0) return opts.allowEmpty ? { items: [] } : { invalidRow: -1 };
 
   const items: SupplyLineDto[] = [];
-  for (const entry of parsed) {
-    if (typeof entry !== 'object' || entry === null) return null;
+  for (const [index, entry] of parsed.entries()) {
+    if (typeof entry !== 'object' || entry === null) return { invalidRow: index };
     const { name, quantity, unit, category, supplyId, presentation, expiresAt } =
       entry as Record<string, unknown>;
-    if (typeof name !== 'string' || name.trim() === '') return null;
+    if (typeof name !== 'string' || name.trim() === '') return { invalidRow: index };
     if (
       typeof quantity !== 'number' ||
       !Number.isInteger(quantity) ||
       quantity < 1
     ) {
-      return null;
+      return { invalidRow: index };
     }
     if (typeof category !== 'string' || !opts.isValidCategory(category)) {
-      return null;
+      return { invalidRow: index };
     }
     if (
       expiresAt !== undefined &&
       expiresAt !== null &&
       (typeof expiresAt !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(expiresAt))
     ) {
-      return null;
+      return { invalidRow: index };
     }
     if (
       supplyId !== undefined &&
       supplyId !== null &&
       (typeof supplyId !== 'string' || !UUID_RE.test(supplyId.trim()))
     ) {
-      return null;
+      return { invalidRow: index };
     }
     if (
       presentation !== undefined &&
       presentation !== null &&
       typeof presentation !== 'string'
     ) {
-      return null;
+      return { invalidRow: index };
     }
     // Validation (above) is the untrusted-input boundary; assembly/trim/drop-empty
     // is shared with the editor path via buildSupplyLineDto so the shape can't drift.
@@ -86,7 +96,7 @@ export function parseSupplyLines(
       }),
     );
   }
-  return items;
+  return { items };
 }
 
 /** Short title for a list of supply lines: the first name, "+N" when more. */


### PR DESCRIPTION
Closes #296

## Parte 1 — fila inválida en `parseSupplyLines`
`parseSupplyLines` devuelve ahora `{ items } | { invalidRow: number }` en vez de `T[] | null`, identificando la primera fila inválida. Se propaga hasta `SupplyLineList`/`InventoryField` (resaltado de fila) y al flujo estricto de edición de inventario (#263), con nuevo mensaje localizado `account.inventory_invalid_row`. Los otros 4 consumidores de `parseSupplyLines` se actualizaron al nuevo tipo pero mantienen su mensaje genérico (no se pidió resaltado ahí).

## Parte 2 — mensajes 4xx localizados
Nuevo helper `localizeBackendError` (`backend-error-messages.ts`) que mapea mensajes de error conocidos del backend (`NeedResourceNotInEmergencyError`, `SupplyLineValidationError`, errores de `offers` y `logistics`) a copy en español, con fallback genérico. Cableado en las 5 server actions con el patrón de reenvío crudo encontradas en todo el repo (`peticion`, `registrar`, `voluntario`, `donar/ofrecer`, `ofrecer-transporte`) — el issue estimaba "≥6", pero un grep completo del repo solo encontró 5 con ese patrón exacto; el resto de `actions.ts` bajo `e/[slug]` ya devuelven mensajes pre-localizados.

## Tests
TDD en ambas partes (tests añadidos primero). `pnpm --filter web test`: 95/95. Build y lint limpios.