### PR TITLE
feat(warehouse-core): estrena el núcleo WMS nuevo con el módulo inventory (Warehouse + Zone)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,13 @@ jobs:
       - name: Run tests — web
         run: pnpm --filter web test
 
+      # warehouse-core ships its own domain unit tests: they compile with tsc to
+      # a throwaway dir and run via `node --test` on the emitted JS (glob support
+      # needs Node ≥ 21, hence after the Node 22 switch above). Kept in the
+      # required Test job so the new WMS core actually gates the merge.
+      - name: Run tests — warehouse-core
+        run: pnpm --filter '@globalemergency/warehouse-core' test
+
   # ── E2E tests ───────────────────────────────────────────────────────────────
   # The unit/int suite (`Test` job) does NOT cover the HTTP e2e specs under
   # apps/api/test — they run via a separate jest config. Run them here so an

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 node_modules/
 dist/
 packages/*/dist/
+packages/*/dist-test/
 .next/
 
 # Generated artifacts

--- a/packages/warehouse-core/.prettierrc
+++ b/packages/warehouse-core/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/warehouse-core/eslint.config.mjs
+++ b/packages/warehouse-core/eslint.config.mjs
@@ -7,7 +7,7 @@ import tseslint from 'typescript-eslint';
 // ajustada a la estructura de este paquete (todo src/ es dominio puro).
 export default tseslint.config(
   {
-    ignores: ['dist', 'eslint.config.mjs'],
+    ignores: ['dist', 'dist-test', 'eslint.config.mjs'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,

--- a/packages/warehouse-core/package.json
+++ b/packages/warehouse-core/package.json
@@ -55,6 +55,16 @@
         "types": "./dist/cjs/logistics/index.d.ts",
         "default": "./dist/cjs/logistics/index.js"
       }
+    },
+    "./inventory": {
+      "import": {
+        "types": "./dist/esm/inventory/index.d.ts",
+        "default": "./dist/esm/inventory/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/inventory/index.d.ts",
+        "default": "./dist/cjs/inventory/index.js"
+      }
     }
   },
   "files": [
@@ -63,6 +73,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))\"",
     "typecheck": "tsc -p tsconfig.esm.json --noEmit",
