### PR TITLE
refactor(web): migrar copias de botón-enlace secundario al átomo LinkButton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ apps/api/uploads/
 
 # Entorno local personal (scripts, seeds, docker extra) — no subir al repo
 .local/
+
+# Local git worktrees for parallel agent work — never commit
+.worktrees/

--- a/apps/api/test/oauth-csrf.e2e-spec.ts
+++ b/apps/api/test/oauth-csrf.e2e-spec.ts
@@ -5,8 +5,14 @@
  * real OAuth credentials. The strategies boot with placeholder clientIDs, so:
  *  - GET /auth/google → Passport issues a 302 redirect to accounts.google.com
  *    (we only care that the state cookie and query param are set).
- *  - GET /auth/google/callback?code=fake&state=WRONG → The callback guard MUST
- *    reject the request with 401 before Passport attempts a token exchange.
+ *  - GET /auth/google/callback?code=fake&state=WRONG → The callback guard
+ *    rejects the request with `UnauthorizedException` before Passport attempts
+ *    a token exchange. `OAuthController` catches ANY callback failure with
+ *    `OAuthExceptionFilter` (#340) and turns it into a friendly `302` redirect
+ *    to `${FRONTEND_URL}/login?error=oauth_failed` instead of a raw `401` —
+ *    deliberate, browser-facing behavior. What still matters for CSRF safety
+ *    is verified directly: the `rh_oauth_state` cookie is cleared/invalidated
+ *    and no `accessToken`/session is produced.
  *
  * No DB seeding is needed because these endpoints do not touch the database
  * before the state check. The invalid-state path is rejected in the guard.
@@ -18,6 +24,9 @@ import type { Server } from 'node:http';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
 import { DomainExceptionFilter } from '../src/contexts/resources/infrastructure/http/domain-exception.filter';
+
+/** Matches the `OAuthExceptionFilter` / `OAuthController` fallback default. */
+const FRONTEND_URL = 'http://localhost:3001';
 
 /**
  * Safely extract the Set-Cookie response header as a string array.
@@ -33,6 +42,38 @@ function getSetCookies(res: { headers: Record<string, unknown> }): string[] {
     return [raw];
   }
   return [];
+}
+
+/**
+ * Asserts that a rejected OAuth callback redirects the browser to the
+ * frontend's friendly failure page — the `OAuthExceptionFilter` behavior
+ * introduced by #340 — and never to the success path (which would carry an
+ * `accessToken`).
+ */
+function expectOAuthFailureRedirect(res: {
+  headers: Record<string, unknown>;
+}): void {
+  const location: unknown = res.headers['location'];
+  const locationStr = typeof location === 'string' ? location : '';
+  expect(locationStr).toBe(`${FRONTEND_URL}/login?error=oauth_failed`);
+  expect(locationStr).not.toContain('/auth/complete#token=');
+}
+
+/**
+ * Asserts that the `rh_oauth_state` CSRF cookie was invalidated in the
+ * response — `res.clearCookie` re-issues it with an empty value and an
+ * `Expires` date in the past — so a leaked/replayed state token cannot be
+ * reused after a rejected callback.
+ */
+function expectStateCookieCleared(res: {
+  headers: Record<string, unknown>;
+}): void {
+  const cookies = getSetCookies(res);
+  const stateCookie = cookies.find((c) => c.startsWith('rh_oauth_state='));
+
+  expect(stateCookie).toBeDefined();
+  expect(stateCookie).toMatch(/^rh_oauth_state=;/);
+  expect(stateCookie).toMatch(/Expires=Thu, 01 Jan 1970/);
 }
 
 describe('OAuth CSRF state protection (e2e)', () => {
@@ -88,27 +129,36 @@ describe('OAuth CSRF state protection (e2e)', () => {
   // ─── Google callback — invalid state ──────────────────────────────────────
 
   describe('GET /auth/google/callback (invalid state)', () => {
-    it('returns 401 when query state does not match cookie', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when query state does not match cookie', async () => {
+      const res = await request(server)
         .get('/auth/google/callback?code=fake&state=WRONG')
         .set('Cookie', 'rh_oauth_state=ORIGINAL')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
 
-    it('returns 401 when state cookie is missing', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when state cookie is missing', async () => {
+      const res = await request(server)
         .get('/auth/google/callback?code=fake&state=some-state')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
 
-    it('returns 401 when query state is missing', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when query state is missing', async () => {
+      const res = await request(server)
         .get('/auth/google/callback?code=fake')
         .set('Cookie', 'rh_oauth_state=some-state')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
 
     it('does not redirect to /auth/complete on invalid state', async () => {
@@ -128,9 +178,10 @@ describe('OAuth CSRF state protection (e2e)', () => {
         .set('Cookie', 'rh_oauth_state=ORIGINAL')
         .redirects(0);
 
-      // The cookie should be cleared (max-age=0 or Expires in the past) OR
-      // the response may set no cookie at all. Either way the auth is rejected.
-      expect(res.status).toBe(401);
+      // Rejected callbacks are redirected (never a raw success response), and
+      // the state cookie must be invalidated so it cannot be replayed.
+      expect(res.status).toBe(302);
+      expectStateCookieCleared(res);
     });
   });
 
@@ -161,19 +212,25 @@ describe('OAuth CSRF state protection (e2e)', () => {
   // ─── Facebook callback — invalid state ────────────────────────────────────
 
   describe('GET /auth/facebook/callback (invalid state)', () => {
-    it('returns 401 when query state does not match cookie', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when query state does not match cookie', async () => {
+      const res = await request(server)
         .get('/auth/facebook/callback?code=fake&state=WRONG')
         .set('Cookie', 'rh_oauth_state=ORIGINAL')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
 
-    it('returns 401 when state cookie is missing', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when state cookie is missing', async () => {
+      const res = await request(server)
         .get('/auth/facebook/callback?code=fake&state=some-state')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
   });
 });

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { requireSession } from '@/lib/auth';
 import { getEmergencyBySlug } from '@/lib/emergencies';
@@ -9,6 +8,7 @@ import { EmptyState } from '@/components/molecules/empty-state';
 import { Badge } from '@/components/atoms/badge';
 import { AppBar } from '@/components/organisms/app-bar';
 import { PageHeading } from '@/components/atoms/page-heading';
+import { LinkButton } from '@/components/atoms/link-button';
 import { getT } from '@/i18n/server';
 
 export const dynamic = 'force-dynamic';
@@ -94,12 +94,13 @@ export default async function MiVoluntariadoPage({ params }: Props) {
               <p className="text-sm text-muted">
                 {ta.not_registered_description}
               </p>
-              <Link
+              <LinkButton
                 href={`/e/${slug}/voluntario`}
-                className="inline-flex items-center justify-center self-center rounded-lg border-2 border-navy px-5 py-3 text-sm font-semibold text-white bg-navy hover:bg-navy-700 focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors"
+                size="md"
+                className="self-center"
               >
                 {ta.register_cta}
-              </Link>
+              </LinkButton>
             </div>
           ) : (
             <article
@@ -159,12 +160,14 @@ export default async function MiVoluntariadoPage({ params }: Props) {
                 </span>
               </div>
 
-              <Link
+              <LinkButton
                 href={`/e/${slug}/voluntario`}
-                className="inline-flex items-center justify-center self-start rounded-lg border-2 border-navy px-4 py-2 text-sm font-semibold text-ink bg-white hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors"
+                variant="secondary"
+                size="sm"
+                className="self-start"
               >
                 {ta.edit_profile_cta}
-              </Link>
+              </LinkButton>
             </article>
           )}
         </section>

--- a/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { requireSession } from '@/lib/auth';
 import { getEmergencyBySlug } from '@/lib/emergencies';
@@ -8,6 +7,7 @@ import { StatusForm } from './status-form';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { AppBar } from '@/components/organisms/app-bar';
 import { PageHeading } from '@/components/atoms/page-heading';
+import { LinkButton } from '@/components/atoms/link-button';
 import { getT } from '@/i18n/server';
 
 export const dynamic = 'force-dynamic';
@@ -92,24 +92,27 @@ export default async function MisPuntosPage({ params }: Props) {
                     />
 
                     <div className="flex flex-wrap gap-3">
-                      <Link
+                      <LinkButton
                         href={`/e/${slug}/mis-puntos/${resource.id}/inventario`}
-                        className="inline-flex items-center justify-center rounded-lg border-2 border-navy px-4 py-2 text-sm font-semibold text-ink bg-white hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors w-fit"
+                        variant="secondary"
+                        size="sm"
                       >
                         {ta.manage_inventory_cta}
-                      </Link>
-                      <Link
+                      </LinkButton>
+                      <LinkButton
                         href={`/e/${slug}/peticion?resourceId=${resource.id}`}
-                        className="inline-flex items-center justify-center rounded-lg border-2 border-navy px-4 py-2 text-sm font-semibold text-ink bg-white hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors w-fit"
+                        variant="secondary"
+                        size="sm"
                       >
                         {ta.declare_needs_cta}
-                      </Link>
-                      <Link
+                      </LinkButton>
+                      <LinkButton
                         href={`/e/${slug}/reportar?resourceId=${resource.id}`}
-                        className="inline-flex items-center justify-center rounded-lg border-2 border-navy px-4 py-2 text-sm font-semibold text-ink bg-white hover:bg-surface focus:outline-none focus:ring-2 focus:ring-navy focus:ring-offset-2 transition-colors w-fit"
+                        variant="secondary"
+                        size="sm"
                       >
                         {ta.report_incident_cta}
-                      </Link>
+                      </LinkButton>
                     </div>
                   </article>
                 </li>

--- a/apps/web/src/components/atoms/link-button.tsx
+++ b/apps/web/src/components/atoms/link-button.tsx
@@ -2,9 +2,11 @@ import Link from 'next/link';
 import type { ComponentProps } from 'react';
 
 type Variant = 'primary' | 'secondary';
+type Size = 'sm' | 'md' | 'lg';
 
 interface LinkButtonProps extends ComponentProps<typeof Link> {
   variant?: Variant;
+  size?: Size;
   fullWidth?: boolean;
 }
 
@@ -16,10 +18,15 @@ const VARIANTS: Record<Variant, string> = {
   secondary: 'text-ink bg-white border-2 border-navy hover:bg-surface',
 };
 
-const SIZE_CLASSES = 'px-6 py-4 text-base';
+const SIZES: Record<Size, string> = {
+  sm: 'px-4 py-2 text-sm',
+  md: 'px-5 py-3 text-sm',
+  lg: 'px-6 py-4 text-base',
+};
 
 export function LinkButton({
   variant = 'primary',
+  size = 'lg',
   fullWidth = false,
   className = '',
   children,
@@ -31,7 +38,7 @@ export function LinkButton({
       className={[
         BASE,
         VARIANTS[variant],
-        SIZE_CLASSES,
+        SIZES[size],
         fullWidth ? 'w-full' : '',
         className,
       ]

--- a/apps/web/src/components/molecules/form-success-screen.tsx
+++ b/apps/web/src/components/molecules/form-success-screen.tsx
@@ -5,6 +5,7 @@ import { LinkButton } from '@/components/atoms/link-button';
 interface SuccessLink {
   href: string;
   label: string;
+  variant?: 'primary' | 'secondary';
 }
 
 interface FormSuccessScreenProps {
@@ -25,6 +26,22 @@ export function FormSuccessScreen({
   secondaryLabel,
   extraLinks = [],
 }: FormSuccessScreenProps) {
+  // Single list of {href, label, variant} instead of three parallel renders
+  // (extraLinks / primary / secondary) — one map covers every link.
+  const links: ReadonlyArray<SuccessLink & { onClick?: () => void }> = [
+    ...extraLinks.map((link) => ({ ...link, variant: 'secondary' as const })),
+    {
+      href: primaryHref,
+      label: primaryLabel,
+      variant: 'primary' as const,
+      // Hard navigation so the form page re-mounts and all controlled state resets.
+      onClick: () => {
+        window.location.href = primaryHref;
+      },
+    },
+    { href: secondaryHref, label: secondaryLabel, variant: 'secondary' as const },
+  ];
+
   return (
     <section
       role="alert"
@@ -35,24 +52,11 @@ export function FormSuccessScreen({
         {message}
       </p>
       <div className="flex flex-col gap-3">
-        {extraLinks.map(({ href, label }) => (
-          <LinkButton key={href} href={href} variant="secondary" fullWidth>
+        {links.map(({ href, label, variant, onClick }) => (
+          <LinkButton key={href} href={href} variant={variant} fullWidth onClick={onClick}>
             {label}
           </LinkButton>
         ))}
-        <LinkButton
-          href={primaryHref}
-          fullWidth
-          // Hard navigation so the form page re-mounts and all controlled state resets.
-          onClick={() => {
-            window.location.href = primaryHref;
-          }}
-        >
-          {primaryLabel}
-        </LinkButton>
-        <LinkButton href={secondaryHref} variant="secondary" fullWidth>
-          {secondaryLabel}
-        </LinkButton>
       </div>
     </section>
   );


### PR DESCRIPTION
Closes #297

## Qué cambia

El átomo `LinkButton` (introducido en #311) ya cubría `FormSuccessScreen`, `voluntario-form` e `intake-receipt`, pero **no** los 5 sitios restantes mencionados en el issue, que seguían con el className de ~200 caracteres copiado a mano:

- `apps/web/src/app/e/[slug]/mis-puntos/page.tsx` — 3 copias (Gestionar inventario / Declarar necesidades / Reportar)
- `apps/web/src/app/e/[slug]/mi-voluntariado/page.tsx` — 2 copias (registrarse como voluntario / editar perfil)

Estos sitios usaban un tamaño más compacto (`px-4 py-2 text-sm` y `px-5 py-3 text-sm`) que el que traía el átomo (`px-6 py-4 text-base`, pensado para los CTA grandes de las pantallas de éxito). Se añadió un prop `size` (`sm` / `md` / `lg`, por defecto `lg` para no romper los usos existentes) a `LinkButton` para cubrir ambos tamaños sin crear un segundo átomo paralelo, y se sustituyeron las 5 copias inline por el átomo.

De paso, tal como sugiere el issue, `FormSuccessScreen` deja de renderizar `extraLinks` / enlace primario / enlace secundario como tres bloques JSX paralelos: ahora arma una única lista `{href, label, variant}` y la recorre con un solo `.map()`. La API pública del componente (`primaryHref`, `secondaryHref`, `extraLinks`, etc.) no cambia, así que no hace falta tocar los 6 formularios que lo consumen.

## Por qué no una migración más agresiva

No se tocó el variant `secondary` de `atoms/button.tsx` (que ya diverge del de `LinkButton`: `border/text-navy` vs `border-2/text-ink`) porque es un componente distinto (`<button>` vs `next/link`) y ese ajuste no formaba parte del alcance de este issue — solo consolidar las copias del botón-enlace.

## Verificación

- `pnpm install --frozen-lockfile`
- `pnpm --filter @reliefhub/api-client build && pnpm --filter web build`
- `pnpm --filter web lint` (0 errores; 1 warning preexistente en `opengraph-image.tsx`, no relacionado a este cambio)
- `pnpm --filter api build` (sin cambios en `apps/api`, build limpio)

No se agregaron tests de componente: `apps/web` no tiene ninguno hoy (todo el `test` script corre solo `*.test.ts` de lógica pura con `node --test`; no hay jsdom/RTL en el proyecto), así que no se introdujo una convención nueva para este refactor puntual.