### PR TITLE
chore(brand): unifica marca a ResponseGrid y alinea la licencia pública a AGPL-3.0 (#300)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build — api-client
-        run: pnpm --filter @reliefhub/api-client build
+        run: pnpm --filter @responsegrid/api-client build
 
       # warehouse-core is a workspace dependency of api: build it (dist/cjs +
       # dist/esm) before nest build resolves it via the exports map.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Multi-emergency **material aid coordination + logistics** platform (org: **Globa
 - **pnpm monorepo**, `packageManager: pnpm@10.33.4` (pinned — use corepack; do NOT let pnpm 11 regenerate the lockfile).
 - **`apps/api`** — NestJS 11, **hexagonal / DDD** (ports & adapters, CQRS-light, domain events via Redis/BullMQ), Drizzle ORM, Postgres 16, Redis 7. Swagger at `/docs`.
 - **`apps/web`** — Next 16 (App Router, React 19), **Atomic Design**, Tailwind 4, Leaflet + `leaflet.markercluster`. Consumes the typed client. (See `apps/web/AGENTS.md` for Next-16 specifics.)
-- **`packages/api-client`** — `@reliefhub/api-client`, openapi-fetch typed client. Regenerate with `pnpm gen:api`.
+- **`packages/api-client`** — `@responsegrid/api-client`, openapi-fetch typed client. Regenerate with `pnpm gen:api`.
 - TDD throughout. Dev infra via docker-compose.
 
 ## Architecture
@@ -73,7 +73,7 @@ pnpm --filter api exec eslint "{src,apps,libs,test}/**/*.ts" --max-warnings=0
 pnpm --filter api exec prettier --check "src/**/*.ts" "test/**/*.ts"
 pnpm --filter api test                  # runInBand; global-setup spins up reliefhub_test + applies migrations
 # web (build the api-client first):
-pnpm --filter @reliefhub/api-client build && pnpm --filter web build
+pnpm --filter @responsegrid/api-client build && pnpm --filter web build
 pnpm --filter web lint
 ```
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,98 +1,30 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# ResponseGrid · API
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+API de la **plataforma de coordinación de ayuda material y logística en emergencias** de [Global Emergency](https://globalemergency.online). Construida con **NestJS 11** siguiendo arquitectura **hexagonal / DDD** (puertos y adaptadores, bounded contexts), **Drizzle ORM** sobre **PostgreSQL 16** y **Redis 7** (BullMQ) para eventos de dominio.
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+> Para la visión de conjunto del monorepo, la arquitectura y el roadmap, consulta el [`README.md`](../../README.md) raíz y **[`AGENTS.md`](../../AGENTS.md)** (guía canónica de convenciones).
 
-## Description
-
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
-
-## Project setup
+## Puesta en marcha
 
 ```bash
-$ pnpm install
+pnpm install                 # desde la raíz del monorepo
+docker compose up -d         # Postgres (5433) + Redis (6380)
+cp apps/api/.env.example apps/api/.env   # rellena JWT_SECRET (≥32 chars en prod)
+pnpm --filter api start:dev  # API en http://localhost:3000 · Swagger en /docs
 ```
 
-## Compile and run the project
+## Calidad
 
 ```bash
-# development
-$ pnpm run start
-
-# watch mode
-$ pnpm run start:dev
-
-# production mode
-$ pnpm run start:prod
+pnpm --filter api build      # nest build — gate crítico de CI (tsc estricto)
+pnpm --filter api lint       # ESLint (max-warnings=0)
+pnpm --filter api test       # unitarios + integración (jest --runInBand)
 ```
 
-## Run tests
+Desarrollo guiado por **TDD**; Clean Code, SOLID y DDD. El `domain/` y `application/` no importan `@nestjs/*`, Drizzle ni infraestructura (regla de ESLint).
 
-```bash
-# unit tests
-$ pnpm run test
+> **Tras tocar DTOs/endpoints:** `pnpm gen:api` regenera el cliente tipado (`packages/api-client/src/schema.ts`).
 
-# e2e tests
-$ pnpm run test:e2e
+## Licencia
 
-# test coverage
-$ pnpm run test:cov
-```
-
-## Deployment
-
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
-
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
-
-```bash
-$ pnpm install -g @nestjs/mau
-$ mau deploy
-```
-
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
-
-## Resources
-
-Check out a few resources that may come in handy when working with NestJS:
-
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
-
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+Publicada bajo **[GNU AGPL-3.0](../../LICENSE)**. Es la licencia autoritativa de todo el código del proyecto (copyleft de red: si ofreces el servicio en red, debes publicar el código fuente correspondiente). La licencia de los **datos** que expone la API pública es distinta: **CC BY-SA 4.0** (ver el portal `/docs`).

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from 'next';
 import path from 'path';
 
 const nextConfig: NextConfig = {
-  transpilePackages: ['@reliefhub/api-client'],
+  transpilePackages: ['@responsegrid/api-client'],
   turbopack: {
     root: path.resolve(__dirname, '../..'),
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "test": "node --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@reliefhub/api-client": "workspace:*",
+    "@responsegrid/api-client": "workspace:*",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "next": "16.2.9",

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Plataforma open source de coordinación de ayuda material y logística en emergencias, de Global Emergency. Se activa por catástrofe: conecta a ciudadanía, organizaciones y coordinación para que la ayuda llegue donde hace falta sin saturar la logística. Información oficial, verificada y en tiempo real. Los datos se aíslan por emergencia y se sirven en HTML renderizado en servidor (citable directamente).
 
-## Qué hace la plataforma (todo gratuito y de código abierto, licencia MIT)
+## Qué hace la plataforma (todo gratuito y de código abierto, licencia AGPL-3.0)
 
 - Puntos de acopio y logísticos verificados, cada uno con su inventario de material declarado.
 - Necesidades de material validadas por coordinación local, con frescura de 48 h.

--- a/apps/web/src/adapters/search-supplies.ts
+++ b/apps/web/src/adapters/search-supplies.ts
@@ -1,5 +1,5 @@
 import { fromSupplyDto, type CatalogueSupply } from '@/domain/supplies/catalogue-supply';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 type SupplyDto = components['schemas']['SupplyDto'];
 

--- a/apps/web/src/app/admin/audit/actions.ts
+++ b/apps/web/src/app/admin/audit/actions.ts
@@ -2,7 +2,7 @@
 
 import { getToken, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 export type AuditEntryDto = components['schemas']['AuditEntryDto'];
 export type AuditListResponseDto = components['schemas']['AuditListResponseDto'];

--- a/apps/web/src/app/admin/points/actions.ts
+++ b/apps/web/src/app/admin/points/actions.ts
@@ -4,7 +4,7 @@ import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { revalidatePath } from 'next/cache';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 export type ResourceAdminListItem =
   components['schemas']['ResourceAdminViewDto'];

--- a/apps/web/src/app/admin/templates/actions.ts
+++ b/apps/web/src/app/admin/templates/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { requireSession, getToken, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 export type TemplateActionResult =
   | { status: 'idle' }

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -660,7 +660,7 @@ for (const p of items) {
                   <div className="rounded-card border border-line bg-surface-alt p-5">
                     <h3 className="font-display text-base font-bold text-navy">{d.links_client_t}</h3>
                     <p className="mt-1.5 text-[14px] leading-[1.55] text-ink-soft">{d.links_client_b}</p>
-                    <code className="mt-2 inline-block font-mono text-[12.5px] text-ink">@reliefhub/api-client</code>
+                    <code className="mt-2 inline-block font-mono text-[12.5px] text-ink">@responsegrid/api-client</code>
                   </div>
                 </div>
               </Section>

--- a/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
+++ b/apps/web/src/app/e/[slug]/donar/ofrecer/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { localizeBackendError } from '@/lib/backend-error-messages';
 import { getT } from '@/i18n/server';

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 export type VolunteerProfile = components['schemas']['VolunteerViewDto'];
 export type MyTask = components['schemas']['MyTaskViewDto'];

--- a/apps/web/src/app/e/[slug]/mi-voluntariado/task-card.tsx
+++ b/apps/web/src/app/e/[slug]/mi-voluntariado/task-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useActionState } from 'react';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { checkInTask, checkOutTask } from './actions';
 import type { CheckActionResult } from './actions';
 import { Button } from '@/components/atoms/button';

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/actions.ts
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { getT } from '@/i18n/server';

--- a/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/inventory-edit-form.tsx
+++ b/apps/web/src/app/e/[slug]/mis-puntos/[resourceId]/inventario/inventory-edit-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useActionState } from 'react';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import type { InventoryState } from './actions';
 import { InventoryField } from '../../../registrar/inventory-field';
 import { Button } from '@/components/atoms/button';

--- a/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
+++ b/apps/web/src/app/e/[slug]/mis-puntos/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getT } from '@/i18n/server';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 export type PublicStatus = components['schemas']['ResourceViewDto']['publicStatus'];
 

--- a/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
+++ b/apps/web/src/app/e/[slug]/ofrecer-transporte/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { localizeBackendError } from '@/lib/backend-error-messages';
 import { getT } from '@/i18n/server';

--- a/apps/web/src/app/e/[slug]/peticion/actions.ts
+++ b/apps/web/src/app/e/[slug]/peticion/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { localizeBackendError } from '@/lib/backend-error-messages';

--- a/apps/web/src/app/e/[slug]/recepcion/actions.ts
+++ b/apps/web/src/app/e/[slug]/recepcion/actions.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation';
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
 import { parseSupplyLines } from '@/lib/supply-lines';

--- a/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/actions.ts
+++ b/apps/web/src/app/e/[slug]/recursos/[resourceId]/reportar-estado/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { requireSession, redirectToLogin, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { getT } from '@/i18n/server';
 
 export type ValidityReason = 'closed' | 'nonexistent' | 'moved' | 'outdated';

--- a/apps/web/src/app/e/[slug]/registrar/actions.ts
+++ b/apps/web/src/app/e/[slug]/registrar/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { parseSupplyLines } from '@/lib/supply-lines';
 import { localizeBackendError } from '@/lib/backend-error-messages';

--- a/apps/web/src/app/e/[slug]/reportar/actions.ts
+++ b/apps/web/src/app/e/[slug]/reportar/actions.ts
@@ -2,7 +2,7 @@
 
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { getT } from '@/i18n/server';
 
 export type ReportType = 'incident' | 'stock' | 'status' | 'other';

--- a/apps/web/src/app/e/[slug]/voluntario/actions.ts
+++ b/apps/web/src/app/e/[slug]/voluntario/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { localizeBackendError } from '@/lib/backend-error-messages';
 import { getT } from '@/i18n/server';

--- a/apps/web/src/app/e/[slug]/voluntario/page.tsx
+++ b/apps/web/src/app/e/[slug]/voluntario/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { requireSession, authHeaders } from '@/lib/auth';
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { registerVolunteer } from './actions';
 import { VoluntarioForm } from './voluntario-form';
 import { AppBar } from '@/components/organisms/app-bar';

--- a/apps/web/src/app/e/[slug]/voluntario/voluntario-form.tsx
+++ b/apps/web/src/app/e/[slug]/voluntario/voluntario-form.tsx
@@ -2,7 +2,7 @@
 
 import { useActionState, useState, useEffect } from 'react';
 import { LinkButton } from '@/components/atoms/link-button';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import type { VolunteerActionState } from './actions';
 import { Button } from '@/components/atoms/button';
 import { Input } from '@/components/atoms/input';

--- a/apps/web/src/app/emergencies/[slug]/manage/actions.ts
+++ b/apps/web/src/app/emergencies/[slug]/manage/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { api } from '@/lib/api';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';

--- a/apps/web/src/app/emergencies/[slug]/manage/logistics/actions.ts
+++ b/apps/web/src/app/emergencies/[slug]/manage/logistics/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { api } from '@/lib/api';
 import { requireSession, authHeaders, redirectToLogin } from '@/lib/auth';
 import { getT } from '@/i18n/server';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 export type ActionResult =
   | { status: 'idle' }

--- a/apps/web/src/app/emergencies/[slug]/manage/logistics/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/logistics/page.tsx
@@ -4,7 +4,7 @@ import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { WorkQueue } from '@/components/organisms/work-queue';
 import { QueueToolbar } from '@/components/molecules/queue-toolbar';
 import { ShipmentsList } from '@/components/organisms/shipments-list';

--- a/apps/web/src/app/emergencies/[slug]/manage/needs/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/needs/page.tsx
@@ -13,7 +13,7 @@ import { SearchBox } from '@/components/molecules/search-box';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { getT } from '@/i18n/server';
 import { getCategoriesCached } from '@/adapters/get-categories';
-import type { paths } from '@reliefhub/api-client';
+import type { paths } from '@responsegrid/api-client';
 
 export const dynamic = 'force-dynamic';
 

--- a/apps/web/src/app/emergencies/[slug]/manage/offers/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/offers/page.tsx
@@ -4,7 +4,7 @@ import { redirectToLogin } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { getEmergencyBySlug } from '@/lib/emergencies';
 import { resolveManageAccess } from '@/lib/manage-access';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { WorkQueue } from '@/components/organisms/work-queue';
 import { QueueToolbar } from '@/components/molecules/queue-toolbar';
 import { OffersQueue } from '@/components/organisms/coordination-queues';

--- a/apps/web/src/app/emergencies/[slug]/manage/volunteers/page.tsx
+++ b/apps/web/src/app/emergencies/[slug]/manage/volunteers/page.tsx
@@ -12,7 +12,7 @@ import { TaskCard } from '@/components/organisms/task-card';
 import { CreateTaskForm } from '@/components/organisms/create-task-form';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { getT } from '@/i18n/server';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { VALID_SKILLS, type VolunteerSkill } from './skills';
 
 export const dynamic = 'force-dynamic';

--- a/apps/web/src/app/emergencies/[slug]/manage/volunteers/skills.ts
+++ b/apps/web/src/app/emergencies/[slug]/manage/volunteers/skills.ts
@@ -1,4 +1,4 @@
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 export type VolunteerSkill = components['schemas']['VolunteerViewDto']['skills'][number];
 

--- a/apps/web/src/components/atoms/status-light.tsx
+++ b/apps/web/src/components/atoms/status-light.tsx
@@ -1,4 +1,4 @@
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import type { Messages } from '@/i18n/messages/es';
 import { es } from '@/i18n/messages/es';
 

--- a/apps/web/src/components/molecules/need-card.tsx
+++ b/apps/web/src/components/molecules/need-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { Card } from '@/components/atoms/card';
 import { PriorityBadge, type Priority } from '@/components/atoms/priority-badge';
 import { FreshnessIndicator } from '@/components/atoms/freshness-indicator';

--- a/apps/web/src/components/molecules/volunteer-card.tsx
+++ b/apps/web/src/components/molecules/volunteer-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useActionState } from 'react';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { updateVolunteerStatus } from '@/app/emergencies/[slug]/manage/volunteers/actions';
 import type { ActionResult } from '@/app/emergencies/[slug]/manage/volunteers/actions';
 import { Badge } from '@/components/atoms/badge';

--- a/apps/web/src/components/molecules/volunteer-suggestion-card.tsx
+++ b/apps/web/src/components/molecules/volunteer-suggestion-card.tsx
@@ -1,4 +1,4 @@
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { SkillTag } from '@/components/atoms/skill-tag';
 import type { getMessages } from '@/i18n';
 

--- a/apps/web/src/components/organisms/capacities-panel.tsx
+++ b/apps/web/src/components/organisms/capacities-panel.tsx
@@ -1,4 +1,4 @@
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import type { Messages } from '@/i18n/messages/es';
 import { Badge } from '@/components/atoms/badge';
 import { EmptyState } from '@/components/molecules/empty-state';

--- a/apps/web/src/components/organisms/coordination-queues.tsx
+++ b/apps/web/src/components/organisms/coordination-queues.tsx
@@ -13,7 +13,7 @@
  * may act, which gates the drawer's action button(s).
  */
 import { useState, useCallback } from 'react';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { Badge } from '@/components/atoms/badge';
 import { VerificationBadge } from '@/components/atoms/verification-badge';
 import { FreshnessIndicator } from '@/components/atoms/freshness-indicator';

--- a/apps/web/src/components/organisms/disputed-queue.tsx
+++ b/apps/web/src/components/organisms/disputed-queue.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState, useTransition } from 'react';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { Button } from '@/components/atoms/button';
 import { ErrorMessage } from '@/components/atoms/error-message';
 import { LocalDate } from '@/components/atoms/local-date';

