### PR TITLE
feat(warehouse-core): añade el agregado Bin (ubicación física) al módulo inventory

### DIFF
--- a/packages/warehouse-core/src/inventory/bin-id.ts
+++ b/packages/warehouse-core/src/inventory/bin-id.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from 'node:crypto';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Identity of a {@link Bin} — a discrete physical location inside a warehouse
+ * (a shelf, a floor spot, a dock door…). A UUID value object: a bin is a
+ * high-write aggregate root of its own (it will hold stock), so it owns an id
+ * and is referenced by warehouse/zone id, not embedded.
+ */
+export class BinId {
+  private constructor(public readonly value: string) {}
+
+  static create(): BinId {
+    return new BinId(randomUUID());
+  }
+
+  static fromString(s: string): BinId {
+    if (!UUID_RE.test(s)) throw new Error(`Invalid BinId: ${s}`);
+    return new BinId(s);
+  }
+
+  equals(o: BinId): boolean {
+    return this.value === o.value;
+  }
+}

--- a/packages/warehouse-core/src/inventory/bin.test.ts
+++ b/packages/warehouse-core/src/inventory/bin.test.ts
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Bin } from './bin.js';
+import { BinId } from './bin-id.js';
+import { WarehouseId } from './warehouse-id.js';
+import { ZoneId } from './zone-id.js';
+import { BinKind, BinStatus } from './inventory-enums.js';
+import { BinArchivedError, BinValidationError } from './inventory-errors.js';
+import { ScopeId } from '../kernel/scope-id.js';
+
+const SCOPE = '11111111-1111-4111-8111-111111111111';
+const WAREHOUSE = '22222222-2222-4222-8222-222222222222';
+const ZONE = '33333333-3333-4333-8333-333333333333';
+
+function make(
+  overrides?: Partial<{
+    code: string;
+    kind: BinKind;
+    zoneId: ZoneId | null;
+  }>,
+): Bin {
+  return Bin.create({
+    id: BinId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    warehouseId: WarehouseId.fromString(WAREHOUSE),
+    zoneId:
+      overrides && 'zoneId' in overrides
+        ? overrides.zoneId
+        : ZoneId.fromString(ZONE),
+    code: overrides?.code ?? 'A-01-01',
+    kind: overrides?.kind ?? BinKind.Shelf,
+  });
+}
+
+test('creates an active bin with a trimmed code and its references', () => {
+  const bin = make({ code: '  A-01-02  ' });
+  assert.equal(bin.status, BinStatus.Active);
+  assert.equal(bin.code, 'A-01-02');
+  assert.equal(bin.kind, BinKind.Shelf);
+  assert.ok(bin.scopeId.equals(ScopeId.fromString(SCOPE)));
+  assert.ok(bin.warehouseId.equals(WarehouseId.fromString(WAREHOUSE)));
+  assert.ok(bin.zoneId?.equals(ZoneId.fromString(ZONE)));
+});
+
+test('creates a bin detached from any zone', () => {
+  const bin = make({ zoneId: null });
+  assert.equal(bin.zoneId, null);
+});
+
+test('rejects an empty or oversized code', () => {
+  assert.throws(() => make({ code: '   ' }), BinValidationError);
+  assert.throws(() => make({ code: 'X'.repeat(33) }), BinValidationError);
+});
+
+test('reassigns and detaches the zone', () => {
+  const bin = make();
+  const other = ZoneId.create();
+  bin.assignZone(other);
+  assert.ok(bin.zoneId?.equals(other));
+  bin.assignZone(null);
+  assert.equal(bin.zoneId, null);
+});
+
+test('blocks and unblocks (both idempotent)', () => {
+  const bin = make();
+  bin.block();
+  assert.equal(bin.status, BinStatus.Blocked);
+  assert.doesNotThrow(() => bin.block());
+  assert.equal(bin.status, BinStatus.Blocked);
+  bin.unblock();
+  assert.equal(bin.status, BinStatus.Active);
+  assert.doesNotThrow(() => bin.unblock());
+  assert.equal(bin.status, BinStatus.Active);
+});
+
+test('archiving freezes all mutations and is idempotent', () => {
+  const bin = make();
+  bin.archive();
+  assert.equal(bin.status, BinStatus.Archived);
+  assert.throws(() => bin.block(), BinArchivedError);
+  assert.throws(() => bin.unblock(), BinArchivedError);
+  assert.throws(() => bin.assignZone(ZoneId.create()), BinArchivedError);
+  assert.doesNotThrow(() => bin.archive());
+});
+
+test('can archive a blocked bin', () => {
+  const bin = make();
+  bin.block();
+  bin.archive();
+  assert.equal(bin.status, BinStatus.Archived);
+});
+
+test('warehouseId is immutable (no setter, survives a snapshot round-trip)', () => {
+  const bin = make({ zoneId: null });
+  bin.block();
+  const snap = bin.toSnapshot();
+  const restored = Bin.fromSnapshot(snap);
+  assert.deepEqual(restored.toSnapshot(), snap);
+  assert.ok(restored instanceof Bin);
+  assert.ok(restored.warehouseId.equals(WarehouseId.fromString(WAREHOUSE)));
+  assert.equal(restored.status, BinStatus.Blocked);
+  assert.equal(restored.zoneId, null);
+});

