### PR TITLE
feat(warehouse-postgres): persistencia del inventario WMS (schema wms.) — Fase 0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,18 @@ jobs:
       - name: Run tests — warehouse-core
         run: pnpm --filter '@globalemergency/warehouse-core' test
 
+      # warehouse-postgres ships integration tests for the WMS `wms.` schema
+      # persistence adapters (the 4 inventory ports + its own migration runner):
+      # unlike warehouse-core's pure unit tests these need a real Postgres, so
+      # they run in the Test job against the service DB. They create their own
+      # `wms` schema in the base `reliefhub` DB → isolated from the api suite's
+      # `reliefhub_test`. Kept in the required Test job so the WMS persistence
+      # layer actually gates the merge.
+      - name: Run tests — warehouse-postgres (integración)
+        env:
+          TEST_DATABASE_URL: postgres://reliefhub:reliefhub@localhost:5433/reliefhub
+        run: pnpm --filter '@globalemergency/warehouse-postgres' test:int
+
   # ── E2E tests ───────────────────────────────────────────────────────────────
   # The unit/int suite (`Test` job) does NOT cover the HTTP e2e specs under
   # apps/api/test — they run via a separate jest config. Run them here so an

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Only apps/api has a .prettierrc; check its src + test dirs.
       # prettier lives in apps/api's deps, so run it from there (root has no prettier bin).
       - name: Prettier — api
         run: pnpm --filter api exec prettier --check "src/**/*.ts" "test/**/*.ts"
+
+      # The workspace @globalemergency/* packages carry their own .prettierrc
+      # (same config as api). Gate warehouse-postgres' TS here too, run via api's
+      # prettier bin with a repo-relative glob.
+      # TODO(#355 follow-up): add packages/warehouse-core/src to this glob once
+      # its preexisting format drift (containers/container.ts, logistics/shipment.ts)
+      # is fixed forward — those files predate this gate and are out of scope here.
+      - name: Prettier — warehouse-postgres
+        run: pnpm --filter api exec prettier --check "../../packages/warehouse-postgres/src/**/*.ts"
 
   # ── Lint ────────────────────────────────────────────────────────────────────
   lint:
@@ -58,6 +66,11 @@ jobs:
       # built dist, so build it first.
       - name: Build — warehouse packages
         run: pnpm --filter '@globalemergency/*' build
+
+      # TODO(#355 follow-up): eslint for @globalemergency/* packages. They ship no
+      # runnable eslint config locally (flat config can't resolve the shared
+      # plugins from the package root), so a lint step here would break rather
+      # than gate. Add it once the packages have a self-contained eslint setup.
 
       # api lint script has --fix; in CI we want read-only + fail on warnings
       - name: Lint — api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,10 @@ jobs:
         run: pnpm --filter api exec prettier --check "src/**/*.ts" "test/**/*.ts"
 
       # The workspace @globalemergency/* packages carry their own .prettierrc
-      # (same config as api). Gate warehouse-postgres' TS here too, run via api's
-      # prettier bin with a repo-relative glob.
-      # TODO(#355 follow-up): add packages/warehouse-core/src to this glob once
-      # its preexisting format drift (containers/container.ts, logistics/shipment.ts)
-      # is fixed forward — those files predate this gate and are out of scope here.
-      - name: Prettier — warehouse-postgres
-        run: pnpm --filter api exec prettier --check "../../packages/warehouse-postgres/src/**/*.ts"
+      # (same config as api). Gate their TS here too, run via api's prettier bin
+      # with repo-relative globs.
+      - name: Prettier — warehouse packages
+        run: pnpm --filter api exec prettier --check "../../packages/warehouse-core/src/**/*.ts" "../../packages/warehouse-postgres/src/**/*.ts"
 
   # ── Lint ────────────────────────────────────────────────────────────────────
   lint:

--- a/packages/warehouse-core/src/containers/container.ts
+++ b/packages/warehouse-core/src/containers/container.ts
@@ -9,11 +9,7 @@ import {
   ContainerSealedError,
   ContainerValidationError,
 } from './container-errors.js';
-import {
-  ScopeId,
-  SupplyLine,
-  SupplyLineSnapshot,
-} from '../kernel/index.js';
+import { ScopeId, SupplyLine, SupplyLineSnapshot } from '../kernel/index.js';
 
 /**
  * Where the container is held right now. Polymorphic reference (no FK), like a

--- a/packages/warehouse-core/src/logistics/shipment.ts
+++ b/packages/warehouse-core/src/logistics/shipment.ts
@@ -1,10 +1,7 @@
 import { ShipmentId } from './shipment-id.js';
 import { ScopeId } from '../kernel/index.js';
 import { CarrierType, ShipmentStatus } from './shipment-enums.js';
-import {
-  SupplyLine,
-  SupplyLineSnapshot,
-} from '../kernel/index.js';
+import { SupplyLine, SupplyLineSnapshot } from '../kernel/index.js';
 import {
   InvalidShipmentRouteError,
   InvalidShipmentTransitionError,

--- a/packages/warehouse-postgres/.prettierrc
+++ b/packages/warehouse-postgres/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/warehouse-postgres/README.md
+++ b/packages/warehouse-postgres/README.md
@@ -2,13 +2,15 @@
 
 Adaptador de **persistencia Postgres/Drizzle** para
 [`@globalemergency/warehouse-core`](../warehouse-core). Es la capa "con pilas":
-el schema, los repos y (en el futuro) las migraciones del WMS viven aquí, para
-que ResponseGrid y el WMS standalone compartan la persistencia **una sola vez**
-en vez de reimplementarla.
+el schema, los repos y las migraciones del WMS viven aquí, para que ResponseGrid
+y el WMS standalone compartan la persistencia **una sola vez** en vez de
+reimplementarla.
 
-> Estado: **precursor in-monorepo**. Primer contenido: las columnas Drizzle y
-> los mappers de la línea de material (`SupplyLine`). Ver épica
-> [#355](https://github.com/GlobalEmergency/ResponseGrid/issues/355).
+> Estado: **precursor in-monorepo**. Contiene (a) las columnas Drizzle y los
+> mappers de la línea de material (`SupplyLine`) y (b) la persistencia del módulo
+> `inventory` de warehouse-core sobre el esquema dedicado `wms.` (almacenes,
+> zonas, ubicaciones, stock y su libro mayor) con runner de migraciones propio.
+> Ver épica [#355](https://github.com/GlobalEmergency/ResponseGrid/issues/355).
 
 ## Principios
 
@@ -21,13 +23,40 @@ en vez de reimplementarla.
 
 ## Contenido
 
+Raíz (`.`) — línea de material:
+
 | Export | Uso |
 | --- | --- |
 | `supplyLineColumns(supplyIdColumn?)` | Factory de las columnas compartidas de una línea de material; se hace *spread* en cada tabla `*_items`. |
 | `SupplyLineRow`, `rowToSupplyLineSnapshot`, `supplyLineToColumns` | Mapeo fila persistida ⇄ `SupplyLineSnapshot` del dominio. |
 
-## Build
+Subpath `./inventory` — persistencia del WMS (esquema `wms.`):
+
+| Export | Uso |
+| --- | --- |
+| `migrateWms(pool, migrationsDir?)` | Runner idempotente que aplica `migrations/wms_*.sql` en orden, rastreándolos en `wms."_migrations"`. Seguro de re-ejecutar. |
+| `DrizzleWarehouseRepository` | Puerto `WarehouseRepository`: upsert del almacén + reemplazo de sus zonas (agregado completo) en transacción. |
+| `DrizzleBinRepository` | Puerto `BinRepository`: upsert + finders por id/código/almacén/scope. |
+| `DrizzleStockItemRepository` | Puerto `StockItemRepository`: alta (INSERT) / actualización con **concurrencia optimista** por `version`; grano único garantizado por índices parciales. Lanza `StaleStockItemError` ante un update obsoleto. |
+| `DrizzleStockMovementRepository` | Puerto `StockMovementRepository`: libro mayor **append-only** con **idempotencia** por `(scope_id, idempotency_key)`. |
+| `warehousesTable`, `zonesTable`, `binsTable`, `stockItemsTable`, `stockMovementsTable`, `wms` | Tablas Drizzle del esquema `wms.` y el `pgSchema`. |
+| `StaleStockItemError` | Choque de concurrencia optimista al persistir un `StockItem`. |
+
+La columna de tenencia es `scope_id` (uuid opaco), **no** `emergency_id`: el
+paquete es agnóstico del sector. Los repos reciben un `NodePgDatabase`
+(`drizzle-orm/node-postgres`) por constructor.
+
+## Build y tests
 
 ```bash
-pnpm --filter @globalemergency/warehouse-postgres build   # dual CJS+ESM
+pnpm --filter @globalemergency/warehouse-postgres build       # dual CJS+ESM
+pnpm --filter @globalemergency/warehouse-postgres typecheck
+pnpm --filter @globalemergency/warehouse-postgres test:int    # integración; requiere Postgres
 ```
+
+Los tests de integración usan `node:test` + `pg` contra un Postgres real
+(`TEST_DATABASE_URL`, por defecto `postgres://reliefhub:reliefhub@localhost:5434/reliefhub`).
+Antes de cada suite hacen `DROP SCHEMA wms CASCADE` + `migrateWms`, de modo que
+las ejecuciones son repetibles. `consumer-validation.test.ts` es la **prueba de
+reutilización**: ejercita dominio + persistencia de punta a punta importando
+sólo `@globalemergency/warehouse-core` + esta librería (nunca `apps/*`).

--- a/packages/warehouse-postgres/migrations/wms_0001_inventory.sql
+++ b/packages/warehouse-postgres/migrations/wms_0001_inventory.sql
@@ -1,0 +1,129 @@
+-- wms_0001_inventory — esquema de persistencia del módulo `inventory` de
+-- warehouse-core. Vive en un esquema Postgres dedicado (`wms`) para que el
+-- paquete pueda migrar de forma independiente del host que lo consuma.
+--
+-- Tenencia: la columna de partición es `scope_id` (uuid opaco), NUNCA
+-- `emergency_id`: el paquete es agnóstico del sector (Protección Civil,
+-- emergencia de ResponseGrid, etc.). El host mapea su propio id a `scope_id`.
+--
+-- Backbone de ubicaciones: warehouse → zone (entidad del agregado Warehouse) y
+-- bin (agregado propio). El stock existente se modela con stock_items (grano
+-- producto × lote × bin × estado, con `version` para concurrencia optimista) y
+-- su libro mayor inmutable stock_movements (asiento de doble pata).
+--
+-- Migración inmutable una vez fusionada (convención del repo): corregir hacia
+-- adelante con un nuevo `wms_*.sql`, nunca editar este fichero.
+
+CREATE SCHEMA IF NOT EXISTS wms;
+
+-- Almacén (agregado raíz). `code` único por scope.
+CREATE TABLE IF NOT EXISTS wms.warehouses (
+  id         uuid PRIMARY KEY,
+  scope_id   uuid NOT NULL,
+  code       text NOT NULL,
+  name       text NOT NULL,
+  address    text,
+  lat        double precision,
+  lng        double precision,
+  status     text NOT NULL,
+  created_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL,
+  CONSTRAINT wms_warehouses_scope_code_uq UNIQUE (scope_id, code)
+);
+
+CREATE INDEX IF NOT EXISTS wms_warehouses_scope_idx ON wms.warehouses (scope_id);
+
+-- Zona (entidad del agregado Warehouse). FK con borrado en cascada: una zona no
+-- existe sin su almacén. `code` único por almacén.
+CREATE TABLE IF NOT EXISTS wms.zones (
+  id           uuid PRIMARY KEY,
+  warehouse_id uuid NOT NULL REFERENCES wms.warehouses (id) ON DELETE CASCADE,
+  code         text NOT NULL,
+  name         text NOT NULL,
+  kind         text NOT NULL,
+  status       text NOT NULL,
+  CONSTRAINT wms_zones_warehouse_code_uq UNIQUE (warehouse_id, code)
+);
+
+CREATE INDEX IF NOT EXISTS wms_zones_warehouse_idx ON wms.zones (warehouse_id);
+
+-- Ubicación física (agregado propio). Referencia almacén y (opcionalmente) zona
+-- por id. `scope_id` denormalizado para listados cross-warehouse. `code` único
+-- por almacén.
+CREATE TABLE IF NOT EXISTS wms.bins (
+  id           uuid PRIMARY KEY,
+  scope_id     uuid NOT NULL,
+  warehouse_id uuid NOT NULL,
+  zone_id      uuid,
+  code         text NOT NULL,
+  kind         text NOT NULL,
+  status       text NOT NULL,
+  created_at   timestamptz NOT NULL,
+  updated_at   timestamptz NOT NULL,
+  CONSTRAINT wms_bins_warehouse_code_uq UNIQUE (warehouse_id, code)
+);
+
+CREATE INDEX IF NOT EXISTS wms_bins_scope_idx ON wms.bins (scope_id);
+CREATE INDEX IF NOT EXISTS wms_bins_warehouse_idx ON wms.bins (warehouse_id);
+
+-- Unidad de existencia (agregado raíz). Grano producto × lote × bin × estado.
+-- `quantity_amount` decimal (numeric(18,6), en sintonía con la escala 6 del VO
+-- Quantity). `version` para concurrencia optimista.
+CREATE TABLE IF NOT EXISTS wms.stock_items (
+  id              uuid PRIMARY KEY,
+  scope_id        uuid NOT NULL,
+  warehouse_id    uuid NOT NULL,
+  bin_id          uuid NOT NULL,
+  supply_id       uuid NOT NULL,
+  lot_code        text,
+  expires_at      timestamptz,
+  quantity_amount numeric(18, 6) NOT NULL,
+  unit            text NOT NULL,
+  status          text NOT NULL,
+  version         integer NOT NULL,
+  created_at      timestamptz NOT NULL,
+  updated_at      timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS wms_stock_items_scope_idx ON wms.stock_items (scope_id);
+CREATE INDEX IF NOT EXISTS wms_stock_items_bin_idx ON wms.stock_items (bin_id);
+CREATE INDEX IF NOT EXISTS wms_stock_items_warehouse_idx ON wms.stock_items (warehouse_id);
+
+-- Grano único (bin, supply, lote, estado). El lote nulo (stock no trazado por
+-- lote) debe seguir siendo único, y un índice UNIQUE ordinario trata cada NULL
+-- como distinto: se usa un par de índices parciales — uno para lote presente,
+-- otro (con lot_code IS NULL) que garantiza una sola fila sin lote por
+-- (bin, supply, estado).
+CREATE UNIQUE INDEX IF NOT EXISTS wms_stock_items_grain_lot_uq
+  ON wms.stock_items (bin_id, supply_id, lot_code, status)
+  WHERE lot_code IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS wms_stock_items_grain_nolot_uq
+  ON wms.stock_items (bin_id, supply_id, status)
+  WHERE lot_code IS NULL;
+
+-- Libro mayor (kardex). Append-only: sólo INSERT, nunca UPDATE/DELETE. Asiento
+-- de doble pata (from/to, cada una StockItem o el exterior=null).
+CREATE TABLE IF NOT EXISTS wms.stock_movements (
+  id              uuid PRIMARY KEY,
+  scope_id        uuid NOT NULL,
+  kind            text NOT NULL,
+  quantity_amount numeric(18, 6) NOT NULL,
+  unit            text NOT NULL,
+  from_item_id    uuid,
+  to_item_id      uuid,
+  reason          text,
+  idempotency_key text,
+  occurred_at     timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS wms_stock_movements_scope_idx ON wms.stock_movements (scope_id);
+CREATE INDEX IF NOT EXISTS wms_stock_movements_from_idx ON wms.stock_movements (from_item_id);
+CREATE INDEX IF NOT EXISTS wms_stock_movements_to_idx ON wms.stock_movements (to_item_id);
+
+-- Idempotencia: clave única por scope cuando está presente (una entrada
+-- reintentada con la misma clave se registra una sola vez). Índice parcial para
+-- no restringir los movimientos sin clave.
+CREATE UNIQUE INDEX IF NOT EXISTS wms_stock_movements_idempotency_uq
+  ON wms.stock_movements (scope_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;

--- a/packages/warehouse-postgres/package.json
+++ b/packages/warehouse-postgres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@globalemergency/warehouse-postgres",
   "version": "0.0.0",
-  "description": "Adaptador de persistencia Postgres/Drizzle para @globalemergency/warehouse-core: columnas y mappers compartidos de la línea de material. Consumido por ResponseGrid y por el WMS standalone.",
+  "description": "Adaptador de persistencia Postgres/Drizzle para @globalemergency/warehouse-core: columnas y mappers compartidos de la línea de material, y el esquema `wms.` del módulo inventory (almacenes/zonas/bins/stock + libro mayor) con su runner de migraciones. Consumido por ResponseGrid y por el WMS standalone.",
   "license": "UNLICENSED",
   "type": "module",
   "sideEffects": false,
@@ -15,14 +15,27 @@
         "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
+    },
+    "./inventory": {
+      "import": {
+        "types": "./dist/esm/inventory/index.d.ts",
+        "default": "./dist/esm/inventory/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/inventory/index.d.ts",
+        "default": "./dist/cjs/inventory/index.js"
+      }
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "migrations"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))\"",
     "typecheck": "tsc -p tsconfig.esm.json --noEmit",
+    "pretest:int": "node -e \"require('fs').rmSync('dist-test', { recursive: true, force: true })\"",
+    "test:int": "tsc -p tsconfig.test.json && node --test --test-concurrency=1 \"dist-test/**/*.test.js\"",
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\""
   },
   "peerDependencies": {
@@ -32,7 +45,10 @@
     "@globalemergency/warehouse-core": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@types/pg": "^8.11.10",
     "drizzle-orm": "^0.45.2",
+    "pg": "^8.13.1",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/warehouse-postgres/src/inventory/consumer-validation.test.ts
+++ b/packages/warehouse-postgres/src/inventory/consumer-validation.test.ts
@@ -1,0 +1,267 @@
+import { after, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Pool } from 'pg';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+// SOLO se importa warehouse-core (dominio) y warehouse-postgres (persistencia).
+// NUNCA `apps/*`: este test es la prueba de que el paquete es reutilizable sin
+// ResponseGrid — un WMS standalone lo consumiría exactamente así.
+import {
+  Warehouse,
+  WarehouseId,
+  ZoneId,
+  ZoneKind,
+  Bin,
+  BinId,
+  BinKind,
+  StockItem,
+  StockItemId,
+  StockMovement,
+  StockMovementId,
+  applyStockMovement,
+  allocateFefo,
+  Quantity,
+  StockStatus,
+  MovementKind,
+} from '@globalemergency/warehouse-core/inventory';
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import {
+  DrizzleWarehouseRepository,
+  DrizzleBinRepository,
+  DrizzleStockItemRepository,
+  DrizzleStockMovementRepository,
+  StaleStockItemError,
+} from './index.js';
+import {
+  newPool,
+  resetSchema,
+  truncateAll,
+  makeDb,
+  uuid,
+} from './test-support.js';
+
+/**
+ * Consumidor de validación standalone: ejercita un flujo dominio + persistencia
+ * de punta a punta (alta de almacén/zona/bin → entrada → traslado bin→bin →
+ * salida FEFO), y comprueba que la concurrencia optimista y la idempotencia se
+ * sostienen sobre la BBDD real. Es la prueba de reutilización del paquete.
+ */
+describe('Consumidor standalone: flujo WMS end-to-end (dominio + persistencia)', () => {
+  let pool: Pool;
+  let db: NodePgDatabase;
+  let warehouses: DrizzleWarehouseRepository;
+  let bins: DrizzleBinRepository;
+  let items: DrizzleStockItemRepository;
+  let movements: DrizzleStockMovementRepository;
+
+  before(async () => {
+    pool = newPool();
+    await resetSchema(pool);
+    db = makeDb(pool);
+    warehouses = new DrizzleWarehouseRepository(db);
+    bins = new DrizzleBinRepository(db);
+    items = new DrizzleStockItemRepository(db);
+    movements = new DrizzleStockMovementRepository(db);
+  });
+
+  after(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(db);
+  });
+
+  it('alta de layout → entrada idempotente → traslado → salida FEFO', async () => {
+    const scopeId = ScopeId.create();
+    const supplyId = uuid();
+    const unit = 'unit';
+
+    // --- 1. Layout: almacén con una zona de almacenaje y dos bins. ----------
+    const storageZoneId = ZoneId.create();
+    const warehouse = Warehouse.create({
+      id: WarehouseId.create(),
+      scopeId,
+      code: 'ALM-CENTRAL',
+      name: 'Almacén Central',
+      zones: [
+        {
+          id: storageZoneId,
+          code: 'ALM',
+          name: 'Almacenaje',
+          kind: ZoneKind.Storage,
+        },
+      ],
+    });
+    await warehouses.save(warehouse);
+
+    const binA = Bin.create({
+      id: BinId.create(),
+      scopeId,
+      warehouseId: warehouse.id,
+      zoneId: storageZoneId,
+      code: 'A-01',
+      kind: BinKind.Shelf,
+    });
+    const binB = Bin.create({
+      id: BinId.create(),
+      scopeId,
+      warehouseId: warehouse.id,
+      zoneId: storageZoneId,
+      code: 'B-01',
+      kind: BinKind.Shelf,
+    });
+    await bins.save(binA);
+    await bins.save(binB);
+
+    // --- 2. Entrada (receipt): item nuevo en binA, lote que caduca pronto. ---
+    const receiptKey = 'albaran-0001';
+    // El grano no existía: se da de alta el item vacío (v1, path INSERT) y luego
+    // se aplica la entrada (v2, path UPDATE con guarda de versión). Así el flujo
+    // ejercita ambos caminos del repositorio.
+    const itemA = StockItem.create({
+      id: StockItemId.create(),
+      scopeId,
+      warehouseId: warehouse.id,
+      binId: binA.id,
+      supplyId,
+      lot: { code: 'L-EARLY', expiresAt: new Date('2026-09-01T00:00:00.000Z') },
+      quantity: Quantity.of(0, unit),
+      status: StockStatus.Available,
+    });
+    await items.save(itemA); // alta (v1)
+
+    const receipt = StockMovement.record({
+      id: StockMovementId.create(),
+      scopeId,
+      kind: MovementKind.Receipt,
+      quantity: Quantity.of(100, unit),
+      toItemId: itemA.id,
+      idempotencyKey: receiptKey,
+    });
+    // Patrón del host: resolver por clave antes de aplicar (guardia anti-doble).
+    const already = await movements.findByIdempotencyKey(scopeId, receiptKey);
+    assert.equal(already, null);
+    applyStockMovement(receipt, { to: itemA });
+    await items.save(itemA); // entrada aplicada (v2)
+    await movements.append(receipt);
+
+    // Reintento del mismo albarán: la idempotencia deja un solo asiento.
+    await movements.append(
+      StockMovement.record({
+        id: StockMovementId.create(),
+        scopeId,
+        kind: MovementKind.Receipt,
+        quantity: Quantity.of(100, unit),
+        toItemId: itemA.id,
+        idempotencyKey: receiptKey,
+      }),
+    );
+    assert.equal((await movements.findByScope(scopeId, {})).length, 1);
+
+    const persistedA = await items.findById(itemA.id);
+    assert.equal(persistedA?.quantity.amount, 100);
+
+    // --- 3. Traslado binA → binB de 30 unidades (mismo lote, item nuevo). ----
+    const itemB = StockItem.create({
+      id: StockItemId.create(),
+      scopeId,
+      warehouseId: warehouse.id,
+      binId: binB.id,
+      supplyId,
+      lot: { code: 'L-EARLY', expiresAt: new Date('2026-09-01T00:00:00.000Z') },
+      quantity: Quantity.of(0, unit),
+      status: StockStatus.Available,
+    });
+    await items.save(itemB); // alta del grano destino (v1)
+
+    const transfer = StockMovement.record({
+      id: StockMovementId.create(),
+      scopeId,
+      kind: MovementKind.Transfer,
+      quantity: Quantity.of(30, unit),
+      fromItemId: itemA.id,
+      toItemId: itemB.id,
+    });
+    const fromItem = await items.findById(itemA.id);
+    assert.ok(fromItem);
+    applyStockMovement(transfer, { from: fromItem, to: itemB });
+    await items.save(fromItem); // A: 100 → 70 (v2 → v3)
+    await items.save(itemB); // B: 0 → 30 (v1 → v2)
+    await movements.append(transfer);
+
+    assert.equal((await items.findById(itemA.id))?.quantity.amount, 70);
+    assert.equal((await items.findById(itemB.id))?.quantity.amount, 30);
+
+    // --- 4. Un segundo lote en binB que caduca MÁS TARDE (para FEFO). --------
+    const itemBLate = StockItem.create({
+      id: StockItemId.create(),
+      scopeId,
+      warehouseId: warehouse.id,
+      binId: binB.id,
+      supplyId,
+      lot: { code: 'L-LATE', expiresAt: new Date('2027-06-01T00:00:00.000Z') },
+      quantity: Quantity.of(50, unit),
+      status: StockStatus.Available,
+    });
+    await items.save(itemBLate);
+
+    // --- 5. Salida FEFO de 90 unidades sobre el stock persistido. -----------
+    // Candidatos = stock disponible del producto en el scope (leído de la BBDD).
+    const candidates = await items.findByScope(scopeId, {
+      status: StockStatus.Available,
+      supplyId,
+    });
+    // Stock disponible: A(70, cad 2026-09) + B-early(30, cad 2026-09) + B-late(50, cad 2027-06) = 150.
+    const plan = allocateFefo(
+      { scopeId, supplyId, quantity: Quantity.of(90, unit) },
+      candidates,
+    );
+    assert.equal(plan.fullyAllocated, true);
+    assert.equal(plan.allocated.amount, 90);
+
+    // FEFO: primero los lotes que caducan antes (L-EARLY: A=70 y B-early=30 =
+    // 100 disponibles) y sólo entonces L-LATE. 90 se cubre con los tempranos.
+    for (const line of plan.lines) {
+      assert.equal(line.item.lot?.code, 'L-EARLY');
+    }
+    assert.equal(
+      plan.lines.reduce((sum, l) => sum + l.quantity.amount, 0),
+      90,
+    );
+
+    // Aplicar la salida: emitir un issue por línea y decrementar el item.
+    for (const line of plan.lines) {
+      const issue = StockMovement.record({
+        id: StockMovementId.create(),
+        scopeId,
+        kind: MovementKind.Issue,
+        quantity: line.quantity,
+        fromItemId: line.item.id,
+      });
+      const fresh = await items.findById(line.item.id);
+      assert.ok(fresh);
+      applyStockMovement(issue, { from: fresh });
+      await items.save(fresh);
+      await movements.append(issue);
+    }
+
+    // El lote tardío queda intacto; el temprano queda a 10 en total.
+    const late = await items.findById(itemBLate.id);
+    assert.equal(late?.quantity.amount, 50);
+    const remainingEarly = (await items.findByScope(scopeId, { supplyId }))
+      .filter((i) => i.lot?.code === 'L-EARLY')
+      .reduce((sum, i) => sum + i.quantity.amount, 0);
+    assert.equal(remainingEarly, 10);
+
+    // --- 6. La concurrencia optimista se sostiene end-to-end. ---------------
+    const stale = await items.findById(itemBLate.id); // v1
+    const winner = await items.findById(itemBLate.id); // v1
+    assert.ok(stale && winner);
+    winner.decrease(Quantity.of(5, unit));
+    await items.save(winner); // v1 → v2
+    stale.decrease(Quantity.of(1, unit)); // sigue en v1
+    await assert.rejects(() => items.save(stale), StaleStockItemError);
+    assert.equal((await items.findById(itemBLate.id))?.quantity.amount, 45);
+  });
+});

