### PR TITLE
feat(warehouse-core): añade ScopeId, el id opaco de tenencia del kernel

### DIFF
--- a/apps/api/src/contexts/supplies/domain/scope-id.spec.ts
+++ b/apps/api/src/contexts/supplies/domain/scope-id.spec.ts
@@ -1,0 +1,31 @@
+import {
+  ScopeId,
+  ScopeIdValidationError,
+} from '@globalemergency/warehouse-core/kernel';
+
+describe('ScopeId', () => {
+  it('create() genera un id no vacío', () => {
+    const id = ScopeId.create();
+    expect(id.value).toBeTruthy();
+    expect(id.value.length).toBeGreaterThan(0);
+  });
+
+  it('fromString acepta cualquier string no vacío y lo recorta', () => {
+    expect(ScopeId.fromString('org-123').value).toBe('org-123');
+    expect(ScopeId.fromString('  abc  ').value).toBe('abc');
+    // No exige formato UUID: es un id de owner opaco y genérico.
+    expect(
+      ScopeId.fromString('11111111-1111-4111-8111-111111111111').value,
+    ).toBe('11111111-1111-4111-8111-111111111111');
+  });
+
+  it('fromString rechaza vacío o solo espacios', () => {
+    expect(() => ScopeId.fromString('')).toThrow(ScopeIdValidationError);
+    expect(() => ScopeId.fromString('   ')).toThrow(ScopeIdValidationError);
+  });
+
+  it('equals compara por valor', () => {
+    expect(ScopeId.fromString('a').equals(ScopeId.fromString('a'))).toBe(true);
+    expect(ScopeId.fromString('a').equals(ScopeId.fromString('b'))).toBe(false);
+  });
+});

