### PR TITLE
feat(warehouse-core): añade recuentos — reconcileCount (conteo físico ↔ sistema → ajuste)

### DIFF
--- a/packages/warehouse-core/src/inventory/cycle-count.test.ts
+++ b/packages/warehouse-core/src/inventory/cycle-count.test.ts
@@ -1,0 +1,126 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { reconcileCount } from './cycle-count.js';
+import { applyStockMovement } from './stock-movement.js';
+import { StockMovementId } from './stock-movement-id.js';
+import { StockItem } from './stock-item.js';
+import { StockItemId } from './stock-item-id.js';
+import { WarehouseId } from './warehouse-id.js';
+import { BinId } from './bin-id.js';
+import { Quantity } from './quantity.js';
+import { StockStatus } from './stock-enums.js';
+import { MovementKind } from './movement-enums.js';
+import { StockValidationError } from './stock-errors.js';
+import { ScopeId } from '../kernel/scope-id.js';
+
+const SCOPE = '11111111-1111-4111-8111-111111111111';
+const WAREHOUSE = '22222222-2222-4222-8222-222222222222';
+const BIN = '44444444-4444-4444-8444-444444444444';
+const SUPPLY = 'AGU-0001';
+
+function item(amount: number, unit = 'unit'): StockItem {
+  return StockItem.create({
+    id: StockItemId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    warehouseId: WarehouseId.fromString(WAREHOUSE),
+    binId: BinId.fromString(BIN),
+    supplyId: SUPPLY,
+    lot: { code: 'L1' },
+    quantity: Quantity.of(amount, unit),
+    status: StockStatus.Available,
+  });
+}
+
+function reconcile(it: StockItem, counted: number) {
+  return reconcileCount({
+    item: it,
+    counted: Quantity.of(counted, it.unit),
+    movementId: StockMovementId.create(),
+    reason: 'recuento',
+  });
+}
+
+test('match: no adjustment when the count equals the system', () => {
+  const r = reconcile(item(10), 10);
+  assert.equal(r.direction, 'match');
+  assert.ok(r.matched);
+  assert.equal(r.variance.amount, 0);
+  assert.equal(r.movement, null);
+});
+
+test('gain: surplus produces an inbound adjustment (null → item)', () => {
+  const it = item(10);
+  const r = reconcile(it, 13);
+  assert.equal(r.direction, 'gain');
+  assert.equal(r.matched, false);
+  assert.equal(r.variance.amount, 3);
+  assert.ok(r.movement);
+  assert.equal(r.movement!.kind, MovementKind.Adjustment);
+  assert.equal(r.movement!.fromItemId, null);
+  assert.ok(r.movement!.toItemId?.equals(it.id));
+  assert.ok(r.movement!.isInbound);
+});
+
+test('loss: shortfall produces an outbound adjustment (item → null)', () => {
+  const it = item(10);
+  const r = reconcile(it, 4);
+  assert.equal(r.direction, 'loss');
+  assert.equal(r.variance.amount, 6);
+  assert.ok(r.movement!.toItemId === null);
+  assert.ok(r.movement!.fromItemId?.equals(it.id));
+  assert.ok(r.movement!.isOutbound);
+});
+
+test('applying a gain adjustment brings the item up to the counted quantity', () => {
+  const it = item(10);
+  const r = reconcile(it, 13);
+  applyStockMovement(r.movement!, { to: it });
+  assert.equal(it.quantity.amount, 13);
+});
+
+test('applying a loss adjustment brings the item down to the counted quantity', () => {
+  const it = item(10);
+  const r = reconcile(it, 4);
+  applyStockMovement(r.movement!, { from: it });
+  assert.equal(it.quantity.amount, 4);
+});
+
+test('works with decimal quantities', () => {
+  const it = item(2.5, 'kg');
+  const r = reconcile(it, 2.75);
+  assert.equal(r.direction, 'gain');
+  assert.equal(r.variance.amount, 0.25);
+  applyStockMovement(r.movement!, { to: it });
+  assert.equal(it.quantity.amount, 2.75);
+});
+
+test('counting to zero produces a full-loss adjustment', () => {
+  const it = item(5);
+  const r = reconcile(it, 0);
+  assert.equal(r.direction, 'loss');
+  assert.equal(r.variance.amount, 5);
+  applyStockMovement(r.movement!, { from: it });
+  assert.equal(it.quantity.amount, 0);
+});
+
+test('rejects a count in a different unit', () => {
+  const it = item(5, 'unit');
+  assert.throws(
+    () =>
+      reconcileCount({
+        item: it,
+        counted: Quantity.of(5, 'kg'),
+        movementId: StockMovementId.create(),
+      }),
+    StockValidationError,
+  );
+});
+
+test('carries scope, reason and reports system/counted quantities', () => {
+  const it = item(10);
+  const r = reconcile(it, 12);
+  assert.equal(r.systemQuantity.amount, 10);
+  assert.equal(r.countedQuantity.amount, 12);
+  assert.ok(r.movement!.scopeId.equals(ScopeId.fromString(SCOPE)));
+  assert.equal(r.movement!.reason, 'recuento');
+});