--- a/packages/warehouse-core/src/inventory/bin.ts
+++ b/packages/warehouse-core/src/inventory/bin.ts
@@ -1,0 +1,171 @@
+import { BinId } from './bin-id.js';
+import { WarehouseId } from './warehouse-id.js';
+import { ZoneId } from './zone-id.js';
+import { BinKind, BinStatus } from './inventory-enums.js';
+import { BinArchivedError, BinValidationError } from './inventory-errors.js';
+import { ScopeId } from '../kernel/index.js';
+
+export interface CreateBinProps {
+  id: BinId;
+  scopeId: ScopeId;
+  warehouseId: WarehouseId;
+  /** The zone this bin sits in. Null = assigned to the warehouse at large. */
+  zoneId?: ZoneId | null;
+  code: string;
+  kind: BinKind;
+}
+
+export interface BinSnapshot {
+  id: string;
+  scopeId: string;
+  warehouseId: string;
+  zoneId: string | null;
+  code: string;
+  kind: BinKind;
+  status: BinStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Aggregate root for a bin (ubicación) — a discrete physical location inside a
+ * warehouse where stock is put away and picked. Its own root (not part of the
+ * {@link Warehouse} aggregate) because bins are numerous and high-write: they
+ * will hold {@link StockItem}s and change state independently, so coupling them
+ * to the warehouse's load/save would serialize the whole layout.
+ *
+ * It references its warehouse and (optionally) its zone **by id**. The building
+ * a bin belongs to is fixed — you don't move a physical location between
+ * warehouses — so `warehouseId` is immutable; the zone assignment can change
+ * (a bin re-mapped to another area of the same warehouse). The cross-aggregate
+ * invariant "zone belongs to this warehouse and is active" is checked by the
+ * application use case (which can load the warehouse); the aggregate guards its
+ * local rules: valid code, immutable building, no mutation once archived.
+ *
+ * Stock is NOT modelled here: {@link StockItem}/{@link StockMovement} (next)
+ * reference a bin by id. This is the leaf of the location backbone.
+ */
+export class Bin {
+  private constructor(
+    public readonly id: BinId,
+    public readonly scopeId: ScopeId,
+    public readonly warehouseId: WarehouseId,
+    private _zoneId: ZoneId | null,
+    public readonly code: string,
+    public readonly kind: BinKind,
+    private _status: BinStatus,
+    public readonly createdAt: Date,
+    private _updatedAt: Date,
+  ) {}
+
+  static create(props: CreateBinProps): Bin {
+    const code = props.code.trim();
+    if (code.length === 0) {
+      throw new BinValidationError('Bin code must not be empty');
+    }
+    if (code.length > 32) {
+      throw new BinValidationError('Bin code must be at most 32 characters');
+    }
+    const now = new Date();
+    return new Bin(
+      props.id,
+      props.scopeId,
+      props.warehouseId,
+      props.zoneId ?? null,
+      code,
+      props.kind,
+      BinStatus.Active,
+      now,
+      now,
+    );
+  }
+
+  static fromSnapshot(s: BinSnapshot): Bin {
+    return new Bin(
+      BinId.fromString(s.id),
+      ScopeId.fromString(s.scopeId),
+      WarehouseId.fromString(s.warehouseId),
+      s.zoneId !== null ? ZoneId.fromString(s.zoneId) : null,
+      s.code,
+      s.kind,
+      s.status,
+      s.createdAt,
+      s.updatedAt,
+    );
+  }
+
+  get zoneId(): ZoneId | null {
+    return this._zoneId;
+  }
+  get status(): BinStatus {
+    return this._status;
+  }
+  get isActive(): boolean {
+    return this._status === BinStatus.Active;
+  }
+  get isBlocked(): boolean {
+    return this._status === BinStatus.Blocked;
+  }
+  get isArchived(): boolean {
+    return this._status === BinStatus.Archived;
+  }
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+
+  /** Re-maps the bin to another zone of its warehouse (or detaches it). */
+  assignZone(zoneId: ZoneId | null): void {
+    this.assertNotArchived();
+    this._zoneId = zoneId;
+    this.touch();
+  }
+
+  /** Takes the bin out of service (active → blocked). Idempotent. */
+  block(): void {
+    this.assertNotArchived();
+    if (this._status === BinStatus.Blocked) return;
+    this._status = BinStatus.Blocked;
+    this.touch();
+  }
+
+  /** Returns the bin to service (blocked → active). Idempotent. */
+  unblock(): void {
+    this.assertNotArchived();
+    if (this._status === BinStatus.Active) return;
+    this._status = BinStatus.Active;
+    this.touch();
+  }
+
+  /** Permanently retires the bin. Idempotent; archived is read-only. */
+  archive(): void {
+    if (this._status === BinStatus.Archived) return;
+    this._status = BinStatus.Archived;
+    this.touch();
+  }
+
+  toSnapshot(): BinSnapshot {
+    return {
+      id: this.id.value,
+      scopeId: this.scopeId.value,
+      warehouseId: this.warehouseId.value,
+      zoneId: this._zoneId ? this._zoneId.value : null,
+      code: this.code,
+      kind: this.kind,
+      status: this._status,
+      createdAt: this.createdAt,
+      updatedAt: this._updatedAt,
+    };
+  }
+
+  private assertNotArchived(): void {
+    if (this.isArchived) {
+      throw new BinArchivedError(
+        `Bin ${this.id.value} is archived and cannot be modified`,
+      );
+    }
+  }
+
+  private touch(): void {
+    this._updatedAt = new Date();
+  }
+}

--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -1,19 +1,29 @@
 /**
  * inventory — el backbone de ubicaciones del WMS nuevo (Fase 2). Aggregate
  * root `Warehouse` (almacén) con sus entidades `Zone` (áreas: recepción/
- * almacenaje/picking/expedición/cuarentena), sobre `ScopeId` (tenencia opaca).
+ * almacenaje/picking/expedición/cuarentena) y el aggregate root `Bin`
+ * (ubicación física), sobre `ScopeId` (tenencia opaca).
  *
- * Dominio puro: sin NestJS, sin ORM, sin infraestructura. Los `Bin` y el stock
- * (`StockItem`/`StockMovement`) llegan en incrementos siguientes y referencian
- * este backbone por id.
+ * Dominio puro: sin NestJS, sin ORM, sin infraestructura. El stock
+ * (`StockItem`/`StockMovement`) llega en incrementos siguientes y referencia
+ * este backbone por id (bin → zona → almacén).
  */
 export { WarehouseId } from './warehouse-id.js';
 export { ZoneId } from './zone-id.js';
-export { WarehouseStatus, ZoneStatus, ZoneKind } from './inventory-enums.js';
+export { BinId } from './bin-id.js';
+export {
+  WarehouseStatus,
+  ZoneStatus,
+  ZoneKind,
+  BinStatus,
+  BinKind,
+} from './inventory-enums.js';
 export {
   WarehouseValidationError,
   DuplicateZoneCodeError,
   WarehouseArchivedError,
+  BinValidationError,
+  BinArchivedError,
 } from './inventory-errors.js';
 export { Warehouse, Zone } from './warehouse.js';
 export type {
@@ -23,8 +33,15 @@ export type {
   ZoneSnapshot,
   WarehouseSnapshot,
 } from './warehouse.js';
+export { Bin } from './bin.js';
+export type { CreateBinProps, BinSnapshot } from './bin.js';
 export {
   WAREHOUSE_REPOSITORY,
   type WarehouseRepository,
   type ListWarehousesFilter,
 } from './ports/warehouse.repository.js';
+export {
+  BIN_REPOSITORY,
+  type BinRepository,
+  type ListBinsFilter,
+} from './ports/bin.repository.js';

--- a/packages/warehouse-core/src/inventory/inventory-enums.ts
+++ b/packages/warehouse-core/src/inventory/inventory-enums.ts
@@ -33,3 +33,31 @@ export enum ZoneKind {
   Shipping = 'shipping',
   Quarantine = 'quarantine',
 }
+
+/**
+ * Lifecycle of a {@link Bin} (ubicación física). `active` = usable for storage
+ * and picking; `blocked` = temporarily out of service (damaged shelf, spill,
+ * maintenance) — it keeps its stock but accepts no new put-aways and is skipped
+ * by allocation; `archived` = permanently retired. `blocked` is the reversible
+ * middle state a warehouse operator toggles day to day.
+ */
+export enum BinStatus {
+  Active = 'active',
+  Blocked = 'blocked',
+  Archived = 'archived',
+}
+
+/**
+ * Physical type of a {@link Bin} — finer than the {@link ZoneKind} of the area
+ * it sits in. `shelf` is a discrete racked location, `bulk` a floor/palletized
+ * spot, `staging` a marshalling square (recepción/expedición), `dock` a loading
+ * door, `quarantine` an isolation hold. Descriptive; put-away/pick rules read it
+ * but the aggregate does not constrain flows on it.
+ */
+export enum BinKind {
+  Shelf = 'shelf',
+  Bulk = 'bulk',
+  Staging = 'staging',
+  Dock = 'dock',
+  Quarantine = 'quarantine',
+}

--- a/packages/warehouse-core/src/inventory/inventory-errors.ts
+++ b/packages/warehouse-core/src/inventory/inventory-errors.ts
@@ -33,3 +33,26 @@ export class WarehouseArchivedError extends Error {
     this.name = 'WarehouseArchivedError';
   }
 }
+
+/**
+ * Raised on invalid bin input (empty/oversized code, empty warehouse id). The
+ * HTTP layer of each host maps it to 422.
+ */
+export class BinValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BinValidationError';
+  }
+}
+
+/**
+ * Raised when mutating an archived bin (blocking, reassigning its zone…). An
+ * archived bin is retired, read-only history; the HTTP layer maps this to 409
+ * Conflict.
+ */
+export class BinArchivedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BinArchivedError';
+  }
+}