+    "test": "tsc -p tsconfig.test.json && node --test \"dist-test/**/*.test.js\"",
+    "pretest": "node -e \"require('fs').rmSync('dist-test', { recursive: true, force: true })\"",
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\""
   },
   "devDependencies": {

--- a/packages/warehouse-core/src/index.ts
+++ b/packages/warehouse-core/src/index.ts
@@ -9,3 +9,4 @@ export * from './kernel/index.js';
 export * from './catalog/index.js';
 export * from './containers/index.js';
 export * from './logistics/index.js';
+export * from './inventory/index.js';

--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -1,0 +1,30 @@
+/**
+ * inventory — el backbone de ubicaciones del WMS nuevo (Fase 2). Aggregate
+ * root `Warehouse` (almacén) con sus entidades `Zone` (áreas: recepción/
+ * almacenaje/picking/expedición/cuarentena), sobre `ScopeId` (tenencia opaca).
+ *
+ * Dominio puro: sin NestJS, sin ORM, sin infraestructura. Los `Bin` y el stock
+ * (`StockItem`/`StockMovement`) llegan en incrementos siguientes y referencian
+ * este backbone por id.
+ */
+export { WarehouseId } from './warehouse-id.js';
+export { ZoneId } from './zone-id.js';
+export { WarehouseStatus, ZoneStatus, ZoneKind } from './inventory-enums.js';
+export {
+  WarehouseValidationError,
+  DuplicateZoneCodeError,
+  WarehouseArchivedError,
+} from './inventory-errors.js';
+export { Warehouse, Zone } from './warehouse.js';
+export type {
+  WarehouseGeo,
+  AddZoneProps,
+  CreateWarehouseProps,
+  ZoneSnapshot,
+  WarehouseSnapshot,
+} from './warehouse.js';
+export {
+  WAREHOUSE_REPOSITORY,
+  type WarehouseRepository,
+  type ListWarehousesFilter,
+} from './ports/warehouse.repository.js';

--- a/packages/warehouse-core/src/inventory/inventory-enums.ts
+++ b/packages/warehouse-core/src/inventory/inventory-enums.ts
@@ -1,0 +1,35 @@
+/**
+ * Lifecycle of a {@link Warehouse}. `active` while in use; `archived` once
+ * decommissioned — an archived warehouse keeps its history (and its bins/stock
+ * for the record) but accepts no new zones and is hidden from the operational
+ * pickers. Deliberately binary: a WMS warehouse is either operating or retired.
+ */
+export enum WarehouseStatus {
+  Active = 'active',
+  Archived = 'archived',
+}
+
+/**
+ * Lifecycle of a {@link Zone}. Mirrors the warehouse: `active` or `archived`.
+ * Archiving a zone (e.g. a bay taken out of service) keeps its id valid for
+ * historical references while removing it from the operational layout.
+ */
+export enum ZoneStatus {
+  Active = 'active',
+  Archived = 'archived',
+}
+
+/**
+ * Functional role of a {@link Zone} within the warehouse — the coarse WMS
+ * layout. `receiving` (recepción) takes inbound goods, `storage` (almacenaje)
+ * holds them, `picking` is the pick face, `shipping` (expedición) stages
+ * outbound, and `quarantine` (cuarentena) isolates damaged/expired/held stock.
+ * Descriptive, not a hard routing constraint — flows are enforced elsewhere.
+ */
+export enum ZoneKind {
+  Receiving = 'receiving',
+  Storage = 'storage',
+  Picking = 'picking',
+  Shipping = 'shipping',
+  Quarantine = 'quarantine',
+}

--- a/packages/warehouse-core/src/inventory/inventory-errors.ts
+++ b/packages/warehouse-core/src/inventory/inventory-errors.ts
@@ -1,0 +1,35 @@
+/**
+ * Raised on invalid warehouse/zone input (empty code or name, out-of-range
+ * coordinates, unknown zone id). The HTTP layer of each host maps it to 422.
+ */
+export class WarehouseValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WarehouseValidationError';
+  }
+}
+
+/**
+ * Raised when two zones in the same warehouse would share a code, or when
+ * adding a zone whose code already exists. Zone codes are the human-facing
+ * labels of the layout and must be unique within their warehouse. The HTTP
+ * layer maps this to 409 Conflict.
+ */
+export class DuplicateZoneCodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DuplicateZoneCodeError';
+  }
+}
+
+/**
+ * Raised when mutating an archived warehouse or zone (adding a zone to an
+ * archived warehouse, renaming an archived zone…). Archived layout is
+ * read-only history; the HTTP layer maps this to 409 Conflict.
+ */
+export class WarehouseArchivedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WarehouseArchivedError';
+  }
+}

--- a/packages/warehouse-core/src/inventory/ports/warehouse.repository.ts
+++ b/packages/warehouse-core/src/inventory/ports/warehouse.repository.ts
@@ -1,0 +1,26 @@
+import { Warehouse } from '../warehouse.js';
+import { WarehouseId } from '../warehouse-id.js';
+import { ScopeId } from '../../kernel/index.js';
+import { WarehouseStatus } from '../inventory-enums.js';
+
+export const WAREHOUSE_REPOSITORY = Symbol('WarehouseRepository');
+
+/** Filter for listing warehouses within a scope. AND-combined. */
+export interface ListWarehousesFilter {
+  status?: WarehouseStatus;
+}
+
+export interface WarehouseRepository {
+  save(warehouse: Warehouse): Promise<void>;
+  findById(id: WarehouseId): Promise<Warehouse | null>;
+  /**
+   * Resolves a warehouse by its human code within a scope. Codes are unique per
+   * scope (the caller/DB enforces it); used to reject duplicates on create and
+   * to look a warehouse up by its label.
+   */
+  findByCode(scopeId: ScopeId, code: string): Promise<Warehouse | null>;
+  findByScope(
+    scopeId: ScopeId,
+    filter: ListWarehousesFilter,
+  ): Promise<Warehouse[]>;
+}