--- a/packages/warehouse-postgres/src/inventory/consumer-validation.test.ts
+++ b/packages/warehouse-postgres/src/inventory/consumer-validation.test.ts
@@ -31,6 +31,7 @@ import {
   DrizzleStockItemRepository,
   DrizzleStockMovementRepository,
   StaleStockItemError,
+  runInWmsTransaction,
 } from './index.js';
 import {
   newPool,
@@ -186,9 +187,13 @@ describe('Consumidor standalone: flujo WMS end-to-end (dominio + persistencia)',
     const fromItem = await items.findById(itemA.id);
     assert.ok(fromItem);
     applyStockMovement(transfer, { from: fromItem, to: itemB });
-    await items.save(fromItem); // A: 100 → 70 (v2 → v3)
-    await items.save(itemB); // B: 0 → 30 (v1 → v2)
-    await movements.append(transfer);
+    // Persistencia ATÓMICA del traslado: ambas patas + el asiento en una sola
+    // transacción (Unit of Work), como exige el dominio de StockMovement.
+    await runInWmsTransaction(db, async (uow) => {
+      await uow.items.save(fromItem); // A: 100 → 70 (v2 → v3)
+      await uow.items.save(itemB); // B: 0 → 30 (v1 → v2)
+      await uow.movements.append(transfer);
+    });
 
     assert.equal((await items.findById(itemA.id))?.quantity.amount, 70);
     assert.equal((await items.findById(itemB.id))?.quantity.amount, 30);
@@ -263,5 +268,69 @@ describe('Consumidor standalone: flujo WMS end-to-end (dominio + persistencia)',
     stale.decrease(Quantity.of(1, unit)); // sigue en v1
     await assert.rejects(() => items.save(stale), StaleStockItemError);
     assert.equal((await items.findById(itemBLate.id))?.quantity.amount, 45);
+  });
+
+  it('un fallo a mitad de runInWmsTransaction revierte todo (sin mutación parcial)', async () => {
+    const scopeId = ScopeId.create();
+    const supplyId = uuid();
+    const unit = 'unit';
+    const warehouseId = WarehouseId.create();
+
+    // Dos items del mismo producto en bins distintos: origen con stock, destino
+    // vacío. Se persisten fuera de la transacción (estado inicial conocido).
+    const from = StockItem.create({
+      id: StockItemId.create(),
+      scopeId,
+      warehouseId,
+      binId: BinId.create(),
+      supplyId,
+      lot: null,
+      quantity: Quantity.of(100, unit),
+      status: StockStatus.Available,
+    });
+    const to = StockItem.create({
+      id: StockItemId.create(),
+      scopeId,
+      warehouseId,
+      binId: BinId.create(),
+      supplyId,
+      lot: null,
+      quantity: Quantity.of(0, unit),
+      status: StockStatus.Available,
+    });
+    await items.save(from);
+    await items.save(to);
+
+    // Traslado en memoria: from 100 → 70, to 0 → 30.
+    const transfer = StockMovement.record({
+      id: StockMovementId.create(),
+      scopeId,
+      kind: MovementKind.Transfer,
+      quantity: Quantity.of(30, unit),
+      fromItemId: from.id,
+      toItemId: to.id,
+    });
+    applyStockMovement(transfer, { from, to });
+
+    const boom = new Error('fallo deliberado a mitad de la transacción');
+    await assert.rejects(
+      () =>
+        runInWmsTransaction(db, async (uow) => {
+          await uow.items.save(from); // se escribe la primera pata…
+          await uow.items.save(to); // …y la segunda…
+          throw boom; // …pero algo falla antes del COMMIT.
+        }),
+      (err) => err === boom,
+    );
+
+    // ROLLBACK: NINGUNA mutación quedó persistida — ambos items siguen en su
+    // estado inicial (v1, 100 y 0), y el asiento nunca se registró.
+    const reloadedFrom = await items.findById(from.id);
+    const reloadedTo = await items.findById(to.id);
+    assert.equal(reloadedFrom?.quantity.amount, 100);
+    assert.equal(reloadedFrom?.version, 1);
+    assert.equal(reloadedTo?.quantity.amount, 0);
+    assert.equal(reloadedTo?.version, 1);
+    assert.equal((await movements.findByScope(scopeId, {})).length, 0);
   });
 });

