### PR TITLE
feat(warehouse-core): añade StockMovement — el kardex (asiento unificado de doble pata)

### DIFF
--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -6,7 +6,8 @@
  *
  * El stock existente se modela con `StockItem` (una fila por producto × lote ×
  * bin × estado, con cantidad decimal + UoM y `version` para concurrencia
- * optimista). El kardex `StockMovement` llega en el incremento siguiente.
+ * optimista) y su libro mayor `StockMovement` (asiento inmutable de doble pata:
+ * `applyStockMovement` decrementa un item e incrementa otro).
  *
  * Dominio puro: sin NestJS, sin ORM, sin infraestructura. Todo referencia el
  * catálogo (`supplyId`) y el backbone (bin → zona → almacén) por id.
@@ -15,6 +16,7 @@ export { WarehouseId } from './warehouse-id.js';
 export { ZoneId } from './zone-id.js';
 export { BinId } from './bin-id.js';
 export { StockItemId } from './stock-item-id.js';
+export { StockMovementId } from './stock-movement-id.js';
 export {
   WarehouseStatus,
   ZoneStatus,
@@ -23,6 +25,7 @@ export {
   BinKind,
 } from './inventory-enums.js';
 export { StockStatus } from './stock-enums.js';
+export { MovementKind } from './movement-enums.js';
 export {
   WarehouseValidationError,
   DuplicateZoneCodeError,
@@ -34,6 +37,7 @@ export {
   StockValidationError,
   QuantityUnitMismatchError,
   InsufficientStockError,
+  StockMovementValidationError,
 } from './stock-errors.js';
 export { Quantity } from './quantity.js';
 export { Lot } from './lot.js';
@@ -53,6 +57,12 @@ export type {
   CreateStockItemProps,
   StockItemSnapshot,
 } from './stock-item.js';
+export { StockMovement, applyStockMovement } from './stock-movement.js';
+export type {
+  RecordStockMovementProps,
+  StockMovementSnapshot,
+  MovementLegs,
+} from './stock-movement.js';
 export {
   WAREHOUSE_REPOSITORY,
   type WarehouseRepository,
@@ -69,3 +79,8 @@ export {
   type ListStockFilter,
   type StockGrainKey,
 } from './ports/stock-item.repository.js';
+export {
+  STOCK_MOVEMENT_REPOSITORY,
+  type StockMovementRepository,
+  type ListMovementsFilter,
+} from './ports/stock-movement.repository.js';

--- a/packages/warehouse-core/src/inventory/movement-enums.ts
+++ b/packages/warehouse-core/src/inventory/movement-enums.ts
@@ -1,0 +1,23 @@
+/**
+ * Business intent of a {@link StockMovement} — the label on the unified
+ * two-leg model. The legs (`from`/`to`) determine the *shape* (inbound if only
+ * `to`, outbound if only `from`, transfer if both); `kind` disambiguates intent
+ * where the shape alone can't:
+ *
+ * - `receipt` (entrada) — inbound from outside: a delivery/donation arrives.
+ * - `issue` (salida) — outbound to outside: consumption, expedición, baja.
+ * - `transfer` (traslado) — internal, both legs set: bin→bin, or a status
+ *   change (available→reserved/quarantine) modelled as a move between the two
+ *   status-partitioned items of the same product/lot/bin.
+ * - `adjustment` (ajuste) — a single-leg correction from a recuento/merma: a
+ *   gain (only `to`) or a loss (only `from`) with no external counterpart.
+ *
+ * Both `receipt` and `adjustment`-gain are inbound; `issue` and
+ * `adjustment`-loss are outbound — hence `kind` is stored, not derived.
+ */
+export enum MovementKind {
+  Receipt = 'receipt',
+  Issue = 'issue',
+  Transfer = 'transfer',
+  Adjustment = 'adjustment',
+}

--- a/packages/warehouse-core/src/inventory/ports/stock-movement.repository.ts
+++ b/packages/warehouse-core/src/inventory/ports/stock-movement.repository.ts
@@ -1,0 +1,40 @@
+import { StockMovement } from '../stock-movement.js';
+import { StockMovementId } from '../stock-movement-id.js';
+import { StockItemId } from '../stock-item-id.js';
+import { ScopeId } from '../../kernel/index.js';
+import { MovementKind } from '../movement-enums.js';
+
+export const STOCK_MOVEMENT_REPOSITORY = Symbol('StockMovementRepository');
+
+/** Filter for listing ledger entries. AND-combined. */
+export interface ListMovementsFilter {
+  kind?: MovementKind;
+  /** Only movements at/after this instant (ISO/Date). */
+  occurredFrom?: Date;
+  /** Only movements at/before this instant. */
+  occurredTo?: Date;
+}
+
+export interface StockMovementRepository {
+  /**
+   * Appends a movement to the ledger. The ledger is immutable — implementations
+   * only insert, never update or delete — and MUST enforce `idempotencyKey`
+   * unique per scope so a retried entrada is recorded once.
+   */
+  append(movement: StockMovement): Promise<void>;
+  findById(id: StockMovementId): Promise<StockMovement | null>;
+  /** Resolves a movement by its idempotency key within a scope, if any. */
+  findByIdempotencyKey(
+    scopeId: ScopeId,
+    idempotencyKey: string,
+  ): Promise<StockMovement | null>;
+  /** Ledger of a single item (its `from` or `to` legs), newest-first. */
+  findByItem(
+    itemId: StockItemId,
+    filter: ListMovementsFilter,
+  ): Promise<StockMovement[]>;
+  findByScope(
+    scopeId: ScopeId,
+    filter: ListMovementsFilter,
+  ): Promise<StockMovement[]>;
+}

--- a/packages/warehouse-core/src/inventory/stock-errors.ts
+++ b/packages/warehouse-core/src/inventory/stock-errors.ts
@@ -31,3 +31,16 @@ export class InsufficientStockError extends Error {
     this.name = 'InsufficientStockError';
   }
 }
+
+/**
+ * Raised on an invalid stock movement (asiento): zero quantity, legs that don't
+ * match its kind (a receipt with a source, a transfer to the same item…), or a
+ * StockItem passed to `applyStockMovement` that doesn't match the movement's
+ * leg id or scope. The HTTP layer maps it to 422 (bad request) or 409.
+ */
+export class StockMovementValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StockMovementValidationError';
+  }
+}

