### PR TITLE
feat(warehouse-core): añade FEFO — servicio de asignación por caducidad

### DIFF
--- a/packages/warehouse-core/src/inventory/fefo-allocation.test.ts
+++ b/packages/warehouse-core/src/inventory/fefo-allocation.test.ts
@@ -1,0 +1,187 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { allocateFefo } from './fefo-allocation.js';
+import { StockItem } from './stock-item.js';
+import { StockItemId } from './stock-item-id.js';
+import { WarehouseId } from './warehouse-id.js';
+import { Quantity } from './quantity.js';
+import { StockStatus } from './stock-enums.js';
+import { ScopeId } from '../kernel/scope-id.js';
+
+const SCOPE = '11111111-1111-4111-8111-111111111111';
+const OTHER_SCOPE = '99999999-9999-4999-8999-999999999999';
+const WH_A = '22222222-2222-4222-8222-222222222222';
+const WH_B = '33333333-3333-4333-8333-333333333333';
+const BIN = '44444444-4444-4444-8444-444444444444';
+const SUPPLY = 'AGU-0001';
+
+let seq = 0;
+
+// Build via fromSnapshot so expiresAt / createdAt / id are fully controlled.
+function item(opts: {
+  amount: number;
+  expiresAt?: string | null;
+  createdAt?: string;
+  supplyId?: string;
+  scope?: string;
+  warehouseId?: string;
+  unit?: string;
+  id?: string;
+}): StockItem {
+  seq += 1;
+  const lotCode = opts.expiresAt === undefined ? 'L' + seq : 'L' + seq;
+  return StockItem.fromSnapshot({
+    id: opts.id ?? `00000000-0000-4000-8000-${String(seq).padStart(12, '0')}`,
+    scopeId: opts.scope ?? SCOPE,
+    warehouseId: opts.warehouseId ?? WH_A,
+    binId: BIN,
+    supplyId: opts.supplyId ?? SUPPLY,
+    lotCode,
+    expiresAt:
+      opts.expiresAt === undefined || opts.expiresAt === null
+        ? null
+        : new Date(opts.expiresAt),
+    quantityAmount: opts.amount,
+    unit: opts.unit ?? 'unit',
+    status: StockStatus.Available,
+    version: 1,
+    createdAt: new Date(opts.createdAt ?? '2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date(opts.createdAt ?? '2026-01-01T00:00:00.000Z'),
+  });
+}
+
+function demand(amount: number, unit = 'unit', warehouseId?: string) {
+  return {
+    scopeId: ScopeId.fromString(SCOPE),
+    supplyId: SUPPLY,
+    quantity: Quantity.of(amount, unit),
+    ...(warehouseId
+      ? { warehouseId: WarehouseId.fromString(warehouseId) }
+      : {}),
+  };
+}
+
+test('draws from the earliest-expiring stock first', () => {
+  const soon = item({ amount: 10, expiresAt: '2026-03-01T00:00:00Z' });
+  const later = item({ amount: 10, expiresAt: '2026-09-01T00:00:00Z' });
+  const plan = allocateFefo(demand(5), [later, soon]);
+  assert.ok(plan.fullyAllocated);
+  assert.equal(plan.lines.length, 1);
+  assert.equal(plan.lines[0]!.item.id.value, soon.id.value);
+  assert.equal(plan.lines[0]!.quantity.amount, 5);
+  assert.equal(plan.allocated.amount, 5);
+  assert.equal(plan.shortfall.amount, 0);
+});
+
+test('spans multiple lots in expiry order, splitting the last draw', () => {
+  const a = item({ amount: 4, expiresAt: '2026-03-01T00:00:00Z' });
+  const b = item({ amount: 4, expiresAt: '2026-06-01T00:00:00Z' });
+  const c = item({ amount: 4, expiresAt: '2026-09-01T00:00:00Z' });
+  const plan = allocateFefo(demand(10), [c, b, a]);
+  assert.ok(plan.fullyAllocated);
+  assert.deepEqual(
+    plan.lines.map((l) => [l.item.id.value, l.quantity.amount]),
+    [
+      [a.id.value, 4],
+      [b.id.value, 4],
+      [c.id.value, 2],
+    ],
+  );
+});
+
+test('never-expiring stock is used last', () => {
+  const noExpiry = item({ amount: 10, expiresAt: null });
+  const expiring = item({ amount: 3, expiresAt: '2026-05-01T00:00:00Z' });
+  const plan = allocateFefo(demand(5), [noExpiry, expiring]);
+  assert.equal(plan.lines[0]!.item.id.value, expiring.id.value);
+  assert.equal(plan.lines[0]!.quantity.amount, 3);
+  assert.equal(plan.lines[1]!.item.id.value, noExpiry.id.value);
+  assert.equal(plan.lines[1]!.quantity.amount, 2);
+});
+
+test('reports a shortfall when stock is insufficient', () => {
+  const only = item({ amount: 3, expiresAt: '2026-05-01T00:00:00Z' });
+  const plan = allocateFefo(demand(10), [only]);
+  assert.equal(plan.fullyAllocated, false);
+  assert.equal(plan.allocated.amount, 3);
+  assert.equal(plan.shortfall.amount, 7);
+  assert.equal(plan.lines.length, 1);
+});
+
+test('ties on expiry break by createdAt (oldest first)', () => {
+  const newer = item({
+    amount: 5,
+    expiresAt: '2026-05-01T00:00:00Z',
+    createdAt: '2026-02-01T00:00:00Z',
+  });
+  const older = item({
+    amount: 5,
+    expiresAt: '2026-05-01T00:00:00Z',
+    createdAt: '2026-01-01T00:00:00Z',
+  });
+  const plan = allocateFefo(demand(3), [newer, older]);
+  assert.equal(plan.lines[0]!.item.id.value, older.id.value);
+});
+
+test('filters out other scopes, products, units, warehouses and empty items', () => {
+  const wrongScope = item({ amount: 10, scope: OTHER_SCOPE });
+  const wrongSupply = item({ amount: 10, supplyId: 'OTR-0002' });
+  const wrongUnit = item({ amount: 10, unit: 'kg' });
+  const empty = item({ amount: 0, expiresAt: '2026-02-01T00:00:00Z' });
+  const good = item({ amount: 6, expiresAt: '2026-03-01T00:00:00Z' });
+  const plan = allocateFefo(demand(6), [
+    wrongScope,
+    wrongSupply,
+    wrongUnit,
+    empty,
+    good,
+  ]);
+  assert.ok(plan.fullyAllocated);
+  assert.equal(plan.lines.length, 1);
+  assert.equal(plan.lines[0]!.item.id.value, good.id.value);
+});
+
+test('restricts to a warehouse when the demand names one', () => {
+  const inA = item({
+    amount: 5,
+    warehouseId: WH_A,
+    expiresAt: '2026-03-01T00:00:00Z',
+  });
+  const inB = item({
+    amount: 5,
+    warehouseId: WH_B,
+    expiresAt: '2026-02-01T00:00:00Z',
+  });
+  const plan = allocateFefo(demand(5, 'unit', WH_A), [inB, inA]);
+  assert.ok(plan.fullyAllocated);
+  assert.equal(plan.lines.length, 1);
+  assert.equal(plan.lines[0]!.item.id.value, inA.id.value);
+});
+
+test('asOf excludes expired lots from allocation', () => {
+  const expired = item({ amount: 10, expiresAt: '2026-01-01T00:00:00Z' });
+  const fresh = item({ amount: 10, expiresAt: '2026-12-01T00:00:00Z' });
+  const plan = allocateFefo(demand(4), [expired, fresh], {
+    asOf: new Date('2026-06-01T00:00:00Z'),
+  });
+  assert.ok(plan.fullyAllocated);
+  assert.equal(plan.lines[0]!.item.id.value, fresh.id.value);
+});
+
+test('empty candidate set yields a full shortfall', () => {
+  const plan = allocateFefo(demand(5), []);
+  assert.equal(plan.fullyAllocated, false);
+  assert.equal(plan.allocated.amount, 0);
+  assert.equal(plan.shortfall.amount, 5);
+  assert.deepEqual(plan.lines, []);
+});
+
+test('exact match allocates fully with no shortfall', () => {
+  const a = item({ amount: 2, expiresAt: '2026-03-01T00:00:00Z' });
+  const b = item({ amount: 3, expiresAt: '2026-04-01T00:00:00Z' });
+  const plan = allocateFefo(demand(5), [a, b]);
+  assert.ok(plan.fullyAllocated);
+  assert.equal(plan.allocated.amount, 5);
+  assert.equal(plan.shortfall.amount, 0);
+  assert.equal(plan.lines.length, 2);
+});

--- a/packages/warehouse-core/src/inventory/fefo-allocation.ts
+++ b/packages/warehouse-core/src/inventory/fefo-allocation.ts
@@ -1,0 +1,127 @@
+import { StockItem } from './stock-item.js';
+import { WarehouseId } from './warehouse-id.js';
+import { Quantity } from './quantity.js';
+import { ScopeId } from '../kernel/index.js';
+
+/** What to fulfil: a quantity of a catalog product within a scope. */
+export interface FefoDemand {
+  scopeId: ScopeId;
+  supplyId: string;
+  quantity: Quantity;
+  /** Restrict allocation to one warehouse; null/absent = any in the scope. */
+  warehouseId?: WarehouseId | null;
+}
+
+export interface FefoOptions {
+  /**
+   * If set, stock whose lot is expired at/before this instant is excluded from
+   * allocation (you don't ship expired goods). If absent, nothing is excluded
+   * on expiry grounds — the caller decides.
+   */
+  asOf?: Date;
+}
+
+/** One draw of the plan: take `quantity` from `item`. */
+export interface AllocationLine {
+  item: StockItem;
+  quantity: Quantity;
+}
+
+export interface AllocationPlan {
+  lines: AllocationLine[];
+  /** Total drawn across all lines (equals the demand when fully allocated). */
+  allocated: Quantity;
+  /** Unmet remainder (zero when fully allocated). */
+  shortfall: Quantity;
+  fullyAllocated: boolean;
+}
+
+/**
+ * Plans a **FEFO** (first-expired-first-out) allocation: given a demand and a
+ * set of candidate {@link StockItem}s (the caller loads them — typically the
+ * available stock of the product in the scope/warehouse), it draws greedily
+ * from the earliest-expiring stock first until the demand is met, and reports
+ * any shortfall.
+ *
+ * Pure and deterministic: no I/O, no mutation. It does **not** move stock — it
+ * returns the draw amounts; the caller turns each {@link AllocationLine} into a
+ * {@link StockMovement} (issue/transfer) and applies it. Ordering is by lot
+ * expiry ascending (never-expiring stock last), tie-broken by `createdAt` then
+ * id so the plan is stable.
+ *
+ * Candidates are filtered to the demand's scope, `supplyId` and unit (and
+ * warehouse if given), skipping empty items and — when `asOf` is set — expired
+ * lots.
+ */
+export function allocateFefo(
+  demand: FefoDemand,
+  candidates: StockItem[],
+  options: FefoOptions = {},
+): AllocationPlan {
+  const unit = demand.quantity.unit;
+  const zero = Quantity.of(0, unit);
+
+  const eligible = candidates
+    .filter((item) => isEligible(item, demand, options))
+    .sort(compareFefo);
+
+  const lines: AllocationLine[] = [];
+  let remaining = demand.quantity;
+
+  for (const item of eligible) {
+    if (remaining.isZero()) break;
+    const take = min(item.quantity, remaining);
+    if (take.isZero()) continue;
+    lines.push({ item, quantity: take });
+    remaining = remaining.minus(take);
+  }
+
+  const allocated = demand.quantity.minus(remaining);
+  return {
+    lines,
+    allocated: allocated.isZero() ? zero : allocated,
+    shortfall: remaining,
+    fullyAllocated: remaining.isZero(),
+  };
+}
+
+function isEligible(
+  item: StockItem,
+  demand: FefoDemand,
+  options: FefoOptions,
+): boolean {
+  if (!item.scopeId.equals(demand.scopeId)) return false;
+  if (item.supplyId !== demand.supplyId) return false;
+  if (item.unit !== demand.quantity.unit) return false;
+  if (item.quantity.isZero()) return false;
+  if (
+    demand.warehouseId != null &&
+    !item.warehouseId.equals(demand.warehouseId)
+  ) {
+    return false;
+  }
+  if (options.asOf !== undefined && item.isExpiredAt(options.asOf))
+    return false;
+  return true;
+}
+
+/** FEFO order: earliest expiry first (no-expiry last), then oldest, then id. */
+function compareFefo(a: StockItem, b: StockItem): number {
+  const ax = a.expiresAt;
+  const bx = b.expiresAt;
+  if (ax !== null && bx !== null) {
+    const d = ax.getTime() - bx.getTime();
+    if (d !== 0) return d;
+  } else if (ax === null && bx !== null) {
+    return 1; // a never expires → after b
+  } else if (ax !== null && bx === null) {
+    return -1; // b never expires → after a
+  }
+  const created = a.createdAt.getTime() - b.createdAt.getTime();
+  if (created !== 0) return created;
+  return a.id.value < b.id.value ? -1 : a.id.value > b.id.value ? 1 : 0;
+}
+
+function min(a: Quantity, b: Quantity): Quantity {
+  return a.isLessThan(b) ? a : b;
+}

--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -7,7 +7,8 @@
  * El stock existente se modela con `StockItem` (una fila por producto × lote ×
  * bin × estado, con cantidad decimal + UoM y `version` para concurrencia
  * optimista) y su libro mayor `StockMovement` (asiento inmutable de doble pata:
- * `applyStockMovement` decrementa un item e incrementa otro).
+ * `applyStockMovement` decrementa un item e incrementa otro). `allocateFefo`
+ * planifica el reparto de una demanda por caducidad (first-expired-first-out).
  *
  * Dominio puro: sin NestJS, sin ORM, sin infraestructura. Todo referencia el
  * catálogo (`supplyId`) y el backbone (bin → zona → almacén) por id.
