### PR TITLE
docs(agents): documenta los paquetes @globalemergency/warehouse-* + puntero a la épica #355

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Multi-emergency **material aid coordination + logistics** platform (org: **Globa
 - **`apps/api`** — NestJS 11, **hexagonal / DDD** (ports & adapters, CQRS-light, domain events via Redis/BullMQ), Drizzle ORM, Postgres 16, Redis 7. Swagger at `/docs`.
 - **`apps/web`** — Next 16 (App Router, React 19), **Atomic Design**, Tailwind 4, Leaflet + `leaflet.markercluster`. Consumes the typed client. (See `apps/web/AGENTS.md` for Next-16 specifics.)
 - **`packages/api-client`** — `@reliefhub/api-client`, openapi-fetch typed client. Regenerate with `pnpm gen:api`.
+- **`packages/warehouse-*`** — `@globalemergency/warehouse-core` (reusable, framework-free WMS domain: `kernel`/`catalog`/`inventory`/`containers`/`logistics` over an opaque `ScopeId`) + `@globalemergency/warehouse-postgres` (Drizzle persistence). Consumed by `apps/api` via `workspace:*`; **pure domain** — ESLint forbids `@nestjs/*`/`drizzle-orm`/`pg`/`apps/*` imports. Own tests run via `node --test` on compiled JS (`pnpm --filter '@globalemergency/warehouse-core' test`). **The extraction-to-OSS-product roadmap is [EPIC #355](https://github.com/GlobalEmergency/ResponseGrid/issues/355)** — read it before touching these packages.
 - TDD throughout. Dev infra via docker-compose.
 
 ## Architecture


### PR DESCRIPTION
## Resumen

`AGENTS.md` (el fichero canónico que todo agente/colaborador lee primero) **no mencionaba** los paquetes `@globalemergency/warehouse-*`, pese a que ya existen y `apps/api` los consume vía `workspace:*`. Este PR cierra ese hueco de documentación para que el relevo sea posible "en frío".

Añade un bullet al **Stack** de `AGENTS.md` que documenta:
- `@globalemergency/warehouse-core` (dominio WMS reutilizable, sin framework: `kernel`/`catalog`/`inventory`/`containers`/`logistics` sobre `ScopeId` opaco) + `@globalemergency/warehouse-postgres` (persistencia Drizzle).
- La **frontera de pureza** (ESLint prohíbe `@nestjs/*`/`drizzle-orm`/`pg`/`apps/*`).
- Cómo corren sus **tests** (`node --test` sobre JS compilado).
- Un **puntero a la [épica #355](https://github.com/GlobalEmergency/ResponseGrid/issues/355)** como mapa de la extracción a producto OSS, con la indicación de leerla antes de tocar los paquetes.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — cambio **docs-only** (`AGENTS.md`), sin impacto en build/lint/test.
- [x] Verifiqué el comportamiento manualmente si aplica — n/a (documentación).
- [x] Actualicé docs, migraciones o cliente API si correspondía — sí: este PR ES la actualización de docs; sin migraciones ni cambios de API.

## Cierre

- Sin issue asociada (mejora de documentación derivada del cierre de la ronda de trabajo de la épica #355).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_