--- a/packages/warehouse-core/src/inventory/ports/bin.repository.ts
+++ b/packages/warehouse-core/src/inventory/ports/bin.repository.ts
@@ -1,0 +1,32 @@
+import { Bin } from '../bin.js';
+import { BinId } from '../bin-id.js';
+import { WarehouseId } from '../warehouse-id.js';
+import { ScopeId } from '../../kernel/index.js';
+import { BinKind, BinStatus } from '../inventory-enums.js';
+
+export const BIN_REPOSITORY = Symbol('BinRepository');
+
+/** Filter for listing bins. AND-combined. */
+export interface ListBinsFilter {
+  status?: BinStatus;
+  kind?: BinKind;
+  /** Only bins mapped to this zone. */
+  zoneId?: string;
+}
+
+export interface BinRepository {
+  save(bin: Bin): Promise<void>;
+  findById(id: BinId): Promise<Bin | null>;
+  /**
+   * Resolves a bin by its code within a warehouse. Codes are unique per
+   * warehouse (the caller/DB enforces it); used to reject duplicates on create
+   * and to look a bin up by its label.
+   */
+  findByCode(warehouseId: WarehouseId, code: string): Promise<Bin | null>;
+  findByWarehouse(
+    warehouseId: WarehouseId,
+    filter: ListBinsFilter,
+  ): Promise<Bin[]>;
+  /** All bins in a tenancy scope (denormalized `scopeId`), for cross-warehouse listing. */
+  findByScope(scopeId: ScopeId, filter: ListBinsFilter): Promise<Bin[]>;
+}