@@ -63,6 +64,13 @@ export type {
   StockMovementSnapshot,
   MovementLegs,
 } from './stock-movement.js';
+export { allocateFefo } from './fefo-allocation.js';
+export type {
+  FefoDemand,
+  FefoOptions,
+  AllocationLine,
+  AllocationPlan,
+} from './fefo-allocation.js';
 export {
   WAREHOUSE_REPOSITORY,
   type WarehouseRepository,


### PR DESCRIPTION
## Resumen

Cierra el **núcleo de dominio de la Fase 2** (épica #355): el servicio **FEFO** (first-expired-first-out) que planifica el reparto de una demanda sobre el stock, consumiendo primero lo que antes caduca. La base ya estaba (`Lot.expiresAt` #374, kardex #376).

En el módulo `inventory` de `@globalemergency/warehouse-core`, función de dominio **pura y determinista**:

- **`allocateFefo(demand, candidates, options?)`** → `AllocationPlan`.
  - `FefoDemand`: `scopeId`, `supplyId`, `quantity` (con UoM), `warehouseId?` (restringe a un almacén).
  - Ordena candidatos por **caducidad ascendente** (los sin caducidad, al final), desempatando por `createdAt` (FIFO) y luego id → plan **estable**.
  - Reparte greedy desde lo más próximo a caducar hasta cubrir la demanda; parte la última línea si hace falta.
  - `AllocationPlan`: `lines[{ item, quantity }]`, `allocated`, `shortfall`, `fullyAllocated`.
  - Filtra candidatos a scope/`supplyId`/unidad (y almacén si se indica), descarta items vacíos y —con `options.asOf`— lotes ya caducados.
- **No mueve stock**: devuelve el plan; el llamante convierte cada `AllocationLine` en un `StockMovement` (issue/transfer) y lo aplica → separación planificación/ejecución.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `build` (dual), `typecheck`, `test` (**56/56** verde; +10 de FEFO), `pnpm --filter api build` (nest, host intacto), Prettier `--check` limpio, frontera pura (sin NestJS/ORM/host).
- [x] Verifiqué el comportamiento manualmente si aplica — los tests cubren: orden por caducidad, reparto multi-lote partiendo la última línea, stock sin caducidad al final, shortfall por insuficiencia, desempate por `createdAt`, filtrado por scope/producto/unidad/almacén/vacíos, exclusión de caducados por `asOf`, set vacío y match exacto.
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica: dominio nuevo del paquete, sin wiring al host, sin endpoints ni migraciones.

## Cierre

- Closes #378

Con esto el **núcleo de dominio de la Fase 2 queda completo** (ubicaciones + StockItem/Quantity/Lot + kardex + FEFO). Lo siguiente sale del dominio puro: persistencia (Fase 0.5) o app de referencia (Fase 3).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_