--- a/packages/warehouse-core/src/inventory/warehouse-id.ts
+++ b/packages/warehouse-core/src/inventory/warehouse-id.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from 'node:crypto';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Identity of a {@link Warehouse} — the physical building a Protección Civil
+ * (or any organization) operates. A UUID value object like every other
+ * aggregate id in the platform: a warehouse keeps its identity across renames
+ * and moves.
+ */
+export class WarehouseId {
+  private constructor(public readonly value: string) {}
+
+  static create(): WarehouseId {
+    return new WarehouseId(randomUUID());
+  }
+
+  static fromString(s: string): WarehouseId {
+    if (!UUID_RE.test(s)) throw new Error(`Invalid WarehouseId: ${s}`);
+    return new WarehouseId(s);
+  }
+
+  equals(o: WarehouseId): boolean {
+    return this.value === o.value;
+  }
+}

--- a/packages/warehouse-core/src/inventory/warehouse.test.ts
+++ b/packages/warehouse-core/src/inventory/warehouse.test.ts
@@ -1,0 +1,206 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Warehouse, Zone } from './warehouse.js';
+import { WarehouseId } from './warehouse-id.js';
+import { ZoneId } from './zone-id.js';
+import { WarehouseStatus, ZoneKind, ZoneStatus } from './inventory-enums.js';
+import {
+  DuplicateZoneCodeError,
+  WarehouseArchivedError,
+  WarehouseValidationError,
+} from './inventory-errors.js';
+import { ScopeId } from '../kernel/scope-id.js';
+
+const SCOPE = '11111111-1111-4111-8111-111111111111';
+
+function make(
+  overrides?: Partial<{
+    code: string;
+    name: string;
+    address: string | null;
+    geo: { lat: number | null; lng: number | null } | null;
+    zones: { id: ZoneId; code: string; name: string; kind: ZoneKind }[];
+  }>,
+): Warehouse {
+  return Warehouse.create({
+    id: WarehouseId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    code: overrides?.code ?? 'ALM-CENTRAL',
+    name: overrides?.name ?? 'Almacén Central',
+    address: overrides?.address ?? 'Calle Mayor 1',
+    geo:
+      overrides && 'geo' in overrides
+        ? overrides.geo
+        : { lat: 10.5, lng: -66.9 },
+    ...(overrides?.zones ? { zones: overrides.zones } : {}),
+  });
+}
+
+test('creates an active warehouse with no zones and normalized fields', () => {
+  const w = make({ code: '  ALM-1  ', name: '  Norte  ', address: '  ' });
+  assert.equal(w.status, WarehouseStatus.Active);
+  assert.equal(w.code, 'ALM-1');
+  assert.equal(w.name, 'Norte');
+  assert.equal(w.address, null);
+  assert.deepEqual(w.zones, []);
+  assert.ok(w.scopeId.equals(ScopeId.fromString(SCOPE)));
+});
+
+test('rejects empty code and empty name', () => {
+  assert.throws(() => make({ code: '   ' }), WarehouseValidationError);
+  assert.throws(() => make({ name: '' }), WarehouseValidationError);
+});
+
+test('rejects a code longer than 32 chars', () => {
+  assert.throws(() => make({ code: 'X'.repeat(33) }), WarehouseValidationError);
+});
+
+test('requires both lat and lng or neither, and validates ranges', () => {
+  assert.throws(
+    () => make({ geo: { lat: 10, lng: null } }),
+    WarehouseValidationError,
+  );
+  assert.throws(
+    () => make({ geo: { lat: 91, lng: 0 } }),
+    WarehouseValidationError,
+  );
+  assert.throws(
+    () => make({ geo: { lat: 0, lng: 181 } }),
+    WarehouseValidationError,
+  );
+  const w = make({ geo: null });
+  assert.deepEqual(w.geo, { lat: null, lng: null });
+});
+
+test('adds a zone and exposes it as an active entity', () => {
+  const w = make();
+  const zone = w.addZone({
+    id: ZoneId.create(),
+    code: 'REC',
+    name: 'Recepción',
+    kind: ZoneKind.Receiving,
+  });
+  assert.equal(zone.status, ZoneStatus.Active);
+  assert.equal(w.zones.length, 1);
+  assert.equal(w.zones[0]!.code, 'REC');
+  assert.equal(w.zones[0]!.kind, ZoneKind.Receiving);
+});
+
+test('rejects a duplicate active zone code', () => {
+  const w = make();
+  w.addZone({
+    id: ZoneId.create(),
+    code: 'STO',
+    name: 'Almacenaje',
+    kind: ZoneKind.Storage,
+  });
+  assert.throws(
+    () =>
+      w.addZone({
+        id: ZoneId.create(),
+        code: 'STO',
+        name: 'Otra',
+        kind: ZoneKind.Storage,
+      }),
+    DuplicateZoneCodeError,
+  );
+});
+
+test('rejects duplicate zone codes at creation time', () => {
+  assert.throws(
+    () =>
+      make({
+        zones: [
+          { id: ZoneId.create(), code: 'A', name: 'A', kind: ZoneKind.Storage },
+          { id: ZoneId.create(), code: 'A', name: 'B', kind: ZoneKind.Picking },
+        ],
+      }),
+    DuplicateZoneCodeError,
+  );
+});
+
+test('lets an archived zone code be reused by a new active zone', () => {
+  const w = make();
+  const zoneId = ZoneId.create();
+  w.addZone({
+    id: zoneId,
+    code: 'DOCK',
+    name: 'Muelle',
+    kind: ZoneKind.Shipping,
+  });
+  w.archiveZone(zoneId);
+  // reusing the archived code is allowed (uniqueness is over active zones)
+  const reused = w.addZone({
+    id: ZoneId.create(),
+    code: 'DOCK',
+    name: 'Muelle 2',
+    kind: ZoneKind.Shipping,
+  });
+  assert.equal(reused.code, 'DOCK');
+});
+
+test('renames a zone and rejects renaming an archived zone', () => {
+  const w = make();
+  const zoneId = ZoneId.create();
+  w.addZone({
+    id: zoneId,
+    code: 'Q',
+    name: 'Cuarentena',
+    kind: ZoneKind.Quarantine,
+  });
+  w.renameZone(zoneId, 'Cuarentena A');
+  assert.equal(w.zones[0]!.name, 'Cuarentena A');
+  w.archiveZone(zoneId);
+  assert.throws(() => w.renameZone(zoneId, 'X'), WarehouseArchivedError);
+});
+
+test('throws when addressing an unknown zone', () => {
+  const w = make();
+  assert.throws(
+    () => w.renameZone(ZoneId.create(), 'X'),
+    WarehouseValidationError,
+  );
+});
+
+test('archiving the warehouse freezes all mutations', () => {
+  const w = make();
+  w.archive();
+  assert.equal(w.status, WarehouseStatus.Archived);
+  assert.throws(() => w.rename('Nuevo'), WarehouseArchivedError);
+  assert.throws(
+    () =>
+      w.addZone({
+        id: ZoneId.create(),
+        code: 'Z',
+        name: 'Z',
+        kind: ZoneKind.Storage,
+      }),
+    WarehouseArchivedError,
+  );
+  // archive is idempotent
+  assert.doesNotThrow(() => w.archive());
+});
+
+test('rename and relocate update the fields', () => {
+  const w = make();
+  w.rename('  Almacén Sur  ');
+  assert.equal(w.name, 'Almacén Sur');
+  w.relocate('Nueva dirección', { lat: 40.4, lng: -3.7 });
+  assert.equal(w.address, 'Nueva dirección');
+  assert.deepEqual(w.geo, { lat: 40.4, lng: -3.7 });
+});
+
+test('round-trips through a snapshot', () => {
+  const w = make();
+  w.addZone({
+    id: ZoneId.create(),
+    code: 'REC',
+    name: 'Recepción',
+    kind: ZoneKind.Receiving,
+  });
+  const snap = w.toSnapshot();
+  const restored = Warehouse.fromSnapshot(snap);
+  assert.deepEqual(restored.toSnapshot(), snap);
+  assert.ok(restored instanceof Warehouse);
+  assert.ok(restored.zones[0] instanceof Zone);
+});

