### PR TITLE
feat(auth): Facebook auto-vincula por email a cuentas sociales existentes

### DIFF
--- a/apps/api/src/contexts/identity/infrastructure/http/facebook.strategy.ts
+++ b/apps/api/src/contexts/identity/infrastructure/http/facebook.strategy.ts
@@ -64,17 +64,18 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
         .join(' ') ||
       email;
 
-    // SECURITY: passport-facebook does not expose a per-email verification
-    // flag, so we cannot assert the provider verified ownership of this email.
-    // We therefore treat Facebook emails as unverified: the identity can still
-    // create a brand-new account or reuse its own prior link, but it can never
-    // auto-unify into a pre-existing account by email match (takeover vector).
+    // Facebook's Graph API only returns an `email` the user has CONFIRMED on
+    // their Facebook account (unconfirmed emails are never returned), so a
+    // returned email is effectively provider-verified. We mark it verified to
+    // allow auto-linking to an existing social-only account by email match.
+    // Note: password-backed accounts are still protected — AuthenticateWithProvider
+    // raises AccountLinkRequiresAuthError for those regardless of this flag.
     return this.authenticateWithProvider.execute({
       provider: AuthProvider.Facebook,
       providerUserId: profile.id,
       email,
       name,
-      emailVerified: false,
+      emailVerified: true,
     });
   }
 }


### PR DESCRIPTION
Elegido: auto-vincular. Facebook solo devuelve emails confirmados → se marca `emailVerified: true` para vincular a una cuenta social-only existente (evita el `UnverifiedProviderEmailError` que bloqueaba el login a usuarios con email ya registrado vía Google). Cuentas con contraseña siguen requiriendo vinculación manual. Gate: build + eslint + prettier + 24 tests.