--- a/packages/warehouse-core/package.json
+++ b/packages/warehouse-core/package.json
@@ -46,6 +46,7 @@
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\""
   },
   "devDependencies": {
+    "@types/node": "^24.0.0",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/warehouse-core/src/kernel/index.ts
+++ b/packages/warehouse-core/src/kernel/index.ts
@@ -13,3 +13,4 @@ export type {
 } from './category-definition.js';
 export { SupplyLine, SupplyLineValidationError } from './supply-line.js';
 export type { SupplyLineProps, SupplyLineSnapshot } from './supply-line.js';
+export { ScopeId, ScopeIdValidationError } from './scope-id.js';

--- a/packages/warehouse-core/src/kernel/scope-id.ts
+++ b/packages/warehouse-core/src/kernel/scope-id.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from 'node:crypto';
+
+/**
+ * ScopeId — el identificador **opaco de tenencia/partición** del núcleo de
+ * almacén. El paquete no sabe qué representa: en el WMS standalone es la
+ * Organización (Protección Civil) dueña del almacén; en ResponseGrid es la
+ * emergencia/centro. Cada host mapea su propio id a un `ScopeId` en la frontera.
+ *
+ * A diferencia de un `EmergencyId`, es deliberadamente **genérico**: acepta
+ * cualquier string no vacío (un owner id no tiene por qué ser un UUID), de modo
+ * que el mismo núcleo sirve a cualquier sector. `create()` genera un UUID como
+ * comodidad, pero `fromString` no exige ese formato.
+ */
+export class ScopeIdValidationError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'ScopeIdValidationError';
+  }
+}
+
+export class ScopeId {
+  private constructor(public readonly value: string) {}
+
+  static create(): ScopeId {
+    return new ScopeId(randomUUID());
+  }
+
+  static fromString(s: string): ScopeId {
+    const trimmed = typeof s === 'string' ? s.trim() : '';
+    if (trimmed === '') {
+      throw new ScopeIdValidationError('ScopeId must be a non-empty string');
+    }
+    return new ScopeId(trimmed);
+  }
+
+  equals(other: ScopeId): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
 
   packages/warehouse-core:
     devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.2
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -6772,7 +6775,7 @@ snapshots:
   '@jest/console@30.4.1':
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       chalk: 4.1.2
       jest-message-util: 30.4.1
       jest-util: 30.4.1
@@ -6786,7 +6789,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
@@ -6794,7 +6797,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
+      jest-config: 30.4.2(@types/node@26.1.0)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -6820,7 +6823,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       jest-mock: 30.4.1
 
   '@jest/expect-utils@30.4.1':
@@ -6838,7 +6841,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.4.1
       '@sinonjs/fake-timers': 15.4.0
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       jest-message-util: 30.4.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
@@ -6856,7 +6859,7 @@ snapshots:
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.4.1':
@@ -6867,7 +6870,7 @@ snapshots:
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -6943,7 +6946,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -7494,11 +7497,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
 
   '@types/cookiejar@2.1.5': {}
 
@@ -7516,7 +7519,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -7553,7 +7556,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
 
   '@types/leaflet.markercluster@1.5.6':
     dependencies:
@@ -7581,7 +7584,7 @@ snapshots:
 
   '@types/oauth@0.9.6':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
 
   '@types/passport-facebook@3.0.4':
     dependencies:
@@ -7629,12 +7632,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
 
   '@types/stack-utils@2.0.3': {}
 
@@ -7642,7 +7645,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       form-data: 4.0.6
 
   '@types/supertest@7.2.0':
@@ -9579,7 +9582,7 @@ snapshots:
       '@jest/expect': 30.4.1
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -9650,6 +9653,38 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.4.2(@types/node@26.1.0)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.4.2
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 26.1.0
+      ts-node: 10.9.2(@types/node@24.13.2)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@30.4.1:
     dependencies:
       '@jest/diff-sequences': 30.4.0
@@ -9674,7 +9709,7 @@ snapshots:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       jest-mock: 30.4.1
       jest-util: 30.4.1
       jest-validate: 30.4.1
@@ -9682,7 +9717,7 @@ snapshots:
   jest-haste-map@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9722,7 +9757,7 @@ snapshots:
   jest-mock@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       jest-util: 30.4.1
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
@@ -9756,7 +9791,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -9785,7 +9820,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -9832,7 +9867,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -9851,7 +9886,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9860,13 +9895,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@30.4.1:
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       '@ungap/structured-clone': 1.3.2
       jest-util: 30.4.1
       merge-stream: 2.0.0


### PR DESCRIPTION
## Resumen

Cuarto incremento de la extracción (épica #355, **Fase 0**). Introduce **`ScopeId`** en `@globalemergency/warehouse-core/kernel`: el **identificador opaco de tenencia/partición** del núcleo de almacén.

- El paquete no sabe qué representa: en el **WMS standalone** es la Organización (Protección Civil) dueña del almacén; en **ResponseGrid** es la emergencia/centro. Cada host mapea su id a un `ScopeId` en la frontera.
- Deliberadamente **genérico**: acepta cualquier string no vacío (`fromString` recorta y valida no-vacío; `create()` genera un UUID por comodidad, sin exigir ese formato) → el mismo núcleo sirve a cualquier sector.
- Es la abstracción que consumirán **`containers`** y **`logistics`** al moverse al paquete: permite la **genericización dirigida** de `EmergencyId` (mapeo en la frontera del host), en vez de un rename global de `EmergencyId` por todo `apps/api`.

Añade `@types/node` al paquete (`ScopeId` usa `node:crypto` para `randomUUID`, igual que `EmergencyId` en el shared kernel; el WMS es server-side). Spec en `apps/api` (`supplies/domain/scope-id.spec.ts`) para cobertura en CI.

Cambio **aditivo y aislado**: `apps/api` aún no consume `ScopeId` (lo hará el incremento de `containers`), así que no toca comportamiento existente.

## Validación

- [x] Gate local: build dual de ambos paquetes ✅, `nest build` ✅, `eslint` ✅, `prettier --check` ✅.
- [x] Type-check completo (incl. specs) **neutral vs `main`**: 46/46.
- [x] Smoke CJS/ESM de `ScopeId` (create/fromString/trim/rechazo de vacío/equals) ✅.
- [x] `test` (el spec de `ScopeId`) / `e2e` / `build`: los valida el CI.

## Cierre

- Parte de #355 (Fase 0 · `ScopeId`). **No cierra** la épica.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_