### PR TITLE
feat(warehouse-core): base data-driven de la taxonomía (CategorySlug + CategoryRegistry)

### DIFF
--- a/packages/warehouse-core/src/kernel/category-errors.ts
+++ b/packages/warehouse-core/src/kernel/category-errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Raised when a category slug is malformed — empty, too long, or not a
+ * lowercase `snake_case` token (`^[a-z][a-z0-9_]*$`). The HTTP layer of each
+ * host maps it to 422.
+ */
+export class CategoryValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CategoryValidationError';
+  }
+}
+
+/**
+ * Raised when a slug is not present in a {@link CategoryRegistry} that was asked
+ * to resolve it. The registry is the data-driven source of truth for which
+ * categories exist, so an unknown slug is a lookup miss, not a format error.
+ */
+export class UnknownCategoryError extends Error {
+  constructor(slug: string) {
+    super(`Unknown category slug: ${slug}`);
+    this.name = 'UnknownCategoryError';
+  }
+}

--- a/packages/warehouse-core/src/kernel/category-registry.test.ts
+++ b/packages/warehouse-core/src/kernel/category-registry.test.ts
@@ -1,0 +1,102 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { CategoryRegistry, CategoryNode } from './category-registry.js';
+import { getCategoryPrefix } from './category.js';
+import { UnknownCategoryError } from './category-errors.js';
+
+const NODES: CategoryNode[] = [
+  { slug: 'food', parentSlug: null, codePrefix: 'FOO' },
+  { slug: 'food_fresh', parentSlug: 'food', codePrefix: null },
+  { slug: 'food_non_perishable', parentSlug: 'food', codePrefix: 'FNP' },
+  { slug: 'medical', parentSlug: null, codePrefix: 'MED' },
+  { slug: 'medicines', parentSlug: 'medical', codePrefix: null },
+  { slug: 'orphan', parentSlug: 'ghost', codePrefix: null },
+];
+
+function registry(): CategoryRegistry {
+  return CategoryRegistry.fromNodes(NODES);
+}
+
+test('has / get / resolve', () => {
+  const r = registry();
+  assert.ok(r.has('food'));
+  assert.ok(!r.has('nope'));
+  assert.equal(r.get('food')?.codePrefix, 'FOO');
+  assert.equal(r.get('nope'), null);
+  assert.equal(r.resolve('medical').slug, 'medical');
+  assert.throws(() => r.resolve('nope'), UnknownCategoryError);
+});
+
+test('parentOf / childrenOf', () => {
+  const r = registry();
+  assert.equal(r.parentOf('food_fresh')?.slug, 'food');
+  assert.equal(r.parentOf('food'), null); // root
+  assert.equal(r.parentOf('orphan'), null); // dangling parent
+  assert.deepEqual(
+    r.childrenOf('food').map((n) => n.slug),
+    ['food_fresh', 'food_non_perishable'],
+  );
+  assert.deepEqual(r.childrenOf('medicines'), []);
+});
+
+test('roots include real roots and nodes with a dangling parent', () => {
+  const r = registry();
+  assert.deepEqual(
+    r.roots().map((n) => n.slug),
+    ['food', 'medical', 'orphan'],
+  );
+});
+
+test('ancestorsOf walks nearest-first to the root', () => {
+  const r = registry();
+  assert.deepEqual(
+    r.ancestorsOf('food_fresh').map((n) => n.slug),
+    ['food'],
+  );
+  assert.deepEqual(r.ancestorsOf('food'), []);
+});
+
+test('prefixFor falls back through the hierarchy then to VAR', () => {
+  const r = registry();
+  assert.equal(r.prefixFor('food'), 'FOO');
+  assert.equal(r.prefixFor('food_fresh'), 'FOO'); // inherits parent
+  assert.equal(r.prefixFor('food_non_perishable'), 'FNP'); // own prefix wins
+  assert.equal(r.prefixFor('medicines'), 'MED'); // inherits medical
+  assert.equal(r.prefixFor('orphan'), 'VAR'); // dangling → fallback
+  assert.equal(r.prefixFor('unknown'), 'VAR');
+});
+
+test('prefixFor matches the free getCategoryPrefix helper', () => {
+  const r = registry();
+  for (const slug of [
+    'food',
+    'food_fresh',
+    'food_non_perishable',
+    'medicines',
+    'orphan',
+    'unknown',
+  ]) {
+    assert.equal(r.prefixFor(slug), getCategoryPrefix(slug, NODES));
+  }
+});
+
+test('is cycle-safe on a parent cycle', () => {
+  const cyclic = CategoryRegistry.fromNodes([
+    { slug: 'a', parentSlug: 'b', codePrefix: null },
+    { slug: 'b', parentSlug: 'a', codePrefix: null },
+  ]);
+  assert.equal(cyclic.prefixFor('a'), 'VAR');
+  assert.deepEqual(
+    cyclic.ancestorsOf('a').map((n) => n.slug),
+    ['b'],
+  );
+});
+
+test('duplicate slugs keep the last (lenient ingest)', () => {
+  const r = CategoryRegistry.fromNodes([
+    { slug: 'x', parentSlug: null, codePrefix: 'AAA' },
+    { slug: 'x', parentSlug: null, codePrefix: 'BBB' },
+  ]);
+  assert.equal(r.get('x')?.codePrefix, 'BBB');
+  assert.deepEqual(r.slugs(), ['x']);
+});

