### PR TITLE
feat(warehouse-core): añade StockItem — la existencia (producto × lote × bin × estado)

### DIFF
--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -4,13 +4,17 @@
  * almacenaje/picking/expedición/cuarentena) y el aggregate root `Bin`
  * (ubicación física), sobre `ScopeId` (tenencia opaca).
  *
- * Dominio puro: sin NestJS, sin ORM, sin infraestructura. El stock
- * (`StockItem`/`StockMovement`) llega en incrementos siguientes y referencia
- * este backbone por id (bin → zona → almacén).
+ * El stock existente se modela con `StockItem` (una fila por producto × lote ×
+ * bin × estado, con cantidad decimal + UoM y `version` para concurrencia
+ * optimista). El kardex `StockMovement` llega en el incremento siguiente.
+ *
+ * Dominio puro: sin NestJS, sin ORM, sin infraestructura. Todo referencia el
+ * catálogo (`supplyId`) y el backbone (bin → zona → almacén) por id.
  */
 export { WarehouseId } from './warehouse-id.js';
 export { ZoneId } from './zone-id.js';
 export { BinId } from './bin-id.js';
+export { StockItemId } from './stock-item-id.js';
 export {
   WarehouseStatus,
   ZoneStatus,
@@ -18,6 +22,7 @@ export {
   BinStatus,
   BinKind,
 } from './inventory-enums.js';
+export { StockStatus } from './stock-enums.js';
 export {
   WarehouseValidationError,
   DuplicateZoneCodeError,
@@ -25,6 +30,13 @@ export {
   BinValidationError,
   BinArchivedError,
 } from './inventory-errors.js';
+export {
+  StockValidationError,
+  QuantityUnitMismatchError,
+  InsufficientStockError,
+} from './stock-errors.js';
+export { Quantity } from './quantity.js';
+export { Lot } from './lot.js';
 export { Warehouse, Zone } from './warehouse.js';
 export type {
   WarehouseGeo,
@@ -35,6 +47,12 @@ export type {
 } from './warehouse.js';
 export { Bin } from './bin.js';
 export type { CreateBinProps, BinSnapshot } from './bin.js';
+export { StockItem } from './stock-item.js';
+export type {
+  LotInput,
+  CreateStockItemProps,
+  StockItemSnapshot,
+} from './stock-item.js';
 export {
   WAREHOUSE_REPOSITORY,
   type WarehouseRepository,
@@ -45,3 +63,9 @@ export {
   type BinRepository,
   type ListBinsFilter,
 } from './ports/bin.repository.js';
+export {
+  STOCK_ITEM_REPOSITORY,
+  type StockItemRepository,
+  type ListStockFilter,
+  type StockGrainKey,
+} from './ports/stock-item.repository.js';

--- a/packages/warehouse-core/src/inventory/lot.ts
+++ b/packages/warehouse-core/src/inventory/lot.ts
@@ -1,0 +1,39 @@
+import { StockValidationError } from './stock-errors.js';
+
+/**
+ * A batch of material: a lot/batch code and its optional expiry. Immutable
+ * value object embedded in a {@link StockItem}. The expiry is what FEFO
+ * (first-expired-first-out) allocation reads; a lot with no expiry never
+ * expires. Stock that is not lot-tracked carries no `Lot` at all (the item's
+ * lot is `null`) rather than a `Lot` with an empty code.
+ */
+export class Lot {
+  private constructor(
+    public readonly code: string,
+    public readonly expiresAt: Date | null,
+  ) {}
+
+  static of(code: string, expiresAt: Date | null = null): Lot {
+    const normalized = typeof code === 'string' ? code.trim() : '';
+    if (normalized.length === 0) {
+      throw new StockValidationError('Lot code must not be empty');
+    }
+    return new Lot(normalized, expiresAt);
+  }
+
+  /** True when the lot has an expiry at or before the given instant. */
+  isExpiredAt(instant: Date): boolean {
+    return (
+      this.expiresAt !== null && this.expiresAt.getTime() <= instant.getTime()
+    );
+  }
+
+  equals(o: Lot): boolean {
+    const sameExpiry =
+      (this.expiresAt === null && o.expiresAt === null) ||
+      (this.expiresAt !== null &&
+        o.expiresAt !== null &&
+        this.expiresAt.getTime() === o.expiresAt.getTime());
+    return this.code === o.code && sameExpiry;
+  }
+}

--- a/packages/warehouse-core/src/inventory/ports/stock-item.repository.ts
+++ b/packages/warehouse-core/src/inventory/ports/stock-item.repository.ts
@@ -1,0 +1,45 @@
+import { StockItem } from '../stock-item.js';
+import { StockItemId } from '../stock-item-id.js';
+import { BinId } from '../bin-id.js';
+import { WarehouseId } from '../warehouse-id.js';
+import { ScopeId } from '../../kernel/index.js';
+import { StockStatus } from '../stock-enums.js';
+
+export const STOCK_ITEM_REPOSITORY = Symbol('StockItemRepository');
+
+/** Filter for listing stock. AND-combined. */
+export interface ListStockFilter {
+  status?: StockStatus;
+  supplyId?: string;
+}
+
+/**
+ * The business grain key of a {@link StockItem}: the unique combination
+ * (bin, supply, lot, status). `lotCode` is null for non-lot-tracked stock. The
+ * receipt path resolves the existing row by this key to add to it, or creates a
+ * new item when absent.
+ */
+export interface StockGrainKey {
+  binId: string;
+  supplyId: string;
+  lotCode: string | null;
+  status: StockStatus;
+}
+
+export interface StockItemRepository {
+  /**
+   * Persists the item. Implementations MUST enforce optimistic concurrency on
+   * `version` (write `WHERE version = snapshot.version - 1`) and reject a stale
+   * update, and MUST uphold the unique grain key (bin, supply, lot, status).
+   */
+  save(item: StockItem): Promise<void>;
+  findById(id: StockItemId): Promise<StockItem | null>;
+  /** Resolves the single item at a grain key, or null if none exists yet. */
+  findByGrain(key: StockGrainKey): Promise<StockItem | null>;
+  findByBin(binId: BinId, filter: ListStockFilter): Promise<StockItem[]>;
+  findByWarehouse(
+    warehouseId: WarehouseId,
+    filter: ListStockFilter,
+  ): Promise<StockItem[]>;
+  findByScope(scopeId: ScopeId, filter: ListStockFilter): Promise<StockItem[]>;
+}

--- a/packages/warehouse-core/src/inventory/quantity.test.ts
+++ b/packages/warehouse-core/src/inventory/quantity.test.ts
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Quantity } from './quantity.js';
+import {
+  QuantityUnitMismatchError,
+  StockValidationError,
+} from './stock-errors.js';
+
+test('normalizes the unit to trimmed lowercase and rounds to 6 decimals', () => {
+  const q = Quantity.of(1.23456789, '  KG  ');
+  assert.equal(q.unit, 'kg');
+  assert.equal(q.amount, 1.234568);
+});
+
+test('rejects negative, NaN and infinite amounts, and empty unit', () => {
+  assert.throws(() => Quantity.of(-1, 'kg'), StockValidationError);
+  assert.throws(() => Quantity.of(Number.NaN, 'kg'), StockValidationError);
+  assert.throws(() => Quantity.of(Infinity, 'kg'), StockValidationError);
+  assert.throws(() => Quantity.of(1, '   '), StockValidationError);
+});
+
+test('plus neutralizes binary-float drift (0.1 + 0.2 === 0.3)', () => {
+  const sum = Quantity.of(0.1, 'l').plus(Quantity.of(0.2, 'l'));
+  assert.equal(sum.amount, 0.3);
+  assert.equal(sum.unit, 'l');
+});
+
+test('minus subtracts and rejects a negative result', () => {
+  const r = Quantity.of(5, 'unit').minus(Quantity.of(2, 'unit'));
+  assert.equal(r.amount, 3);
+  assert.throws(
+    () => Quantity.of(1, 'unit').minus(Quantity.of(2, 'unit')),
+    StockValidationError,
+  );
+});
+
+test('arithmetic and comparison across units throw', () => {
+  const kg = Quantity.of(1, 'kg');
+  const l = Quantity.of(1, 'l');
+  assert.throws(() => kg.plus(l), QuantityUnitMismatchError);
+  assert.throws(() => kg.minus(l), QuantityUnitMismatchError);
+  assert.throws(() => kg.isLessThan(l), QuantityUnitMismatchError);
+});
+
+test('isZero / isLessThan / equals', () => {
+  assert.ok(Quantity.of(0, 'kg').isZero());
+  assert.ok(!Quantity.of(0.5, 'kg').isZero());
+  assert.ok(Quantity.of(1, 'kg').isLessThan(Quantity.of(2, 'kg')));
+  assert.ok(Quantity.of(2, 'kg').equals(Quantity.of(2, 'kg')));
+  assert.ok(!Quantity.of(2, 'kg').equals(Quantity.of(2, 'l')));
+});

--- a/packages/warehouse-core/src/inventory/quantity.ts
+++ b/packages/warehouse-core/src/inventory/quantity.ts
@@ -1,0 +1,79 @@
+import {
+  QuantityUnitMismatchError,
+  StockValidationError,
+} from './stock-errors.js';
+
+/**
+ * Decimal scale for stored amounts. Amounts are rounded to 6 decimal places on
+ * every construction and arithmetic step, which keeps a `numeric(18,6)` column
+ * and float arithmetic in agreement and neutralizes binary-float drift
+ * (`0.1 + 0.2`). Six places covers grams/millilitres without surprises.
+ */
+const SCALE = 6;
+const FACTOR = 10 ** SCALE;
+
+function round(amount: number): number {
+  // +0 avoids a signed negative zero leaking into snapshots/equality.
+  return Math.round(amount * FACTOR) / FACTOR + 0;
+}
+
+/**
+ * A measured amount of material in a single unit of measure — the decimal
+ * quantity of a {@link StockItem}. Immutable value object: arithmetic returns a
+ * new `Quantity` and never mutates. Units are opaque strings (e.g. `unit`,
+ * `kg`, `l`, `box`), normalized to trimmed lowercase; combining two quantities
+ * requires the same unit (no unit conversion here). Amounts are non-negative
+ * and rounded to 6 decimals.
+ */
+export class Quantity {
+  private constructor(
+    public readonly amount: number,
+    public readonly unit: string,
+  ) {}
+
+  static of(amount: number, unit: string): Quantity {
+    if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+      throw new StockValidationError('Quantity amount must be a finite number');
+    }
+    if (amount < 0) {
+      throw new StockValidationError('Quantity amount must not be negative');
+    }
+    const normalizedUnit = typeof unit === 'string' ? unit.trim() : '';
+    if (normalizedUnit.length === 0) {
+      throw new StockValidationError('Quantity unit must not be empty');
+    }
+    return new Quantity(round(amount), normalizedUnit.toLowerCase());
+  }
+
+  plus(o: Quantity): Quantity {
+    this.assertSameUnit(o);
+    return Quantity.of(this.amount + o.amount, this.unit);
+  }
+
+  /** Subtracts, throwing {@link StockValidationError} if the result is negative. */
+  minus(o: Quantity): Quantity {
+    this.assertSameUnit(o);
+    return Quantity.of(round(this.amount - o.amount), this.unit);
+  }
+
+  isZero(): boolean {
+    return this.amount === 0;
+  }
+
+  isLessThan(o: Quantity): boolean {
+    this.assertSameUnit(o);
+    return this.amount < o.amount;
+  }
+
+  equals(o: Quantity): boolean {
+    return this.amount === o.amount && this.unit === o.unit;
+  }
+
+  private assertSameUnit(o: Quantity): void {
+    if (this.unit !== o.unit) {
+      throw new QuantityUnitMismatchError(
+        `Cannot combine quantities of "${this.unit}" and "${o.unit}"`,
+      );
+    }
+  }
+}

--- a/packages/warehouse-core/src/inventory/stock-enums.ts
+++ b/packages/warehouse-core/src/inventory/stock-enums.ts
@@ -1,0 +1,18 @@
+/**
+ * Disposition of a {@link StockItem} — part of its grain, so the same
+ * product/lot/bin can hold quantity in several statuses at once, and moving
+ * stock between statuses is a transfer between two items (decrease one,
+ * increase the other), recorded by a movement.
+ *
+ * `available` is free to allocate; `reserved` is committed to an order/pick but
+ * still physically present; `quarantine` (cuarentena) is held pending
+ * inspection/return; `damaged` (dañado) is unsellable/unusable. Expiry is NOT a
+ * status — it is derived from the lot's `expiresAt` so a single expiry date
+ * drives FEFO and reporting without a state transition.
+ */
+export enum StockStatus {
+  Available = 'available',
+  Reserved = 'reserved',
+  Quarantine = 'quarantine',
+  Damaged = 'damaged',
+}

--- a/packages/warehouse-core/src/inventory/stock-errors.ts
+++ b/packages/warehouse-core/src/inventory/stock-errors.ts
@@ -1,0 +1,33 @@
+/**
+ * Raised on invalid stock input: negative/NaN quantity, empty unit or lot code,
+ * empty supply/bin id. The HTTP layer of each host maps it to 422.
+ */
+export class StockValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StockValidationError';
+  }
+}
+
+/**
+ * Raised when an arithmetic or comparison mixes two {@link Quantity} values of
+ * different units (kg vs unit…). Quantities are only combinable within one unit
+ * of measure; converting between units is out of scope for the aggregate.
+ */
+export class QuantityUnitMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'QuantityUnitMismatchError';
+  }
+}
+
+/**
+ * Raised when decreasing a {@link StockItem} by more than it holds. Stock can
+ * never go negative; the HTTP layer maps this to 409 Conflict.
+ */
+export class InsufficientStockError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InsufficientStockError';
+  }
+}

