### PR TITLE
feat(web): revela el contacto en las tarjetas de lista para usuarios logueados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ apps/api/uploads/
 
 # Entorno local personal (scripts, seeds, docker extra) — no subir al repo
 .local/
+
+# Local git worktrees for parallel agent work — never commit
+.worktrees/

--- a/apps/api/test/oauth-csrf.e2e-spec.ts
+++ b/apps/api/test/oauth-csrf.e2e-spec.ts
@@ -5,8 +5,14 @@
  * real OAuth credentials. The strategies boot with placeholder clientIDs, so:
  *  - GET /auth/google → Passport issues a 302 redirect to accounts.google.com
  *    (we only care that the state cookie and query param are set).
- *  - GET /auth/google/callback?code=fake&state=WRONG → The callback guard MUST
- *    reject the request with 401 before Passport attempts a token exchange.
+ *  - GET /auth/google/callback?code=fake&state=WRONG → The callback guard
+ *    rejects the request with `UnauthorizedException` before Passport attempts
+ *    a token exchange. `OAuthController` catches ANY callback failure with
+ *    `OAuthExceptionFilter` (#340) and turns it into a friendly `302` redirect
+ *    to `${FRONTEND_URL}/login?error=oauth_failed` instead of a raw `401` —
+ *    deliberate, browser-facing behavior. What still matters for CSRF safety
+ *    is verified directly: the `rh_oauth_state` cookie is cleared/invalidated
+ *    and no `accessToken`/session is produced.
  *
  * No DB seeding is needed because these endpoints do not touch the database
  * before the state check. The invalid-state path is rejected in the guard.
@@ -18,6 +24,9 @@ import type { Server } from 'node:http';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
 import { DomainExceptionFilter } from '../src/contexts/resources/infrastructure/http/domain-exception.filter';
+
+/** Matches the `OAuthExceptionFilter` / `OAuthController` fallback default. */
+const FRONTEND_URL = 'http://localhost:3001';
 
 /**
  * Safely extract the Set-Cookie response header as a string array.
@@ -33,6 +42,38 @@ function getSetCookies(res: { headers: Record<string, unknown> }): string[] {
     return [raw];
   }
   return [];
+}
+
+/**
+ * Asserts that a rejected OAuth callback redirects the browser to the
+ * frontend's friendly failure page — the `OAuthExceptionFilter` behavior
+ * introduced by #340 — and never to the success path (which would carry an
+ * `accessToken`).
+ */
+function expectOAuthFailureRedirect(res: {
+  headers: Record<string, unknown>;
+}): void {
+  const location: unknown = res.headers['location'];
+  const locationStr = typeof location === 'string' ? location : '';
+  expect(locationStr).toBe(`${FRONTEND_URL}/login?error=oauth_failed`);
+  expect(locationStr).not.toContain('/auth/complete#token=');
+}
+
+/**
+ * Asserts that the `rh_oauth_state` CSRF cookie was invalidated in the
+ * response — `res.clearCookie` re-issues it with an empty value and an
+ * `Expires` date in the past — so a leaked/replayed state token cannot be
+ * reused after a rejected callback.
+ */
+function expectStateCookieCleared(res: {
+  headers: Record<string, unknown>;
+}): void {
+  const cookies = getSetCookies(res);
+  const stateCookie = cookies.find((c) => c.startsWith('rh_oauth_state='));
+
+  expect(stateCookie).toBeDefined();
+  expect(stateCookie).toMatch(/^rh_oauth_state=;/);
+  expect(stateCookie).toMatch(/Expires=Thu, 01 Jan 1970/);
 }
 
 describe('OAuth CSRF state protection (e2e)', () => {
@@ -88,27 +129,36 @@ describe('OAuth CSRF state protection (e2e)', () => {
   // ─── Google callback — invalid state ──────────────────────────────────────
 
   describe('GET /auth/google/callback (invalid state)', () => {
-    it('returns 401 when query state does not match cookie', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when query state does not match cookie', async () => {
+      const res = await request(server)
         .get('/auth/google/callback?code=fake&state=WRONG')
         .set('Cookie', 'rh_oauth_state=ORIGINAL')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
 
-    it('returns 401 when state cookie is missing', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when state cookie is missing', async () => {
+      const res = await request(server)
         .get('/auth/google/callback?code=fake&state=some-state')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
 
-    it('returns 401 when query state is missing', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when query state is missing', async () => {
+      const res = await request(server)
         .get('/auth/google/callback?code=fake')
         .set('Cookie', 'rh_oauth_state=some-state')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
 
     it('does not redirect to /auth/complete on invalid state', async () => {
@@ -128,9 +178,10 @@ describe('OAuth CSRF state protection (e2e)', () => {
         .set('Cookie', 'rh_oauth_state=ORIGINAL')
         .redirects(0);
 
-      // The cookie should be cleared (max-age=0 or Expires in the past) OR
-      // the response may set no cookie at all. Either way the auth is rejected.
-      expect(res.status).toBe(401);
+      // Rejected callbacks are redirected (never a raw success response), and
+      // the state cookie must be invalidated so it cannot be replayed.
+      expect(res.status).toBe(302);
+      expectStateCookieCleared(res);
     });
   });
 
@@ -161,19 +212,25 @@ describe('OAuth CSRF state protection (e2e)', () => {
   // ─── Facebook callback — invalid state ────────────────────────────────────
 
   describe('GET /auth/facebook/callback (invalid state)', () => {
-    it('returns 401 when query state does not match cookie', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when query state does not match cookie', async () => {
+      const res = await request(server)
         .get('/auth/facebook/callback?code=fake&state=WRONG')
         .set('Cookie', 'rh_oauth_state=ORIGINAL')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
 
-    it('returns 401 when state cookie is missing', async () => {
-      await request(server)
+    it('redirects to /login?error=oauth_failed when state cookie is missing', async () => {
+      const res = await request(server)
         .get('/auth/facebook/callback?code=fake&state=some-state')
-        .redirects(0)
-        .expect(401);
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expectOAuthFailureRedirect(res);
+      expectStateCookieCleared(res);
     });
   });
 });

--- a/apps/web/src/app/api/public-proxy/[...path]/proxy-core.test.ts
+++ b/apps/web/src/app/api/public-proxy/[...path]/proxy-core.test.ts
@@ -1,0 +1,148 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isAllowedResourcePath,
+  proxyPublicResources,
+  type FetchLike,
+} from './proxy-core.ts';
+
+const EMERGENCY = '11111111-1111-4111-8111-111111111111';
+const LIST_SEGMENTS = ['emergencies', EMERGENCY, 'public', 'resources'];
+
+// ── Allowlist: the session token must only ever reach the public resources
+// read family, never any other API endpoint (the core security boundary). ──────
+
+test('allowlist permits the public resources read family', () => {
+  assert.equal(isAllowedResourcePath(LIST_SEGMENTS), true);
+  assert.equal(
+    isAllowedResourcePath([...LIST_SEGMENTS, 'nearby']),
+    true,
+  );
+  assert.equal(
+    isAllowedResourcePath([...LIST_SEGMENTS, 'in-bounds']),
+    true,
+  );
+  assert.equal(
+    isAllowedResourcePath([...LIST_SEGMENTS, 'facets']),
+    true,
+  );
+  // detail (resourceId is a UUID)
+  assert.equal(
+    isAllowedResourcePath([...LIST_SEGMENTS, EMERGENCY]),
+    true,
+  );
+});
+
+test('allowlist rejects any non-resources endpoint and path traversal', () => {
+  assert.equal(isAllowedResourcePath(['auth', 'me']), false);
+  assert.equal(
+    isAllowedResourcePath(['emergencies', EMERGENCY, 'manage', 'resources']),
+    false,
+  );
+  assert.equal(
+    isAllowedResourcePath(['emergencies', EMERGENCY, 'public', 'needs']),
+    false,
+  );
+  assert.equal(
+    isAllowedResourcePath(['emergencies', 'not-a-uuid', 'public', 'resources']),
+    false,
+  );
+  assert.equal(
+    isAllowedResourcePath([...LIST_SEGMENTS, '..', 'secret']),
+    false,
+  );
+  assert.equal(isAllowedResourcePath([...LIST_SEGMENTS, 'bogus-sub']), false);
+});
+
+// ── Fake API mirroring the #267 server-side redaction: it reveals `contact`
+// only when a Bearer token arrives, and redacts it (null) otherwise. ───────────
+
+const fakeApi: FetchLike = (_url, init) => {
+  const authed = typeof init.headers.Authorization === 'string';
+  const body = JSON.stringify({
+    items: [{ id: 'r1', hasContact: true, contact: authed ? '+58 555 0000' : null }],
+    total: 1,
+  });
+  return Promise.resolve(
+    new Response(body, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+};
+
+test('anonymous (no token) → contact stays redacted through the proxy', async () => {
+  const res = await proxyPublicResources({
+    base: 'http://api',
+    segments: LIST_SEGMENTS,
+    search: '?page=1&limit=50',
+    token: null,
+    fetchFn: fakeApi,
+  });
+  assert.equal(res.status, 200);
+  const data = (await res.json()) as {
+    items: { contact: string | null; hasContact: boolean }[];
+  };
+  assert.equal(data.items[0].contact, null);
+  // hasContact still true so the card can say "log in to see it".
+  assert.equal(data.items[0].hasContact, true);
+  // Per-user response must never be shared-cached.
+  assert.equal(res.headers.get('cache-control'), 'private, no-store');
+});
+
+test('authenticated (token) → proxy forwards Bearer and contact is revealed', async () => {
+  const res = await proxyPublicResources({
+    base: 'http://api',
+    segments: LIST_SEGMENTS,
+    search: '?page=1&limit=50',
+    token: 'valid-jwt',
+    fetchFn: fakeApi,
+  });
+  assert.equal(res.status, 200);
+  const data = (await res.json()) as { items: { contact: string | null }[] };
+  assert.equal(data.items[0].contact, '+58 555 0000');
+});
+
+test('forwards the exact upstream URL and Bearer header for allowed reads', async () => {
+  let seenUrl = '';
+  let seenAuth: string | undefined;
+  const spy: FetchLike = (url, init) => {
+    seenUrl = url;
+    seenAuth = init.headers.Authorization;
+    return Promise.resolve(
+      new Response('{"items":[],"total":0}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  };
+  await proxyPublicResources({
+    base: 'http://api:3000',
+    segments: LIST_SEGMENTS,
+    search: '?page=2&limit=50',
+    token: 'tok',
+    fetchFn: spy,
+  });
+  assert.equal(
+    seenUrl,
+    `http://api:3000/emergencies/${EMERGENCY}/public/resources?page=2&limit=50`,
+  );
+  assert.equal(seenAuth, 'Bearer tok');
+});
+
+test('never forwards the session token to a non-allowlisted endpoint', async () => {
+  let called = false;
+  const spy: FetchLike = () => {
+    called = true;
+    return Promise.resolve(new Response('{}'));
+  };
+  const res = await proxyPublicResources({
+    base: 'http://api',
+    segments: ['auth', 'me'],
+    search: '',
+    token: 'valid-jwt',
+    fetchFn: spy,
+  });
+  assert.equal(res.status, 404);
+  assert.equal(called, false);
+});

--- a/apps/web/src/app/api/public-proxy/[...path]/proxy-core.ts
+++ b/apps/web/src/app/api/public-proxy/[...path]/proxy-core.ts
@@ -1,0 +1,144 @@
+/**
+ * Server-side proxy core for public resource browsing (#268).
+ *
+ * The public resource list / nearby / in-bounds endpoints redact `contact`
+ * (the PII of non-official points) for anonymous callers and reveal it when a
+ * valid Bearer token is present (#267). The browser cannot attach the httpOnly
+ * `rh_token` cookie as a Bearer header, so ResourceList's client-side refetches
+ * (filter / paginate / nearby) always looked anonymous and lost the contact for
+ * logged-in users — even though the server-rendered detail page showed it.
+ *
+ * This module forwards those specific reads through the Next server, attaching
+ * the session token server-side. The token is NEVER exposed to client JS, and
+ * two invariants keep the #267 security property intact:
+ *
+ *   - an allowlist restricts forwarding to the public `resources` read family
+ *     ONLY, so the session token can never be relayed to any other API endpoint
+ *     (a client cannot turn this proxy into an authenticated call to `/auth/me`,
+ *     a management route, etc.);
+ *   - responses are marked non-cacheable (`private, no-store`): they vary by the
+ *     per-user session cookie, so a contact-revealed response can never be
+ *     served from a shared cache to an anonymous visitor.
+ *
+ * An anonymous caller (no cookie) sends no Authorization header, so the API
+ * still redacts `contact` to `null` — exactly as it does today.
+ *
+ * Kept as a pure, framework-free module (no `next/*`, no `@/` aliases) so the
+ * security wiring is unit-testable under `node --test`.
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Static sub-routes of `.../public/resources` that are safe to proxy. */
+const SUBRESOURCES = new Set(['nearby', 'in-bounds', 'facets']);
+
+/**
+ * Allowlist: the ONLY upstream paths this proxy will attach the session token
+ * to. Restricted to the public `resources` read family for a single emergency:
+ *
+ *   emergencies/{uuid}/public/resources                  (list)
+ *   emergencies/{uuid}/public/resources/nearby           (nearby)
+ *   emergencies/{uuid}/public/resources/in-bounds        (map viewport)
+ *   emergencies/{uuid}/public/resources/facets           (filter counts)
+ *   emergencies/{uuid}/public/resources/{uuid}           (detail)
+ *
+ * Everything else is rejected, so the session token can never reach another
+ * endpoint. Path traversal is impossible: each segment is validated and the
+ * emergency id must be a UUID.
+ */
+export function isAllowedResourcePath(segments: readonly string[]): boolean {
+  if (
+    segments.some(
+      (s) =>
+        s === '' ||
+        s === '.' ||
+        s === '..' ||
+        s.includes('/') ||
+        s.includes('\\'),
+    )
+  ) {
+    return false;
+  }
+  if (segments.length < 4 || segments.length > 5) return false;
+
+  const [context, emergencyId, scope, resources, sub] = segments;
+  if (
+    context !== 'emergencies' ||
+    scope !== 'public' ||
+    resources !== 'resources'
+  ) {
+    return false;
+  }
+  if (!UUID_RE.test(emergencyId)) return false;
+  if (segments.length === 5 && !(SUBRESOURCES.has(sub) || UUID_RE.test(sub))) {
+    return false;
+  }
+  return true;
+}
+
+/** Minimal `fetch` shape used by the proxy — injectable so tests can fake the API. */
+export type FetchLike = (
+  url: string,
+  init: { headers: Record<string, string>; cache: 'no-store' },
+) => Promise<Response>;
+
+export interface ProxyRequest {
+  /** Upstream API base URL (no trailing slash), e.g. `http://localhost:3000`. */
+  base: string;
+  /** Path segments after the proxy prefix, e.g. `['emergencies', id, 'public', 'resources']`. */
+  segments: string[];
+  /** Raw query string including the leading `?` (or empty). */
+  search: string;
+  /** Session token read server-side, or `null` for an anonymous visitor. */
+  token: string | null;
+  fetchFn: FetchLike;
+}
+
+/**
+ * Forwards an allowlisted public-resource read to the API, attaching the
+ * session token as a Bearer when present. Returns a non-cacheable response.
+ */
+export async function proxyPublicResources(req: ProxyRequest): Promise<Response> {
+  if (!isAllowedResourcePath(req.segments)) {
+    return jsonResponse({ error: 'Not found' }, 404);
+  }
+
+  const url = `${req.base}/${req.segments.join('/')}${req.search}`;
+  const headers: Record<string, string> = {};
+  // Attach the token ONLY server-side; an anonymous visitor (no token) sends no
+  // Authorization header, so the API keeps redacting `contact` (#267).
+  if (req.token !== null && req.token !== '') {
+    headers.Authorization = `Bearer ${req.token}`;
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await req.fetchFn(url, { headers, cache: 'no-store' });
+  } catch {
+    return jsonResponse({ error: 'Upstream request failed' }, 502);
+  }
+
+  const body = await upstream.text();
+  const contentType =
+    upstream.headers.get('content-type') ?? 'application/json';
+  return new Response(body, {
+    status: upstream.status,
+    headers: {
+      'content-type': contentType,
+      // Per-user (varies by the session cookie): never store in a shared cache,
+      // so a contact-revealed response can't leak to an anonymous visitor.
+      'cache-control': 'private, no-store',
+    },
+  });
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'private, no-store',
+    },
+  });
+}

--- a/apps/web/src/app/api/public-proxy/[...path]/route.ts
+++ b/apps/web/src/app/api/public-proxy/[...path]/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest } from 'next/server';
+import { getToken } from '@/lib/auth';
+import { proxyPublicResources } from './proxy-core';
+
+/**
+ * GET /api/public-proxy/emergencies/:id/public/resources[/...]
+ *
+ * Same-origin proxy for the public resource list / nearby / in-bounds reads
+ * that {@link ResourceList} refetches client-side (#268). It reads the httpOnly
+ * `rh_token` cookie server-side and forwards it as a Bearer to the API, so a
+ * logged-in user sees the (non-official) `contact` in the list cards too — not
+ * only on the server-rendered detail page.
+ *
+ * Security (enforced in {@link proxyPublicResources}): the token is attached
+ * server-side only and is relayed strictly to the allowlisted public
+ * `resources` read family. An anonymous visitor sends no cookie → no
+ * Authorization header → the API still redacts `contact` to null (#267).
+ */
+
+const API_BASE = process.env.API_URL ?? 'http://localhost:3000';
+
+// Per-user (reads the session cookie): must never be statically cached.
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const { path } = await params;
+  const token = await getToken();
+  return proxyPublicResources({
+    base: API_BASE,
+    segments: path,
+    search: request.nextUrl.search,
+    token,
+    fetchFn: fetch,
+  });
+}

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
-import { getToken } from '@/lib/auth';
+import { getToken, authHeaders } from '@/lib/auth';
 import { type ResourceViewDto } from '@/lib/group-by-country';
 import { AppBar } from '@/components/organisms/app-bar';
 import { ResourceList } from '@/components/organisms/resource-list';
@@ -98,6 +98,11 @@ export default async function EmergencyPage({ params, searchParams }: Props) {
         path: { emergencyId },
         query: { page: 1, limit: 50 },
       },
+      // Forward the session so a logged-in user sees the (non-official) contact
+      // in the list cards on first paint too, matching the client-side proxy
+      // refetch (#268). Anonymous callers (no token) still get it redacted, and
+      // an expired token fails open on the optional-auth endpoint → redacted.
+      ...(token !== null && { headers: authHeaders(token) }),
     }),
     api.GET('/emergencies/{emergencyId}/public/resources/facets', {
       params: { path: { emergencyId } },

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -15,13 +15,14 @@ import type { Locale } from '@/i18n';
 
 type NearbyResourceViewDto = components['schemas']['NearbyResourceViewDto'];
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
-if (!API_URL) {
-  console.error(
-    '[ResourceList] NEXT_PUBLIC_API_URL is not set — ' +
-      '"Load more" will fail. Set this env var in your deployment.',
-  );
-}
+/**
+ * Client-side resource reads go through the same-origin server proxy (#268),
+ * NOT directly to NEXT_PUBLIC_API_URL. The proxy attaches the httpOnly session
+ * cookie as a Bearer server-side, so a logged-in user sees the (non-official)
+ * `contact` in the list cards too — while an anonymous visitor still gets it
+ * redacted (#267). A relative base is resolved against the current origin.
+ */
+const PROXY_BASE = '/api/public-proxy';
 
 const LIMIT = 50;
 
@@ -102,7 +103,7 @@ export function ResourceList({
     setPage(1);
     setLoadMoreError(false);
     startTransition(async () => {
-      const client = createResponseGridClient(API_URL);
+      const client = createResponseGridClient(PROXY_BASE);
       const { data } = await client.GET(
         '/emergencies/{emergencyId}/public/resources',
         {
@@ -140,7 +141,7 @@ export function ResourceList({
     setLoadMoreError(false);
     startTransition(async () => {
       const nextPage = page + 1;
-      const client = createResponseGridClient(API_URL);
+      const client = createResponseGridClient(PROXY_BASE);
       const { data } = await client.GET(
         '/emergencies/{emergencyId}/public/resources',
         {
@@ -186,7 +187,7 @@ export function ResourceList({
     lat: number;
     lng: number;
   }) {
-    const client = createResponseGridClient(API_URL);
+    const client = createResponseGridClient(PROXY_BASE);
     const { data } = await client.GET(
       '/emergencies/{emergencyId}/public/resources/nearby',
       {


### PR DESCRIPTION
Closes #268

## Qué cambia

En #267 la redacción de `contact` pasó a ser server-side: los endpoints públicos de recursos ocultan `contact → null` para llamantes anónimos en recursos no-oficiales (manteniendo `hasContact` para el aviso "Inicia sesión para ver"). Hasta ahora solo la **ficha de detalle** (server-rendered) reenviaba el token, así que en las **tarjetas de lista** el contacto quedaba redactado para todos: `ResourceList` refetchea en cliente (filtros, paginación, cercanía) y la cookie de sesión es httpOnly, inaccesible al JS.

Esta PR enruta ese browsing público a través de un **proxy same-origin server-side** que adjunta la cookie de sesión como Bearer:

- **Nuevo route handler** `apps/web/src/app/api/public-proxy/[...path]/route.ts`: lee el token httpOnly en el servidor y lo reenvía a la API pública de recursos.
- **`ResourceList`** consume ese proxy (`/api/public-proxy`) en vez de llamar directo a `NEXT_PUBLIC_API_URL` (lista + cercanía).
- **Carga inicial SSR** (`/e/[slug]`) ahora también reenvía el token, para que el contacto sea consistente en el primer render y tras filtrar/paginar.
- La card ya soportaba ambos casos vía `hasContact` — sin cambios.

## Invariante de seguridad (#267) preservada

- El token se adjunta **solo en el servidor**; nunca se expone al JS del cliente.
- Un **allowlist** (`proxy-core.ts`) restringe el reenvío a la familia de lectura pública `emergencies/{uuid}/public/resources` (lista/nearby/in-bounds/facets/detalle) y valida cada segmento (sin path traversal): el token **nunca** puede llegar a otro endpoint.
- Un visitante **anónimo** no envía cookie → sin cabecera `Authorization` → la API sigue redactando `contact` a `null`.
- Respuestas marcadas `private, no-store`: al variar por la cookie de sesión, una respuesta con contacto revelado **no puede** servirse desde una caché compartida a un usuario anónimo.
- Un token expirado hace *fail-open* en el `OptionalJwtAuthGuard` → tratado como anónimo (redactado), sin 500.

## Tests (TDD)

Lógica de seguridad extraída a un módulo puro y framework-free (`proxy-core.ts`) para poder testearla bajo `node --test`:

- **anónimo (sin token) → `contact: null`** a través del proxy (y `hasContact: true`).
- **autenticado (token) → el proxy reenvía el Bearer y el contacto se revela.**
- el allowlist acepta la familia de lectura de recursos y **rechaza** cualquier otro endpoint (`/auth/me`, rutas de `manage`, `public/needs`) y el path traversal.
- el token **nunca** se reenvía a un path no permitido (el fetch upstream no se invoca).
- cabecera y URL upstream exactas para lecturas permitidas; `cache-control: private, no-store`.

## Alcance

El mapa (`in-bounds`) refetchea en cliente pero **no muestra `contact`** (solo ubicación/nombre/estado), así que no se reenrutó — no aporta ni a la UX ni a la seguridad. El allowlist incluye `in-bounds` de todas formas por si se necesitara.

## Gate

`pnpm install --frozen-lockfile`, `pnpm --filter @reliefhub/api-client build && pnpm --filter web build`, `pnpm --filter web lint` (0 errores) y `pnpm --filter web test` (98/98) en verde. No se toca `apps/api` ni DTOs (sin `gen:api`).