### PR DESCRIPTION
## Resumen

Cierra el **backbone de ubicaciones** de la Fase 2 (épica #355): tras `Warehouse` y `Zone` (#370), añade el **`Bin`** — la ubicación física donde se hará put-away y picking del stock.

En el módulo `inventory` de `@globalemergency/warehouse-core`, dominio puro sobre `ScopeId`:

- **`Bin`** (aggregate root propio, **no** parte del agregado `Warehouse`): son numerosos y de alta escritura, tendrán stock y cambian de estado por su cuenta, así que acoplarlos al load/save del almacén serializaría toda la disposición.
- Referencia `warehouseId` (inmutable — un lugar físico no cambia de edificio) y `zoneId` opcional (reasignable dentro del almacén). `scopeId` denormalizado para listado por tenencia.
- Campos: `code` (único por almacén), `kind` (`shelf`/`bulk`/`staging`/`dock`/`quarantine`), `status` (`active`/`blocked`/`archived`), timestamps.
- Comportamientos: `assignZone` (reasignar/desasignar), `block`/`unblock` (fuera/dentro de servicio, idempotentes), `archive` (retiro permanente, solo lectura). Snapshots round-trip.
- Invariantes locales: `code` no vacío/≤32, `warehouseId` inmutable, archivado = solo lectura. La invariante cruzada "la zona pertenece a este almacén y está activa" la valida el caso de uso del host (que sí ve el almacén), no el agregado — mismo patrón que el árbol de `containers`.
- Port `BinRepository` (`save`/`findById`/`findByCode`/`findByWarehouse`/`findByScope`).

El stock (`StockItem`/`StockMovement`, FEFO, salidas) referenciará el bin por id en los siguientes incrementos.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `build` (dual), `typecheck` (exactOptionalPropertyTypes), `test` (**21/21** verde: 13 warehouse + 8 bin), `pnpm --filter api build` (nest, host intacto), Prettier `--check` limpio, frontera pura (sin NestJS/ORM/host).
- [x] Verifiqué el comportamiento manualmente si aplica — 8 tests de dominio cubren creación/normalización, bin sin zona, validación de código, reasignación/desasignación de zona, block/unblock idempotentes, congelación al archivar (incl. archivar un bin bloqueado) y round-trip de snapshot con `warehouseId` inmutable.
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica: dominio nuevo del paquete, sin wiring al host, sin endpoints ni migraciones.

## Cierre

- Closes #372

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_