--- a/packages/warehouse-core/src/inventory/stock-item-id.ts
+++ b/packages/warehouse-core/src/inventory/stock-item-id.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from 'node:crypto';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Identity of a {@link StockItem} — one row of existence at the grain
+ * product × lot × bin × status. A UUID value object; the *business* grain key
+ * (bin, supply, lot, status) is a separate unique constraint enforced by the
+ * repository, so the surrogate id stays stable even as quantity changes.
+ */
+export class StockItemId {
+  private constructor(public readonly value: string) {}
+
+  static create(): StockItemId {
+    return new StockItemId(randomUUID());
+  }
+
+  static fromString(s: string): StockItemId {
+    if (!UUID_RE.test(s)) throw new Error(`Invalid StockItemId: ${s}`);
+    return new StockItemId(s);
+  }
+
+  equals(o: StockItemId): boolean {
+    return this.value === o.value;
+  }
+}

--- a/packages/warehouse-core/src/inventory/stock-item.test.ts
+++ b/packages/warehouse-core/src/inventory/stock-item.test.ts
@@ -1,0 +1,116 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { StockItem } from './stock-item.js';
+import { StockItemId } from './stock-item-id.js';
+import { WarehouseId } from './warehouse-id.js';
+import { BinId } from './bin-id.js';
+import { Quantity } from './quantity.js';
+import { StockStatus } from './stock-enums.js';
+import {
+  InsufficientStockError,
+  StockValidationError,
+} from './stock-errors.js';
+import { ScopeId } from '../kernel/scope-id.js';
+
+const SCOPE = '11111111-1111-4111-8111-111111111111';
+const WAREHOUSE = '22222222-2222-4222-8222-222222222222';
+const BIN = '44444444-4444-4444-8444-444444444444';
+const SUPPLY = 'AGU-0001';
+const EXPIRY = new Date('2027-01-01T00:00:00.000Z');
+
+function make(
+  overrides?: Partial<{
+    supplyId: string;
+    lot: { code: string; expiresAt?: Date | null } | null;
+    quantity: Quantity;
+    status: StockStatus;
+  }>,
+): StockItem {
+  return StockItem.create({
+    id: StockItemId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    warehouseId: WarehouseId.fromString(WAREHOUSE),
+    binId: BinId.fromString(BIN),
+    supplyId: overrides?.supplyId ?? SUPPLY,
+    lot:
+      overrides && 'lot' in overrides
+        ? overrides.lot
+        : { code: 'L-2026-07', expiresAt: EXPIRY },
+    quantity: overrides?.quantity ?? Quantity.of(100, 'unit'),
+    status: overrides?.status ?? StockStatus.Available,
+  });
+}
+
+test('creates stock at version 1 with its grain and lot', () => {
+  const s = make();
+  assert.equal(s.version, 1);
+  assert.equal(s.status, StockStatus.Available);
+  assert.equal(s.supplyId, SUPPLY);
+  assert.equal(s.quantity.amount, 100);
+  assert.equal(s.unit, 'unit');
+  assert.equal(s.lot?.code, 'L-2026-07');
+  assert.deepEqual(s.expiresAt, EXPIRY);
+});
+
+test('rejects an empty supplyId', () => {
+  assert.throws(() => make({ supplyId: '   ' }), StockValidationError);
+});
+
+test('supports non-lot-tracked stock (no lot)', () => {
+  const s = make({ lot: null });
+  assert.equal(s.lot, null);
+  assert.equal(s.expiresAt, null);
+  assert.equal(s.isExpiredAt(new Date('2030-01-01T00:00:00Z')), false);
+});
+
+test('increase adds quantity and bumps the version', () => {
+  const s = make({ quantity: Quantity.of(10, 'kg') });
+  s.increase(Quantity.of(2.5, 'kg'));
+  assert.equal(s.quantity.amount, 12.5);
+  assert.equal(s.version, 2);
+});
+
+test('decrease removes quantity, bumps version, and guards against going negative', () => {
+  const s = make({ quantity: Quantity.of(5, 'unit') });
+  s.decrease(Quantity.of(3, 'unit'));
+  assert.equal(s.quantity.amount, 2);
+  assert.equal(s.version, 2);
+  assert.throws(
+    () => s.decrease(Quantity.of(10, 'unit')),
+    InsufficientStockError,
+  );
+  // rejected mutation left state untouched
+  assert.equal(s.quantity.amount, 2);
+  assert.equal(s.version, 2);
+});
+
+test('mutations across a different unit are rejected', () => {
+  const s = make({ quantity: Quantity.of(5, 'unit') });
+  assert.throws(() => s.increase(Quantity.of(1, 'kg')));
+  assert.throws(() => s.decrease(Quantity.of(1, 'kg')));
+  assert.throws(() => s.adjustTo(Quantity.of(1, 'kg')), StockValidationError);
+});
+
+test('adjustTo sets an absolute quantity (cycle count)', () => {
+  const s = make({ quantity: Quantity.of(5, 'unit') });
+  s.adjustTo(Quantity.of(7, 'unit'));
+  assert.equal(s.quantity.amount, 7);
+  assert.equal(s.version, 2);
+});
+
+test('isExpiredAt reflects the lot expiry', () => {
+  const s = make({ lot: { code: 'L1', expiresAt: EXPIRY } });
+  assert.equal(s.isExpiredAt(new Date('2026-12-31T00:00:00Z')), false);
+  assert.equal(s.isExpiredAt(new Date('2027-06-01T00:00:00Z')), true);
+});
+
+test('round-trips through a snapshot preserving version and grain', () => {
+  const s = make({ quantity: Quantity.of(42.5, 'l') });
+  s.increase(Quantity.of(7.5, 'l')); // version → 2
+  const snap = s.toSnapshot();
+  const restored = StockItem.fromSnapshot(snap);
+  assert.deepEqual(restored.toSnapshot(), snap);
+  assert.ok(restored instanceof StockItem);
+  assert.equal(restored.version, 2);
+  assert.equal(restored.quantity.amount, 50);
+});