--- a/packages/warehouse-postgres/src/inventory/db.ts
+++ b/packages/warehouse-postgres/src/inventory/db.ts
@@ -1,0 +1,16 @@
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import type { NodePgQueryResultHKT } from 'drizzle-orm/node-postgres';
+
+/**
+ * Tipo compartido de "handle de base de datos" del paquete. Tanto una conexión
+ * de nivel superior (`NodePgDatabase`, obtenida con `drizzle(pool)`) como una
+ * transacción (`tx`, el argumento de `db.transaction(...)`) satisfacen este tipo,
+ * porque ambas extienden `PgDatabase<NodePgQueryResultHKT>`.
+ *
+ * Los 4 repositorios se tipan sobre `WmsDatabase` (en vez de `NodePgDatabase`)
+ * para que se puedan construir tanto sobre el `db` global — auto-commit por
+ * conexión del pool — como sobre un `tx`, sin ningún `as`. Esto es lo que
+ * habilita la Unit of Work ({@link ./unit-of-work.js}): componer save de ambas
+ * patas + append del libro mayor en una única transacción atómica.
+ */
+export type WmsDatabase = PgDatabase<NodePgQueryResultHKT>;

--- a/packages/warehouse-postgres/src/inventory/drizzle-bin.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-bin.repository.test.ts
@@ -1,0 +1,153 @@
+import { after, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Pool } from 'pg';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import {
+  Bin,
+  BinId,
+  BinKind,
+  BinStatus,
+  WarehouseId,
+  ZoneId,
+} from '@globalemergency/warehouse-core/inventory';
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import { DrizzleBinRepository } from './drizzle-bin.repository.js';
+import { newPool, resetSchema, truncateAll, makeDb } from './test-support.js';
+
+describe('DrizzleBinRepository (integración)', () => {
+  let pool: Pool;
+  let db: NodePgDatabase;
+  let repo: DrizzleBinRepository;
+
+  before(async () => {
+    pool = newPool();
+    await resetSchema(pool);
+    db = makeDb(pool);
+    repo = new DrizzleBinRepository(db);
+  });
+
+  after(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(db);
+  });
+
+  function newBin(opts: {
+    scopeId: ScopeId;
+    warehouseId: WarehouseId;
+    zoneId?: ZoneId | null;
+    code?: string;
+    kind?: BinKind;
+  }): Bin {
+    return Bin.create({
+      id: BinId.create(),
+      scopeId: opts.scopeId,
+      warehouseId: opts.warehouseId,
+      zoneId: opts.zoneId ?? null,
+      code: opts.code ?? 'A-01',
+      kind: opts.kind ?? BinKind.Shelf,
+    });
+  }
+
+  it('save + findById reconstruye el bin', async () => {
+    const scopeId = ScopeId.create();
+    const warehouseId = WarehouseId.create();
+    const zoneId = ZoneId.create();
+    const bin = newBin({ scopeId, warehouseId, zoneId });
+    await repo.save(bin);
+
+    const loaded = await repo.findById(bin.id);
+    assert.ok(loaded);
+    assert.deepEqual(loaded.toSnapshot(), bin.toSnapshot());
+  });
+
+  it('save hace upsert: persiste cambios de zona y estado', async () => {
+    const scopeId = ScopeId.create();
+    const warehouseId = WarehouseId.create();
+    const bin = newBin({ scopeId, warehouseId });
+    await repo.save(bin);
+
+    const newZone = ZoneId.create();
+    bin.assignZone(newZone);
+    bin.block();
+    await repo.save(bin);
+
+    const loaded = await repo.findById(bin.id);
+    assert.ok(loaded);
+    assert.equal(loaded.zoneId?.value, newZone.value);
+    assert.equal(loaded.status, BinStatus.Blocked);
+  });
+
+  it('findByCode resuelve por almacén + código', async () => {
+    const scopeId = ScopeId.create();
+    const warehouseId = WarehouseId.create();
+    const bin = newBin({ scopeId, warehouseId, code: 'DOCK-3' });
+    await repo.save(bin);
+
+    const found = await repo.findByCode(warehouseId, 'DOCK-3');
+    assert.ok(found);
+    assert.equal(found.id.value, bin.id.value);
+    assert.equal(await repo.findByCode(WarehouseId.create(), 'DOCK-3'), null);
+  });
+
+  it('findByWarehouse filtra por estado, tipo y zona', async () => {
+    const scopeId = ScopeId.create();
+    const warehouseId = WarehouseId.create();
+    const zoneA = ZoneId.create();
+    const shelf = newBin({
+      scopeId,
+      warehouseId,
+      zoneId: zoneA,
+      code: 'S1',
+      kind: BinKind.Shelf,
+    });
+    const dock = newBin({
+      scopeId,
+      warehouseId,
+      code: 'D1',
+      kind: BinKind.Dock,
+    });
+    dock.block();
+    await repo.save(shelf);
+    await repo.save(dock);
+
+    assert.equal((await repo.findByWarehouse(warehouseId, {})).length, 2);
+    assert.equal(
+      (await repo.findByWarehouse(warehouseId, { kind: BinKind.Dock })).length,
+      1,
+    );
+    assert.equal(
+      (await repo.findByWarehouse(warehouseId, { status: BinStatus.Active }))
+        .length,
+      1,
+    );
+    const inZoneA = await repo.findByWarehouse(warehouseId, {
+      zoneId: zoneA.value,
+    });
+    assert.equal(inZoneA.length, 1);
+    assert.equal(inZoneA[0]?.code, 'S1');
+  });
+
+  it('findByScope lista los bins de una tenencia', async () => {
+    const scopeId = ScopeId.create();
+    const otherScope = ScopeId.create();
+    await repo.save(
+      newBin({ scopeId, warehouseId: WarehouseId.create(), code: 'X1' }),
+    );
+    await repo.save(
+      newBin({ scopeId, warehouseId: WarehouseId.create(), code: 'X2' }),
+    );
+    await repo.save(
+      newBin({
+        scopeId: otherScope,
+        warehouseId: WarehouseId.create(),
+        code: 'Y1',
+      }),
+    );
+
+    assert.equal((await repo.findByScope(scopeId, {})).length, 2);
+    assert.equal((await repo.findByScope(otherScope, {})).length, 1);
+  });
+});

--- a/packages/warehouse-postgres/src/inventory/drizzle-bin.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-bin.repository.ts
@@ -1,0 +1,104 @@
+import { and, eq, type SQL } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import {
+  Bin,
+  BinId,
+  WarehouseId,
+} from '@globalemergency/warehouse-core/inventory';
+import type {
+  BinRepository,
+  ListBinsFilter,
+} from '@globalemergency/warehouse-core/inventory';
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import { binsTable } from './schema.js';
+import { rowToBinSnapshot, binSnapshotToRow } from './mappers.js';
+
+/**
+ * Adaptador Drizzle/Postgres del puerto {@link BinRepository}. El bin es un
+ * agregado propio y plano (sin hijos): `save` es un upsert directo por id, y los
+ * finders reconstruyen vía `Bin.fromSnapshot`.
+ */
+export class DrizzleBinRepository implements BinRepository {
+  constructor(private readonly db: NodePgDatabase) {}
+
+  async save(bin: Bin): Promise<void> {
+    const s = bin.toSnapshot();
+    await this.db
+      .insert(binsTable)
+      .values(binSnapshotToRow(s))
+      .onConflictDoUpdate({
+        target: binsTable.id,
+        set: {
+          // El almacén de un bin es inmutable; la zona y el estado sí cambian.
+          zoneId: s.zoneId,
+          status: s.status,
+          updatedAt: s.updatedAt,
+        },
+      });
+  }
+
+  async findById(id: BinId): Promise<Bin | null> {
+    const [row] = await this.db
+      .select()
+      .from(binsTable)
+      .where(eq(binsTable.id, id.value))
+      .limit(1);
+    return row ? Bin.fromSnapshot(rowToBinSnapshot(row)) : null;
+  }
+
+  async findByCode(
+    warehouseId: WarehouseId,
+    code: string,
+  ): Promise<Bin | null> {
+    const [row] = await this.db
+      .select()
+      .from(binsTable)
+      .where(
+        and(
+          eq(binsTable.warehouseId, warehouseId.value),
+          eq(binsTable.code, code),
+        ),
+      )
+      .limit(1);
+    return row ? Bin.fromSnapshot(rowToBinSnapshot(row)) : null;
+  }
+
+  async findByWarehouse(
+    warehouseId: WarehouseId,
+    filter: ListBinsFilter,
+  ): Promise<Bin[]> {
+    const rows = await this.db
+      .select()
+      .from(binsTable)
+      .where(
+        and(
+          eq(binsTable.warehouseId, warehouseId.value),
+          ...binFilters(filter),
+        ),
+      );
+    return rows.map((row) => Bin.fromSnapshot(rowToBinSnapshot(row)));
+  }
+
+  async findByScope(scopeId: ScopeId, filter: ListBinsFilter): Promise<Bin[]> {
+    const rows = await this.db
+      .select()
+      .from(binsTable)
+      .where(and(eq(binsTable.scopeId, scopeId.value), ...binFilters(filter)));
+    return rows.map((row) => Bin.fromSnapshot(rowToBinSnapshot(row)));
+  }
+}
+
+/** Condiciones AND del filtro común de bins (estado/tipo/zona). */
+function binFilters(filter: ListBinsFilter): SQL[] {
+  const conditions: SQL[] = [];
+  if (filter.status !== undefined) {
+    conditions.push(eq(binsTable.status, filter.status));
+  }
+  if (filter.kind !== undefined) {
+    conditions.push(eq(binsTable.kind, filter.kind));
+  }
+  if (filter.zoneId !== undefined) {
+    conditions.push(eq(binsTable.zoneId, filter.zoneId));
+  }
+  return conditions;
+}

--- a/packages/warehouse-postgres/src/inventory/drizzle-bin.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-bin.repository.ts
@@ -1,5 +1,4 @@
 import { and, eq, type SQL } from 'drizzle-orm';