--- a/packages/warehouse-core/src/inventory/stock-movement-id.ts
+++ b/packages/warehouse-core/src/inventory/stock-movement-id.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from 'node:crypto';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Identity of a {@link StockMovement} — one immutable line of the stock ledger
+ * (kardex). A UUID value object; the ledger is append-only, so an id is minted
+ * once and never reused.
+ */
+export class StockMovementId {
+  private constructor(public readonly value: string) {}
+
+  static create(): StockMovementId {
+    return new StockMovementId(randomUUID());
+  }
+
+  static fromString(s: string): StockMovementId {
+    if (!UUID_RE.test(s)) throw new Error(`Invalid StockMovementId: ${s}`);
+    return new StockMovementId(s);
+  }
+
+  equals(o: StockMovementId): boolean {
+    return this.value === o.value;
+  }
+}

--- a/packages/warehouse-core/src/inventory/stock-movement.test.ts
+++ b/packages/warehouse-core/src/inventory/stock-movement.test.ts
@@ -1,0 +1,222 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { StockMovement, applyStockMovement } from './stock-movement.js';
+import { StockMovementId } from './stock-movement-id.js';
+import { StockItem } from './stock-item.js';
+import { StockItemId } from './stock-item-id.js';
+import { WarehouseId } from './warehouse-id.js';
+import { BinId } from './bin-id.js';
+import { Quantity } from './quantity.js';
+import { StockStatus } from './stock-enums.js';
+import { MovementKind } from './movement-enums.js';
+import {
+  InsufficientStockError,
+  StockMovementValidationError,
+} from './stock-errors.js';
+import { ScopeId } from '../kernel/scope-id.js';
+
+const SCOPE = '11111111-1111-4111-8111-111111111111';
+const OTHER_SCOPE = '99999999-9999-4999-8999-999999999999';
+const WAREHOUSE = '22222222-2222-4222-8222-222222222222';
+const BIN_A = '44444444-4444-4444-8444-444444444444';
+const BIN_B = '55555555-5555-4555-8555-555555555555';
+const SUPPLY = 'AGU-0001';
+
+function item(
+  binId: string,
+  amount: number,
+  status: StockStatus = StockStatus.Available,
+  scope: string = SCOPE,
+): StockItem {
+  return StockItem.create({
+    id: StockItemId.create(),
+    scopeId: ScopeId.fromString(scope),
+    warehouseId: WarehouseId.fromString(WAREHOUSE),
+    binId: BinId.fromString(binId),
+    supplyId: SUPPLY,
+    lot: { code: 'L1' },
+    quantity: Quantity.of(amount, 'unit'),
+    status,
+  });
+}
+
+function record(
+  props: Partial<{
+    kind: MovementKind;
+    quantity: Quantity;
+    fromItemId: StockItemId | null;
+    toItemId: StockItemId | null;
+    idempotencyKey: string | null;
+  }>,
+): StockMovement {
+  return StockMovement.record({
+    id: StockMovementId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    kind: props.kind ?? MovementKind.Receipt,
+    quantity: props.quantity ?? Quantity.of(10, 'unit'),
+    fromItemId: props.fromItemId ?? null,
+    toItemId: props.toItemId ?? null,
+    idempotencyKey: props.idempotencyKey ?? null,
+  });
+}
+
+test('records a receipt (inbound: only a to leg)', () => {
+  const to = item(BIN_A, 0);
+  const m = record({ kind: MovementKind.Receipt, toItemId: to.id });
+  assert.ok(m.isInbound);
+  assert.ok(!m.isTransfer);
+  assert.equal(m.fromItemId, null);
+  assert.ok(m.toItemId?.equals(to.id));
+});
+
+test('rejects a zero-quantity movement', () => {
+  assert.throws(
+    () =>
+      record({
+        kind: MovementKind.Receipt,
+        quantity: Quantity.of(0, 'unit'),
+        toItemId: StockItemId.create(),
+      }),
+    StockMovementValidationError,
+  );
+});
+
+test('enforces leg shape per kind', () => {
+  const a = StockItemId.create();
+  const b = StockItemId.create();
+  // receipt must not have a from leg
+  assert.throws(
+    () => record({ kind: MovementKind.Receipt, fromItemId: a, toItemId: b }),
+    StockMovementValidationError,
+  );
+  // issue must have only a from leg
+  assert.throws(
+    () => record({ kind: MovementKind.Issue, toItemId: b }),
+    StockMovementValidationError,
+  );
+  // transfer needs both legs and they must differ
+  assert.throws(
+    () => record({ kind: MovementKind.Transfer, fromItemId: a }),
+    StockMovementValidationError,
+  );
+  assert.throws(
+    () => record({ kind: MovementKind.Transfer, fromItemId: a, toItemId: a }),
+    StockMovementValidationError,
+  );
+  // adjustment needs exactly one leg
+  assert.throws(
+    () => record({ kind: MovementKind.Adjustment, fromItemId: a, toItemId: b }),
+    StockMovementValidationError,
+  );
+  assert.throws(
+    () => record({ kind: MovementKind.Adjustment }),
+    StockMovementValidationError,
+  );
+});
+
+test('applies a receipt: increases the target only', () => {
+  const to = item(BIN_A, 5);
+  const m = record({
+    kind: MovementKind.Receipt,
+    quantity: Quantity.of(3, 'unit'),
+    toItemId: to.id,
+  });
+  applyStockMovement(m, { to });
+  assert.equal(to.quantity.amount, 8);
+});
+
+test('applies an issue: decreases the source only', () => {
+  const from = item(BIN_A, 5);
+  const m = record({
+    kind: MovementKind.Issue,
+    quantity: Quantity.of(2, 'unit'),
+    fromItemId: from.id,
+  });
+  applyStockMovement(m, { from });
+  assert.equal(from.quantity.amount, 3);
+});
+
+test('applies a transfer: conserves quantity across both legs', () => {
+  const from = item(BIN_A, 10);
+  const to = item(BIN_B, 0);
+  const m = record({
+    kind: MovementKind.Transfer,
+    quantity: Quantity.of(4, 'unit'),
+    fromItemId: from.id,
+    toItemId: to.id,
+  });
+  applyStockMovement(m, { from, to });
+  assert.equal(from.quantity.amount, 6);
+  assert.equal(to.quantity.amount, 4);
+});
+
+test('an insufficient transfer aborts before touching the target', () => {
+  const from = item(BIN_A, 1);
+  const to = item(BIN_B, 0);
+  const m = record({
+    kind: MovementKind.Transfer,
+    quantity: Quantity.of(5, 'unit'),
+    fromItemId: from.id,
+    toItemId: to.id,
+  });
+  assert.throws(
+    () => applyStockMovement(m, { from, to }),
+    InsufficientStockError,
+  );
+  assert.equal(from.quantity.amount, 1); // untouched
+  assert.equal(to.quantity.amount, 0); // never increased
+});
+
+test('rejects legs that do not match the movement (missing, wrong id, wrong scope)', () => {
+  const to = item(BIN_A, 0);
+  const m = record({ kind: MovementKind.Receipt, toItemId: to.id });
+  // missing required leg
+  assert.throws(() => applyStockMovement(m, {}), StockMovementValidationError);
+  // wrong item id
+  assert.throws(
+    () => applyStockMovement(m, { to: item(BIN_A, 0) }),
+    StockMovementValidationError,
+  );
+  // providing a source to an inbound movement
+  const from = item(BIN_B, 0);
+  const m2 = record({ kind: MovementKind.Receipt, toItemId: to.id });
+  assert.throws(
+    () => applyStockMovement(m2, { from, to }),
+    StockMovementValidationError,
+  );
+});
+
+test('rejects a leg item from a different scope', () => {
+  const to = item(BIN_A, 0, StockStatus.Available, OTHER_SCOPE);
+  const m = StockMovement.record({
+    id: StockMovementId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    kind: MovementKind.Receipt,
+    quantity: Quantity.of(1, 'unit'),
+    toItemId: to.id,
+  });
+  assert.throws(
+    () => applyStockMovement(m, { to }),
+    StockMovementValidationError,
+  );
+});
+
+test('normalizes reason/idempotencyKey and round-trips through a snapshot', () => {
+  const to = item(BIN_A, 0);
+  const m = StockMovement.record({
+    id: StockMovementId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    kind: MovementKind.Receipt,
+    quantity: Quantity.of(12.5, 'kg'),
+    toItemId: to.id,
+    reason: '  albarán 42  ',
+    idempotencyKey: '  key-abc  ',
+    occurredAt: new Date('2026-07-07T10:00:00.000Z'),
+  });
+  assert.equal(m.reason, 'albarán 42');
+  assert.equal(m.idempotencyKey, 'key-abc');
+  const snap = m.toSnapshot();
+  const restored = StockMovement.fromSnapshot(snap);
+  assert.deepEqual(restored.toSnapshot(), snap);
+  assert.ok(restored instanceof StockMovement);
+});