--- a/packages/warehouse-core/src/inventory/stock-item.ts
+++ b/packages/warehouse-core/src/inventory/stock-item.ts
@@ -1,0 +1,202 @@
+import { StockItemId } from './stock-item-id.js';
+import { WarehouseId } from './warehouse-id.js';
+import { BinId } from './bin-id.js';
+import { Quantity } from './quantity.js';
+import { Lot } from './lot.js';
+import { StockStatus } from './stock-enums.js';
+import {
+  InsufficientStockError,
+  StockValidationError,
+} from './stock-errors.js';
+import { ScopeId } from '../kernel/index.js';
+
+export interface LotInput {
+  code: string;
+  expiresAt?: Date | null;
+}
+
+export interface CreateStockItemProps {
+  id: StockItemId;
+  scopeId: ScopeId;
+  warehouseId: WarehouseId;
+  binId: BinId;
+  /** The catalog product (Supply) this stock is of, referenced by id. */
+  supplyId: string;
+  /** The batch, or null for non-lot-tracked stock. */
+  lot?: LotInput | null;
+  quantity: Quantity;
+  status: StockStatus;
+}
+
+export interface StockItemSnapshot {
+  id: string;
+  scopeId: string;
+  warehouseId: string;
+  binId: string;
+  supplyId: string;
+  lotCode: string | null;
+  expiresAt: Date | null;
+  quantityAmount: number;
+  unit: string;
+  status: StockStatus;
+  version: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Aggregate root for a unit of existence — the material actually present, at
+ * the grain **product × lot × bin × status**: one row per (supply, lot, bin,
+ * status), holding a decimal {@link Quantity}. This grain is what lets the WMS
+ * do FEFO (each lot its own expiry), multi-location stock (same product in many
+ * bins) and status-partitioned holds (available vs quarantine…) without a
+ * parallel model.
+ *
+ * The grain fields — `supplyId`, `binId`, `lot`, `status` — are the item's
+ * identity and are **immutable**: moving stock (bin→bin, available→reserved,
+ * relabelling a lot) is a transfer between two items (decrease one, increase
+ * another), recorded by a {@link StockMovement} (next increment). Only the
+ * quantity mutates here, guarded so it never goes negative and always shares
+ * the item's unit. Every mutation bumps `version` for optimistic concurrency:
+ * the repository writes with a `WHERE version = :expected` and rejects a stale
+ * update.
+ *
+ * References its warehouse/bin and its catalog product **by id** (`scopeId`
+ * denormalized for tenancy queries). The kardex, put-away rules and allocation
+ * live above this aggregate; here we guard the local invariant: quantity ≥ 0,
+ * single unit, immutable grain.
+ */
+export class StockItem {
+  private constructor(
+    public readonly id: StockItemId,
+    public readonly scopeId: ScopeId,
+    public readonly warehouseId: WarehouseId,
+    public readonly binId: BinId,
+    public readonly supplyId: string,
+    public readonly lot: Lot | null,
+    public readonly status: StockStatus,
+    private _quantity: Quantity,
+    private _version: number,
+    public readonly createdAt: Date,
+    private _updatedAt: Date,
+  ) {}
+
+  static create(props: CreateStockItemProps): StockItem {
+    const supplyId =
+      typeof props.supplyId === 'string' ? props.supplyId.trim() : '';
+    if (supplyId.length === 0) {
+      throw new StockValidationError('StockItem supplyId must not be empty');
+    }
+    const lot =
+      props.lot != null
+        ? Lot.of(props.lot.code, props.lot.expiresAt ?? null)
+        : null;
+    const now = new Date();
+    return new StockItem(
+      props.id,
+      props.scopeId,
+      props.warehouseId,
+      props.binId,
+      supplyId,
+      lot,
+      props.status,
+      props.quantity,
+      1,
+      now,
+      now,
+    );
+  }
+
+  static fromSnapshot(s: StockItemSnapshot): StockItem {
+    const lot =
+      s.lotCode !== null ? Lot.of(s.lotCode, s.expiresAt ?? null) : null;
+    return new StockItem(
+      StockItemId.fromString(s.id),
+      ScopeId.fromString(s.scopeId),
+      WarehouseId.fromString(s.warehouseId),
+      BinId.fromString(s.binId),
+      s.supplyId,
+      lot,
+      s.status,
+      Quantity.of(s.quantityAmount, s.unit),
+      s.version,
+      s.createdAt,
+      s.updatedAt,
+    );
+  }
+
+  get quantity(): Quantity {
+    return this._quantity;
+  }
+  get unit(): string {
+    return this._quantity.unit;
+  }
+  get version(): number {
+    return this._version;
+  }
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+  get expiresAt(): Date | null {
+    return this.lot?.expiresAt ?? null;
+  }
+
+  /** True when this item's lot has an expiry at or before the given instant. */
+  isExpiredAt(instant: Date): boolean {
+    return this.lot?.isExpiredAt(instant) ?? false;
+  }
+
+  /** Adds stock (a receipt or an incoming transfer leg). Same unit required. */
+  increase(quantity: Quantity): void {
+    this._quantity = this._quantity.plus(quantity);
+    this.bump();
+  }
+
+  /**
+   * Removes stock (an issue/consumption or an outgoing transfer leg). Throws
+   * {@link InsufficientStockError} if the item holds less than requested.
+   */
+  decrease(quantity: Quantity): void {
+    if (this._quantity.isLessThan(quantity)) {
+      throw new InsufficientStockError(
+        `StockItem ${this.id.value} holds ${this._quantity.amount} ${this.unit}, cannot remove ${quantity.amount}`,
+      );
+    }
+    this._quantity = this._quantity.minus(quantity);
+    this.bump();
+  }
+
+  /** Sets the quantity to an absolute value (cycle count / recuento). */
+  adjustTo(quantity: Quantity): void {
+    if (quantity.unit !== this.unit) {
+      throw new StockValidationError(
+        `Cannot adjust "${this.unit}" stock to a "${quantity.unit}" quantity`,
+      );
+    }
+    this._quantity = quantity;
+    this.bump();
+  }
+
+  toSnapshot(): StockItemSnapshot {
+    return {
+      id: this.id.value,
+      scopeId: this.scopeId.value,
+      warehouseId: this.warehouseId.value,
+      binId: this.binId.value,
+      supplyId: this.supplyId,
+      lotCode: this.lot?.code ?? null,
+      expiresAt: this.lot?.expiresAt ?? null,
+      quantityAmount: this._quantity.amount,
+      unit: this._quantity.unit,
+      status: this.status,
+      version: this._version,
+      createdAt: this.createdAt,
+      updatedAt: this._updatedAt,
+    };
+  }
+
+  private bump(): void {
+    this._version += 1;
+    this._updatedAt = new Date();
+  }
+}


### PR DESCRIPTION
## Resumen

El **corazón del WMS** (Fase 2, épica #355): tras el backbone de ubicaciones (`Warehouse`/`Zone`/`Bin`, #370/#372), el stock real — la existencia de material.

En el módulo `inventory` de `@globalemergency/warehouse-core`, dominio puro sobre `ScopeId`:

- **`StockItem`** (aggregate root) al grano **producto × lote × bin × estado**: una fila por combinación, con cantidad decimal. Este grano habilita FEFO (cada lote su caducidad), stock multi-ubicación (mismo producto en varios bins) y holds por estado (available vs quarantine…) sin un modelo paralelo.
  - Grano **inmutable** (`supplyId`/`binId`/`lot`/`status`, todo referenciado por id): mover stock (bin→bin, available→reserved, relabel de lote) es una transferencia entre dos items — la registrará `StockMovement`. Aquí solo muta la cantidad: `increase`/`decrease` (guarda no-negativo) / `adjustTo` (recuento).
  - **`version`** para concurrencia optimista desde el inicio: cada mutación lo incrementa; el repo escribe `WHERE version = :esperada` y rechaza un update rancio.
- **`Quantity`** (VO): cantidad decimal + UoM opaca (`unit`/`kg`/`l`/…). `plus`/`minus`/`isLessThan`/`equals`; no negativa; misma-unidad obligatoria (sin conversión); **redondeo a 6 decimales** que neutraliza el drift de float (`0.1 + 0.2 === 0.3`) y concuerda con una columna `numeric(18,6)`.
- **`Lot`** (VO): código de lote + caducidad opcional (`expiresAt`), la fecha que lee FEFO. Stock no trazado por lote = sin `Lot`.
- **`StockStatus`**: `available`/`reserved`/`quarantine`/`damaged`. La caducidad **no** es un estado — se deriva del lote, así una sola fecha alimenta FEFO y reporting sin transición.
- Port `StockItemRepository` (`save`/`findById`/`findByGrain`/`findByBin`/`findByWarehouse`/`findByScope`), con el contrato de unicidad de grano + optimistic locking documentado.

`StockMovement` (kardex: entradas/salidas/traslados/ajustes, que orquesta estas mutaciones y registra el asiento) llega en el incremento siguiente.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `build` (dual), `typecheck` (exactOptionalPropertyTypes), `test` (**36/36** verde: 13 warehouse + 8 bin + 6 quantity + 9 stock-item), `pnpm --filter api build` (nest, host intacto), Prettier `--check` limpio, frontera pura (sin NestJS/ORM/host).
- [x] Verifiqué el comportamiento manualmente si aplica — los tests cubren: normalización/redondeo de `Quantity` y el caso `0.1+0.2`, mismatch de unidades, `increase`/`decrease` con guarda de insuficiencia (estado intacto tras el rechazo), `adjustTo`, stock sin lote, `isExpiredAt`, y round-trip de snapshot preservando `version` y grano.
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica: dominio nuevo del paquete, sin wiring al host, sin endpoints ni migraciones.

## Cierre

- Closes #374

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_