--- a/apps/web/src/components/organisms/emergency-directory-card.tsx
+++ b/apps/web/src/components/organisms/emergency-directory-card.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { RelativeTime } from '@/components/atoms/relative-time';
 
 type EmergencyViewDto = components['schemas']['EmergencyViewDto'];

--- a/apps/web/src/components/organisms/emergency-map-wrapper.tsx
+++ b/apps/web/src/components/organisms/emergency-map-wrapper.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import type { MapPoint } from './emergency-map';
-import { createResponseGridClient } from '@reliefhub/api-client';
+import { createResponseGridClient } from '@responsegrid/api-client';
 import type { Map as LeafletMap, LatLngBounds } from 'leaflet';
 
 // Leaflet must only run in the browser — dynamic with ssr:false is only

--- a/apps/web/src/components/organisms/expired-need-card.tsx
+++ b/apps/web/src/components/organisms/expired-need-card.tsx
@@ -2,7 +2,7 @@
 
 import { useActionState } from 'react';
 import { renewNeed } from '@/app/emergencies/[slug]/manage/actions';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import type { ActionResult } from '@/app/emergencies/[slug]/manage/actions';
 import { Button } from '@/components/atoms/button';
 import { ErrorMessage } from '@/components/atoms/error-message';

--- a/apps/web/src/components/organisms/need-detail.tsx
+++ b/apps/web/src/components/organisms/need-detail.tsx
@@ -6,7 +6,7 @@ import {
   editNeed,
   discardNeed,
 } from '@/app/emergencies/[slug]/manage/actions';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import type { ActionResult } from '@/app/emergencies/[slug]/manage/actions';
 import { Badge } from '@/components/atoms/badge';
 import { Button } from '@/components/atoms/button';