--- a/packages/warehouse-core/src/inventory/cycle-count.ts
+++ b/packages/warehouse-core/src/inventory/cycle-count.ts
@@ -1,0 +1,103 @@
+import { StockItem } from './stock-item.js';
+import { StockMovement } from './stock-movement.js';
+import { StockMovementId } from './stock-movement-id.js';
+import { Quantity } from './quantity.js';
+import { MovementKind } from './movement-enums.js';
+import { StockValidationError } from './stock-errors.js';
+
+/** Outcome of comparing a physical count with the system quantity. */
+export type CountDirection = 'match' | 'gain' | 'loss';
+
+export interface CycleCountInput {
+  /** The StockItem being counted (a single grain: product × lot × bin × status). */
+  item: StockItem;
+  /** The quantity physically found. Must share the item's unit. */
+  counted: Quantity;
+  /** Id for the adjustment movement (minted by the caller; unused on a match). */
+  movementId: StockMovementId;
+  /** Free-text note (e.g. "recuento cíclico 2026-07"). */
+  reason?: string | null;
+  idempotencyKey?: string | null;
+  occurredAt?: Date;
+}
+
+export interface CycleCountResult {
+  direction: CountDirection;
+  /** `true` when the count matches the system (no adjustment needed). */
+  matched: boolean;
+  /** What the system held before the count. */
+  systemQuantity: Quantity;
+  /** What was physically found. */
+  countedQuantity: Quantity;
+  /** Magnitude of the discrepancy (zero when matched). */
+  variance: Quantity;
+  /**
+   * The adjustment to apply, or null on a match. It is a recorded but
+   * **not-yet-applied** `Adjustment` movement (plan/execute split, like FEFO):
+   * a gain is inbound (`null → item`), a loss is outbound (`item → null`).
+   * The caller applies it with `applyStockMovement` and persists — after which
+   * `item.quantity === counted`.
+   */
+  movement: StockMovement | null;
+}
+
+/**
+ * Reconciles a **cycle count** (recuento) of a single {@link StockItem} against
+ * its system quantity and produces the {@link StockMovement} of kind
+ * `adjustment` that would bring the system in line with what was physically
+ * found:
+ *
+ * - counted **=** system → `match`, no movement.
+ * - counted **>** system → `gain`: an inbound adjustment for the surplus.
+ * - counted **<** system → `loss`: an outbound adjustment for the shortfall.
+ *
+ * Pure and deterministic: it does not mutate the item nor apply the movement —
+ * it returns the plan. The caller applies it (`applyStockMovement`) and persists
+ * the item + appends the asiento atomically. Counting across a different unit is
+ * rejected (a recuento can't change the unit of measure).
+ */
+export function reconcileCount(input: CycleCountInput): CycleCountResult {
+  const system = input.item.quantity;
+  const counted = input.counted;
+
+  if (counted.unit !== system.unit) {
+    throw new StockValidationError(
+      `Cannot reconcile a "${system.unit}" StockItem against a "${counted.unit}" count`,
+    );
+  }
+
+  if (counted.equals(system)) {
+    return {
+      direction: 'match',
+      matched: true,
+      systemQuantity: system,
+      countedQuantity: counted,
+      variance: Quantity.of(0, system.unit),
+      movement: null,
+    };
+  }
+
+  const gain = system.isLessThan(counted);
+  const variance = gain ? counted.minus(system) : system.minus(counted);
+
+  const movement = StockMovement.record({
+    id: input.movementId,
+    scopeId: input.item.scopeId,
+    kind: MovementKind.Adjustment,
+    quantity: variance,
+    fromItemId: gain ? null : input.item.id,
+    toItemId: gain ? input.item.id : null,
+    reason: input.reason ?? null,
+    idempotencyKey: input.idempotencyKey ?? null,
+    ...(input.occurredAt !== undefined ? { occurredAt: input.occurredAt } : {}),
+  });
+
+  return {
+    direction: gain ? 'gain' : 'loss',
+    matched: false,
+    systemQuantity: system,
+    countedQuantity: counted,
+    variance,
+    movement,
+  };
+}