--- a/packages/warehouse-core/src/kernel/category-registry.ts
+++ b/packages/warehouse-core/src/kernel/category-registry.ts
@@ -1,0 +1,129 @@
+import { CategoryDefinition } from './category-definition.js';
+import { UnknownCategoryError } from './category-errors.js';
+
+/**
+ * The minimal shape the registry needs from a category: its slug, its parent in
+ * the hierarchy (or null at the root) and its optional code prefix. Both
+ * {@link CategoryDefinition} and the `categories` table rows are structurally
+ * assignable to this.
+ */
+export interface CategoryNode {
+  slug: string;
+  parentSlug: string | null;
+  codePrefix: string | null;
+}
+
+const PREFIX_FALLBACK = 'VAR';
+
+/**
+ * A data-driven view of a category taxonomy — the configurable counterpart of
+ * the hard-coded {@link Category} enum. Built from the category rows a host
+ * loads (the `categories` table), it answers membership, hierarchy and code
+ * prefix questions without the closed enum, so categories can be added or
+ * re-parented in data.
+ *
+ * Pure and immutable: it takes a snapshot of the nodes at construction. Ingest
+ * is lenient (trusted data — duplicate slugs keep the last, dangling parents
+ * just end a walk) so it never rejects existing rows; strict *format*
+ * validation of new input is {@link CategorySlug}'s job.
+ */
+export class CategoryRegistry {
+  private readonly bySlug: Map<string, CategoryNode>;
+
+  private constructor(bySlug: Map<string, CategoryNode>) {
+    this.bySlug = bySlug;
+  }
+
+  static fromNodes(nodes: readonly CategoryNode[]): CategoryRegistry {
+    const bySlug = new Map<string, CategoryNode>();
+    for (const node of nodes) {
+      bySlug.set(node.slug, {
+        slug: node.slug,
+        parentSlug: node.parentSlug,
+        codePrefix: node.codePrefix,
+      });
+    }
+    return new CategoryRegistry(bySlug);
+  }
+
+  static fromDefinitions(
+    definitions: readonly CategoryDefinition[],
+  ): CategoryRegistry {
+    return CategoryRegistry.fromNodes(
+      definitions.map((d) => ({
+        slug: d.slug,
+        parentSlug: d.parentSlug,
+        codePrefix: d.codePrefix,
+      })),
+    );
+  }
+
+  has(slug: string): boolean {
+    return this.bySlug.has(slug);
+  }
+
+  get(slug: string): CategoryNode | null {
+    return this.bySlug.get(slug) ?? null;
+  }
+
+  resolve(slug: string): CategoryNode {
+    const node = this.bySlug.get(slug);
+    if (node === undefined) throw new UnknownCategoryError(slug);
+    return node;
+  }
+
+  /** Every slug in the taxonomy, in insertion order. */
+  slugs(): string[] {
+    return [...this.bySlug.keys()];
+  }
+
+  /** The direct parent, or null at a root or when the parent is unknown. */
+  parentOf(slug: string): CategoryNode | null {
+    const parentSlug = this.bySlug.get(slug)?.parentSlug ?? null;
+    return parentSlug !== null ? (this.bySlug.get(parentSlug) ?? null) : null;
+  }
+
+  /** Direct children of a slug, in insertion order. */
+  childrenOf(slug: string): CategoryNode[] {
+    return [...this.bySlug.values()].filter((n) => n.parentSlug === slug);
+  }
+
+  /** Top-level categories (no parent, or a parent that isn't in the registry). */
+  roots(): CategoryNode[] {
+    return [...this.bySlug.values()].filter(
+      (n) => n.parentSlug === null || !this.bySlug.has(n.parentSlug),
+    );
+  }
+
+  /** Ancestors from the nearest parent up to the root (cycle-safe). */
+  ancestorsOf(slug: string): CategoryNode[] {
+    const chain: CategoryNode[] = [];
+    const visited = new Set<string>([slug]);
+    let current = this.bySlug.get(slug)?.parentSlug ?? null;
+    while (current !== null && !visited.has(current)) {
+      visited.add(current);
+      const node = this.bySlug.get(current);
+      if (node === undefined) break;
+      chain.push(node);
+      current = node.parentSlug;
+    }
+    return chain;
+  }
+
+  /**
+   * The code prefix for a slug: its own `codePrefix`, else the nearest
+   * ancestor's, else `VAR`. Cycle-safe. Data-driven equivalent of the free
+   * `getCategoryPrefix` helper, sharing its walk over the hierarchy.
+   */
+  prefixFor(slug: string): string {
+    const visited = new Set<string>();
+    let current: string | null = slug;
+    while (current !== null && !visited.has(current)) {
+      visited.add(current);
+      const node = this.bySlug.get(current);
+      if (node?.codePrefix) return node.codePrefix;
+      current = node?.parentSlug ?? null;
+    }
+    return PREFIX_FALLBACK;
+  }
+}

