### PR TITLE
feat(warehouse-core): añade reservas — reserveStock / releaseReservation (available ↔ reserved)

### DIFF
--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -8,8 +8,10 @@
  * bin × estado, con cantidad decimal + UoM y `version` para concurrencia
  * optimista) y su libro mayor `StockMovement` (asiento inmutable de doble pata:
  * `applyStockMovement` decrementa un item e incrementa otro). `allocateFefo`
- * planifica el reparto de una demanda por caducidad (first-expired-first-out) y
- * `reconcileCount` concilia un recuento físico con el sistema (ajuste).
+ * planifica el reparto de una demanda por caducidad (first-expired-first-out),
+ * `reconcileCount` concilia un recuento físico con el sistema (ajuste) y
+ * `reserveStock`/`releaseReservation` comprometen/liberan stock (available ↔
+ * reserved) sin sacarlo del bin.
  *
  * Dominio puro: sin NestJS, sin ORM, sin infraestructura. Todo referencia el
  * catálogo (`supplyId`) y el backbone (bin → zona → almacén) por id.
@@ -78,6 +80,8 @@ export type {
   CycleCountInput,
   CycleCountResult,
 } from './cycle-count.js';
+export { reserveStock, releaseReservation } from './reservations.js';
+export type { ReservationInput } from './reservations.js';
 export {
   WAREHOUSE_REPOSITORY,
   type WarehouseRepository,

--- a/packages/warehouse-core/src/inventory/reservations.test.ts
+++ b/packages/warehouse-core/src/inventory/reservations.test.ts
@@ -1,0 +1,179 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { reserveStock, releaseReservation } from './reservations.js';
+import { applyStockMovement } from './stock-movement.js';
+import { StockMovementId } from './stock-movement-id.js';
+import { StockItem } from './stock-item.js';
+import { StockItemId } from './stock-item-id.js';
+import { WarehouseId } from './warehouse-id.js';
+import { BinId } from './bin-id.js';
+import { Quantity } from './quantity.js';
+import { StockStatus } from './stock-enums.js';
+import { MovementKind } from './movement-enums.js';
+import { StockValidationError } from './stock-errors.js';
+import { ScopeId } from '../kernel/scope-id.js';
+
+const SCOPE = '11111111-1111-4111-8111-111111111111';
+const OTHER_SCOPE = '99999999-9999-4999-8999-999999999999';
+const WAREHOUSE = '22222222-2222-4222-8222-222222222222';
+const BIN = '44444444-4444-4444-8444-444444444444';
+const OTHER_BIN = '55555555-5555-4555-8555-555555555555';
+const SUPPLY = 'AGU-0001';
+
+function item(
+  status: StockStatus,
+  amount: number,
+  overrides?: {
+    binId?: string;
+    supplyId?: string;
+    scope?: string;
+    unit?: string;
+    lotCode?: string | null;
+  },
+): StockItem {
+  return StockItem.create({
+    id: StockItemId.create(),
+    scopeId: ScopeId.fromString(overrides?.scope ?? SCOPE),
+    warehouseId: WarehouseId.fromString(WAREHOUSE),
+    binId: BinId.fromString(overrides?.binId ?? BIN),
+    supplyId: overrides?.supplyId ?? SUPPLY,
+    lot:
+      overrides && 'lotCode' in overrides
+        ? overrides.lotCode === null
+          ? null
+          : { code: overrides.lotCode }
+        : { code: 'L1' },
+    quantity: Quantity.of(amount, overrides?.unit ?? 'unit'),
+    status,
+  });
+}
+
+function reserve(from: StockItem, to: StockItem, qty: number) {
+  return reserveStock({
+    from,
+    to,
+    quantity: Quantity.of(qty, from.unit),
+    movementId: StockMovementId.create(),
+    reason: 'pick 42',
+  });
+}
+
+test('reserveStock produces an available→reserved transfer', () => {
+  const from = item(StockStatus.Available, 10);
+  const to = item(StockStatus.Reserved, 0);
+  const m = reserve(from, to, 4);
+  assert.equal(m.kind, MovementKind.Transfer);
+  assert.ok(m.fromItemId?.equals(from.id));
+  assert.ok(m.toItemId?.equals(to.id));
+  assert.ok(m.isTransfer);
+});
+
+test('applying a reservation moves quantity without leaving the bin', () => {
+  const from = item(StockStatus.Available, 10);
+  const to = item(StockStatus.Reserved, 0);
+  const m = reserve(from, to, 4);
+  applyStockMovement(m, { from, to });
+  assert.equal(from.quantity.amount, 6);
+  assert.equal(to.quantity.amount, 4);
+});
+
+test('releaseReservation is the inverse (reserved→available)', () => {
+  const from = item(StockStatus.Reserved, 4);
+  const to = item(StockStatus.Available, 6);
+  const m = releaseReservation({
+    from,
+    to,
+    quantity: Quantity.of(4, 'unit'),
+    movementId: StockMovementId.create(),
+  });
+  applyStockMovement(m, { from, to });
+  assert.equal(from.quantity.amount, 0);
+  assert.equal(to.quantity.amount, 10);
+});
+
+test('reserving more than available is caught when applied', () => {
+  const from = item(StockStatus.Available, 3);
+  const to = item(StockStatus.Reserved, 0);
+  const m = reserve(from, to, 5);
+  assert.throws(() => applyStockMovement(m, { from, to }));
+  assert.equal(from.quantity.amount, 3); // untouched
+});
+
+test('rejects wrong statuses', () => {
+  // reserve requires Available → Reserved
+  assert.throws(
+    () =>
+      reserve(item(StockStatus.Reserved, 5), item(StockStatus.Reserved, 0), 1),
+    StockValidationError,
+  );
+  assert.throws(
+    () =>
+      reserve(
+        item(StockStatus.Available, 5),
+        item(StockStatus.Available, 0),
+        1,
+      ),
+    StockValidationError,
+  );
+  // release requires Reserved → Available
+  assert.throws(
+    () =>
+      releaseReservation({
+        from: item(StockStatus.Available, 5),
+        to: item(StockStatus.Available, 0),
+        quantity: Quantity.of(1, 'unit'),
+        movementId: StockMovementId.create(),
+      }),
+    StockValidationError,
+  );
+});
+
+test('rejects a pair that differs in more than status', () => {
+  const from = item(StockStatus.Available, 10);
+  // different bin
+  assert.throws(
+    () => reserve(from, item(StockStatus.Reserved, 0, { binId: OTHER_BIN }), 1),
+    StockValidationError,
+  );
+  // different product
+  assert.throws(
+    () =>
+      reserve(from, item(StockStatus.Reserved, 0, { supplyId: 'OTR-0002' }), 1),
+    StockValidationError,
+  );
+  // different scope
+  assert.throws(
+    () =>
+      reserve(from, item(StockStatus.Reserved, 0, { scope: OTHER_SCOPE }), 1),
+    StockValidationError,
+  );
+  // different lot
+  assert.throws(
+    () => reserve(from, item(StockStatus.Reserved, 0, { lotCode: 'L2' }), 1),
+    StockValidationError,
+  );
+});
+
+test('rejects a quantity in a different unit', () => {
+  const from = item(StockStatus.Available, 10, { unit: 'unit' });
+  const to = item(StockStatus.Reserved, 0, { unit: 'unit' });
+  assert.throws(
+    () =>
+      reserveStock({
+        from,
+        to,
+        quantity: Quantity.of(1, 'kg'),
+        movementId: StockMovementId.create(),
+      }),
+    StockValidationError,
+  );
+});
+
+test('supports non-lot-tracked stock (both lots null)', () => {
+  const from = item(StockStatus.Available, 5, { lotCode: null });
+  const to = item(StockStatus.Reserved, 0, { lotCode: null });
+  const m = reserve(from, to, 2);
+  applyStockMovement(m, { from, to });
+  assert.equal(from.quantity.amount, 3);
+  assert.equal(to.quantity.amount, 2);
+});

--- a/packages/warehouse-core/src/inventory/reservations.ts
+++ b/packages/warehouse-core/src/inventory/reservations.ts
@@ -1,0 +1,115 @@
+import { StockItem } from './stock-item.js';
+import { StockMovement } from './stock-movement.js';
+import { StockMovementId } from './stock-movement-id.js';
+import { Quantity } from './quantity.js';
+import { StockStatus } from './stock-enums.js';
+import { MovementKind } from './movement-enums.js';
+import { StockValidationError } from './stock-errors.js';
+
+export interface ReservationInput {
+  /** Source item (Available for a reservation, Reserved for a release). */
+  from: StockItem;
+  /** Target item — same grain as `from` except its status. */
+  to: StockItem;
+  quantity: Quantity;
+  /** Id for the transfer movement (minted by the caller). */
+  movementId: StockMovementId;
+  reason?: string | null;
+  idempotencyKey?: string | null;
+  occurredAt?: Date;
+}
+
+/**
+ * Reserves stock: commits `quantity` of an **available** item to a **reserved**
+ * counterpart of the *same grain* (same product/lot/bin) — the stock stays
+ * physically in the bin, only its disposition changes. Returned as a `transfer`
+ * {@link StockMovement} that is **not applied** (plan/execute split): the caller
+ * runs `applyStockMovement` (which decreases `from` and increases `to`,
+ * conserving quantity and guarding non-negativity) and persists.
+ */
+export function reserveStock(input: ReservationInput): StockMovement {
+  return buildStatusTransfer(
+    input,
+    StockStatus.Available,
+    StockStatus.Reserved,
+  );
+}
+
+/**
+ * Releases a reservation: the inverse of {@link reserveStock}, moving
+ * `quantity` from a **reserved** item back to its **available** counterpart of
+ * the same grain. Returned as a not-yet-applied `transfer` movement.
+ */
+export function releaseReservation(input: ReservationInput): StockMovement {
+  return buildStatusTransfer(
+    input,
+    StockStatus.Reserved,
+    StockStatus.Available,
+  );
+}
+
+function buildStatusTransfer(
+  input: ReservationInput,
+  expectedFrom: StockStatus,
+  expectedTo: StockStatus,
+): StockMovement {
+  const { from, to, quantity } = input;
+
+  if (from.status !== expectedFrom) {
+    throw new StockValidationError(
+      `Reservation source must be ${expectedFrom}, got ${from.status}`,
+    );
+  }
+  if (to.status !== expectedTo) {
+    throw new StockValidationError(
+      `Reservation target must be ${expectedTo}, got ${to.status}`,
+    );
+  }
+  assertSameGrainExceptStatus(from, to);
+  if (quantity.unit !== from.unit) {
+    throw new StockValidationError(
+      `Reservation quantity unit "${quantity.unit}" does not match the stock unit "${from.unit}"`,
+    );
+  }
+
+  return StockMovement.record({
+    id: input.movementId,
+    scopeId: from.scopeId,
+    kind: MovementKind.Transfer,
+    quantity,
+    fromItemId: from.id,
+    toItemId: to.id,
+    reason: input.reason ?? null,
+    idempotencyKey: input.idempotencyKey ?? null,
+    ...(input.occurredAt !== undefined ? { occurredAt: input.occurredAt } : {}),
+  });
+}
+
+/** The two items must be the same grain in everything but status. */
+function assertSameGrainExceptStatus(from: StockItem, to: StockItem): void {
+  if (!from.scopeId.equals(to.scopeId)) {
+    throw new StockValidationError('Reservation items are in different scopes');
+  }
+  if (from.supplyId !== to.supplyId) {
+    throw new StockValidationError(
+      'Reservation items are of different products',
+    );
+  }
+  if (!from.binId.equals(to.binId)) {
+    throw new StockValidationError('Reservation items are in different bins');
+  }
+  if (from.unit !== to.unit) {
+    throw new StockValidationError(
+      'Reservation items have different units of measure',
+    );
+  }
+  if (!sameLot(from, to)) {
+    throw new StockValidationError('Reservation items are of different lots');
+  }
+}
+
+function sameLot(from: StockItem, to: StockItem): boolean {
+  if (from.lot === null && to.lot === null) return true;
+  if (from.lot === null || to.lot === null) return false;
+  return from.lot.equals(to.lot);
+}


### PR DESCRIPTION
## Resumen

Fase 2 (épica #355): el **compañero de FEFO** que completa el ciclo **asignación → picking**. Una reserva compromete stock disponible a una demanda (pedido/pick) **sin sacarlo del bin**: un `Transfer` entre los dos `StockItem` particionados por estado del mismo grano (mismo producto/lote/bin), moviendo cantidad `available → reserved`. La liberación es el inverso.

> **Independiente de la migración #382** (no toca `SupplyLine`/`Category`/host/web) y **no es min/max** (aparcado). Solo añade ficheros nuevos en `warehouse-core/src/inventory`.

En el módulo `inventory` de `@globalemergency/warehouse-core`, servicios de dominio **puros**:

- **`reserveStock(input)`** → `StockMovement` (Transfer `available → reserved`, **sin aplicar**).
- **`releaseReservation(input)`** → el inverso (`reserved → available`).
- Invariantes: `from`/`to` comparten grano **salvo el estado** (mismo `supplyId`/`binId`/lote/unidad/scope) y tienen los estados correctos; cantidad en la unidad del stock.
- Patrón plan/ejecución (como FEFO/recuentos): devuelve el movimiento; el llamante hace `applyStockMovement` (conserva cantidad, guarda no-negatividad) + persiste. La cantidad **no sale del bin**.

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `build` (dual), `typecheck`, `test` (**85/85** verde; +8 de reservas), `pnpm --filter api build` (nest, host intacto), Prettier `--check` limpio, frontera pura.
- [x] Verifiqué el comportamiento manualmente si aplica — los tests cubren: transfer available→reserved y su aplicación (la cantidad se mueve sin salir del bin), la liberación inversa, el aborto por reserva insuficiente al aplicar, rechazo de estados incorrectos, rechazo de pares que difieren en más que el estado (bin/producto/scope/lote), rechazo por unidad distinta, y stock sin lote.
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica: dominio nuevo del paquete, sin wiring al host.

## Cierre

- Closes #390

_El emparejamiento reserva↔pedido/pick y la confirmación de salida (`issue` del kardex) quedan para la capa de aplicación del host._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_