--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -8,7 +8,8 @@
  * bin × estado, con cantidad decimal + UoM y `version` para concurrencia
  * optimista) y su libro mayor `StockMovement` (asiento inmutable de doble pata:
  * `applyStockMovement` decrementa un item e incrementa otro). `allocateFefo`
- * planifica el reparto de una demanda por caducidad (first-expired-first-out).
+ * planifica el reparto de una demanda por caducidad (first-expired-first-out) y
+ * `reconcileCount` concilia un recuento físico con el sistema (ajuste).
  *
  * Dominio puro: sin NestJS, sin ORM, sin infraestructura. Todo referencia el
  * catálogo (`supplyId`) y el backbone (bin → zona → almacén) por id.
@@ -71,6 +72,12 @@ export type {
   AllocationLine,
   AllocationPlan,
 } from './fefo-allocation.js';
+export { reconcileCount } from './cycle-count.js';
+export type {
+  CountDirection,
+  CycleCountInput,
+  CycleCountResult,
+} from './cycle-count.js';
 export {
   WAREHOUSE_REPOSITORY,
   type WarehouseRepository,


### PR DESCRIPTION
## Resumen

Refinamiento de la **Fase 2** (épica #355, «recuentos»): servicio de dominio **puro** que concilia el conteo físico de un `StockItem` con la cantidad de sistema y produce el `StockMovement` de ajuste. Se apoya en lo ya construido (kardex #376, `StockItem` #374).

> **Independiente de la migración #382**: no toca `SupplyLine`/`Category`/host/web — solo añade ficheros nuevos en `warehouse-core/src/inventory`. Sin solape de ficheros → sin conflicto.

En el módulo `inventory` de `@globalemergency/warehouse-core`:

- **`reconcileCount(input)`** → `CycleCountResult`:
  - **match** (contado = sistema) → sin movimiento.
  - **gain** (contado > sistema) → `Adjustment` inbound (`null → item`), variance = contado − sistema.
  - **loss** (contado < sistema) → `Adjustment` outbound (`item → null`), variance = sistema − contado.
  - Devuelve `{ direction, matched, systemQuantity, countedQuantity, variance, movement }`.
- El `movement` se **registra pero no se aplica** (patrón plan/ejecución, como FEFO): el llamante hace `applyStockMovement` + persiste el item y el asiento. Tras aplicar, `item.quantity === counted`.
- Valida misma unidad (contado vs item); reutiliza `StockValidationError`.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `build` (dual), `typecheck`, `test` (**77/77** verde; +9 de recuentos), `pnpm --filter api build` (nest, host intacto), Prettier `--check` limpio, frontera pura.
- [x] Verifiqué el comportamiento manualmente si aplica — los tests cubren match/gain/loss, la aplicación del ajuste que lleva el item exactamente a la cantidad contada (subida y bajada, incl. a cero), cantidades decimales, rechazo por unidad distinta, y el reporte de scope/reason/system/counted.
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica: dominio nuevo del paquete, sin wiring al host, sin endpoints ni migraciones.

## Cierre

- Closes #388

_El recuento a nivel de bin (varios items, altas por sobrantes y mermas por faltantes) compone a partir de este bloque atómico y queda como futuro._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_