--- a/packages/warehouse-core/src/kernel/category-slug.test.ts
+++ b/packages/warehouse-core/src/kernel/category-slug.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { CategorySlug } from './category-slug.js';
+import { Category, CORE_CATEGORY_SLUGS } from './category.js';
+import { CategoryValidationError } from './category-errors.js';
+
+test('normalizes trim + lowercase', () => {
+  const slug = CategorySlug.of('  Medical_Equipment  ');
+  assert.equal(slug.value, 'medical_equipment');
+  assert.equal(slug.toString(), 'medical_equipment');
+});
+
+test('accepts every core category slug', () => {
+  for (const slug of CORE_CATEGORY_SLUGS) {
+    assert.equal(CategorySlug.of(slug).value, slug);
+  }
+  assert.equal(CategorySlug.of(Category.Food).value, 'food');
+});
+
+test('rejects empty, oversized and non-snake_case tokens', () => {
+  assert.throws(() => CategorySlug.of('   '), CategoryValidationError);
+  assert.throws(() => CategorySlug.of('x'.repeat(65)), CategoryValidationError);
+  assert.throws(() => CategorySlug.of('1food'), CategoryValidationError); // leading digit
+  assert.throws(() => CategorySlug.of('food-fresh'), CategoryValidationError); // hyphen
+  assert.throws(() => CategorySlug.of('food fresh'), CategoryValidationError); // space
+  assert.throws(() => CategorySlug.of('Food!'), CategoryValidationError);
+});
+
+test('equals compares by value', () => {
+  assert.ok(CategorySlug.of('food').equals(CategorySlug.of('FOOD')));
+  assert.ok(!CategorySlug.of('food').equals(CategorySlug.of('water')));
+});

