### PR TITLE
docs(agents): añade `pnpm --filter web test` al gate documentado (#351)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ pnpm --filter api test                  # runInBand; global-setup spins up relie
 # web (build the api-client first):
 pnpm --filter @reliefhub/api-client build && pnpm --filter web build
 pnpm --filter web lint
+pnpm --filter web test                  # node --test on .ts → needs Node ≥22.6 (native type-stripping); CI runs this step on Node 22
 ```
 
 If you change dependencies, regenerate the lockfile with `pnpm install` (pnpm 10.33.4) and commit `pnpm-lock.yaml` — lockfiles do **not** 3-way-merge cleanly, so regenerate after any merge that touched deps (else the Docker build fails on `--frozen-lockfile`).


### PR DESCRIPTION
Closes #351

## Contexto
El issue #351 pedía dos cosas: (1) cablear `pnpm --filter web test` en CI, y (2) reflejarlo en el gate de `AGENTS.md`.

**El punto (1) ya está hecho en `main`**: el commit `699c026` (#354) añadió al job `Test` un step que corre `pnpm --filter web test` en **Node 22** (necesario por el type-stripping nativo de `node --test` sobre `.ts`), y está en el job **requerido**, así que ya gatea el merge. Verificado en `.github/workflows/ci.yml`.

## Cambio
Solo faltaba la parte (2): el gate documentado en `AGENTS.md` (sección *The gate*) listaba `web build` y `web lint` pero no `web test`. Se añade la línea, con la nota del Node ≥22.6 que usa CI, para que el gate documentado quede en sincronía con lo que CI realmente ejecuta.

Con esto, los tests de `apps/web` (drift de rutas, backend-error-messages, app-bar-context, supply-lines, etc.) ya no son advisory: bloquean el merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_019VvSt5e3JoUEe2VF1EUrZY)_