--- a/apps/web/src/components/organisms/needs-list.tsx
+++ b/apps/web/src/components/organisms/needs-list.tsx
@@ -8,8 +8,8 @@
  */
 
 import { useState, useTransition, type ReactNode } from 'react';
-import { createResponseGridClient } from '@reliefhub/api-client';
-import type { components } from '@reliefhub/api-client';
+import { createResponseGridClient } from '@responsegrid/api-client';
+import type { components } from '@responsegrid/api-client';
 import { NeedCard } from '@/components/molecules/need-card';
 import { NearbyButton } from '@/components/molecules/nearby-button';
 import { DistanceBadge } from '@/components/atoms/distance-badge';

--- a/apps/web/src/components/organisms/offer-detail.tsx
+++ b/apps/web/src/components/organisms/offer-detail.tsx
@@ -8,7 +8,7 @@ import {
   editOffer,
   discardOffer,
 } from '@/app/emergencies/[slug]/manage/actions';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import type { ActionResult } from '@/app/emergencies/[slug]/manage/actions';
 import { Badge } from '@/components/atoms/badge';
 import { Button } from '@/components/atoms/button';

--- a/apps/web/src/components/organisms/personnel-need-panel.tsx
+++ b/apps/web/src/components/organisms/personnel-need-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useTransition } from 'react';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { SkillTag } from '@/components/atoms/skill-tag';
 import { ErrorMessage } from '@/components/atoms/error-message';
 import { VolunteerSuggestionCard } from '@/components/molecules/volunteer-suggestion-card';

