### PR TITLE
feat(warehouse-core): añade gestión de caducidad — findExpired/expiringWithin/expiryStatusOf/nextToExpire

### DIFF
--- a/packages/warehouse-core/src/inventory/expiry.test.ts
+++ b/packages/warehouse-core/src/inventory/expiry.test.ts
@@ -1,0 +1,133 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  expiryStatusOf,
+  findExpired,
+  expiringWithin,
+  nextToExpire,
+} from './expiry.js';
+import { StockItem } from './stock-item.js';
+import { StockStatus } from './stock-enums.js';
+
+const SCOPE = '11111111-1111-4111-8111-111111111111';
+const WAREHOUSE = '22222222-2222-4222-8222-222222222222';
+const BIN = '44444444-4444-4444-8444-444444444444';
+const SUPPLY = 'AGU-0001';
+const ASOF = new Date('2026-07-01T00:00:00.000Z');
+
+let seq = 0;
+
+// Build via fromSnapshot so expiresAt / quantity / id are fully controlled.
+function item(opts: {
+  expiresAt: string | null;
+  amount?: number;
+  id?: string;
+}): StockItem {
+  seq += 1;
+  return StockItem.fromSnapshot({
+    id: opts.id ?? `00000000-0000-4000-8000-${String(seq).padStart(12, '0')}`,
+    scopeId: SCOPE,
+    warehouseId: WAREHOUSE,
+    binId: BIN,
+    supplyId: SUPPLY,
+    lotCode: opts.expiresAt === null ? null : 'L' + seq,
+    expiresAt: opts.expiresAt === null ? null : new Date(opts.expiresAt),
+    quantityAmount: opts.amount ?? 10,
+    unit: 'unit',
+    status: StockStatus.Available,
+    version: 1,
+    createdAt: ASOF,
+    updatedAt: ASOF,
+  });
+}
+
+const days = (n: number) => ({ asOf: ASOF, withinDays: n });
+
+test('expiryStatusOf classifies no_expiry / expired / near / ok', () => {
+  assert.equal(
+    expiryStatusOf(item({ expiresAt: null }), { asOf: ASOF }),
+    'no_expiry',
+  );
+  assert.equal(
+    expiryStatusOf(item({ expiresAt: '2026-06-01T00:00:00Z' }), { asOf: ASOF }),
+    'expired',
+  );
+  // exactly at asOf counts as expired
+  assert.equal(
+    expiryStatusOf(item({ expiresAt: '2026-07-01T00:00:00Z' }), { asOf: ASOF }),
+    'expired',
+  );
+  // within default 30-day window
+  assert.equal(
+    expiryStatusOf(item({ expiresAt: '2026-07-20T00:00:00Z' }), { asOf: ASOF }),
+    'near',
+  );
+  // beyond 30 days
+  assert.equal(
+    expiryStatusOf(item({ expiresAt: '2026-09-01T00:00:00Z' }), { asOf: ASOF }),
+    'ok',
+  );
+  // custom near window
+  assert.equal(
+    expiryStatusOf(item({ expiresAt: '2026-07-20T00:00:00Z' }), {
+      asOf: ASOF,
+      nearWithinDays: 7,
+    }),
+    'ok',
+  );
+});
+
+test('findExpired returns only expired (qty>0), earliest first', () => {
+  const a = item({ expiresAt: '2026-06-15T00:00:00Z' });
+  const b = item({ expiresAt: '2026-05-01T00:00:00Z' });
+  const future = item({ expiresAt: '2026-12-01T00:00:00Z' });
+  const empty = item({ expiresAt: '2026-01-01T00:00:00Z', amount: 0 });
+  const noLot = item({ expiresAt: null });
+  const result = findExpired([a, b, future, empty, noLot], ASOF);
+  assert.deepEqual(
+    result.map((i) => i.id.value),
+    [b.id.value, a.id.value],
+  );
+});
+
+test('expiringWithin excludes already-expired and beyond-window', () => {
+  const expired = item({ expiresAt: '2026-06-01T00:00:00Z' });
+  const soon = item({ expiresAt: '2026-07-10T00:00:00Z' });
+  const soon2 = item({ expiresAt: '2026-07-05T00:00:00Z' });
+  const far = item({ expiresAt: '2026-09-01T00:00:00Z' });
+  const empty = item({ expiresAt: '2026-07-06T00:00:00Z', amount: 0 });
+  const result = expiringWithin([expired, soon, far, soon2, empty], days(30));
+  assert.deepEqual(
+    result.map((i) => i.id.value),
+    [soon2.id.value, soon.id.value],
+  );
+});
+
+test('expiringWithin includes the exact window boundary', () => {
+  const boundary = item({ expiresAt: '2026-07-31T00:00:00Z' }); // exactly +30 days
+  const justOver = item({ expiresAt: '2026-08-01T00:00:00Z' });
+  const result = expiringWithin([boundary, justOver], days(30));
+  assert.deepEqual(
+    result.map((i) => i.id.value),
+    [boundary.id.value],
+  );
+});
+
+test('nextToExpire returns the most urgent lot-tracked item (incl. expired)', () => {
+  const expired = item({ expiresAt: '2026-05-01T00:00:00Z' });
+  const later = item({ expiresAt: '2026-08-01T00:00:00Z' });
+  const noLot = item({ expiresAt: null });
+  assert.equal(
+    nextToExpire([later, noLot, expired])?.id.value,
+    expired.id.value,
+  );
+});
+
+test('nextToExpire returns null when nothing is lot-tracked or all empty', () => {
+  assert.equal(nextToExpire([item({ expiresAt: null })]), null);
+  assert.equal(
+    nextToExpire([item({ expiresAt: '2026-05-01T00:00:00Z', amount: 0 })]),
+    null,
+  );
+  assert.equal(nextToExpire([]), null);
+});