--- a/packages/warehouse-core/src/inventory/stock-movement.ts
+++ b/packages/warehouse-core/src/inventory/stock-movement.ts
@@ -1,0 +1,253 @@
+import { StockMovementId } from './stock-movement-id.js';
+import { StockItemId } from './stock-item-id.js';
+import { StockItem } from './stock-item.js';
+import { Quantity } from './quantity.js';
+import { MovementKind } from './movement-enums.js';
+import { StockMovementValidationError } from './stock-errors.js';
+import { ScopeId } from '../kernel/index.js';
+
+export interface RecordStockMovementProps {
+  id: StockMovementId;
+  scopeId: ScopeId;
+  kind: MovementKind;
+  quantity: Quantity;
+  /** Source StockItem, or null for an inbound movement (receipt / adjustment-gain). */
+  fromItemId?: StockItemId | null;
+  /** Target StockItem, or null for an outbound movement (issue / adjustment-loss). */
+  toItemId?: StockItemId | null;
+  /** Free-text reason / note (recuento, merma, nº de albarán…). */
+  reason?: string | null;
+  /**
+   * Optional idempotency key. The repository enforces it unique per scope, so a
+   * retried receipt (same key) is recorded once — the app resolves an existing
+   * movement by key before applying, guarding against double entradas.
+   */
+  idempotencyKey?: string | null;
+  occurredAt?: Date;
+}
+
+export interface StockMovementSnapshot {
+  id: string;
+  scopeId: string;
+  kind: MovementKind;
+  quantityAmount: number;
+  unit: string;
+  fromItemId: string | null;
+  toItemId: string | null;
+  reason: string | null;
+  idempotencyKey: string | null;
+  occurredAt: Date;
+}
+
+/** The StockItem aggregates a movement's legs refer to, passed to be mutated. */
+export interface MovementLegs {
+  from?: StockItem | null;
+  to?: StockItem | null;
+}
+
+/**
+ * An immutable line of the stock ledger (kardex) — the **unified two-leg
+ * movement** (option A). Every stock change is one record with a `from` leg and
+ * a `to` leg, each a {@link StockItem} or the exterior (null):
+ *
+ * - receipt (entrada): `null → to`
+ * - issue (salida): `from → null`
+ * - transfer (traslado): `from → to` (bin→bin, or a status change modelled as a
+ *   move between the two status-partitioned items)
+ * - adjustment (ajuste): a single leg — gain (`null → to`) or loss (`from → null`)
+ *
+ * The same {@link Quantity} flows out of `from` and into `to`, so conservation
+ * is structural: the record is only the *asiento*; {@link applyStockMovement}
+ * is the domain service that applies it to the actual StockItem aggregates
+ * (decrease one, increase the other), delegating the unit and non-negativity
+ * guards to those aggregates. Orchestration (load items, apply, persist all +
+ * append the ledger, atomically) is the host's application layer.
+ */
+export class StockMovement {
+  private constructor(
+    public readonly id: StockMovementId,
+    public readonly scopeId: ScopeId,
+    public readonly kind: MovementKind,
+    public readonly quantity: Quantity,
+    public readonly fromItemId: StockItemId | null,
+    public readonly toItemId: StockItemId | null,
+    public readonly reason: string | null,
+    public readonly idempotencyKey: string | null,
+    public readonly occurredAt: Date,
+  ) {}
+
+  static record(props: RecordStockMovementProps): StockMovement {
+    if (props.quantity.isZero()) {
+      throw new StockMovementValidationError(
+        'Stock movement quantity must be greater than zero',
+      );
+    }
+    const from = props.fromItemId ?? null;
+    const to = props.toItemId ?? null;
+    assertLegsMatchKind(props.kind, from, to);
+
+    return new StockMovement(
+      props.id,
+      props.scopeId,
+      props.kind,
+      props.quantity,
+      from,
+      to,
+      normalizeText(props.reason),
+      normalizeText(props.idempotencyKey),
+      props.occurredAt ?? new Date(),
+    );
+  }
+
+  static fromSnapshot(s: StockMovementSnapshot): StockMovement {
+    return new StockMovement(
+      StockMovementId.fromString(s.id),
+      ScopeId.fromString(s.scopeId),
+      s.kind,
+      Quantity.of(s.quantityAmount, s.unit),
+      s.fromItemId !== null ? StockItemId.fromString(s.fromItemId) : null,
+      s.toItemId !== null ? StockItemId.fromString(s.toItemId) : null,
+      s.reason,
+      s.idempotencyKey,
+      s.occurredAt,
+    );
+  }
+
+  get isInbound(): boolean {
+    return this.fromItemId === null;
+  }
+  get isOutbound(): boolean {
+    return this.toItemId === null;
+  }
+  get isTransfer(): boolean {
+    return this.fromItemId !== null && this.toItemId !== null;
+  }
+
+  toSnapshot(): StockMovementSnapshot {
+    return {
+      id: this.id.value,
+      scopeId: this.scopeId.value,
+      kind: this.kind,
+      quantityAmount: this.quantity.amount,
+      unit: this.quantity.unit,
+      fromItemId: this.fromItemId?.value ?? null,
+      toItemId: this.toItemId?.value ?? null,
+      reason: this.reason,
+      idempotencyKey: this.idempotencyKey,
+      occurredAt: this.occurredAt,
+    };
+  }
+}
+
+/**
+ * Applies a recorded movement to the StockItem aggregates of its legs: the
+ * `from` item is decreased and the `to` item increased by the movement's
+ * quantity. The provided items MUST match the movement's leg ids and scope. The
+ * `from` leg is applied first, so an {@link InsufficientStockError} aborts the
+ * whole move before the target is touched. Unit and non-negativity are enforced
+ * by {@link StockItem.decrease}/{@link StockItem.increase}.
+ */
+export function applyStockMovement(
+  movement: StockMovement,
+  legs: MovementLegs,
+): void {
+  const from = legs.from ?? null;
+  const to = legs.to ?? null;
+
+  if (movement.fromItemId !== null) {
+    if (from === null) {
+      throw new StockMovementValidationError(
+        `Movement ${movement.id.value} requires its 'from' StockItem`,
+      );
+    }
+    assertItemMatchesLeg(movement, from, movement.fromItemId, 'from');
+  } else if (from !== null) {
+    throw new StockMovementValidationError(
+      `Movement ${movement.id.value} has no 'from' leg but a source item was provided`,
+    );
+  }
+
+  if (movement.toItemId !== null) {
+    if (to === null) {
+      throw new StockMovementValidationError(
+        `Movement ${movement.id.value} requires its 'to' StockItem`,
+      );
+    }
+    assertItemMatchesLeg(movement, to, movement.toItemId, 'to');
+  } else if (to !== null) {
+    throw new StockMovementValidationError(
+      `Movement ${movement.id.value} has no 'to' leg but a target item was provided`,
+    );
+  }
+
+  // Decrease the source first: an insufficient-stock error aborts before the
+  // target is mutated, keeping the pair consistent.
+  if (from !== null) from.decrease(movement.quantity);
+  if (to !== null) to.increase(movement.quantity);
+}
+
+function assertLegsMatchKind(
+  kind: MovementKind,
+  from: StockItemId | null,
+  to: StockItemId | null,
+): void {
+  switch (kind) {
+    case MovementKind.Receipt:
+      if (from !== null || to === null) {
+        throw new StockMovementValidationError(
+          'A receipt must have only a target (to) leg',
+        );
+      }
+      return;
+    case MovementKind.Issue:
+      if (from === null || to !== null) {
+        throw new StockMovementValidationError(
+          'An issue must have only a source (from) leg',
+        );
+      }
+      return;
+    case MovementKind.Transfer:
+      if (from === null || to === null) {
+        throw new StockMovementValidationError(
+          'A transfer must have both source and target legs',
+        );
+      }
+      if (from.equals(to)) {
+        throw new StockMovementValidationError(
+          'A transfer must move between two different StockItems',
+        );
+      }
+      return;
+    case MovementKind.Adjustment:
+      if ((from === null) === (to === null)) {
+        throw new StockMovementValidationError(
+          'An adjustment must have exactly one leg (a gain or a loss)',
+        );
+      }
+      return;
+  }
+}
+
+function assertItemMatchesLeg(
+  movement: StockMovement,
+  item: StockItem,
+  legId: StockItemId,
+  leg: 'from' | 'to',
+): void {
+  if (!item.id.equals(legId)) {
+    throw new StockMovementValidationError(
+      `Movement ${movement.id.value} '${leg}' item ${item.id.value} does not match leg ${legId.value}`,
+    );
+  }
+  if (!item.scopeId.equals(movement.scopeId)) {
+    throw new StockMovementValidationError(
+      `Movement ${movement.id.value} '${leg}' item is in a different scope`,
+    );
+  }
+}
+
+function normalizeText(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}