--- a/packages/warehouse-core/src/inventory/warehouse.ts
+++ b/packages/warehouse-core/src/inventory/warehouse.ts
@@ -1,0 +1,367 @@
+import { WarehouseId } from './warehouse-id.js';
+import { ZoneId } from './zone-id.js';
+import { WarehouseStatus, ZoneKind, ZoneStatus } from './inventory-enums.js';
+import {
+  DuplicateZoneCodeError,
+  WarehouseArchivedError,
+  WarehouseValidationError,
+} from './inventory-errors.js';
+import { ScopeId } from '../kernel/index.js';
+
+/** Optional geographic point of the warehouse building (WGS84). */
+export interface WarehouseGeo {
+  lat: number | null;
+  lng: number | null;
+}
+
+export interface AddZoneProps {
+  id: ZoneId;
+  code: string;
+  name: string;
+  kind: ZoneKind;
+}
+
+export interface CreateWarehouseProps {
+  id: WarehouseId;
+  scopeId: ScopeId;
+  code: string;
+  name: string;
+  address?: string | null;
+  geo?: WarehouseGeo | null;
+  zones?: AddZoneProps[];
+}
+
+export interface ZoneSnapshot {
+  id: string;
+  code: string;
+  name: string;
+  kind: ZoneKind;
+  status: ZoneStatus;
+}
+
+export interface WarehouseSnapshot {
+  id: string;
+  scopeId: string;
+  code: string;
+  name: string;
+  address: string | null;
+  lat: number | null;
+  lng: number | null;
+  status: WarehouseStatus;
+  zones: ZoneSnapshot[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * A logical area inside a warehouse (recepción, almacenaje, expedición…). An
+ * *entity* of the {@link Warehouse} aggregate: it has its own stable id and
+ * lifecycle but is only reached through its warehouse, which guards the
+ * cross-zone invariant (unique code). Bins and, later, stock reference a zone
+ * by {@link ZoneId}.
+ */
+export class Zone {
+  private constructor(
+    public readonly id: ZoneId,
+    private _code: string,
+    private _name: string,
+    private _kind: ZoneKind,
+    private _status: ZoneStatus,
+  ) {}
+
+  static create(props: AddZoneProps): Zone {
+    const code = normalizeCode(props.code, 'Zone code');
+    const name = normalizeName(props.name, 'Zone name');
+    return new Zone(props.id, code, name, props.kind, ZoneStatus.Active);
+  }
+
+  static fromSnapshot(s: ZoneSnapshot): Zone {
+    return new Zone(ZoneId.fromString(s.id), s.code, s.name, s.kind, s.status);
+  }
+
+  get code(): string {
+    return this._code;
+  }
+  get name(): string {
+    return this._name;
+  }
+  get kind(): ZoneKind {
+    return this._kind;
+  }
+  get status(): ZoneStatus {
+    return this._status;
+  }
+  get isArchived(): boolean {
+    return this._status === ZoneStatus.Archived;
+  }
+
+  rename(name: string): void {
+    this.assertActive();
+    this._name = normalizeName(name, 'Zone name');
+  }
+
+  archive(): void {
+    this._status = ZoneStatus.Archived;
+  }
+
+  toSnapshot(): ZoneSnapshot {
+    return {
+      id: this.id.value,
+      code: this._code,
+      name: this._name,
+      kind: this._kind,
+      status: this._status,
+    };
+  }
+
+  private assertActive(): void {
+    if (this.isArchived) {
+      throw new WarehouseArchivedError(
+        `Zone ${this.id.value} is archived and cannot be modified`,
+      );
+    }
+  }
+}
+
+/**
+ * Aggregate root for a warehouse (almacén) — the physical building an
+ * organización operates, partitioned by an opaque {@link ScopeId} (a Prote/
+ * organización in the standalone WMS, a centro/emergencia in ResponseGrid).
+ *
+ * It owns its {@link Zone} entities: zones are few, always loaded with their
+ * warehouse, and the root guards their only cross-entity invariant — a zone
+ * code is unique within its warehouse. Bins (numerous, high-write, holding
+ * stock) are a *separate* aggregate that references this one by id, keeping
+ * this root small.
+ *
+ * The material a warehouse holds is NOT modelled here: stock lives in the
+ * StockItem/StockMovement aggregates (added next), which reference a bin →
+ * zone → warehouse by id. This root is the location backbone.
+ */
+export class Warehouse {
+  private constructor(
+    public readonly id: WarehouseId,
+    public readonly scopeId: ScopeId,
+    private _code: string,
+    private _name: string,
+    private _address: string | null,
+    private _geo: WarehouseGeo,
+    private _status: WarehouseStatus,
+    private _zones: Zone[],
+    public readonly createdAt: Date,
+    private _updatedAt: Date,
+  ) {}
+
+  static create(props: CreateWarehouseProps): Warehouse {
+    const code = normalizeCode(props.code, 'Warehouse code');
+    const name = normalizeName(props.name, 'Warehouse name');
+    const address = normalizeAddress(props.address ?? null);
+    const geo = normalizeGeo(props.geo ?? null);
+
+    const zones = (props.zones ?? []).map((z) => Zone.create(z));
+    assertUniqueZoneCodes(zones);
+
+    const now = new Date();
+    return new Warehouse(
+      props.id,
+      props.scopeId,
+      code,
+      name,
+      address,
+      geo,
+      WarehouseStatus.Active,
+      zones,
+      now,
+      now,
+    );
+  }
+
+  static fromSnapshot(s: WarehouseSnapshot): Warehouse {
+    return new Warehouse(
+      WarehouseId.fromString(s.id),
+      ScopeId.fromString(s.scopeId),
+      s.code,
+      s.name,
+      s.address,
+      { lat: s.lat, lng: s.lng },
+      s.status,
+      s.zones.map((z) => Zone.fromSnapshot(z)),
+      s.createdAt,
+      s.updatedAt,
+    );
+  }
+
+  get code(): string {
+    return this._code;
+  }
+  get name(): string {
+    return this._name;
+  }
+  get address(): string | null {
+    return this._address;
+  }
+  get geo(): WarehouseGeo {
+    return { ...this._geo };
+  }
+  get status(): WarehouseStatus {
+    return this._status;
+  }
+  get isArchived(): boolean {
+    return this._status === WarehouseStatus.Archived;
+  }
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+
+  /** The warehouse's zones (defensive copy — mutate through the root). */
+  get zones(): Zone[] {
+    return [...this._zones];
+  }
+
+  rename(name: string): void {
+    this.assertActive();
+    this._name = normalizeName(name, 'Warehouse name');
+    this.touch();
+  }
+
+  relocate(address: string | null, geo: WarehouseGeo | null): void {
+    this.assertActive();
+    this._address = normalizeAddress(address);
+    this._geo = normalizeGeo(geo);
+    this.touch();
+  }
+
+  addZone(props: AddZoneProps): Zone {
+    this.assertActive();
+    const zone = Zone.create(props);
+    if (this.activeZoneCodeExists(zone.code)) {
+      throw new DuplicateZoneCodeError(
+        `Zone code "${zone.code}" already exists in warehouse ${this.id.value}`,
+      );
+    }
+    this._zones.push(zone);
+    this.touch();
+    return zone;
+  }
+
+  renameZone(zoneId: ZoneId, name: string): void {
+    this.assertActive();
+    this.requireZone(zoneId).rename(name);
+    this.touch();
+  }
+
+  archiveZone(zoneId: ZoneId): void {
+    this.assertActive();
+    this.requireZone(zoneId).archive();
+    this.touch();
+  }
+
+  /** Retires the whole warehouse. Idempotent; archived layout is read-only. */
+  archive(): void {
+    if (this.isArchived) return;
+    this._status = WarehouseStatus.Archived;
+    this.touch();
+  }
+
+  toSnapshot(): WarehouseSnapshot {
+    return {
+      id: this.id.value,
+      scopeId: this.scopeId.value,
+      code: this._code,
+      name: this._name,
+      address: this._address,
+      lat: this._geo.lat,
+      lng: this._geo.lng,
+      status: this._status,
+      zones: this._zones.map((z) => z.toSnapshot()),
+      createdAt: this.createdAt,
+      updatedAt: this._updatedAt,
+    };
+  }
+
+  private requireZone(zoneId: ZoneId): Zone {
+    const zone = this._zones.find((z) => z.id.equals(zoneId));
+    if (!zone) {
+      throw new WarehouseValidationError(
+        `Zone ${zoneId.value} not found in warehouse ${this.id.value}`,
+      );
+    }
+    return zone;
+  }
+
+  private activeZoneCodeExists(code: string): boolean {
+    return this._zones.some((z) => !z.isArchived && z.code === code);
+  }
+
+  private assertActive(): void {
+    if (this.isArchived) {
+      throw new WarehouseArchivedError(
+        `Warehouse ${this.id.value} is archived and cannot be modified`,
+      );
+    }
+  }
+
+  private touch(): void {
+    this._updatedAt = new Date();
+  }
+}
+
+function normalizeCode(value: string, label: string): string {
+  const code = typeof value === 'string' ? value.trim() : '';
+  if (code.length === 0) {
+    throw new WarehouseValidationError(`${label} must not be empty`);
+  }
+  if (code.length > 32) {
+    throw new WarehouseValidationError(
+      `${label} must be at most 32 characters`,
+    );
+  }
+  return code;
+}
+
+function normalizeName(value: string, label: string): string {
+  const name = typeof value === 'string' ? value.trim() : '';
+  if (name.length === 0) {
+    throw new WarehouseValidationError(`${label} must not be empty`);
+  }
+  return name;
+}
+
+function normalizeAddress(value: string | null): string | null {
+  if (value === null) return null;
+  const address = value.trim();
+  return address.length === 0 ? null : address;
+}
+
+function normalizeGeo(geo: WarehouseGeo | null): WarehouseGeo {
+  if (geo === null) return { lat: null, lng: null };
+  const { lat, lng } = geo;
+  if ((lat === null) !== (lng === null)) {
+    throw new WarehouseValidationError(
+      'Warehouse coordinates require both lat and lng, or neither',
+    );
+  }
+  if (lat !== null && (lat < -90 || lat > 90)) {
+    throw new WarehouseValidationError(
+      'Warehouse lat must be within [-90, 90]',
+    );
+  }
+  if (lng !== null && (lng < -180 || lng > 180)) {
+    throw new WarehouseValidationError(
+      'Warehouse lng must be within [-180, 180]',
+    );
+  }
+  return { lat, lng };
+}
+
+function assertUniqueZoneCodes(zones: Zone[]): void {
+  const seen = new Set<string>();
+  for (const zone of zones) {
+    if (seen.has(zone.code)) {
+      throw new DuplicateZoneCodeError(
+        `Duplicate zone code "${zone.code}" in warehouse creation`,
+      );
+    }
+    seen.add(zone.code);
+  }
+}

--- a/packages/warehouse-core/src/inventory/zone-id.ts
+++ b/packages/warehouse-core/src/inventory/zone-id.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from 'node:crypto';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Identity of a {@link Zone} — a logical area inside a warehouse (recepción,
+ * almacenaje, expedición…). It is an *entity* within the {@link Warehouse}
+ * aggregate (loaded and saved with its warehouse), but it still owns a stable
+ * id so bins and, later, stock can reference it without depending on its code.
+ */
+export class ZoneId {
+  private constructor(public readonly value: string) {}
+
+  static create(): ZoneId {
+    return new ZoneId(randomUUID());
+  }
+
+  static fromString(s: string): ZoneId {
+    if (!UUID_RE.test(s)) throw new Error(`Invalid ZoneId: ${s}`);
+    return new ZoneId(s);
+  }
+
+  equals(o: ZoneId): boolean {
+    return this.value === o.value;
+  }
+}

--- a/packages/warehouse-core/tsconfig.base.json
+++ b/packages/warehouse-core/tsconfig.base.json
@@ -13,5 +13,6 @@
     "sourceMap": true,
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/warehouse-core/tsconfig.test.json
+++ b/packages/warehouse-core/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.esm.json",
+  "compilerOptions": {
+    "outDir": "dist-test",
+    "declaration": false,
+    "declarationMap": false,
+    "noEmitOnError": true
+  },
+  "include": ["src"],
+  "exclude": []
+}


### PR DESCRIPTION
## Resumen

Arranca la **Fase 2** de la épica #355 — construir el núcleo WMS nuevo (la parte "~60% a construir", la que **no** se extrae de ResponseGrid) — con el primer ladrillo: el **backbone de ubicaciones**.

Nuevo módulo `inventory` en `@globalemergency/warehouse-core` (subpath export `./inventory`), dominio puro sobre `ScopeId` (tenencia opaca: Prote/organización en el WMS standalone):

- **`Warehouse`** (aggregate root): `code`/`name`, dirección y coordenadas opcionales, estado `active`/`archived`, timestamps. Posee sus `Zone`.
- **`Zone`** (entidad del agregado): `code` único dentro del almacén, `name`, `kind` (recepción/almacenaje/picking/expedición/cuarentena), estado. Se añade/renombra/archiva a través del root, que guarda la unicidad de código.
- Invariantes: `code`/`name` no vacíos, coordenadas válidas (lat/lng ambas o ninguna, rangos WGS84), código de zona único entre zonas activas, agregado archivado = solo lectura. Snapshots round-trip.
- Port `WarehouseRepository` (`save`/`findById`/`findByCode`/`findByScope`).

**Tests propios del paquete:** el WMS core estrena su propia suite. Los tests compilan con `tsc` a un dir descartable (`dist-test/`, git-ignored, fuera de `files`) y corren con `node --test` sobre el JS emitido — necesario porque el type-stripping puro de Node no soporta `enum` ni parameter properties, que son el idioma del dominio. Nuevo step de CI **"Run tests — warehouse-core"** en el job requerido `Test` para que gateen el merge. Se añade un `.prettierrc` propio del paquete (comillas simples, viaja con él al extraerlo a OSS).

`Bin` (agregado propio que referencia warehouse+zone por id) y el stock (`StockItem`/`StockMovement`, FEFO, salidas) llegan en incrementos siguientes.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `pnpm --filter '@globalemergency/warehouse-core' build` (dual CJS+ESM), `typecheck` (exactOptionalPropertyTypes), `test` (13/13 verde), `pnpm --filter api build` (nest, host intacto), Prettier `--check` del paquete limpio.
- [x] Verifiqué el comportamiento manualmente si aplica — 13 tests de dominio cubren creación/normalización, validación de coordenadas, alta/renombrado/archivado de zonas, unicidad de código (incl. reutilización de código archivado), congelación al archivar y round-trip de snapshot.
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica: módulo nuevo del paquete, sin wiring al host, sin endpoints ni migraciones.

## Cierre

- Closes #370

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_