--- a/packages/warehouse-core/src/inventory/expiry.ts
+++ b/packages/warehouse-core/src/inventory/expiry.ts
@@ -1,0 +1,101 @@
+import { StockItem } from './stock-item.js';
+
+/**
+ * Where a {@link StockItem} sits relative to its lot expiry at a given instant:
+ * `no_expiry` (not lot-tracked or no expiry), `expired` (at/after the expiry),
+ * `near` (within the near-expiry window) or `ok`.
+ */
+export type ExpiryStatus = 'no_expiry' | 'ok' | 'near' | 'expired';
+
+export interface ExpiryStatusOptions {
+  asOf: Date;
+  /** Days ahead that count as "near expiry". Default 30. */
+  nearWithinDays?: number;
+}
+
+export interface ExpiringWithinOptions {
+  asOf: Date;
+  /** Size of the look-ahead window in days. */
+  withinDays: number;
+}
+
+const DAY_MS = 86_400_000;
+const DEFAULT_NEAR_DAYS = 30;
+
+/**
+ * Expiry visibility over the stock — the proactive companion of FEFO: while
+ * `allocateFefo` *consumes* the earliest-expiring stock first, these read-only,
+ * deterministic helpers *surface* what has expired (to quarantine/write off) and
+ * what expires soon (to prioritize). `asOf` is always explicit (never an
+ * internal clock) so the results are testable and reproducible. Items with no
+ * lot/expiry and zero-quantity items are ignored.
+ */
+export function expiryStatusOf(
+  item: StockItem,
+  options: ExpiryStatusOptions,
+): ExpiryStatus {
+  const expiresAt = item.expiresAt;
+  if (expiresAt === null) return 'no_expiry';
+  const asOfMs = options.asOf.getTime();
+  const expMs = expiresAt.getTime();
+  if (expMs <= asOfMs) return 'expired';
+  const nearDays = options.nearWithinDays ?? DEFAULT_NEAR_DAYS;
+  if (expMs <= asOfMs + nearDays * DAY_MS) return 'near';
+  return 'ok';
+}
+
+/** Items already expired at `asOf` (quantity > 0), earliest expiry first. */
+export function findExpired(items: StockItem[], asOf: Date): StockItem[] {
+  const asOfMs = asOf.getTime();
+  return items
+    .filter(
+      (i) =>
+        !i.quantity.isZero() &&
+        i.expiresAt !== null &&
+        i.expiresAt.getTime() <= asOfMs,
+    )
+    .sort(byExpiryAsc);
+}
+
+/**
+ * Items **not yet expired** at `asOf` that expire within the look-ahead window
+ * (`asOf < expiresAt ≤ asOf + withinDays`), quantity > 0, earliest expiry first.
+ * Already-expired stock is excluded — that is {@link findExpired}'s job.
+ */
+export function expiringWithin(
+  items: StockItem[],
+  options: ExpiringWithinOptions,
+): StockItem[] {
+  const asOfMs = options.asOf.getTime();
+  const limitMs = asOfMs + options.withinDays * DAY_MS;
+  return items
+    .filter((i) => {
+      if (i.quantity.isZero() || i.expiresAt === null) return false;
+      const e = i.expiresAt.getTime();
+      return e > asOfMs && e <= limitMs;
+    })
+    .sort(byExpiryAsc);
+}
+
+/**
+ * The most urgent lot-tracked item (quantity > 0) — the earliest expiry,
+ * including already-expired stock — or null if none is lot-tracked.
+ */
+export function nextToExpire(items: StockItem[]): StockItem | null {
+  const withExpiry = items
+    .filter((i) => !i.quantity.isZero() && i.expiresAt !== null)
+    .sort(byExpiryAsc);
+  return withExpiry[0] ?? null;
+}
+
+/** Earliest expiry first; no-expiry last; ties broken by id for stability. */
+function byExpiryAsc(a: StockItem, b: StockItem): number {
+  const ax = a.expiresAt;
+  const bx = b.expiresAt;
+  if (ax === null && bx === null) return 0;
+  if (ax === null) return 1;
+  if (bx === null) return -1;
+  const d = ax.getTime() - bx.getTime();
+  if (d !== 0) return d;
+  return a.id.value < b.id.value ? -1 : a.id.value > b.id.value ? 1 : 0;
+}