### PR DESCRIPTION
## Resumen

El **libro mayor de stock** (kardex) de la Fase 2 (épica #355): tras `StockItem` (#374), el asiento inmutable que registra cada cambio y lo aplica. **Modelo unificado de doble pata (opción A):** `from`/`to`, cada pata un `StockItem` o el exterior (`null`).

En el módulo `inventory` de `@globalemergency/warehouse-core`, dominio puro sobre `ScopeId`:

- **`StockMovement`** (registro inmutable / asiento): `id`, `scopeId`, `kind`, `quantity` (una sola, la que fluye), `fromItemId`/`toItemId`, `reason`, `idempotencyKey`, `occurredAt`.
  - Formas: **receipt** (`null → to`), **issue** (`from → null`), **transfer** (`from → to`), **adjustment** (una sola pata: gain o loss). `MovementKind` etiqueta la intención donde la forma no basta (receipt vs adjustment-gain). Valida la forma según `kind`, cantidad > 0, transfer entre items distintos.
- **`applyStockMovement(movement, { from?, to? })`** — servicio de dominio que materializa *"mover = decrementar uno + incrementar otro"*: valida que los items casen con las patas (id + scope), decrementa el `from` **primero** (un `InsufficientStockError` aborta antes de tocar el `to`) e incrementa el `to`. La unidad y la no-negatividad las garantizan los `StockItem`; la conservación de cantidad es estructural (una sola `quantity` en ambas patas).
- **Idempotencia de entradas** vía `idempotencyKey` (único por scope en el port); el asiento es append-only.
- Port `StockMovementRepository` (`append`/`findById`/`findByIdempotencyKey`/`findByItem`/`findByScope`) con inmutabilidad + unicidad de key documentadas.

La orquestación transaccional (cargar items, aplicar, persistir todo + append del asiento, atómicamente) es la capa de aplicación de cada host.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `build` (dual), `typecheck`, `test` (**46/46** verde; +10 de movement), `pnpm --filter api build` (nest, host intacto), Prettier `--check` limpio, frontera pura (sin NestJS/ORM/host).
- [x] Verifiqué el comportamiento manualmente si aplica — los tests cubren: validación de forma por `kind`, cantidad cero, aplicación de receipt/issue/transfer con **conservación**, aborto de un transfer insuficiente **sin tocar el target**, rechazo de patas que no casan (ausente/id/scope) y round-trip de snapshot con normalización de `reason`/`idempotencyKey`.
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica: dominio nuevo del paquete, sin wiring al host, sin endpoints ni migraciones.

## Cierre

- Closes #376

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_