--- a/apps/web/src/components/organisms/public-resource-card.tsx
+++ b/apps/web/src/components/organisms/public-resource-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import Link from 'next/link';
 import { VerificationBadge } from '@/components/atoms/verification-badge';
 import { StatusLight } from '@/components/atoms/status-light';

--- a/apps/web/src/components/organisms/resource-detail.tsx
+++ b/apps/web/src/components/organisms/resource-detail.tsx
@@ -6,7 +6,7 @@ import {
   editResource,
   discardResource,
 } from '@/app/emergencies/[slug]/manage/actions';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import type { ActionResult } from '@/app/emergencies/[slug]/manage/actions';
 import { Button } from '@/components/atoms/button';
 import { ErrorMessage } from '@/components/atoms/error-message';

--- a/apps/web/src/components/organisms/resource-list.tsx
+++ b/apps/web/src/components/organisms/resource-list.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useTransition, useEffect, useMemo, useRef } from 'react';
-import { createResponseGridClient } from '@reliefhub/api-client';
-import type { components } from '@reliefhub/api-client';
+import { createResponseGridClient } from '@responsegrid/api-client';
+import type { components } from '@responsegrid/api-client';
 import { groupByCountry, type ResourceViewDto } from '@/lib/group-by-country';
 import { PublicResourceCard } from '@/components/organisms/public-resource-card';
 import { ResourceFilterBar } from '@/components/molecules/resource-filter-bar';