--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -11,7 +11,8 @@
  * planifica el reparto de una demanda por caducidad (first-expired-first-out),
  * `reconcileCount` concilia un recuento físico con el sistema (ajuste) y
  * `reserveStock`/`releaseReservation` comprometen/liberan stock (available ↔
- * reserved) sin sacarlo del bin.
+ * reserved) sin sacarlo del bin, y los helpers de caducidad (`findExpired`/
+ * `expiringWithin`/`expiryStatusOf`/`nextToExpire`) dan visibilidad proactiva.
  *
  * Dominio puro: sin NestJS, sin ORM, sin infraestructura. Todo referencia el
  * catálogo (`supplyId`) y el backbone (bin → zona → almacén) por id.
@@ -82,6 +83,17 @@ export type {
 } from './cycle-count.js';
 export { reserveStock, releaseReservation } from './reservations.js';
 export type { ReservationInput } from './reservations.js';
+export {
+  expiryStatusOf,
+  findExpired,
+  expiringWithin,
+  nextToExpire,
+} from './expiry.js';
+export type {
+  ExpiryStatus,
+  ExpiryStatusOptions,
+  ExpiringWithinOptions,
+} from './expiry.js';
 export {
   WAREHOUSE_REPOSITORY,
   type WarehouseRepository,


### PR DESCRIPTION
## Resumen

Fase 2 (épica #355): el **compañero proactivo de FEFO**. Mientras `allocateFefo` (#378) *consume* primero lo que antes caduca, estos helpers dan **visibilidad** de la caducidad — stock ya caducado (a cuarentena/baja) y próximo a caducar (a priorizar/alertar). Clave para almacenes de Protección Civil (medicamentos/agua/comida).

> **Independiente de #382** (migración) y **no es min/max**. Solo añade ficheros nuevos en `warehouse-core/src/inventory`.

En el módulo `inventory` de `@globalemergency/warehouse-core`, funciones **puras y deterministas** (la fecha `asOf` se pasa explícita, nunca `new Date()` interno → testable/reproducible):

- **`expiryStatusOf(item, { asOf, nearWithinDays })`** → `no_expiry` / `ok` / `near` / `expired` (ventana "near" por defecto 30 días).
- **`findExpired(items, asOf)`** → caducados (qty>0), earliest-first.
- **`expiringWithin(items, { asOf, withinDays })`** → **aún no caducados** que caducan dentro de la ventana (`asOf < expiresAt ≤ asOf+withinDays`), earliest-first.
- **`nextToExpire(items)`** → el item lot-trazado más urgente (incluye ya caducados), o `null`.
- Ignoran items sin lote/caducidad y de cantidad cero; **no mutan nada** — el llamante decide (cuarentena vía transfer, baja vía issue, alerta).

## Validación

- [x] Pasé el gate que toca para esta zona del repo — `build` (dual), `typecheck`, `test` (**91/91** verde; +6 de caducidad), `pnpm --filter api build` (nest, host intacto), Prettier `--check` limpio, frontera pura.
- [x] Verifiqué el comportamiento manualmente si aplica — los tests cubren la clasificación de estado (incl. borde exacto = caducado y ventana custom), `findExpired` con orden y exclusión de vacíos/sin-lote, `expiringWithin` excluyendo ya-caducados y fuera de ventana (con borde exacto incluido), y `nextToExpire` (más urgente incl. caducado, y `null`).
- [x] Actualicé docs, migraciones o cliente API si correspondía — no aplica: dominio nuevo del paquete, sin wiring al host.

## Cierre

- Closes #393

_Una consulta a nivel de repositorio (SQL por `expires_at`) puede añadirse luego en el host/`warehouse-postgres`; esto es el núcleo de dominio puro._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC6C4vKVk2tv3z54AtEZdD)_