-import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import {
   Bin,
   BinId,
@@ -10,6 +9,7 @@ import type {
   ListBinsFilter,
 } from '@globalemergency/warehouse-core/inventory';
 import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import type { WmsDatabase } from './db.js';
 import { binsTable } from './schema.js';
 import { rowToBinSnapshot, binSnapshotToRow } from './mappers.js';
 
@@ -19,7 +19,7 @@ import { rowToBinSnapshot, binSnapshotToRow } from './mappers.js';
  * finders reconstruyen vía `Bin.fromSnapshot`.
  */
 export class DrizzleBinRepository implements BinRepository {
-  constructor(private readonly db: NodePgDatabase) {}
+  constructor(private readonly db: WmsDatabase) {}
 
   async save(bin: Bin): Promise<void> {
     const s = bin.toSnapshot();

--- a/packages/warehouse-postgres/src/inventory/drizzle-stock-item.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-stock-item.repository.test.ts
@@ -12,7 +12,10 @@ import {
 } from '@globalemergency/warehouse-core/inventory';
 import { ScopeId } from '@globalemergency/warehouse-core/kernel';
 import { DrizzleStockItemRepository } from './drizzle-stock-item.repository.js';
-import { StaleStockItemError } from './stock-persistence-errors.js';
+import {
+  StaleStockItemError,
+  DuplicateStockItemError,
+} from './stock-persistence-errors.js';
 import {
   newPool,
   resetSchema,
@@ -136,14 +139,32 @@ describe('DrizzleStockItemRepository (integración)', () => {
     assert.equal(loaded?.version, 2);
   });
 
-  it('el índice de grano rechaza un segundo item en el mismo grano (lote nulo)', async () => {
+  it('el índice de grano traduce el duplicado (lote nulo) a DuplicateStockItemError', async () => {
     const scopeId = ScopeId.create();
     const binId = BinId.create();
     const supplyId = uuid();
     await repo.save(newItem({ scopeId, binId, supplyId, lot: null }));
 
-    await assert.rejects(() =>
-      repo.save(newItem({ scopeId, binId, supplyId, lot: null })),
+    await assert.rejects(
+      () => repo.save(newItem({ scopeId, binId, supplyId, lot: null })),
+      DuplicateStockItemError,
+    );
+  });
+
+  it('el índice de grano traduce el duplicado CON lote a DuplicateStockItemError', async () => {
+    const scopeId = ScopeId.create();
+    const binId = BinId.create();
+    const supplyId = uuid();
+    await repo.save(
+      newItem({ scopeId, binId, supplyId, lot: { code: 'L-DUP' } }),
+    );
+
+    await assert.rejects(
+      () =>
+        repo.save(
+          newItem({ scopeId, binId, supplyId, lot: { code: 'L-DUP' } }),
+        ),
+      DuplicateStockItemError,
     );
   });
 

--- a/packages/warehouse-postgres/src/inventory/drizzle-stock-item.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-stock-item.repository.test.ts
@@ -1,0 +1,183 @@
+import { after, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Pool } from 'pg';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import {
+  StockItem,
+  StockItemId,
+  BinId,
+  WarehouseId,
+  Quantity,
+  StockStatus,
+} from '@globalemergency/warehouse-core/inventory';
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import { DrizzleStockItemRepository } from './drizzle-stock-item.repository.js';
+import { StaleStockItemError } from './stock-persistence-errors.js';
+import {
+  newPool,
+  resetSchema,
+  truncateAll,
+  makeDb,
+  uuid,
+} from './test-support.js';
+
+describe('DrizzleStockItemRepository (integración)', () => {
+  let pool: Pool;
+  let db: NodePgDatabase;
+  let repo: DrizzleStockItemRepository;
+
+  before(async () => {
+    pool = newPool();
+    await resetSchema(pool);
+    db = makeDb(pool);
+    repo = new DrizzleStockItemRepository(db);
+  });
+
+  after(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(db);
+  });
+
+  function newItem(opts: {
+    scopeId: ScopeId;
+    warehouseId?: WarehouseId;
+    binId?: BinId;
+    supplyId?: string;
+    lot?: { code: string; expiresAt?: Date | null } | null;
+    amount?: number;
+    unit?: string;
+    status?: StockStatus;
+  }): StockItem {
+    return StockItem.create({
+      id: StockItemId.create(),
+      scopeId: opts.scopeId,
+      warehouseId: opts.warehouseId ?? WarehouseId.create(),
+      binId: opts.binId ?? BinId.create(),
+      supplyId: opts.supplyId ?? uuid(),
+      lot: opts.lot ?? null,
+      quantity: Quantity.of(opts.amount ?? 10, opts.unit ?? 'unit'),
+      status: opts.status ?? StockStatus.Available,
+    });
+  }
+
+  it('save (alta) + findById conserva el snapshot, incluida la cantidad decimal', async () => {
+    const scopeId = ScopeId.create();
+    const item = newItem({
+      scopeId,
+      lot: { code: 'L-1', expiresAt: new Date('2027-01-01T00:00:00.000Z') },
+      amount: 12.345678,
+      unit: 'kg',
+    });
+    await repo.save(item);
+
+    const loaded = await repo.findById(item.id);
+    assert.ok(loaded);
+    assert.deepEqual(loaded.toSnapshot(), item.toSnapshot());
+    assert.equal(loaded.quantity.amount, 12.345678);
+  });
+
+  it('findByGrain resuelve por (bin, supply, lote, estado), con lote nulo', async () => {
+    const scopeId = ScopeId.create();
+    const binId = BinId.create();
+    const supplyId = uuid();
+    const withLot = newItem({
+      scopeId,
+      binId,
+      supplyId,
+      lot: { code: 'L-9' },
+    });
+    const noLot = newItem({ scopeId, binId, supplyId, lot: null });
+    await repo.save(withLot);
+    await repo.save(noLot);
+
+    const foundNoLot = await repo.findByGrain({
+      binId: binId.value,
+      supplyId,
+      lotCode: null,
+      status: StockStatus.Available,
+    });
+    assert.ok(foundNoLot);
+    assert.equal(foundNoLot.id.value, noLot.id.value);
+
+    const foundLot = await repo.findByGrain({
+      binId: binId.value,
+      supplyId,
+      lotCode: 'L-9',
+      status: StockStatus.Available,
+    });
+    assert.ok(foundLot);
+    assert.equal(foundLot.id.value, withLot.id.value);
+  });
+
+  it('save aplica concurrencia optimista: un update obsoleto es rechazado', async () => {
+    const scopeId = ScopeId.create();
+    const item = newItem({ scopeId, amount: 10, unit: 'unit' });
+    await repo.save(item);
+
+    // Dos lecturas independientes del mismo item (v1).
+    const a = await repo.findById(item.id);
+    const b = await repo.findById(item.id);
+    assert.ok(a && b);
+
+    // `a` incrementa y persiste → v2.
+    a.increase(Quantity.of(5, 'unit'));
+    await repo.save(a);
+
+    // `b` (todavía v1) intenta persistir → StaleStockItemError.
+    b.decrease(Quantity.of(2, 'unit'));
+    await assert.rejects(() => repo.save(b), StaleStockItemError);
+
+    // El estado en BBDD es el de `a` (15).
+    const loaded = await repo.findById(item.id);
+    assert.equal(loaded?.quantity.amount, 15);
+    assert.equal(loaded?.version, 2);
+  });
+
+  it('el índice de grano rechaza un segundo item en el mismo grano (lote nulo)', async () => {
+    const scopeId = ScopeId.create();
+    const binId = BinId.create();
+    const supplyId = uuid();
+    await repo.save(newItem({ scopeId, binId, supplyId, lot: null }));
+
+    await assert.rejects(() =>
+      repo.save(newItem({ scopeId, binId, supplyId, lot: null })),
+    );
+  });
+
+  it('findByBin / findByWarehouse / findByScope filtran por estado y producto', async () => {
+    const scopeId = ScopeId.create();
+    const warehouseId = WarehouseId.create();
+    const binId = BinId.create();
+    const supplyId = uuid();
+    const available = newItem({
+      scopeId,
+      warehouseId,
+      binId,
+      supplyId,
+      status: StockStatus.Available,
+    });
+    const reserved = newItem({
+      scopeId,
+      warehouseId,
+      binId,
+      supplyId,
+      status: StockStatus.Reserved,
+    });
+    await repo.save(available);
+    await repo.save(reserved);
+
+    assert.equal((await repo.findByBin(binId, {})).length, 2);
+    assert.equal(
+      (await repo.findByBin(binId, { status: StockStatus.Reserved })).length,
+      1,
+    );
+    assert.equal(
+      (await repo.findByWarehouse(warehouseId, { supplyId })).length,
+      2,
+    );
+    assert.equal((await repo.findByScope(scopeId, {})).length, 2);
+  });
+});

--- a/packages/warehouse-postgres/src/inventory/drizzle-stock-item.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-stock-item.repository.ts
@@ -1,0 +1,154 @@
+import { and, eq, isNull, type SQL } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import {
+  StockItem,
+  StockItemId,
+  BinId,
+  WarehouseId,
+} from '@globalemergency/warehouse-core/inventory';
+import type {
+  StockItemRepository,
+  ListStockFilter,
+  StockGrainKey,
+} from '@globalemergency/warehouse-core/inventory';
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import { stockItemsTable } from './schema.js';
+import { rowToStockItemSnapshot, stockItemSnapshotToRow } from './mappers.js';
+import { StaleStockItemError } from './stock-persistence-errors.js';
+
+/**
+ * Adaptador Drizzle/Postgres del puerto {@link StockItemRepository}.
+ *
+ * Concurrencia optimista: un item nuevo (version === 1) se INSERTA; uno
+ * existente se ACTUALIZA con `WHERE id = :id AND version = :version - 1`. Si el
+ * UPDATE no afecta filas, otro proceso ganó la carrera → {@link StaleStockItemError}.
+ *
+ * El grano único (bin, supply, lote, estado) lo garantizan los índices únicos
+ * parciales de la migración `wms_0001` (uno para lote presente, otro para lote
+ * nulo): la BBDD rechaza un segundo item en el mismo grano.
+ */
+export class DrizzleStockItemRepository implements StockItemRepository {
+  constructor(private readonly db: NodePgDatabase) {}
+
+  async save(item: StockItem): Promise<void> {
+    const s = item.toSnapshot();
+    if (s.version === 1) {
+      // Alta: el índice de grano rechaza un duplicado con un error de la BBDD.
+      await this.db.insert(stockItemsTable).values(stockItemSnapshotToRow(s));
+      return;
+    }
+
+    // Actualización con guarda de versión. `version - 1` es la versión que el
+    // agregado leyó antes de mutar; si la fila ya no la tiene, está obsoleta.
+    const result = await this.db
+      .update(stockItemsTable)
+      .set({
+        // El grano (bin/supply/lote/estado) es inmutable; sólo cambian
+        // cantidad, versión y updatedAt.
+        quantityAmount: s.quantityAmount.toString(),
+        version: s.version,
+        updatedAt: s.updatedAt,
+      })
+      .where(
+        and(
+          eq(stockItemsTable.id, s.id),
+          eq(stockItemsTable.version, s.version - 1),
+        ),
+      )
+      .returning({ id: stockItemsTable.id });
+
+    if (result.length === 0) {
+      throw new StaleStockItemError(s.id, s.version - 1);
+    }
+  }
+
+  async findById(id: StockItemId): Promise<StockItem | null> {
+    const [row] = await this.db
+      .select()
+      .from(stockItemsTable)
+      .where(eq(stockItemsTable.id, id.value))
+      .limit(1);
+    return row ? StockItem.fromSnapshot(rowToStockItemSnapshot(row)) : null;
+  }
+
+  async findByGrain(key: StockGrainKey): Promise<StockItem | null> {
+    // El lote nulo se compara con IS NULL, no con `= NULL`.
+    const lotCondition =
+      key.lotCode === null
+        ? isNull(stockItemsTable.lotCode)
+        : eq(stockItemsTable.lotCode, key.lotCode);
+    const [row] = await this.db
+      .select()
+      .from(stockItemsTable)
+      .where(
+        and(
+          eq(stockItemsTable.binId, key.binId),
+          eq(stockItemsTable.supplyId, key.supplyId),
+          lotCondition,
+          eq(stockItemsTable.status, key.status),
+        ),
+      )
+      .limit(1);
+    return row ? StockItem.fromSnapshot(rowToStockItemSnapshot(row)) : null;
+  }
+
+  async findByBin(binId: BinId, filter: ListStockFilter): Promise<StockItem[]> {
+    const rows = await this.db
+      .select()
+      .from(stockItemsTable)
+      .where(
+        and(eq(stockItemsTable.binId, binId.value), ...stockFilters(filter)),
+      );
+    return rows.map((row) =>
+      StockItem.fromSnapshot(rowToStockItemSnapshot(row)),
+    );
+  }
+
+  async findByWarehouse(
+    warehouseId: WarehouseId,
+    filter: ListStockFilter,
+  ): Promise<StockItem[]> {
+    const rows = await this.db
+      .select()
+      .from(stockItemsTable)
+      .where(
+        and(
+          eq(stockItemsTable.warehouseId, warehouseId.value),
+          ...stockFilters(filter),
+        ),
+      );
+    return rows.map((row) =>
+      StockItem.fromSnapshot(rowToStockItemSnapshot(row)),
+    );
+  }
+
+  async findByScope(
+    scopeId: ScopeId,
+    filter: ListStockFilter,
+  ): Promise<StockItem[]> {
+    const rows = await this.db
+      .select()
+      .from(stockItemsTable)
+      .where(
+        and(
+          eq(stockItemsTable.scopeId, scopeId.value),
+          ...stockFilters(filter),
+        ),
+      );
+    return rows.map((row) =>
+      StockItem.fromSnapshot(rowToStockItemSnapshot(row)),
+    );
+  }
+}
+
+/** Condiciones AND del filtro común de stock (estado/producto). */
+function stockFilters(filter: ListStockFilter): SQL[] {
+  const conditions: SQL[] = [];
+  if (filter.status !== undefined) {
+    conditions.push(eq(stockItemsTable.status, filter.status));
+  }
+  if (filter.supplyId !== undefined) {
+    conditions.push(eq(stockItemsTable.supplyId, filter.supplyId));
+  }
+  return conditions;
+}

--- a/packages/warehouse-postgres/src/inventory/drizzle-stock-item.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-stock-item.repository.ts
@@ -1,5 +1,4 @@
 import { and, eq, isNull, type SQL } from 'drizzle-orm';
-import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import {
   StockItem,
   StockItemId,
@@ -12,9 +11,14 @@ import type {
   StockGrainKey,
 } from '@globalemergency/warehouse-core/inventory';
 import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import type { WmsDatabase } from './db.js';
 import { stockItemsTable } from './schema.js';
 import { rowToStockItemSnapshot, stockItemSnapshotToRow } from './mappers.js';
-import { StaleStockItemError } from './stock-persistence-errors.js';
+import {
+  StaleStockItemError,
+  DuplicateStockItemError,
+} from './stock-persistence-errors.js';
+import { isUniqueViolation } from './pg-errors.js';
 
 /**
  * Adaptador Drizzle/Postgres del puerto {@link StockItemRepository}.
@@ -28,13 +32,26 @@ import { StaleStockItemError } from './stock-persistence-errors.js';
  * nulo): la BBDD rechaza un segundo item en el mismo grano.
  */
 export class DrizzleStockItemRepository implements StockItemRepository {
-  constructor(private readonly db: NodePgDatabase) {}
+  constructor(private readonly db: WmsDatabase) {}
 
   async save(item: StockItem): Promise<void> {
     const s = item.toSnapshot();
     if (s.version === 1) {
-      // Alta: el índice de grano rechaza un duplicado con un error de la BBDD.
-      await this.db.insert(stockItemsTable).values(stockItemSnapshotToRow(s));
+      // Alta: el índice de grano rechaza un duplicado con un `23505` crudo de
+      // Postgres. Se traduce a un error tipado para que el host no vea un 500.
+      try {
+        await this.db.insert(stockItemsTable).values(stockItemSnapshotToRow(s));
+      } catch (err) {
+        if (isUniqueViolation(err)) {
+          throw new DuplicateStockItemError(
+            s.binId,
+            s.supplyId,
+            s.lotCode,
+            s.status,
+          );
+        }
+        throw err;
+      }
       return;
     }
 

--- a/packages/warehouse-postgres/src/inventory/drizzle-stock-movement.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-stock-movement.repository.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@globalemergency/warehouse-core/inventory';
 import { ScopeId } from '@globalemergency/warehouse-core/kernel';
 import { DrizzleStockMovementRepository } from './drizzle-stock-movement.repository.js';
+import { IdempotencyKeyConflictError } from './stock-persistence-errors.js';
 import { newPool, resetSchema, truncateAll, makeDb } from './test-support.js';
 
 describe('DrizzleStockMovementRepository (integración)', () => {
@@ -78,6 +79,40 @@ describe('DrizzleStockMovementRepository (integración)', () => {
     const byKey = await repo.findByIdempotencyKey(scopeId, key);
     assert.ok(byKey);
     assert.equal(byKey.id.value, first.id.value);
+  });
+
+  it('misma clave + movimiento DISTINTO lanza IdempotencyKeyConflictError y deja una sola fila', async () => {
+    const scopeId = ScopeId.create();
+    const toItemId = StockItemId.create();
+    const key = 'albaran-99';
+
+    // Primer asiento con la clave.
+    const first = receipt({
+      scopeId,
+      toItemId,
+      amount: 8,
+      idempotencyKey: key,
+    });
+    await repo.append(first);
+
+    // Reutiliza la clave para un movimiento distinto (otra cantidad): conflicto.
+    const conflicting = receipt({
+      scopeId,
+      toItemId,
+      amount: 999,
+      idempotencyKey: key,
+    });
+    await assert.rejects(
+      () => repo.append(conflicting),
+      IdempotencyKeyConflictError,
+    );
+
+    // El asiento en conflicto NO se persistió: sigue habiendo una sola fila (la
+    // original).
+    const all = await repo.findByScope(scopeId, {});
+    assert.equal(all.length, 1);
+    assert.equal(all[0]?.id.value, first.id.value);
+    assert.equal(all[0]?.quantity.amount, 8);
   });
 
   it('la clave de idempotencia es única por scope, no global', async () => {

--- a/packages/warehouse-postgres/src/inventory/drizzle-stock-movement.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-stock-movement.repository.test.ts
@@ -1,0 +1,167 @@
+import { after, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Pool } from 'pg';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import {
+  StockMovement,
+  StockMovementId,
+  StockItemId,
+  Quantity,
+  MovementKind,
+} from '@globalemergency/warehouse-core/inventory';
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import { DrizzleStockMovementRepository } from './drizzle-stock-movement.repository.js';
+import { newPool, resetSchema, truncateAll, makeDb } from './test-support.js';
+
+describe('DrizzleStockMovementRepository (integración)', () => {
+  let pool: Pool;
+  let db: NodePgDatabase;
+  let repo: DrizzleStockMovementRepository;
+
+  before(async () => {
+    pool = newPool();
+    await resetSchema(pool);
+    db = makeDb(pool);
+    repo = new DrizzleStockMovementRepository(db);
+  });
+
+  after(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(db);
+  });
+
+  function receipt(opts: {
+    scopeId: ScopeId;
+    toItemId: StockItemId;
+    amount?: number;
+    idempotencyKey?: string | null;
+  }): StockMovement {
+    return StockMovement.record({
+      id: StockMovementId.create(),
+      scopeId: opts.scopeId,
+      kind: MovementKind.Receipt,
+      quantity: Quantity.of(opts.amount ?? 8, 'unit'),
+      toItemId: opts.toItemId,
+      reason: 'Entrada de donación',
+      idempotencyKey: opts.idempotencyKey ?? null,
+    });
+  }
+
+  it('append + findById conserva el asiento', async () => {
+    const scopeId = ScopeId.create();
+    const movement = receipt({ scopeId, toItemId: StockItemId.create() });
+    await repo.append(movement);
+
+    const loaded = await repo.findById(movement.id);
+    assert.ok(loaded);
+    assert.deepEqual(loaded.toSnapshot(), movement.toSnapshot());
+  });
+
+  it('idempotencia: la misma clave insertada dos veces deja una sola fila', async () => {
+    const scopeId = ScopeId.create();
+    const toItemId = StockItemId.create();
+    const key = 'albaran-42';
+
+    const first = receipt({ scopeId, toItemId, idempotencyKey: key });
+    await repo.append(first);
+    // Reintento con la misma clave (id distinto) → no-op.
+    const retry = receipt({ scopeId, toItemId, idempotencyKey: key });
+    await repo.append(retry);
+
+    const all = await repo.findByScope(scopeId, {});
+    assert.equal(all.length, 1);
+    assert.equal(all[0]?.id.value, first.id.value);
+
+    const byKey = await repo.findByIdempotencyKey(scopeId, key);
+    assert.ok(byKey);
+    assert.equal(byKey.id.value, first.id.value);
+  });
+
+  it('la clave de idempotencia es única por scope, no global', async () => {
+    const scopeA = ScopeId.create();
+    const scopeB = ScopeId.create();
+    const key = 'ref-1';
+    await repo.append(
+      receipt({
+        scopeId: scopeA,
+        toItemId: StockItemId.create(),
+        idempotencyKey: key,
+      }),
+    );
+    await repo.append(
+      receipt({
+        scopeId: scopeB,
+        toItemId: StockItemId.create(),
+        idempotencyKey: key,
+      }),
+    );
+
+    assert.ok(await repo.findByIdempotencyKey(scopeA, key));
+    assert.ok(await repo.findByIdempotencyKey(scopeB, key));
+  });
+
+  it('findByItem devuelve movimientos donde el item es pata from o to, newest-first', async () => {
+    const scopeId = ScopeId.create();
+    const itemId = StockItemId.create();
+
+    const inbound = StockMovement.record({
+      id: StockMovementId.create(),
+      scopeId,
+      kind: MovementKind.Receipt,
+      quantity: Quantity.of(5, 'unit'),
+      toItemId: itemId,
+      occurredAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const outbound = StockMovement.record({
+      id: StockMovementId.create(),
+      scopeId,
+      kind: MovementKind.Issue,
+      quantity: Quantity.of(2, 'unit'),
+      fromItemId: itemId,
+      occurredAt: new Date('2026-02-01T00:00:00.000Z'),
+    });
+    await repo.append(inbound);
+    await repo.append(outbound);
+
+    const ledger = await repo.findByItem(itemId, {});
+    assert.equal(ledger.length, 2);
+    // newest-first: el issue de febrero antes que el receipt de enero.
+    assert.equal(ledger[0]?.id.value, outbound.id.value);
+    assert.equal(ledger[1]?.id.value, inbound.id.value);
+  });
+
+  it('findByScope filtra por tipo y ventana temporal', async () => {
+    const scopeId = ScopeId.create();
+    const early = StockMovement.record({
+      id: StockMovementId.create(),
+      scopeId,
+      kind: MovementKind.Receipt,
+      quantity: Quantity.of(1, 'unit'),
+      toItemId: StockItemId.create(),
+      occurredAt: new Date('2026-01-10T00:00:00.000Z'),
+    });
+    const late = StockMovement.record({
+      id: StockMovementId.create(),
+      scopeId,
+      kind: MovementKind.Issue,
+      quantity: Quantity.of(1, 'unit'),
+      fromItemId: StockItemId.create(),
+      occurredAt: new Date('2026-03-10T00:00:00.000Z'),
+    });
+    await repo.append(early);
+    await repo.append(late);
+
+    assert.equal(
+      (await repo.findByScope(scopeId, { kind: MovementKind.Issue })).length,
+      1,
+    );
+    const windowed = await repo.findByScope(scopeId, {
+      occurredFrom: new Date('2026-02-01T00:00:00.000Z'),
+    });
+    assert.equal(windowed.length, 1);
+    assert.equal(windowed[0]?.id.value, late.id.value);
+  });
+});

--- a/packages/warehouse-postgres/src/inventory/drizzle-stock-movement.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-stock-movement.repository.ts
@@ -1,0 +1,136 @@
+import { and, desc, eq, gte, isNotNull, lte, or, type SQL } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import {
+  StockMovement,
+  StockMovementId,
+  StockItemId,
+} from '@globalemergency/warehouse-core/inventory';
+import type {
+  StockMovementRepository,
+  ListMovementsFilter,
+} from '@globalemergency/warehouse-core/inventory';
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import { stockMovementsTable } from './schema.js';
+import {
+  rowToStockMovementSnapshot,
+  stockMovementSnapshotToRow,
+} from './mappers.js';
+
+/**
+ * Adaptador Drizzle/Postgres del puerto {@link StockMovementRepository}. El
+ * libro mayor es inmutable: `append` sólo inserta, nunca actualiza ni borra.
+ *
+ * Idempotencia: el índice único parcial `(scope_id, idempotency_key)` de la
+ * migración `wms_0001` garantiza que una entrada reintentada con la misma clave
+ * se registre una sola vez. Ante conflicto de clave se hace no-op
+ * (`onConflictDoNothing`), de modo que un recibo reintentado deja exactamente
+ * un asiento.
+ */
+export class DrizzleStockMovementRepository implements StockMovementRepository {
+  constructor(private readonly db: NodePgDatabase) {}
+
+  async append(movement: StockMovement): Promise<void> {
+    const s = movement.toSnapshot();
+    const insert = this.db
+      .insert(stockMovementsTable)
+      .values(stockMovementSnapshotToRow(s));
+    // Con clave de idempotencia, el reintento es no-op; sin clave no hay grano
+    // que colisione y siempre se inserta.
+    if (s.idempotencyKey !== null) {
+      // El árbitro del ON CONFLICT debe replicar el predicado del índice único
+      // parcial (`WHERE idempotency_key IS NOT NULL`), de ahí el `targetWhere`.
+      await insert.onConflictDoNothing({
+        target: [
+          stockMovementsTable.scopeId,
+          stockMovementsTable.idempotencyKey,
+        ],
+        where: isNotNull(stockMovementsTable.idempotencyKey),
+      });
+    } else {
+      await insert;
+    }
+  }
+
+  async findById(id: StockMovementId): Promise<StockMovement | null> {
+    const [row] = await this.db
+      .select()
+      .from(stockMovementsTable)
+      .where(eq(stockMovementsTable.id, id.value))
+      .limit(1);
+    return row
+      ? StockMovement.fromSnapshot(rowToStockMovementSnapshot(row))
+      : null;
+  }
+
+  async findByIdempotencyKey(
+    scopeId: ScopeId,
+    idempotencyKey: string,
+  ): Promise<StockMovement | null> {
+    const [row] = await this.db
+      .select()
+      .from(stockMovementsTable)
+      .where(
+        and(
+          eq(stockMovementsTable.scopeId, scopeId.value),
+          eq(stockMovementsTable.idempotencyKey, idempotencyKey),
+        ),
+      )
+      .limit(1);
+    return row
+      ? StockMovement.fromSnapshot(rowToStockMovementSnapshot(row))
+      : null;
+  }
+
+  async findByItem(
+    itemId: StockItemId,
+    filter: ListMovementsFilter,
+  ): Promise<StockMovement[]> {
+    // Un item aparece como pata `from` o `to`: se filtra por cualquiera de las dos.
+    const legCondition = or(
+      eq(stockMovementsTable.fromItemId, itemId.value),
+      eq(stockMovementsTable.toItemId, itemId.value),
+    );
+    const rows = await this.db
+      .select()
+      .from(stockMovementsTable)
+      .where(and(legCondition, ...movementFilters(filter)))
+      .orderBy(desc(stockMovementsTable.occurredAt));
+    return rows.map((row) =>
+      StockMovement.fromSnapshot(rowToStockMovementSnapshot(row)),
+    );
+  }
+
+  async findByScope(
+    scopeId: ScopeId,
+    filter: ListMovementsFilter,
+  ): Promise<StockMovement[]> {
+    const rows = await this.db
+      .select()
+      .from(stockMovementsTable)
+      .where(
+        and(
+          eq(stockMovementsTable.scopeId, scopeId.value),
+          ...movementFilters(filter),
+        ),
+      )
+      .orderBy(desc(stockMovementsTable.occurredAt));
+    return rows.map((row) =>
+      StockMovement.fromSnapshot(rowToStockMovementSnapshot(row)),
+    );
+  }
+}
+
+/** Condiciones AND del filtro común del libro mayor (tipo/ventana temporal). */
+function movementFilters(filter: ListMovementsFilter): SQL[] {
+  const conditions: SQL[] = [];
+  if (filter.kind !== undefined) {
+    conditions.push(eq(stockMovementsTable.kind, filter.kind));
+  }
+  if (filter.occurredFrom !== undefined) {
+    conditions.push(gte(stockMovementsTable.occurredAt, filter.occurredFrom));
+  }
+  if (filter.occurredTo !== undefined) {
+    conditions.push(lte(stockMovementsTable.occurredAt, filter.occurredTo));
+  }
+  return conditions;
+}

--- a/packages/warehouse-postgres/src/inventory/drizzle-stock-movement.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-stock-movement.repository.ts
@@ -1,5 +1,4 @@
 import { and, desc, eq, gte, isNotNull, lte, or, type SQL } from 'drizzle-orm';
-import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import {
   StockMovement,
   StockMovementId,
@@ -10,11 +9,13 @@ import type {
   ListMovementsFilter,
 } from '@globalemergency/warehouse-core/inventory';
 import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import type { WmsDatabase } from './db.js';
 import { stockMovementsTable } from './schema.js';
 import {
   rowToStockMovementSnapshot,
   stockMovementSnapshotToRow,
 } from './mappers.js';
+import { IdempotencyKeyConflictError } from './stock-persistence-errors.js';
 
 /**
  * Adaptador Drizzle/Postgres del puerto {@link StockMovementRepository}. El
@@ -22,32 +23,51 @@ import {
  *
  * Idempotencia: el índice único parcial `(scope_id, idempotency_key)` de la
  * migración `wms_0001` garantiza que una entrada reintentada con la misma clave
- * se registre una sola vez. Ante conflicto de clave se hace no-op
- * (`onConflictDoNothing`), de modo que un recibo reintentado deja exactamente
- * un asiento.
+ * se registre una sola vez. Ante conflicto de clave, si el asiento ya persistido
+ * es el MISMO movimiento lógico (mismo tipo/cantidad/unidad/patas) es un
+ * reintento legítimo → no-op; si es DISTINTO, la clave se está reutilizando en
+ * conflicto y se lanza {@link IdempotencyKeyConflictError} en vez de silenciar
+ * un doble-registro divergente.
  */
 export class DrizzleStockMovementRepository implements StockMovementRepository {
-  constructor(private readonly db: NodePgDatabase) {}
+  constructor(private readonly db: WmsDatabase) {}
 
   async append(movement: StockMovement): Promise<void> {
     const s = movement.toSnapshot();
-    const insert = this.db
+    // Sin clave de idempotencia no hay grano que colisione: inserción directa.
+    if (s.idempotencyKey === null) {
+      await this.db
+        .insert(stockMovementsTable)
+        .values(stockMovementSnapshotToRow(s));
+      return;
+    }
+
+    // Con clave: inserta con `onConflictDoNothing` y `.returning` para saber si
+    // se insertó (fila devuelta) o chocó (sin filas). El árbitro replica el
+    // predicado del índice único parcial (`WHERE idempotency_key IS NOT NULL`).
+    const inserted = await this.db
       .insert(stockMovementsTable)
-      .values(stockMovementSnapshotToRow(s));
-    // Con clave de idempotencia, el reintento es no-op; sin clave no hay grano
-    // que colisione y siempre se inserta.
-    if (s.idempotencyKey !== null) {
-      // El árbitro del ON CONFLICT debe replicar el predicado del índice único
-      // parcial (`WHERE idempotency_key IS NOT NULL`), de ahí el `targetWhere`.
-      await insert.onConflictDoNothing({
+      .values(stockMovementSnapshotToRow(s))
+      .onConflictDoNothing({
         target: [
           stockMovementsTable.scopeId,
           stockMovementsTable.idempotencyKey,
         ],
         where: isNotNull(stockMovementsTable.idempotencyKey),
-      });
-    } else {
-      await insert;
+      })
+      .returning({ id: stockMovementsTable.id });
+
+    if (inserted.length > 0) return; // Insertado: nada más que hacer.
+
+    // Conflicto de clave: carga el asiento existente y compáralo. Si es el mismo
+    // movimiento lógico es un reintento idempotente (no-op); si difiere, la
+    // clave se reutiliza para otro movimiento → error tipado.
+    const existing = await this.findByIdempotencyKey(
+      movement.scopeId,
+      s.idempotencyKey,
+    );
+    if (existing === null || !isSameLogicalMovement(existing, movement)) {
+      throw new IdempotencyKeyConflictError(s.scopeId, s.idempotencyKey);
     }
   }
 
@@ -94,7 +114,11 @@ export class DrizzleStockMovementRepository implements StockMovementRepository {
       .select()
       .from(stockMovementsTable)
       .where(and(legCondition, ...movementFilters(filter)))
-      .orderBy(desc(stockMovementsTable.occurredAt));
+      // Orden determinista: por instante desc y, para empates, por id desc.
+      .orderBy(
+        desc(stockMovementsTable.occurredAt),
+        desc(stockMovementsTable.id),
+      );
     return rows.map((row) =>
       StockMovement.fromSnapshot(rowToStockMovementSnapshot(row)),
     );
@@ -113,11 +137,34 @@ export class DrizzleStockMovementRepository implements StockMovementRepository {
           ...movementFilters(filter),
         ),
       )
-      .orderBy(desc(stockMovementsTable.occurredAt));
+      // Orden determinista: por instante desc y, para empates, por id desc.
+      .orderBy(
+        desc(stockMovementsTable.occurredAt),
+        desc(stockMovementsTable.id),
+      );
     return rows.map((row) =>
       StockMovement.fromSnapshot(rowToStockMovementSnapshot(row)),
     );
   }
+}
+
+/**
+ * True si dos movimientos representan el MISMO asiento lógico: mismo tipo,
+ * cantidad, unidad y patas (from/to). El id y el `occurredAt` pueden diferir
+ * entre el reintento y el original y aun así ser el mismo movimiento; lo que
+ * distingue un reintento legítimo de una reutilización en conflicto de la clave
+ * es que el contenido del asiento coincida.
+ */
+function isSameLogicalMovement(a: StockMovement, b: StockMovement): boolean {
+  const x = a.toSnapshot();
+  const y = b.toSnapshot();
+  return (
+    x.kind === y.kind &&
+    x.quantityAmount === y.quantityAmount &&
+    x.unit === y.unit &&
+    x.fromItemId === y.fromItemId &&
+    x.toItemId === y.toItemId
+  );
 }
 
 /** Condiciones AND del filtro común del libro mayor (tipo/ventana temporal). */

--- a/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.test.ts
@@ -100,6 +100,44 @@ describe('DrizzleWarehouseRepository (integración)', () => {
     assert.equal(onlyActive[0]?.code, 'A');
   });
 
+  it('findByScope lista varios almacenes agrupando sus zonas correctamente (sin N+1)', async () => {
+    const scopeId = ScopeId.create();
+    const a = newWarehouse(scopeId, 'A'); // 2 zonas: REC, ALM
+    const b = newWarehouse(scopeId, 'B');
+    // A B le añadimos una tercera zona para distinguir el agrupado por almacén.
+    b.addZone({
+      id: ZoneId.create(),
+      code: 'EXP',
+      name: 'Expedición',
+      kind: ZoneKind.Shipping,
+    });
+    await repo.save(a);
+    await repo.save(b);
+
+    const all = await repo.findByScope(scopeId, {});
+    assert.equal(all.length, 2);
+
+    const loadedA = all.find((w) => w.code === 'A');
+    const loadedB = all.find((w) => w.code === 'B');
+    assert.ok(loadedA && loadedB);
+
+    // Cada almacén recibe SÓLO sus zonas (agrupado por warehouse_id correcto).
+    assert.deepEqual(loadedA.zones.map((z) => z.code).sort(), ['ALM', 'REC']);
+    assert.deepEqual(loadedB.zones.map((z) => z.code).sort(), [
+      'ALM',
+      'EXP',
+      'REC',
+    ]);
+    // Reconstrucción fiel del agregado.
+    assert.deepEqual(loadedA.toSnapshot(), a.toSnapshot());
+    assert.deepEqual(loadedB.toSnapshot(), b.toSnapshot());
+  });
+
+  it('findByScope con cero almacenes devuelve lista vacía (no consulta zonas)', async () => {
+    const empty = await repo.findByScope(ScopeId.create(), {});
+    assert.deepEqual(empty, []);
+  });
+
   it('save reemplaza las zonas (upsert del agregado completo)', async () => {
     const scopeId = ScopeId.create();
     const warehouse = newWarehouse(scopeId);

--- a/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.test.ts
@@ -1,0 +1,133 @@
+import { after, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Pool } from 'pg';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import {
+  Warehouse,
+  WarehouseId,
+  ZoneId,
+  ZoneKind,
+  WarehouseStatus,
+} from '@globalemergency/warehouse-core/inventory';
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import { DrizzleWarehouseRepository } from './drizzle-warehouse.repository.js';
+import { newPool, resetSchema, truncateAll, makeDb } from './test-support.js';
+
+describe('DrizzleWarehouseRepository (integración)', () => {
+  let pool: Pool;
+  let db: NodePgDatabase;
+  let repo: DrizzleWarehouseRepository;
+
+  before(async () => {
+    pool = newPool();
+    await resetSchema(pool);
+    db = makeDb(pool);
+    repo = new DrizzleWarehouseRepository(db);
+  });
+
+  after(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(db);
+  });
+
+  function newWarehouse(scopeId: ScopeId, code = 'ALM-1'): Warehouse {
+    return Warehouse.create({
+      id: WarehouseId.create(),
+      scopeId,
+      code,
+      name: 'Almacén Central',
+      address: 'Calle Mayor 1',
+      geo: { lat: 40.4, lng: -3.7 },
+      zones: [
+        {
+          id: ZoneId.create(),
+          code: 'REC',
+          name: 'Recepción',
+          kind: ZoneKind.Receiving,
+        },
+        {
+          id: ZoneId.create(),
+          code: 'ALM',
+          name: 'Almacenaje',
+          kind: ZoneKind.Storage,
+        },
+      ],
+    });
+  }
+
+  it('save + findById reconstruye el agregado con sus zonas', async () => {
+    const scopeId = ScopeId.create();
+    const warehouse = newWarehouse(scopeId);
+    await repo.save(warehouse);
+
+    const loaded = await repo.findById(warehouse.id);
+    assert.ok(loaded);
+    assert.deepEqual(loaded.toSnapshot(), warehouse.toSnapshot());
+    assert.equal(loaded.zones.length, 2);
+  });
+
+  it('findByCode resuelve por scope + código', async () => {
+    const scopeId = ScopeId.create();
+    const warehouse = newWarehouse(scopeId, 'DEP-9');
+    await repo.save(warehouse);
+
+    const found = await repo.findByCode(scopeId, 'DEP-9');
+    assert.ok(found);
+    assert.equal(found.id.value, warehouse.id.value);
+
+    const other = await repo.findByCode(ScopeId.create(), 'DEP-9');
+    assert.equal(other, null);
+  });
+
+  it('findByScope filtra por estado', async () => {
+    const scopeId = ScopeId.create();
+    const active = newWarehouse(scopeId, 'A');
+    const archived = newWarehouse(scopeId, 'B');
+    archived.archive();
+    await repo.save(active);
+    await repo.save(archived);
+
+    const all = await repo.findByScope(scopeId, {});
+    assert.equal(all.length, 2);
+
+    const onlyActive = await repo.findByScope(scopeId, {
+      status: WarehouseStatus.Active,
+    });
+    assert.equal(onlyActive.length, 1);
+    assert.equal(onlyActive[0]?.code, 'A');
+  });
+
+  it('save reemplaza las zonas (upsert del agregado completo)', async () => {
+    const scopeId = ScopeId.create();
+    const warehouse = newWarehouse(scopeId);
+    await repo.save(warehouse);
+
+    warehouse.addZone({
+      id: ZoneId.create(),
+      code: 'EXP',
+      name: 'Expedición',
+      kind: ZoneKind.Shipping,
+    });
+    warehouse.renameZone(warehouse.zones[0]!.id, 'Recepción Norte');
+    await repo.save(warehouse);
+
+    const loaded = await repo.findById(warehouse.id);
+    assert.ok(loaded);
+    assert.equal(loaded.zones.length, 3);
+    assert.deepEqual(loaded.zones.map((z) => z.code).sort(), [
+      'ALM',
+      'EXP',
+      'REC',
+    ]);
+    const rec = loaded.zones.find((z) => z.code === 'REC');
+    assert.equal(rec?.name, 'Recepción Norte');
+  });
+
+  it('findById devuelve null cuando no existe', async () => {
+    const missing = await repo.findById(WarehouseId.create());
+    assert.equal(missing, null);
+  });
+});

--- a/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.ts
@@ -1,0 +1,113 @@
+import { and, eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import {
+  Warehouse,
+  WarehouseId,
+} from '@globalemergency/warehouse-core/inventory';
+import type {
+  WarehouseRepository,
+  ListWarehousesFilter,
+} from '@globalemergency/warehouse-core/inventory';
+// ScopeId es del kernel (tenencia genérica), no del módulo inventory.
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import { warehousesTable, zonesTable } from './schema.js';
+import {
+  rowsToWarehouseSnapshot,
+  warehouseSnapshotToRow,
+  zoneSnapshotToRow,
+} from './mappers.js';
+
+/**
+ * Adaptador Drizzle/Postgres del puerto {@link WarehouseRepository}. El almacén
+ * es un agregado que posee sus zonas (entidades): se persisten en su propia
+ * tabla `wms.zones` (FK con cascada) y se reconstruye vía
+ * `Warehouse.fromSnapshot` con el array de zonas.
+ *
+ * `save` es un upsert del almacén + reemplazo total de sus zonas (delete +
+ * reinsert) dentro de una transacción: las zonas son pocas y siempre se cargan
+ * con su almacén, así que el reemplazo es la operación correcta más simple y
+ * respeta el invariante de "estado completo del agregado".
+ */
+export class DrizzleWarehouseRepository implements WarehouseRepository {
+  constructor(private readonly db: NodePgDatabase) {}
+
+  async save(warehouse: Warehouse): Promise<void> {
+    const s = warehouse.toSnapshot();
+    await this.db.transaction(async (tx) => {
+      await tx
+        .insert(warehousesTable)
+        .values(warehouseSnapshotToRow(s))
+        .onConflictDoUpdate({
+          target: warehousesTable.id,
+          set: {
+            code: s.code,
+            name: s.name,
+            address: s.address,
+            lat: s.lat,
+            lng: s.lng,
+            status: s.status,
+            updatedAt: s.updatedAt,
+          },
+        });
+
+      // Reemplazo total de zonas: borra las actuales y reinserta el snapshot.
+      await tx.delete(zonesTable).where(eq(zonesTable.warehouseId, s.id));
+      if (s.zones.length > 0) {
+        await tx
+          .insert(zonesTable)
+          .values(s.zones.map((z) => zoneSnapshotToRow(s.id, z)));
+      }
+    });
+  }
+
+  async findById(id: WarehouseId): Promise<Warehouse | null> {
+    const [row] = await this.db
+      .select()
+      .from(warehousesTable)
+      .where(eq(warehousesTable.id, id.value))
+      .limit(1);
+    if (!row) return null;
+    return this.hydrate(row);
+  }
+
+  async findByCode(scopeId: ScopeId, code: string): Promise<Warehouse | null> {
+    const [row] = await this.db
+      .select()
+      .from(warehousesTable)
+      .where(
+        and(
+          eq(warehousesTable.scopeId, scopeId.value),
+          eq(warehousesTable.code, code),
+        ),
+      )
+      .limit(1);
+    if (!row) return null;
+    return this.hydrate(row);
+  }
+
+  async findByScope(
+    scopeId: ScopeId,
+    filter: ListWarehousesFilter,
+  ): Promise<Warehouse[]> {
+    const conditions = [eq(warehousesTable.scopeId, scopeId.value)];
+    if (filter.status !== undefined) {
+      conditions.push(eq(warehousesTable.status, filter.status));
+    }
+    const rows = await this.db
+      .select()
+      .from(warehousesTable)
+      .where(and(...conditions));
+    return Promise.all(rows.map((row) => this.hydrate(row)));
+  }
+
+  /** Carga las zonas del almacén y reconstruye el agregado. */
+  private async hydrate(
+    row: typeof warehousesTable.$inferSelect,
+  ): Promise<Warehouse> {
+    const zones = await this.db
+      .select()
+      .from(zonesTable)
+      .where(eq(zonesTable.warehouseId, row.id));
+    return Warehouse.fromSnapshot(rowsToWarehouseSnapshot(row, zones));
+  }
+}

--- a/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.ts
@@ -1,5 +1,4 @@
-import { and, eq } from 'drizzle-orm';
-import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { and, eq, inArray } from 'drizzle-orm';
 import {
   Warehouse,
   WarehouseId,
@@ -10,6 +9,7 @@ import type {
 } from '@globalemergency/warehouse-core/inventory';
 // ScopeId es del kernel (tenencia genérica), no del módulo inventory.
 import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import type { WmsDatabase } from './db.js';
 import { warehousesTable, zonesTable } from './schema.js';
 import {
   rowsToWarehouseSnapshot,
@@ -29,7 +29,7 @@ import {
  * respeta el invariante de "estado completo del agregado".
  */
 export class DrizzleWarehouseRepository implements WarehouseRepository {
-  constructor(private readonly db: NodePgDatabase) {}
+  constructor(private readonly db: WmsDatabase) {}
 
   async save(warehouse: Warehouse): Promise<void> {
     const s = warehouse.toSnapshot();
@@ -97,10 +97,10 @@ export class DrizzleWarehouseRepository implements WarehouseRepository {
       .select()
       .from(warehousesTable)
       .where(and(...conditions));
-    return Promise.all(rows.map((row) => this.hydrate(row)));
+    return this.hydrateMany(rows);
   }
 
-  /** Carga las zonas del almacén y reconstruye el agregado. */
+  /** Carga las zonas del almacén y reconstruye el agregado (un solo almacén). */
   private async hydrate(
     row: typeof warehousesTable.$inferSelect,
   ): Promise<Warehouse> {
@@ -109,5 +109,36 @@ export class DrizzleWarehouseRepository implements WarehouseRepository {
       .from(zonesTable)
       .where(eq(zonesTable.warehouseId, row.id));
     return Warehouse.fromSnapshot(rowsToWarehouseSnapshot(row, zones));
+  }
+
+  /**
+   * Hidrata varios almacenes sin N+1: una única consulta de zonas
+   * `WHERE warehouse_id IN (<ids>)` y agrupación en memoria por almacén, en vez
+   * de una consulta de zonas por almacén.
+   */
+  private async hydrateMany(
+    rows: (typeof warehousesTable.$inferSelect)[],
+  ): Promise<Warehouse[]> {
+    if (rows.length === 0) return [];
+
+    const ids = rows.map((row) => row.id);
+    const zones = await this.db
+      .select()
+      .from(zonesTable)
+      .where(inArray(zonesTable.warehouseId, ids));
+
+    // Agrupa las zonas por su warehouseId para el ensamblado por almacén.
+    const zonesByWarehouse = new Map<string, (typeof zones)[number][]>();
+    for (const zone of zones) {
+      const bucket = zonesByWarehouse.get(zone.warehouseId);
+      if (bucket) bucket.push(zone);
+      else zonesByWarehouse.set(zone.warehouseId, [zone]);
+    }
+
+    return rows.map((row) =>
+      Warehouse.fromSnapshot(
+        rowsToWarehouseSnapshot(row, zonesByWarehouse.get(row.id) ?? []),
+      ),
+    );
   }
 }

--- a/packages/warehouse-postgres/src/inventory/index.ts
+++ b/packages/warehouse-postgres/src/inventory/index.ts
@@ -30,5 +30,11 @@ export { DrizzleWarehouseRepository } from './drizzle-warehouse.repository.js';
 export { DrizzleBinRepository } from './drizzle-bin.repository.js';
 export { DrizzleStockItemRepository } from './drizzle-stock-item.repository.js';
 export { DrizzleStockMovementRepository } from './drizzle-stock-movement.repository.js';
-export { StaleStockItemError } from './stock-persistence-errors.js';
+export {
+  StaleStockItemError,
+  DuplicateStockItemError,
+  IdempotencyKeyConflictError,
+} from './stock-persistence-errors.js';
+export type { WmsDatabase } from './db.js';
+export { runInWmsTransaction, type WmsUnitOfWork } from './unit-of-work.js';
 export { migrateWms } from './migrate.js';

--- a/packages/warehouse-postgres/src/inventory/index.ts
+++ b/packages/warehouse-postgres/src/inventory/index.ts
@@ -1,0 +1,34 @@
+/**
+ * inventory — capa de persistencia Postgres/Drizzle del módulo `inventory` de
+ * warehouse-core. Esquema dedicado `wms.`, runner de migraciones propio y los
+ * adaptadores de los 4 puertos (warehouse/bin/stock-item/stock-movement).
+ *
+ * Consumible por cualquier host (ResponseGrid o el WMS standalone) sin acoplarse
+ * a él: sólo depende de warehouse-core y de drizzle/pg.
+ */
+export {
+  wms,
+  warehousesTable,
+  zonesTable,
+  binsTable,
+  stockItemsTable,
+  stockMovementsTable,
+} from './schema.js';
+export {
+  rowToZoneSnapshot,
+  rowsToWarehouseSnapshot,
+  warehouseSnapshotToRow,
+  zoneSnapshotToRow,
+  rowToBinSnapshot,
+  binSnapshotToRow,
+  rowToStockItemSnapshot,
+  stockItemSnapshotToRow,
+  rowToStockMovementSnapshot,
+  stockMovementSnapshotToRow,
+} from './mappers.js';
+export { DrizzleWarehouseRepository } from './drizzle-warehouse.repository.js';
+export { DrizzleBinRepository } from './drizzle-bin.repository.js';
+export { DrizzleStockItemRepository } from './drizzle-stock-item.repository.js';
+export { DrizzleStockMovementRepository } from './drizzle-stock-movement.repository.js';
+export { StaleStockItemError } from './stock-persistence-errors.js';
+export { migrateWms } from './migrate.js';

--- a/packages/warehouse-postgres/src/inventory/mappers.ts
+++ b/packages/warehouse-postgres/src/inventory/mappers.ts
@@ -1,0 +1,221 @@
+import type {
+  WarehouseSnapshot,
+  ZoneSnapshot,
+  BinSnapshot,
+  StockItemSnapshot,
+  StockMovementSnapshot,
+} from '@globalemergency/warehouse-core/inventory';
+import {
+  WarehouseStatus,
+  ZoneStatus,
+  ZoneKind,
+  BinStatus,
+  BinKind,
+  StockStatus,
+  MovementKind,
+} from '@globalemergency/warehouse-core/inventory';
+import type {
+  warehousesTable,
+  zonesTable,
+  binsTable,
+  stockItemsTable,
+  stockMovementsTable,
+} from './schema.js';
+
+type WarehouseRow = typeof warehousesTable.$inferSelect;
+type ZoneRow = typeof zonesTable.$inferSelect;
+type BinRow = typeof binsTable.$inferSelect;
+type StockItemRow = typeof stockItemsTable.$inferSelect;
+type StockMovementRow = typeof stockMovementsTable.$inferSelect;
+
+/**
+ * `numeric` de Postgres llega a la app como string (gotcha del repo). Se
+ * convierte a number para el snapshot del dominio, que trabaja con `number`
+ * (el VO Quantity redondea a escala 6, en sintonía con `numeric(18,6)`).
+ */
+function numericToNumber(value: string): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) {
+    throw new Error(`Valor numeric no finito en la BBDD: "${value}"`);
+  }
+  return n;
+}
+
+// --- Warehouse + Zone ------------------------------------------------------
+
+/** Fila de zona → {@link ZoneSnapshot} (sin la FK warehouse_id, implícita). */
+export function rowToZoneSnapshot(row: ZoneRow): ZoneSnapshot {
+  return {
+    id: row.id,
+    code: row.code,
+    name: row.name,
+    kind: row.kind as ZoneKind,
+    status: row.status as ZoneStatus,
+  };
+}
+
+/**
+ * Ensambla el {@link WarehouseSnapshot} a partir de la fila del almacén y sus
+ * filas de zona (ya cargadas). El agregado se reconstruye luego con
+ * `Warehouse.fromSnapshot`.
+ */
+export function rowsToWarehouseSnapshot(
+  row: WarehouseRow,
+  zones: ZoneRow[],
+): WarehouseSnapshot {
+  return {
+    id: row.id,
+    scopeId: row.scopeId,
+    code: row.code,
+    name: row.name,
+    address: row.address ?? null,
+    lat: row.lat ?? null,
+    lng: row.lng ?? null,
+    status: row.status as WarehouseStatus,
+    zones: zones.map(rowToZoneSnapshot),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** {@link WarehouseSnapshot} → columnas de la fila del almacén (sin las zonas). */
+export function warehouseSnapshotToRow(
+  s: WarehouseSnapshot,
+): typeof warehousesTable.$inferInsert {
+  return {
+    id: s.id,
+    scopeId: s.scopeId,
+    code: s.code,
+    name: s.name,
+    address: s.address,
+    lat: s.lat,
+    lng: s.lng,
+    status: s.status,
+    createdAt: s.createdAt,
+    updatedAt: s.updatedAt,
+  };
+}
+
+/** {@link ZoneSnapshot} + su warehouseId → columnas de la fila de zona. */
+export function zoneSnapshotToRow(
+  warehouseId: string,
+  s: ZoneSnapshot,
+): typeof zonesTable.$inferInsert {
+  return {
+    id: s.id,
+    warehouseId,
+    code: s.code,
+    name: s.name,
+    kind: s.kind,
+    status: s.status,
+  };
+}
+
+// --- Bin -------------------------------------------------------------------
+
+export function rowToBinSnapshot(row: BinRow): BinSnapshot {
+  return {
+    id: row.id,
+    scopeId: row.scopeId,
+    warehouseId: row.warehouseId,
+    zoneId: row.zoneId ?? null,
+    code: row.code,
+    kind: row.kind as BinKind,
+    status: row.status as BinStatus,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function binSnapshotToRow(
+  s: BinSnapshot,
+): typeof binsTable.$inferInsert {
+  return {
+    id: s.id,
+    scopeId: s.scopeId,
+    warehouseId: s.warehouseId,
+    zoneId: s.zoneId,
+    code: s.code,
+    kind: s.kind,
+    status: s.status,
+    createdAt: s.createdAt,
+    updatedAt: s.updatedAt,
+  };
+}
+
+// --- StockItem -------------------------------------------------------------
+
+export function rowToStockItemSnapshot(row: StockItemRow): StockItemSnapshot {
+  return {
+    id: row.id,
+    scopeId: row.scopeId,
+    warehouseId: row.warehouseId,
+    binId: row.binId,
+    supplyId: row.supplyId,
+    lotCode: row.lotCode ?? null,
+    expiresAt: row.expiresAt ?? null,
+    quantityAmount: numericToNumber(row.quantityAmount),
+    unit: row.unit,
+    status: row.status as StockStatus,
+    version: row.version,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function stockItemSnapshotToRow(
+  s: StockItemSnapshot,
+): typeof stockItemsTable.$inferInsert {
+  return {
+    id: s.id,
+    scopeId: s.scopeId,
+    warehouseId: s.warehouseId,
+    binId: s.binId,
+    supplyId: s.supplyId,
+    lotCode: s.lotCode,
+    expiresAt: s.expiresAt,
+    // `numeric` acepta string; se serializa con la escala del VO (6 decimales).
+    quantityAmount: s.quantityAmount.toString(),
+    unit: s.unit,
+    status: s.status,
+    version: s.version,
+    createdAt: s.createdAt,
+    updatedAt: s.updatedAt,
+  };
+}
+
+// --- StockMovement ---------------------------------------------------------
+
+export function rowToStockMovementSnapshot(
+  row: StockMovementRow,
+): StockMovementSnapshot {
+  return {
+    id: row.id,
+    scopeId: row.scopeId,
+    kind: row.kind as MovementKind,
+    quantityAmount: numericToNumber(row.quantityAmount),
+    unit: row.unit,
+    fromItemId: row.fromItemId ?? null,
+    toItemId: row.toItemId ?? null,
+    reason: row.reason ?? null,
+    idempotencyKey: row.idempotencyKey ?? null,
+    occurredAt: row.occurredAt,
+  };
+}
+
+export function stockMovementSnapshotToRow(
+  s: StockMovementSnapshot,
+): typeof stockMovementsTable.$inferInsert {
+  return {
+    id: s.id,
+    scopeId: s.scopeId,
+    kind: s.kind,
+    quantityAmount: s.quantityAmount.toString(),
+    unit: s.unit,
+    fromItemId: s.fromItemId,
+    toItemId: s.toItemId,
+    reason: s.reason,
+    idempotencyKey: s.idempotencyKey,
+    occurredAt: s.occurredAt,
+  };
+}

--- a/packages/warehouse-postgres/src/inventory/migrate.test.ts
+++ b/packages/warehouse-postgres/src/inventory/migrate.test.ts
@@ -1,0 +1,53 @@
+import { after, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Pool } from 'pg';
+import { migrateWms } from './migrate.js';
+import { newPool } from './test-support.js';
+
+describe('migrateWms (integración)', () => {
+  let pool: Pool;
+
+  before(() => {
+    pool = newPool();
+  });
+
+  after(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    // Esquema fresco: obliga a que la migración tenga que aplicar de cero.
+    await pool.query('DROP SCHEMA IF EXISTS wms CASCADE');
+  });
+
+  it('dos migrateWms concurrentes sobre un esquema fresco resuelven sin error y no doble-aplican', async () => {
+    // El advisory lock de sesión serializa ambos runners en la BBDD: uno aplica
+    // y el otro, al tomar el cerrojo después, ve todo ya aplicado (no-op).
+    const [a, b] = await Promise.all([migrateWms(pool), migrateWms(pool)]);
+
+    // Exactamente uno aplicó el set completo; el otro no aplicó nada.
+    const appliedCounts = [a.length, b.length].sort((x, y) => x - y);
+    assert.equal(appliedCounts[0], 0);
+    assert.ok(
+      appliedCounts[1]! > 0,
+      'uno de los runners debe haber aplicado las migraciones',
+    );
+
+    // El registro de control tiene exactamente el set aplicado una sola vez (sin
+    // duplicados: `name` es PK, así que un doble-apply habría fallado antes).
+    const { rows } = await pool.query<{ name: string }>(
+      'SELECT name FROM wms."_migrations" ORDER BY name',
+    );
+    const names = rows.map((r) => r.name);
+    assert.deepEqual(names, [...new Set(names)]);
+    assert.equal(names.length, appliedCounts[1]);
+  });
+
+  it('re-ejecutar migrateWms sobre un esquema ya migrado es no-op (idempotente)', async () => {
+    const firstRun = await migrateWms(pool);
+    assert.ok(firstRun.length > 0);
+
+    const secondRun = await migrateWms(pool);
+    assert.deepEqual(secondRun, []);
+  });
+});

--- a/packages/warehouse-postgres/src/inventory/migrate.ts
+++ b/packages/warehouse-postgres/src/inventory/migrate.ts
@@ -1,0 +1,114 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { Pool } from 'pg';
+
+/**
+ * Runner de migraciones propio del paquete (decisión de diseño): warehouse-postgres
+ * migra su esquema `wms.` de forma independiente del host, de modo que el WMS
+ * standalone puede desplegar sin depender del sistema de migraciones de
+ * ResponseGrid.
+ *
+ * Aplica los ficheros `wms_*.sql` de `migrations/` en orden de nombre, cada uno
+ * dentro de su propia transacción, y los rastrea de forma idempotente en la
+ * tabla `wms."_migrations"` (name text primary key). Re-ejecutar es seguro: los
+ * ya aplicados se saltan. Los `.sql` usan `IF NOT EXISTS`, así que incluso una
+ * aplicación parcial converge.
+ */
+
+/** Nombre del paquete, usado para anclar la búsqueda del directorio. */
+const PACKAGE_SEGMENT = join('packages', 'warehouse-postgres');
+
+/**
+ * Localiza el directorio `migrations/` del paquete sin depender del sistema de
+ * módulos (ni `__dirname` de CJS ni `import.meta` de ESM), para que ambos builds
+ * compilen y funcionen igual. Prioridad:
+ *
+ *   1. La env `WMS_MIGRATIONS_DIR` (override explícito).
+ *   2. Ascendiendo desde `process.cwd()`: `<cwd>/migrations` (cuando se ejecuta
+ *      desde la raíz del paquete) o `<x>/packages/warehouse-postgres/migrations`
+ *      (cuando se ejecuta desde la raíz del monorepo).
+ *
+ * Un consumidor externo que no encaje en ese layout pasa el directorio explícito
+ * a {@link migrateWms} o define la env.
+ */
+function resolveMigrationsDir(): string {
+  const fromEnv = process.env.WMS_MIGRATIONS_DIR;
+  if (fromEnv) return fromEnv;
+
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i += 1) {
+    const localCandidate = join(dir, 'migrations');
+    if (existsSync(localCandidate)) return localCandidate;
+    const monorepoCandidate = join(dir, PACKAGE_SEGMENT, 'migrations');
+    if (existsSync(monorepoCandidate)) return monorepoCandidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Fallback: relativo al cwd (mejor un error claro de readdir que un silencio).
+  return join(process.cwd(), 'migrations');
+}
+
+async function ensureMigrationsTable(pool: Pool): Promise<void> {
+  await pool.query('CREATE SCHEMA IF NOT EXISTS wms');
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS wms."_migrations" (
+       name text PRIMARY KEY,
+       applied_at timestamptz NOT NULL DEFAULT now()
+     )`,
+  );
+}
+
+async function appliedMigrations(pool: Pool): Promise<Set<string>> {
+  const { rows } = await pool.query<{ name: string }>(
+    'SELECT name FROM wms."_migrations"',
+  );
+  return new Set(rows.map((r) => r.name));
+}
+
+async function migrationFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir);
+  return entries
+    .filter((name) => name.startsWith('wms_') && name.endsWith('.sql'))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Aplica las migraciones pendientes del esquema `wms.` contra el pool dado.
+ * Idempotente y seguro de re-ejecutar. Devuelve los nombres aplicados en esta
+ * llamada (vacío si ya estaba todo al día). Se puede pasar `migrationsDir`
+ * explícito; por defecto se resuelve con {@link resolveMigrationsDir}.
+ */
+export async function migrateWms(
+  pool: Pool,
+  migrationsDir: string = resolveMigrationsDir(),
+): Promise<string[]> {
+  await ensureMigrationsTable(pool);
+  const already = await appliedMigrations(pool);
+  const files = await migrationFiles(migrationsDir);
+  const applied: string[] = [];
+
+  for (const file of files) {
+    if (already.has(file)) continue;
+    const sql = await readFile(join(migrationsDir, file), 'utf8');
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(sql);
+      await client.query(
+        'INSERT INTO wms."_migrations" (name) VALUES ($1) ON CONFLICT DO NOTHING',
+        [file],
+      );
+      await client.query('COMMIT');
+      applied.push(file);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  return applied;
+}

--- a/packages/warehouse-postgres/src/inventory/migrate.ts
+++ b/packages/warehouse-postgres/src/inventory/migrate.ts
@@ -14,10 +14,24 @@ import type { Pool } from 'pg';
  * tabla `wms."_migrations"` (name text primary key). Re-ejecutar es seguro: los
  * ya aplicados se saltan. Los `.sql` usan `IF NOT EXISTS`, así que incluso una
  * aplicación parcial converge.
+ *
+ * Cerrojo entre procesos: dos runners concurrentes (dos instancias de la app
+ * arrancando a la vez, o procesos en paralelo) se serializan con un
+ * `pg_advisory_lock` de sesión sobre una clave constante ANTES de leer las
+ * migraciones aplicadas, de modo que el patrón check-then-apply no compita. El
+ * cerrojo se libera en un `finally`. Todo sigue siendo idempotente.
  */
 
 /** Nombre del paquete, usado para anclar la búsqueda del directorio. */
 const PACKAGE_SEGMENT = join('packages', 'warehouse-postgres');
+
+/**
+ * Clave constante del advisory lock de sesión. Un valor fijo dentro del rango de
+ * `bigint` de Postgres (derivado como hash constante de 'warehouse-postgres:wms')
+ * para que todos los runners del esquema `wms.` compitan por el MISMO cerrojo,
+ * sin colisionar con otros advisory locks del host.
+ */
+const WMS_MIGRATION_LOCK_KEY = 4310472051201983n;
 
 /**
  * Localiza el directorio `migrations/` del paquete sin depender del sistema de
@@ -83,6 +97,35 @@ async function migrationFiles(dir: string): Promise<string[]> {
 export async function migrateWms(
   pool: Pool,
   migrationsDir: string = resolveMigrationsDir(),
+): Promise<string[]> {
+  // Cerrojo de sesión sobre un cliente dedicado: serializa runners concurrentes
+  // en la BBDD antes del check-then-apply. Adquirir y liberar sobre el MISMO
+  // cliente (el advisory lock es por sesión), de ahí que no se use el pool.
+  const lockClient = await pool.connect();
+  try {
+    await lockClient.query('SELECT pg_advisory_lock($1)', [
+      WMS_MIGRATION_LOCK_KEY.toString(),
+    ]);
+    return await applyPendingMigrations(pool, migrationsDir);
+  } finally {
+    try {
+      await lockClient.query('SELECT pg_advisory_unlock($1)', [
+        WMS_MIGRATION_LOCK_KEY.toString(),
+      ]);
+    } finally {
+      lockClient.release();
+    }
+  }
+}
+
+/**
+ * Cuerpo idempotente de la migración, ya bajo el advisory lock: asegura la tabla
+ * de control, lee lo aplicado y aplica los ficheros pendientes en orden, cada
+ * uno en su propia transacción.
+ */
+async function applyPendingMigrations(
+  pool: Pool,
+  migrationsDir: string,
 ): Promise<string[]> {
   await ensureMigrationsTable(pool);
   const already = await appliedMigrations(pool);

--- a/packages/warehouse-postgres/src/inventory/pg-errors.ts
+++ b/packages/warehouse-postgres/src/inventory/pg-errors.ts
@@ -1,0 +1,24 @@
+/**
+ * Helpers para clasificar errores crudos del driver `pg` por su `code`
+ * (SQLSTATE), sin acoplar los repositorios a la forma interna del error.
+ */
+
+/** SQLSTATE de violación de unicidad (unique_violation). */
+const UNIQUE_VIOLATION = '23505';
+
+/**
+ * True si el error (o algún error de su cadena `cause`) es una violación de
+ * índice/constraint único (`23505`). Drizzle envuelve el error crudo del driver
+ * en un `DrizzleQueryError`, así que el `code` de Postgres no está en el error de
+ * nivel superior sino en `.cause`; por eso se recorre la cadena (con un tope de
+ * profundidad como guarda anti-ciclos).
+ */
+export function isUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (typeof current !== 'object' || current === null) return false;
+    if ((current as { code?: unknown }).code === UNIQUE_VIOLATION) return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}

--- a/packages/warehouse-postgres/src/inventory/schema.ts
+++ b/packages/warehouse-postgres/src/inventory/schema.ts
@@ -1,0 +1,106 @@
+import {
+  pgSchema,
+  uuid,
+  text,
+  timestamp,
+  doublePrecision,
+  integer,
+  numeric,
+} from 'drizzle-orm/pg-core';
+
+/**
+ * Esquema Postgres dedicado del WMS. Aísla las tablas del módulo `inventory` en
+ * `wms.` para que warehouse-postgres pueda migrar y convivir con el host sin
+ * colisionar con sus tablas. Refleja `migrations/wms_0001_inventory.sql` (la
+ * fuente de verdad del DDL; este objeto sólo describe las columnas para el
+ * query builder tipado de Drizzle).
+ */
+export const wms = pgSchema('wms');
+
+/** Almacén (agregado raíz). `code` único por scope. */
+export const warehousesTable = wms.table('warehouses', {
+  id: uuid('id').primaryKey(),
+  scopeId: uuid('scope_id').notNull(),
+  code: text('code').notNull(),
+  name: text('name').notNull(),
+  address: text('address'),
+  lat: doublePrecision('lat'),
+  lng: doublePrecision('lng'),
+  status: text('status').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});
+
+/**
+ * Zona (entidad del agregado Warehouse). FK a `warehouses` con borrado en
+ * cascada. `code` único por almacén.
+ */
+export const zonesTable = wms.table('zones', {
+  id: uuid('id').primaryKey(),
+  warehouseId: uuid('warehouse_id').notNull(),
+  code: text('code').notNull(),
+  name: text('name').notNull(),
+  kind: text('kind').notNull(),
+  status: text('status').notNull(),
+});
+
+/**
+ * Ubicación física (agregado propio). Referencia almacén y (opcionalmente) zona
+ * por id; `scope_id` denormalizado para listados por scope.
+ */
+export const binsTable = wms.table('bins', {
+  id: uuid('id').primaryKey(),
+  scopeId: uuid('scope_id').notNull(),
+  warehouseId: uuid('warehouse_id').notNull(),
+  zoneId: uuid('zone_id'),
+  code: text('code').notNull(),
+  kind: text('kind').notNull(),
+  status: text('status').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});
+
+/**
+ * Unidad de existencia (agregado raíz). Grano producto × lote × bin × estado.
+ * `quantityAmount` es `numeric(18,6)`: Drizzle lo devuelve como string, así que
+ * el mapper lo convierte a number con cuidado (evita el 500 por `.toISOString`
+ * y afines del gotcha de SQL crudo). `version` para concurrencia optimista.
+ */
+export const stockItemsTable = wms.table('stock_items', {
+  id: uuid('id').primaryKey(),
+  scopeId: uuid('scope_id').notNull(),
+  warehouseId: uuid('warehouse_id').notNull(),
+  binId: uuid('bin_id').notNull(),
+  supplyId: uuid('supply_id').notNull(),
+  lotCode: text('lot_code'),
+  expiresAt: timestamp('expires_at', { withTimezone: true }),
+  quantityAmount: numeric('quantity_amount', {
+    precision: 18,
+    scale: 6,
+  }).notNull(),
+  unit: text('unit').notNull(),
+  status: text('status').notNull(),
+  version: integer('version').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});
+
+/**
+ * Libro mayor (kardex). Append-only. Asiento de doble pata: `fromItemId` y
+ * `toItemId` (cada una una StockItem o el exterior=null).
+ */
+export const stockMovementsTable = wms.table('stock_movements', {
+  id: uuid('id').primaryKey(),
+  scopeId: uuid('scope_id').notNull(),
+  kind: text('kind').notNull(),
+  quantityAmount: numeric('quantity_amount', {
+    precision: 18,
+    scale: 6,
+  }).notNull(),
+  unit: text('unit').notNull(),
+  fromItemId: uuid('from_item_id'),
+  toItemId: uuid('to_item_id'),
+  reason: text('reason'),
+  idempotencyKey: text('idempotency_key'),
+  occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull(),
+});

--- a/packages/warehouse-postgres/src/inventory/stock-persistence-errors.ts
+++ b/packages/warehouse-postgres/src/inventory/stock-persistence-errors.ts
@@ -1,0 +1,24 @@
+/**
+ * Errores de la capa de persistencia del stock. Viven en warehouse-postgres, no
+ * en el dominio puro (warehouse-core): son fallos de concurrencia/almacenamiento
+ * del adaptador, no invariantes del negocio. El host los mapea a HTTP (409).
+ */
+
+/**
+ * Se lanza cuando `StockItemRepository.save` detecta un choque de concurrencia
+ * optimista: el UPDATE con `WHERE version = version_esperada` no afectó a
+ * ninguna fila porque otro proceso ya actualizó (o borró) el item. El llamante
+ * debe recargar el snapshot y reintentar.
+ */
+export class StaleStockItemError extends Error {
+  constructor(
+    public readonly stockItemId: string,
+    public readonly expectedVersion: number,
+  ) {
+    super(
+      `StockItem ${stockItemId} fue modificado concurrentemente ` +
+        `(se esperaba la versión ${expectedVersion}); recargue y reintente`,
+    );
+    this.name = 'StaleStockItemError';
+  }
+}

--- a/packages/warehouse-postgres/src/inventory/stock-persistence-errors.ts
+++ b/packages/warehouse-postgres/src/inventory/stock-persistence-errors.ts
@@ -22,3 +22,48 @@ export class StaleStockItemError extends Error {
     this.name = 'StaleStockItemError';
   }
 }
+
+/**
+ * Se lanza cuando el alta (`version === 1`) de una StockItem viola el índice
+ * único de grano (bin, supply, lote, estado): otro proceso ya dio de alta ese
+ * mismo grano (primera entrada concurrente o un create reintentado). Es la
+ * traducción tipada del error crudo `23505` de Postgres, para que el host no vea
+ * un 500 sino un conflicto identificable. El llamante debe cargar el item
+ * existente por grano y aplicar la mutación sobre él en vez de reinsertar.
+ */
+export class DuplicateStockItemError extends Error {
+  constructor(
+    public readonly binId: string,
+    public readonly supplyId: string,
+    public readonly lotCode: string | null,
+    public readonly status: string,
+  ) {
+    super(
+      `Ya existe una StockItem para el grano ` +
+        `(bin ${binId}, supply ${supplyId}, lote ${lotCode ?? 'null'}, estado ${status}); ` +
+        `cargue el item existente por grano y aplique la mutación sobre él`,
+    );
+    this.name = 'DuplicateStockItemError';
+  }
+}
+
+/**
+ * Se lanza cuando un `StockMovementRepository.append` con clave de idempotencia
+ * choca con un asiento ya persistido bajo esa misma `(scope_id, idempotency_key)`
+ * pero que representa un movimiento DISTINTO (otro tipo/cantidad/unidad/patas).
+ * No es un reintento legítimo (que sería no-op), sino una reutilización de clave
+ * en conflicto: silenciarla ocultaría un doble-registro divergente, así que se
+ * lanza para que el host lo detecte (mapea a 409).
+ */
+export class IdempotencyKeyConflictError extends Error {
+  constructor(
+    public readonly scopeId: string,
+    public readonly idempotencyKey: string,
+  ) {
+    super(
+      `La clave de idempotencia "${idempotencyKey}" del scope ${scopeId} ya está ` +
+        `registrada para un movimiento distinto; no es un reintento del mismo asiento`,
+    );
+    this.name = 'IdempotencyKeyConflictError';
+  }
+}

--- a/packages/warehouse-postgres/src/inventory/test-support.ts
+++ b/packages/warehouse-postgres/src/inventory/test-support.ts
@@ -24,6 +24,14 @@ export function newPool(): Pool {
 /**
  * Deja el esquema `wms` limpio y migrado, para que cada suite arranque desde un
  * estado repetible: `DROP SCHEMA wms CASCADE` + `migrateWms`.
+ *
+ * NOTA sobre `--test-concurrency=1` (script `test:int`): los ficheros de test
+ * comparten la MISMA BBDD y cada suite hace este `DROP SCHEMA wms CASCADE` en su
+ * `before`. Correr los ficheros en serie evita que el reset de una suite borre
+ * el esquema mientras otra está a mitad de sus tests. Es una preocupación
+ * distinta del advisory lock de {@link migrateWms} (que serializa runners de
+ * migración concurrentes DENTRO de la BBDD): NO quitar `--test-concurrency=1`
+ * pensando que el lock lo cubre — no protege del `DROP SCHEMA` entre ficheros.
  */
 export async function resetSchema(pool: Pool): Promise<void> {
   await pool.query('DROP SCHEMA IF EXISTS wms CASCADE');

--- a/packages/warehouse-postgres/src/inventory/test-support.ts
+++ b/packages/warehouse-postgres/src/inventory/test-support.ts
@@ -1,0 +1,48 @@
+import { Pool } from 'pg';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { sql } from 'drizzle-orm';
+import { migrateWms } from './index.js';
+
+/**
+ * Utilidades de los tests de integración. NO forman parte de la API pública del
+ * paquete (no se exportan desde el barrel): sólo dan soporte a los `*.test.ts`.
+ * Importan únicamente warehouse-postgres + pg/drizzle; nunca `apps/*`.
+ */
+
+/**
+ * Postgres de test. Un contenedor `wms-test-pg` corre en localhost:5434
+ * (user/pass/db = reliefhub). Se puede sobreescribir con `TEST_DATABASE_URL`.
+ */
+export const TEST_DATABASE_URL =
+  process.env.TEST_DATABASE_URL ??
+  'postgres://reliefhub:reliefhub@localhost:5434/reliefhub';
+
+export function newPool(): Pool {
+  return new Pool({ connectionString: TEST_DATABASE_URL });
+}
+
+/**
+ * Deja el esquema `wms` limpio y migrado, para que cada suite arranque desde un
+ * estado repetible: `DROP SCHEMA wms CASCADE` + `migrateWms`.
+ */
+export async function resetSchema(pool: Pool): Promise<void> {
+  await pool.query('DROP SCHEMA IF EXISTS wms CASCADE');
+  await migrateWms(pool);
+}
+
+/** Vacía las tablas de datos entre tests (mantiene el esquema/migraciones). */
+export async function truncateAll(db: NodePgDatabase): Promise<void> {
+  // CASCADE + RESTART IDENTITY: borra almacenes y, por la FK con cascada, zonas.
+  await db.execute(
+    sql`TRUNCATE TABLE wms.stock_movements, wms.stock_items, wms.bins, wms.zones, wms.warehouses RESTART IDENTITY CASCADE`,
+  );
+}
+
+export function makeDb(pool: Pool): NodePgDatabase {
+  return drizzle(pool);
+}
+
+/** UUID v4 aleatorio (para ids de test que no vienen de un VO). */
+export function uuid(): string {
+  return crypto.randomUUID();
+}

--- a/packages/warehouse-postgres/src/inventory/unit-of-work.ts
+++ b/packages/warehouse-postgres/src/inventory/unit-of-work.ts
@@ -1,0 +1,56 @@
+import type { WmsDatabase } from './db.js';
+import { DrizzleWarehouseRepository } from './drizzle-warehouse.repository.js';
+import { DrizzleBinRepository } from './drizzle-bin.repository.js';
+import { DrizzleStockItemRepository } from './drizzle-stock-item.repository.js';
+import { DrizzleStockMovementRepository } from './drizzle-stock-movement.repository.js';
+
+/**
+ * Los 4 repositorios del módulo inventory, ligados a una misma transacción.
+ * Es lo que recibe el callback de {@link runInWmsTransaction}: úsalos para
+ * componer varias escrituras (p. ej. las dos patas de un traslado + el asiento
+ * del libro mayor) de forma atómica.
+ */
+export interface WmsUnitOfWork {
+  warehouses: DrizzleWarehouseRepository;
+  bins: DrizzleBinRepository;
+  items: DrizzleStockItemRepository;
+  movements: DrizzleStockMovementRepository;
+}
+
+/**
+ * Unit of Work mínima del paquete warehouse-postgres. El dominio
+ * ({@link StockMovement}) exige que el host persista "ambas patas + el asiento"
+ * de un traslado ATÓMICAMENTE, pero cada repositorio, construido sobre el `db`
+ * del pool, auto-commitea en su propia conexión. Esta función abre una
+ * transacción (`db.transaction`), construye los 4 repositorios ligados al `tx`
+ * y se los pasa al callback: todo lo que se escriba dentro comparte la misma
+ * transacción, así que confirma o revierte en bloque.
+ *
+ * No es un framework: es la pieza justa para componer transaccionalmente los
+ * repositorios sin tocar los puertos de warehouse-core (esto vive sólo en
+ * warehouse-postgres). Si el callback lanza, drizzle hace ROLLBACK y el error se
+ * propaga; si retorna, hace COMMIT y devuelve el valor del callback.
+ *
+ * @example
+ * await runInWmsTransaction(db, async ({ items, movements }) => {
+ *   await items.save(fromItem);
+ *   await items.save(toItem);
+ *   await movements.append(transfer);
+ * });
+ */
+export async function runInWmsTransaction<T>(
+  db: WmsDatabase,
+  work: (uow: WmsUnitOfWork) => Promise<T>,
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    const uow: WmsUnitOfWork = {
+      // `tx` satisface `WmsDatabase` (extiende `PgDatabase<NodePgQueryResultHKT>`),
+      // así que los repositorios se construyen sin ningún cast.
+      warehouses: new DrizzleWarehouseRepository(tx),
+      bins: new DrizzleBinRepository(tx),
+      items: new DrizzleStockItemRepository(tx),
+      movements: new DrizzleStockMovementRepository(tx),
+    };
+    return work(uow);
+  });
+}

--- a/packages/warehouse-postgres/tsconfig.base.json
+++ b/packages/warehouse-postgres/tsconfig.base.json
@@ -13,5 +13,6 @@
     "sourceMap": true,
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/inventory/test-support.ts"]
 }

--- a/packages/warehouse-postgres/tsconfig.cjs.json
+++ b/packages/warehouse-postgres/tsconfig.cjs.json
@@ -10,6 +10,9 @@
       "@globalemergency/warehouse-core": [
         "../warehouse-core/dist/esm/index.d.ts"
       ],
+      "@globalemergency/warehouse-core/inventory": [
+        "../warehouse-core/dist/esm/inventory/index.d.ts"
+      ],
       "@globalemergency/warehouse-core/*": [
         "../warehouse-core/dist/esm/*/index.d.ts"
       ]

--- a/packages/warehouse-postgres/tsconfig.test.json
+++ b/packages/warehouse-postgres/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.esm.json",
+  "compilerOptions": {
+    "outDir": "dist-test",
+    "declaration": false,
+    "declarationMap": false,
+    "noEmitOnError": true
+  },
+  "include": ["src"],
+  "exclude": []
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,9 +281,18 @@ importers:
         specifier: workspace:*
         version: link:../warehouse-core
     devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.2
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+      pg:
+        specifier: ^8.13.1
+        version: 8.22.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -7610,7 +7619,7 @@ snapshots:
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.0
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -8753,8 +8762,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -8780,7 +8789,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@10.2.2)
@@ -8791,21 +8800,21 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8816,7 +8825,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Closes #383 · Fase 0.5 de la épica #355.

Baja al paquete `@globalemergency/warehouse-postgres` la capa de persistencia del módulo `inventory` de warehouse-core (dominio puro, ya completo), sobre un **schema Postgres `wms.` dedicado**, con **runner de migraciones propio** para que el WMS pueda desplegar independiente del host. Cierra los 2 criterios de Done abiertos de la épica (migraciones `wms.` + consumidor de validación sin ResponseGrid).

## Qué incluye
- **Schema `wms.`** (`warehouses`/`zones`/`bins`/`stock_items`/`stock_movements`) con las invariantes como constraints: grano único `(bin,supply,lote,estado)` con par de índices parciales que respeta el lote nulo, `version` para lock optimista, idempotencia `(scope,idempotency_key)` append-only.
- **4 adaptadores Drizzle** de los ports (`Warehouse`/`Bin`/`StockItem`/`StockMovement`), sobre `scope_id` (agnóstico del host).
- **Runner de migraciones propio** del paquete (tabla `wms._migrations`, idempotente, con `pg_advisory_lock` para runners concurrentes).
- **UnitOfWork** (`runInWmsTransaction`) para componer un traslado (dos patas + asiento) de forma atómica.
- **Consumidor de validación standalone**: int-tests con pool propio, sin ningún import de `apps/*` — recepción → traslado bin→bin → salida FEFO, verificando lock optimista e idempotencia.
- **CI**: job `Test` corre los int-tests contra Postgres (schema `wms` aislado del `reliefhub_test`); el job `Format` cubre ahora ambos paquetes `@globalemergency/*`.

## Endurecido tras revisión de código (3 lentes: persistencia/SQL, concurrencia, mantenibilidad)
- Violación de unicidad en alta de stock → `DuplicateStockItemError` tipado (no error crudo del driver).
- `append` detecta reuso divergente de clave de idempotencia → `IdempotencyKeyConflictError` (deja de silenciar).
- Advisory lock en el runner de migraciones (arranque multi-instancia).
- Fin del N+1 al hidratar zonas (`IN (...)`).
- Sin tocar los puertos de warehouse-core.

## Verificación
Build (api-client/warehouse/api/web), lint (api/web), prettier (ambos paquetes), warehouse-core 85 tests, warehouse-postgres 28 int-tests — todo en verde local. Rebasado sobre `main` (reservas #391 / recuentos #389): persistencia compatible sin cambios.

No toca `apps/api`/`apps/web` en runtime (el export raíz del paquete no cambia; en warehouse-core solo 2 reformats cosméticos).