--- a/packages/warehouse-core/src/kernel/category-slug.ts
+++ b/packages/warehouse-core/src/kernel/category-slug.ts
@@ -1,0 +1,46 @@
+import { CategoryValidationError } from './category-errors.js';
+
+const SLUG_RE = /^[a-z][a-z0-9_]*$/;
+const MAX_LENGTH = 64;
+
+/**
+ * The identity of an aid-material category as a **data-driven slug** — the open
+ * counterpart of the closed {@link Category} enum. A `CategorySlug` is any
+ * validated `snake_case` token (`food`, `medical_equipment`, `hygiene_infantile`,
+ * or a tenant-defined subcategory), so the taxonomy can grow through data
+ * (the `categories` table / {@link CategoryRegistry}) without a code change.
+ *
+ * `of()` normalizes (trim + lowercase) and validates the *format*; membership in
+ * a concrete taxonomy is a separate concern owned by {@link CategoryRegistry}.
+ * The enum stays as the canonical seed of core slugs (`CORE_CATEGORY_SLUGS`).
+ */
+export class CategorySlug {
+  private constructor(public readonly value: string) {}
+
+  static of(value: string): CategorySlug {
+    const normalized =
+      typeof value === 'string' ? value.trim().toLowerCase() : '';
+    if (normalized.length === 0) {
+      throw new CategoryValidationError('Category slug must not be empty');
+    }
+    if (normalized.length > MAX_LENGTH) {
+      throw new CategoryValidationError(
+        `Category slug must be at most ${MAX_LENGTH} characters`,
+      );
+    }
+    if (!SLUG_RE.test(normalized)) {
+      throw new CategoryValidationError(
+        `Category slug "${value}" must be a lowercase snake_case token (^[a-z][a-z0-9_]*$)`,
+      );
+    }
+    return new CategorySlug(normalized);
+  }
+
+  equals(o: CategorySlug): boolean {
+    return this.value === o.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/packages/warehouse-core/src/kernel/category.ts
+++ b/packages/warehouse-core/src/kernel/category.ts
@@ -32,6 +32,14 @@ export enum Category {
   OtherPets = 'other_pets',
 }
 
+/**
+ * The canonical seed of core category slugs — the values of the {@link Category}
+ * enum as plain strings. The taxonomy is *open* (a `CategoryRegistry` can carry
+ * finer, data-driven subcategories), but these are the ones guaranteed to exist
+ * and to have code-level meaning.
+ */
+export const CORE_CATEGORY_SLUGS: readonly string[] = Object.values(Category);
+
 export function isCoreCategory(slug: string): boolean {
   return Object.values(Category).includes(slug as Category);
 }

--- a/packages/warehouse-core/src/kernel/index.ts
+++ b/packages/warehouse-core/src/kernel/index.ts
@@ -5,12 +5,24 @@
  *
  * No depende de infraestructura, NestJS ni ORM: es dominio puro.
  */
-export { Category, isCoreCategory, getCategoryPrefix } from './category.js';
+export {
+  Category,
+  CORE_CATEGORY_SLUGS,
+  isCoreCategory,
+  getCategoryPrefix,
+} from './category.js';
 export type {
   CategoryDefinition,
   CategoryTranslation,
   CategoryKind,
 } from './category-definition.js';
+export { CategorySlug } from './category-slug.js';
+export {
+  CategoryValidationError,
+  UnknownCategoryError,
+} from './category-errors.js';
+export { CategoryRegistry } from './category-registry.js';
+export type { CategoryNode } from './category-registry.js';
 export { SupplyLine, SupplyLineValidationError } from './supply-line.js';
 export type { SupplyLineProps, SupplyLineSnapshot } from './supply-line.js';
 export { ScopeId, ScopeIdValidationError } from './scope-id.js';


### PR DESCRIPTION
## Resumen

**Fase 0** de la épica #355 — abrir `Category` de enum cerrado a **slug data-driven** (taxonomía configurable). Este PR introduce la **base en el kernel** sin tocar consumidores, igual que `ScopeId` (#365) se introdujo antes de genericizar los contextos.

> **Alcance:** la migración *completa* (`SupplyLine.category: Category` → slug) es transversal y **breaking** (DTOs → `gen:api`, cliente API, web), así que va en un PR follow-up. Esto es solo la base de dominio, 100% verificable en local. **Host intacto, `tsc`-neutral estable (46/46).**

En el kernel de `@globalemergency/warehouse-core`, dominio puro:

- **`CategorySlug`** (VO): la identidad de categoría como slug validado y **abierto** (`^[a-z][a-z0-9_]*$`, normaliza trim+lowercase, ≤64). Contrapartida del enum cerrado; valida el *formato*, no la pertenencia.
- **`CategoryRegistry`**: vista data-driven de la taxonomía, construida desde las filas de categorías (`fromNodes` / `fromDefinitions`). Responde membership, jerarquía y prefijo sin el enum: `has`/`get`/`resolve`/`parentOf`/`childrenOf`/`roots`/`ancestorsOf`/`prefixFor`/`slugs`. Ingesta **lenient** (dato de confianza: dedup last-wins, padres colgantes cierran el walk), **cycle-safe**. `prefixFor` es el equivalente data-driven de `getCategoryPrefix` (mismo algoritmo, con test que lo verifica).
- Enum `Category` reencuadrado como **semilla core**: nuevo `CORE_CATEGORY_SLUGS`. `isCoreCategory`/`getCategoryPrefix` **intactos** (cero cambio para sus consumidores).
- `CategoryValidationError` / `UnknownCategoryError`.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `build` (dual), `typecheck`, `test` (**68/68** verde; +12 nuevos), `pnpm --filter api build` (nest, host intacto), **tsc-neutral 46/46** (sin regresión), Prettier `--check` limpio, frontera pura.
- [x] Verifiqué el comportamiento manualmente si aplica — los tests cubren: normalización/validación de `CategorySlug` (incl. todos los slugs core), y del registry: membership/resolve, jerarquía (parent/children/roots/ancestors con padre colgante), `prefixFor` con herencia + fallback `VAR`, **paridad con `getCategoryPrefix`**, cycle-safety y dedup lenient.
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica: solo adiciones al kernel, sin cambiar firmas existentes, sin endpoints ni migraciones.

## Cierre

- Closes #380

_Follow-up (fuera de este PR): migrar `SupplyLine` + consumidores de `Category` a `CategorySlug`/registry (breaking, `gen:api`, web)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_