--- a/apps/web/src/components/organisms/shipment-detail.tsx
+++ b/apps/web/src/components/organisms/shipment-detail.tsx
@@ -10,7 +10,7 @@ import {
   cancelShipment,
   type ActionResult,
 } from '@/app/emergencies/[slug]/manage/logistics/actions';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { Badge } from '@/components/atoms/badge';
 import { Button } from '@/components/atoms/button';
 import { Select } from '@/components/atoms/select';

--- a/apps/web/src/components/organisms/shipments-list.tsx
+++ b/apps/web/src/components/organisms/shipments-list.tsx
@@ -6,7 +6,7 @@
 // server action has already revalidated) to reflect the new status server-side.
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import { Badge } from '@/components/atoms/badge';
 import { EmptyState } from '@/components/molecules/empty-state';
 import { ShipmentDetail } from '@/components/organisms/shipment-detail';

--- a/apps/web/src/components/organisms/task-card.tsx
+++ b/apps/web/src/components/organisms/task-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useActionState, useState } from 'react';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import {
   assignVolunteer,
   unassignVolunteer,

--- a/apps/web/src/domain/supplies/catalogue-supply.ts
+++ b/apps/web/src/domain/supplies/catalogue-supply.ts
@@ -1,4 +1,4 @@
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 type SupplyDto = components['schemas']['SupplyDto'];
 

--- a/apps/web/src/domain/supplies/category.ts
+++ b/apps/web/src/domain/supplies/category.ts
@@ -1,4 +1,4 @@
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 type CategoryDto = components['schemas']['CategoryDto'];
 

--- a/apps/web/src/domain/supplies/supply-line.ts
+++ b/apps/web/src/domain/supplies/supply-line.ts
@@ -1,4 +1,4 @@
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 import type { CatalogueSupply } from '@/domain/supplies/catalogue-supply';
 import type { Category } from '@/domain/supplies/category';
 

--- a/apps/web/src/i18n/messages/en.ts
+++ b/apps/web/src/i18n/messages/en.ts
@@ -41,7 +41,7 @@ export const en = {
       legal_heading: 'Legal',
       privacy: 'Privacy',
       terms: 'Terms & conditions',
-      copyright: '© {year} Global Emergency · Open source (MIT)',
+      copyright: '© {year} Global Emergency · Open source (AGPL-3.0)',
       built_by: 'Built by volunteers',
       aria_label: 'Footer',
       bots_heading: 'Help via chat',
@@ -157,7 +157,7 @@ export const en = {
     features_cta: 'See all features',
     features_heading: 'The whole operation on a single platform',
     features_intro:
-      'ResponseGrid is not just another map: it is the full infrastructure to coordinate material aid in a disaster. All free and open source (MIT licence), with data hosted in the EU (GDPR).',
+      'ResponseGrid is not just another map: it is the full infrastructure to coordinate material aid in a disaster. All free and open source (AGPL-3.0 licence), with data hosted in the EU (GDPR).',
     features: [
       {
         icon: '📍',
@@ -212,7 +212,7 @@ export const en = {
       {
         icon: '🔌',
         title: 'Public API and open source',
-        body: 'Read-only open data, developer documentation and fully auditable code (MIT).',
+        body: 'Read-only open data, developer documentation and fully auditable code (AGPL-3.0).',
       },
     ],
 
@@ -1199,7 +1199,7 @@ export const en = {
       },
       {
         heading: 'Trust, open data and developers',
-        body: 'Every resource shows its trust level: unverified, validated by coordination or accredited organisation. The platform is open source (MIT licence), hosts data in the EU (GDPR) and offers a read-only public API with developer documentation.',
+        body: 'Every resource shows its trust level: unverified, validated by coordination or accredited organisation. The platform is open source (AGPL-3.0 licence), hosts data in the EU (GDPR) and offers a read-only public API with developer documentation.',
       },
     ],
     cta_heading: 'Want to help now?',
@@ -1217,7 +1217,7 @@ export const en = {
     lead:
       'ResponseGrid is a free, non-profit platform by Global Emergency. It connects citizens, organisations and coordinators during a disaster so every effort is useful, verified and doesn’t overload logistics.',
     stat_open: 'Open source',
-    stat_open_value: 'MIT',
+    stat_open_value: 'AGPL-3.0',
     stat_realtime: 'Real-time information',
     stat_realtime_value: '24/7',
     stat_data: 'Data hosted in the EU',
@@ -1230,7 +1230,7 @@ export const en = {
       'We publish only points and campaigns verified by local coordination, validate real needs and match supply offers with those who request them. All information is official and in real time.',
     open_heading: 'Open source, built by volunteers',
     open_body:
-      'The code is open (MIT licence) and built and maintained by volunteers. Anyone can audit it, improve it or deploy it for their own region.',
+      'The code is open (AGPL-3.0 licence) and built and maintained by volunteers. Anyone can audit it, improve it or deploy it for their own region.',
     ge_heading: 'Part of Global Emergency',
     ge_body:
       'ResponseGrid is one of Global Emergency’s projects, an initiative that democratises access to professional technology for Civil Protection and emergency services.',
@@ -1272,7 +1272,7 @@ export const en = {
   transparency: {
     meta_title: 'Transparency — ResponseGrid',
     meta_description:
-      'Transparency at ResponseGrid: verification before publishing, data protected in the EU (GDPR), open source under the MIT licence and open governance by volunteers.',
+      'Transparency at ResponseGrid: verification before publishing, data protected in the EU (GDPR), open source under the AGPL-3.0 licence and open governance by volunteers.',
     overline: 'Transparency',
     h1: 'Transparency and trust, by design',
     lead:
@@ -1283,9 +1283,9 @@ export const en = {
     data_heading: 'Your data, protected',
     data_body:
       'Privacy by design: we ask for the minimum data, sensitive locations are published with approximate coordinates, and personal data (such as the contact details of those who offer or request help) is never exposed. Data hosted in the EU, GDPR-compliant.',
-    license_heading: 'Open source (MIT)',
+    license_heading: 'Open source (AGPL-3.0)',
     license_body:
-      'All the code is public and under the MIT licence. Anyone can audit it, contribute or deploy it. No black boxes: what you see is what it does.',
+      'All the code is public and under the AGPL-3.0 licence. Anyone can audit it, contribute or deploy it. No black boxes: what you see is what it does.',
     governance_heading: 'Open governance',
     governance_body:
       'ResponseGrid is a Global Emergency project, maintained by volunteers. Decisions and the roadmap are discussed in the open in the public repository.',
@@ -1526,7 +1526,7 @@ export const en = {
     links_openapi_b: 'The OpenAPI JSON, to generate clients or import into your tools.',
     links_client_t: 'Typed TypeScript client',
     links_client_b:
-      'The @reliefhub/api-client package (openapi-fetch): types and autocomplete to consume the API from TypeScript.',
+      'The @responsegrid/api-client package (openapi-fetch): types and autocomplete to consume the API from TypeScript.',
 
     // Tables
     th_field: 'Field',

--- a/apps/web/src/i18n/messages/es.ts
+++ b/apps/web/src/i18n/messages/es.ts
@@ -40,7 +40,7 @@ export const es = {
       legal_heading: 'Legal',
       privacy: 'Privacidad',
       terms: 'Términos y condiciones',
-      copyright: '© {year} Global Emergency · Código abierto (MIT)',
+      copyright: '© {year} Global Emergency · Código abierto (AGPL-3.0)',
       built_by: 'Hecho por voluntarios',
       aria_label: 'Pie de página',
       bots_heading: 'Ayuda por chat',
@@ -163,7 +163,7 @@ export const es = {
     features_cta: 'Ver todas las funcionalidades',
     features_heading: 'Todo el operativo en una sola plataforma',
     features_intro:
-      'ResponseGrid no es un mapa más: es la infraestructura completa para coordinar ayuda material en una catástrofe. Todo gratuito y de código abierto (licencia MIT), con los datos alojados en la UE (RGPD).',
+      'ResponseGrid no es un mapa más: es la infraestructura completa para coordinar ayuda material en una catástrofe. Todo gratuito y de código abierto (licencia AGPL-3.0), con los datos alojados en la UE (RGPD).',
     features: [
       {
         icon: '📍',
@@ -218,7 +218,7 @@ export const es = {
       {
         icon: '🔌',
         title: 'API pública y open source',
-        body: 'Datos abiertos de solo lectura, documentación para desarrolladores y todo el código auditable (MIT).',
+        body: 'Datos abiertos de solo lectura, documentación para desarrolladores y todo el código auditable (AGPL-3.0).',
       },
     ],
 
@@ -1238,7 +1238,7 @@ export const es = {
       },
       {
         heading: 'Confianza, datos abiertos y desarrolladores',
-        body: 'Todo recurso muestra su nivel de confianza: sin verificar, verificado por coordinación u organización acreditada. La plataforma es de código abierto (licencia MIT), aloja los datos en la UE (RGPD) y ofrece una API pública de solo lectura con documentación para desarrolladores.',
+        body: 'Todo recurso muestra su nivel de confianza: sin verificar, verificado por coordinación u organización acreditada. La plataforma es de código abierto (licencia AGPL-3.0), aloja los datos en la UE (RGPD) y ofrece una API pública de solo lectura con documentación para desarrolladores.',
       },
     ],
     cta_heading: '¿Quieres ayudar ahora?',
@@ -1256,7 +1256,7 @@ export const es = {
     lead:
       'ResponseGrid es una plataforma libre y sin ánimo de lucro de Global Emergency. Conecta a la ciudadanía, las organizaciones y la coordinación durante una catástrofe para que cada esfuerzo sea útil, verificado y sin saturar la logística.',
     stat_open: 'Código abierto',
-    stat_open_value: 'MIT',
+    stat_open_value: 'AGPL-3.0',
     stat_realtime: 'Información en tiempo real',
     stat_realtime_value: '24/7',
     stat_data: 'Datos alojados en la UE',
@@ -1269,7 +1269,7 @@ export const es = {
       'Publicamos solo puntos y campañas verificados por coordinación local, validamos las necesidades reales y casamos las ofertas de material con quien las pide. Toda la información es oficial y en tiempo real.',
     open_heading: 'Open source y de los voluntarios',
     open_body:
-      'El código es abierto (licencia MIT) y está hecho y mantenido por personas voluntarias. Cualquiera puede auditarlo, mejorarlo o desplegarlo para su territorio.',
+      'El código es abierto (licencia AGPL-3.0) y está hecho y mantenido por personas voluntarias. Cualquiera puede auditarlo, mejorarlo o desplegarlo para su territorio.',
     ge_heading: 'Parte de Global Emergency',
     ge_body:
       'ResponseGrid es uno de los proyectos de Global Emergency, una iniciativa que democratiza el acceso a tecnología profesional para Protección Civil y los servicios de emergencia.',
@@ -1311,7 +1311,7 @@ export const es = {
   transparency: {
     meta_title: 'Transparencia — ResponseGrid',
     meta_description:
-      'Transparencia en ResponseGrid: verificación antes de publicar, datos protegidos en la UE (RGPD), código abierto bajo licencia MIT y gobernanza abierta por voluntarios.',
+      'Transparencia en ResponseGrid: verificación antes de publicar, datos protegidos en la UE (RGPD), código abierto bajo licencia AGPL-3.0 y gobernanza abierta por voluntarios.',
     overline: 'Transparencia',
     h1: 'Transparencia y confianza, por diseño',
     lead:
@@ -1322,9 +1322,9 @@ export const es = {
     data_heading: 'Tus datos, protegidos',
     data_body:
       'Privacidad por diseño: pedimos los datos mínimos, las ubicaciones sensibles se publican con coordenadas aproximadas y los datos personales (como los datos de contacto de quienes ofrecen o solicitan ayuda) nunca se exponen. Datos alojados en la UE, conforme al RGPD.',
-    license_heading: 'Código abierto (MIT)',
+    license_heading: 'Código abierto (AGPL-3.0)',
     license_body:
-      'Todo el código es público y está bajo licencia MIT. Cualquiera puede auditarlo, contribuir o desplegarlo. Sin cajas negras: lo que ves es lo que hace.',
+      'Todo el código es público y está bajo licencia AGPL-3.0. Cualquiera puede auditarlo, contribuir o desplegarlo. Sin cajas negras: lo que ves es lo que hace.',
     governance_heading: 'Gobernanza abierta',
     governance_body:
       'ResponseGrid es un proyecto de Global Emergency, mantenido por voluntarios. Las decisiones y la hoja de ruta se debaten en abierto en el repositorio público.',
@@ -1567,7 +1567,7 @@ export const es = {
     links_openapi_b: 'El JSON de OpenAPI, para generar clientes o importar en tus herramientas.',
     links_client_t: 'Cliente TypeScript tipado',
     links_client_b:
-      'Paquete @reliefhub/api-client (openapi-fetch): tipos y autocompletado para consumir la API desde TypeScript.',
+      'Paquete @responsegrid/api-client (openapi-fetch): tipos y autocompletado para consumir la API desde TypeScript.',
 
     // Tablas
     th_field: 'Campo',

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { createResponseGridClient } from '@reliefhub/api-client';
+import { createResponseGridClient } from '@responsegrid/api-client';
 
 /**
  * Pre-configured API client — use ONLY in Server Components or Server Actions.

--- a/apps/web/src/lib/emergencies.ts
+++ b/apps/web/src/lib/emergencies.ts
@@ -1,6 +1,6 @@
 import { cache } from 'react';
 import { api } from '@/lib/api';
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 export type EmergencyViewDto = components['schemas']['EmergencyViewDto'];
 

--- a/apps/web/src/lib/group-by-country.ts
+++ b/apps/web/src/lib/group-by-country.ts
@@ -11,7 +11,7 @@
  * for any record that happens to be stored that way.
  */
 
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 
 export type ResourceViewDto = components['schemas']['ResourceViewDto'];
 

--- a/apps/web/src/lib/supply-lines.ts
+++ b/apps/web/src/lib/supply-lines.ts
@@ -1,4 +1,4 @@
-import type { components } from '@reliefhub/api-client';
+import type { components } from '@responsegrid/api-client';
 // Relative + .ts extension (not the `@/` alias) so the `node --test` runner,
 // which does not resolve tsconfig paths, can load this value import.
 import { buildSupplyLineDto } from '../domain/supplies/supply-line.ts';

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -15,7 +15,7 @@ pnpm --filter api exec prettier --check "src/**/*.ts" "test/**/*.ts"
 pnpm --filter api test
 
 # Web (si tocas apps/web)
-pnpm --filter @reliefhub/api-client build
+pnpm --filter @responsegrid/api-client build
 pnpm --filter web build
 pnpm --filter web lint
 ```

--- a/docs/deploy/aws-free-tier.md
+++ b/docs/deploy/aws-free-tier.md
@@ -85,7 +85,7 @@ Las **migraciones se aplican solas** (servicio `migrate`, idempotente). Caddy pi
 
 1. **Importa el repo** en Vercel.
 2. **Root Directory:** `apps/web`.
-3. **Build Command** (override): `pnpm --filter @reliefhub/api-client build && next build`.
+3. **Build Command** (override): `pnpm --filter @responsegrid/api-client build && next build`.
 4. **Environment Variables:**
    - `API_URL` = `https://api.tudominio.com`
    - `NEXT_PUBLIC_API_URL` = `https://api.tudominio.com`

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "reliefhub",
+  "name": "responsegrid",
   "private": true,
   "packageManager": "pnpm@10.33.4",
   "scripts": {
     "dev:infra": "docker compose up -d",
     "api:dev": "pnpm --filter api start:dev",
     "api:test": "pnpm --filter api test",
-    "gen:api": "pnpm --filter api gen:openapi && pnpm --filter @reliefhub/api-client generate"
+    "gen:api": "pnpm --filter api gen:openapi && pnpm --filter @responsegrid/api-client generate"
   },
   "pnpm": {
     "overrides": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reliefhub/api-client",
+  "name": "@responsegrid/api-client",
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/warehouse-core/eslint.config.mjs
+++ b/packages/warehouse-core/eslint.config.mjs
@@ -29,7 +29,7 @@ export default tseslint.config(
                 'warehouse-core es dominio puro: no puede importar ORM/driver de BD.',
             },
             {
-              group: ['**/apps/*', '@reliefhub/*'],
+              group: ['**/apps/*', '@responsegrid/*'],
               message:
                 'Dependencia unidireccional: warehouse-core nunca importa de los hosts.',
             },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,7 +194,7 @@ importers:
 
   apps/web:
     dependencies:
-      '@reliefhub/api-client':
+      '@responsegrid/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
       leaflet:
@@ -8735,7 +8735,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -8772,7 +8772,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8786,7 +8786,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Resumen

Resuelve las dos incoherencias de percepción externa de la #300 (marca y licencia). Alcance acordado con el mantenedor: **licencia + rename del SDK público**.

### 1. Licencia — MIT → AGPL-3.0
La licencia autoritativa es **AGPL-3.0** (fichero `LICENSE`), pero el copy de cara al usuario declaraba **MIT**. Alineadas todas las menciones públicas:
- `apps/web/src/i18n/messages/{es,en}.ts` (copyright, hero, transparencia, stat "Código abierto", sección de licencia).
- `apps/web/public/llms.txt`.
- `apps/api/README.md` — era boilerplate íntegro de NestJS ("Nest is MIT licensed"); reemplazado por un README real de la API que indica AGPL-3.0.
- La licencia de **datos** del portal `/docs` (**CC BY-SA 4.0**) es distinta y se **mantiene** intacta.

### 2. Naming — `@reliefhub/api-client` → `@responsegrid/api-client`
Renombrado el scope del SDK público (el `createClient` ya era `createResponseGridClient`) y el `name` del `package.json` raíz `reliefhub` → `responsegrid`:
- Paquete `packages/api-client/package.json`, dependencia en `apps/web/package.json`, `transpilePackages` de `next.config.ts`, script `gen:api`, filtro de build en `ci.yml` e imports en toda la web.
- `pnpm-lock.yaml` regenerado (pnpm 10.33.4).
- Guard `no-restricted-imports` de `warehouse-core` actualizado al nuevo scope para que no quede como no-op.

> Nota: el monorepo tiene ahora también el scope `@globalemergency/*` (warehouse-core, #356). Mantengo `@responsegrid` para el **SDK público** (marca de producto, tal como pide la issue); si se quiere unificar todo a un único scope, es una decisión aparte.

### Fuera de alcance (deuda documentada en #300)
Identificadores internos no visibles: usuario/BD Postgres `reliefhub`, prefijo `rh_live_`, dominios de credenciales demo (`coord@reliefhub.org`). Y la badge MIT del perfil de la org, que vive en `GlobalEmergency/.github` (repo distinto, inaccesible desde aquí).

> ⚠️ **Deploy Vercel:** el *Build Command* del proyecto en el dashboard referencia el nombre viejo del paquete (`pnpm --filter @reliefhub/api-client build && next build`). Tras este rename hay que actualizarlo a `@responsegrid/api-client`, o el preview y el deploy de producción fallan. Config externa al repo.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `@responsegrid/api-client` build ✓, `web lint` (0 errores) ✓, `web build` ✓. El `reliefhub` interno de Postgres en `ci.yml` queda intacto a propósito.
- [x] Verifiqué el comportamiento manualmente si aplica — build de web OK con el nuevo scope; sin referencias `MIT` ni `@reliefhub/api-client` residuales (salvo `docs/features/*` *frozen legacy*).
- [x] Actualicé docs, migraciones o cliente API si correspondía — `AGENTS.md`, `docs/DEFINITION_OF_DONE.md`, `docs/deploy/aws-free-tier.md`, `apps/api/README.md`; no hubo cambios de schema (sin migraciones).

## Cierre

- Closes #300