### PR TITLE
feat(supplies): abre Category de enum cerrado a slug validado (data-driven) — Fase 0

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3011,28 +3011,9 @@
             "name": "category",
             "required": false,
             "in": "query",
-            "description": "Filter by item category (needs with at least one item of this category)",
+            "description": "Filter by item category slug (needs with at least one item of this category). Core slugs: food, water, hygiene, clothing, medical, shelter, tools, other, medicines, medical_equipment, medical_supplies, medical_personnel, food_fresh, food_non_perishable, hygiene_infantile, hygiene_personal, tools_extraction, other_pets.",
             "schema": {
-              "enum": [
-                "food",
-                "water",
-                "hygiene",
-                "clothing",
-                "medical",
-                "shelter",
-                "tools",
-                "other",
-                "medicines",
-                "medical_equipment",
-                "medical_supplies",
-                "medical_personnel",
-                "food_fresh",
-                "food_non_perishable",
-                "hygiene_infantile",
-                "hygiene_personal",
-                "tools_extraction",
-                "other_pets"
-              ],
+              "example": "water",
               "type": "string"
             }
           },
@@ -3275,28 +3256,9 @@
             "name": "category",
             "required": false,
             "in": "query",
-            "description": "Filter by item category (needs with at least one item of this category)",
+            "description": "Filter by item category slug (needs with at least one item of this category). Core slugs: food, water, hygiene, clothing, medical, shelter, tools, other, medicines, medical_equipment, medical_supplies, medical_personnel, food_fresh, food_non_perishable, hygiene_infantile, hygiene_personal, tools_extraction, other_pets.",
             "schema": {
-              "enum": [
-                "food",
-                "water",
-                "hygiene",
-                "clothing",
-                "medical",
-                "shelter",
-                "tools",
-                "other",
-                "medicines",
-                "medical_equipment",
-                "medical_supplies",
-                "medical_personnel",
-                "food_fresh",
-                "food_non_perishable",
-                "hygiene_infantile",
-                "hygiene_personal",
-                "tools_extraction",
-                "other_pets"
-              ],
+              "example": "water",
               "type": "string"
             }
           },
@@ -10019,27 +9981,8 @@
           },
           "category": {
             "type": "string",
-            "enum": [
-              "food",
-              "water",
-              "hygiene",
-              "clothing",
-              "medical",
-              "shelter",
-              "tools",
-              "other",
-              "medicines",
-              "medical_equipment",
-              "medical_supplies",
-              "medical_personnel",
-              "food_fresh",
-              "food_non_perishable",
-              "hygiene_infantile",
-              "hygiene_personal",
-              "tools_extraction",
-              "other_pets"
-            ],
-            "example": "water"
+            "example": "water",
+            "description": "Slug de categoría de material (data-driven, lowercase snake_case). Los slugs core son: food, water, hygiene, clothing, medical, shelter, tools, other, medicines, medical_equipment, medical_supplies, medical_personnel, food_fresh, food_non_perishable, hygiene_infantile, hygiene_personal, tools_extraction, other_pets. El conjunto es abierto: la taxonomía puede crecer vía datos (tabla `categories`)."
           },
           "presentation": {
             "type": "string",
@@ -10256,27 +10199,8 @@
           },
           "category": {
             "type": "string",
-            "enum": [
-              "food",
-              "water",
-              "hygiene",
-              "clothing",
-              "medical",
-              "shelter",
-              "tools",
-              "other",
-              "medicines",
-              "medical_equipment",
-              "medical_supplies",
-              "medical_personnel",
-              "food_fresh",
-              "food_non_perishable",
-              "hygiene_infantile",
-              "hygiene_personal",
-              "tools_extraction",
-              "other_pets"
-            ],
-            "example": "water"
+            "example": "water",
+            "description": "Slug de categoría de material (data-driven, lowercase snake_case)."
           },
           "presentation": {
             "type": "string",
@@ -13781,27 +13705,8 @@
           },
           "category": {
             "type": "string",
-            "enum": [
-              "food",
-              "water",
-              "hygiene",
-              "clothing",
-              "medical",
-              "shelter",
-              "tools",
-              "other",
-              "medicines",
-              "medical_equipment",
-              "medical_supplies",
-              "medical_personnel",
-              "food_fresh",
-              "food_non_perishable",
-              "hygiene_infantile",
-              "hygiene_personal",
-              "tools_extraction",
-              "other_pets"
-            ],
-            "example": "water"
+            "example": "water",
+            "description": "Slug de categoría de material (data-driven, lowercase snake_case)."
           },
           "presentation": {
             "type": "string",

--- a/apps/api/src/contexts/needs/application/create-need.ts
+++ b/apps/api/src/contexts/needs/application/create-need.ts
@@ -6,7 +6,7 @@ import { NeedResourceNotInEmergencyError } from '../domain/need-errors';
 import { Need } from '../domain/need';
 import { NeedId } from '../domain/need-id';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
-import { Priority, Category, PersonnelSkill } from '../domain/need-enums';
+import { Priority, PersonnelSkill } from '../domain/need-enums';
 import { Location } from '../../../shared/domain/location';
 import { SupplyLine } from '@globalemergency/warehouse-core/kernel';
 import { EmergencyNotAcceptingIntakeError } from '../../emergencies/domain/emergency-not-accepting-intake.error';
@@ -19,7 +19,8 @@ export interface CreateNeedItemCommand {
   name: string;
   quantity: number;
   unit: string | null;
-  category: Category;
+  /** Slug de categoría (data-driven); el formato lo valida SupplyLine. */
+  category: string;
   supplyId?: string | null;
   /** Presentation / route of administration (#61). Optional. */
   presentation?: string | null;

--- a/apps/api/src/contexts/needs/application/get-needs-queue.ts
+++ b/apps/api/src/contexts/needs/application/get-needs-queue.ts
@@ -1,11 +1,11 @@
 import { NeedRepository, NeedFilters } from '../domain/ports/need.repository';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
-import { Category, Priority } from '../domain/need-enums';
+import { Priority } from '../domain/need-enums';
 import { NeedView, toNeedView } from './need-view';
 
 export interface GetNeedsQueueQuery {
   emergencyId: string;
-  category?: Category;
+  category?: string;
   priority?: Priority;
 }
 

--- a/apps/api/src/contexts/needs/application/get-public-needs.ts
+++ b/apps/api/src/contexts/needs/application/get-public-needs.ts
@@ -1,11 +1,11 @@
 import { NeedRepository, NeedFilters } from '../domain/ports/need.repository';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
-import { Category, Priority } from '../domain/need-enums';
+import { Priority } from '../domain/need-enums';
 import { NeedView, toPublicNeedView } from './need-view';
 
 export interface GetPublicNeedsQuery {
   emergencyId: string;
-  category?: Category;
+  category?: string;
   priority?: Priority;
   /** Filter to needs linked to a specific resource / final recipient (#60). */
   resourceId?: string;

--- a/apps/api/src/contexts/needs/domain/ports/need.repository.ts
+++ b/apps/api/src/contexts/needs/domain/ports/need.repository.ts
@@ -1,12 +1,12 @@
 import { Need } from '../need';
 import { NeedId } from '../need-id';
 import { EmergencyId } from '../../../../shared/domain/emergency-id';
-import { Category, NeedStatus, Priority } from '../need-enums';
+import { NeedStatus, Priority } from '../need-enums';
 
 export const NEED_REPOSITORY = Symbol('NeedRepository');
 
 export interface NeedFilters {
-  category?: Category;
+  category?: string;
   priority?: Priority;
   /** Filter by linked resource / final recipient (#60). */
   resourceId?: string | null;

--- a/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
+++ b/apps/api/src/contexts/needs/infrastructure/http/needs.controller.ts
@@ -42,7 +42,11 @@ import { RenewNeed, GetExpiredNeeds } from '../../application/renew-need';
 import { SuggestVolunteersForNeed } from '../../application/suggest-volunteers-for-need';
 import { CreateTaskFromNeed } from '../../application/create-task-from-need';
 import { NeedView } from '../../application/need-view';
-import { Category, Priority } from '../../domain/need-enums';
+import { Priority } from '../../domain/need-enums';
+import {
+  CORE_CATEGORY_SLUGS,
+  isCoreCategory,
+} from '@globalemergency/warehouse-core/kernel';
 import {
   CreateNeedDto,
   AssignNeedManagerDto,
@@ -171,10 +175,12 @@ export class NeedsController {
   })
   @ApiQuery({
     name: 'category',
-    enum: Category,
+    type: String,
+    example: 'water',
     required: false,
     description:
-      'Filter by item category (needs with at least one item of this category)',
+      'Filter by item category slug (needs with at least one item of this category). ' +
+      `Core slugs: ${CORE_CATEGORY_SLUGS.join(', ')}.`,
   })
   @ApiQuery({
     name: 'priority',
@@ -210,9 +216,8 @@ export class NeedsController {
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
   ): Promise<NeedView[]> {
-    const validCategory = Object.values(Category).includes(category as Category)
-      ? (category as Category)
-      : undefined;
+    const validCategory =
+      category !== undefined && isCoreCategory(category) ? category : undefined;
     const validPriority = Object.values(Priority).includes(priority as Priority)
       ? (priority as Priority)
       : undefined;
@@ -306,10 +311,12 @@ export class NeedsController {
   })
   @ApiQuery({
     name: 'category',
-    enum: Category,
+    type: String,
+    example: 'water',
     required: false,
     description:
-      'Filter by item category (needs with at least one item of this category)',
+      'Filter by item category slug (needs with at least one item of this category). ' +
+      `Core slugs: ${CORE_CATEGORY_SLUGS.join(', ')}.`,
   })
   @ApiQuery({
     name: 'priority',
@@ -327,9 +334,8 @@ export class NeedsController {
     @Query('category') category?: string,
     @Query('priority') priority?: string,
   ): Promise<NeedView[]> {
-    const validCategory = Object.values(Category).includes(category as Category)
-      ? (category as Category)
-      : undefined;
+    const validCategory =
+      category !== undefined && isCoreCategory(category) ? category : undefined;
     const validPriority = Object.values(Priority).includes(priority as Priority)
       ? (priority as Priority)
       : undefined;

--- a/apps/api/src/contexts/offers/application/edit-offer.ts
+++ b/apps/api/src/contexts/offers/application/edit-offer.ts
@@ -1,7 +1,6 @@
 import { OfferRepository } from '../domain/ports/offer.repository';
 import { OfferId } from '../domain/offer-id';
 import { EditOfferProps } from '../domain/donation-offer';
-import { Category } from '../domain/offer-enums';
 import {
   SupplyLine,
   SupplyLineSnapshot,
@@ -16,7 +15,8 @@ export interface EditOfferItemCommand {
   name: string;
   quantity: number;
   unit: string | null;
-  category: Category;
+  /** Slug de categoría (data-driven); el formato lo valida SupplyLine. */
+  category: string;
   supplyId?: string | null;
   presentation: string | null;
 }

--- a/apps/api/src/contexts/offers/application/get-donation-intake-by-id.ts
+++ b/apps/api/src/contexts/offers/application/get-donation-intake-by-id.ts
@@ -1,7 +1,6 @@
 import { DonationIntakeId } from '../domain/donation-intake-id';
 import { DonationIntakeRepository } from '../domain/ports/donation-intake.repository';
 import { DonationIntakeNotFoundError } from './donation-intake-not-found.error';
-import { Category } from '../domain/offer-enums';
 
 export interface DonationIntakeLineView {
   id: string;
@@ -9,7 +8,8 @@ export interface DonationIntakeLineView {
   name: string;
   quantity: number;
   unit: string | null;
-  category: Category;
+  /** Slug de categoría (data-driven). */
+  category: string;
   supplyId: string | null;
   presentation: string | null;
   expiresAt: string | null;

--- a/apps/api/src/contexts/offers/application/get-donation-intake-tracking.ts
+++ b/apps/api/src/contexts/offers/application/get-donation-intake-tracking.ts
@@ -1,5 +1,4 @@
 import { EmergencyId } from '../../../shared/domain/emergency-id';
-import { Category } from '@globalemergency/warehouse-core/kernel';
 import { DonationIntakeRepository } from '../domain/ports/donation-intake.repository';
 import { IntakeResourceLookup } from '../domain/ports/intake-resource-lookup';
 import { DonationIntakeNotFoundError } from './donation-intake-not-found.error';
@@ -8,7 +7,8 @@ export interface DonationIntakeTrackingLine {
   name: string;
   quantity: number;
   unit: string | null;
-  category: Category;
+  /** Slug de categoría (data-driven). */
+  category: string;
   supplyId: string | null;
   presentation: string | null;
 }

--- a/apps/api/src/contexts/offers/application/submit-offer.ts
+++ b/apps/api/src/contexts/offers/application/submit-offer.ts
@@ -5,7 +5,6 @@ import { NeedLookup } from '../domain/ports/need-lookup';
 import { DonationOffer } from '../domain/donation-offer';
 import { OfferId } from '../domain/offer-id';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
-import { Category } from '../domain/offer-enums';
 import { SupplyLine } from '@globalemergency/warehouse-core/kernel';
 import { Location } from '../../../shared/domain/location';
 import { Author, AuthorProps } from '../../../shared/domain/author';
@@ -39,7 +38,8 @@ export interface SubmitOfferItemCommand {
   name: string;
   quantity: number;
   unit: string | null;
-  category: Category;
+  /** Slug de categoría (data-driven); el formato lo valida SupplyLine. */
+  category: string;
   supplyId?: string | null;
   presentation: string | null;
 }

--- a/apps/api/src/contexts/offers/infrastructure/in-memory-offer.repository.ts
+++ b/apps/api/src/contexts/offers/infrastructure/in-memory-offer.repository.ts
@@ -56,7 +56,7 @@ export class InMemoryOfferRepository implements OfferRepository {
         (s) =>
           s.emergencyId === emergencyId.value &&
           s.status === OfferStatus.Open &&
-          s.items.some((i) => (i.category as string) === category),
+          s.items.some((i) => i.category === category),
       )
       .map((s) => DonationOffer.fromSnapshot(s));
     return Promise.resolve(result);

--- a/apps/api/src/contexts/resources/application/register-resource.ts
+++ b/apps/api/src/contexts/resources/application/register-resource.ts
@@ -2,7 +2,7 @@ import { ResourceRepository } from '../domain/ports/resource.repository';
 import { EventBus } from '../domain/ports/event-bus';
 import { ResourceEmergencyStatusReader } from '../domain/ports/emergency-status-reader';
 import { Resource, Provenance } from '../domain/resource';
-import { SupplyLine, Category } from '@globalemergency/warehouse-core/kernel';
+import { SupplyLine } from '@globalemergency/warehouse-core/kernel';
 import { ResourceId } from '../domain/resource-id';
 import { EmergencyId } from '../../../shared/domain/emergency-id';
 import { ResourceType } from '../domain/resource-enums';
@@ -36,7 +36,8 @@ export interface RegisterResourceCommand {
     name: string;
     quantity: number;
     unit?: string | null;
-    category: Category;
+    /** Slug de categoría (data-driven); el formato lo valida SupplyLine. */
+    category: string;
     supplyId?: string | null;
     presentation?: string | null;
     expiresAt?: string | null;

--- a/apps/api/src/contexts/resources/application/resource-view.ts
+++ b/apps/api/src/contexts/resources/application/resource-view.ts
@@ -5,7 +5,6 @@ import {
   PublicStatus,
 } from '../domain/resource-enums';
 import { LocationProps } from '../../../shared/domain/location';
-import { Category } from '@globalemergency/warehouse-core/kernel';
 
 export interface ResourceView {
   id: string;
@@ -53,7 +52,8 @@ export interface ResourceView {
  * endpoint returns this; list/map views use the lighter ResourceView.
  */
 export interface ResourceDetailView extends ResourceView {
-  inventoryCategories: Category[];
+  /** Distinct category slugs present in the place's declared inventory. */
+  inventoryCategories: string[];
 }
 
 export function toResourceView(r: Resource): ResourceView {

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.int-spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.int-spec.ts
@@ -18,10 +18,7 @@ import {
   resourcesTable,
 } from '../../../resources/infrastructure/drizzle/schema';
 import { DrizzleSupplyLinkBackfillRepository } from './drizzle-supply-link-backfill.repository';
-import type {
-  SupplyLineSnapshot,
-  Category,
-} from '@globalemergency/warehouse-core/kernel';
+import type { SupplyLineSnapshot } from '@globalemergency/warehouse-core/kernel';
 import type { Pool } from 'pg';
 
 const URL =
@@ -48,7 +45,7 @@ function containerLine(
     name,
     quantity: 1,
     unit: null,
-    category: 'water' as Category,
+    category: 'water',
     supplyId,
     presentation: null,
     expiresAt: null,

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply-link-backfill.repository.spec.ts
@@ -11,7 +11,7 @@ function line(overrides: Partial<SupplyLineSnapshot>): SupplyLineSnapshot {
     presentation: null,
     expiresAt: null,
     ...overrides,
-  } as SupplyLineSnapshot;
+  };
 }
 
 describe('relinkContainerLines', () => {

--- a/apps/api/src/contexts/supplies/infrastructure/http/category-slug.validator.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/category-slug.validator.ts
@@ -1,0 +1,71 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, Validate } from 'class-validator';
+import type {
+  ValidationArguments,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { ValidatorConstraint } from 'class-validator';
+import {
+  CategorySlug,
+  CategoryValidationError,
+  CORE_CATEGORY_SLUGS,
+} from '@globalemergency/warehouse-core/kernel';
+
+/**
+ * Validación *de formato* del slug de categoría en la frontera HTTP, alineada
+ * con {@link CategorySlug} del kernel (trim + lowercase + snake_case).
+ *
+ * Sustituye al antiguo `@IsEnum(Category)`: la categoría dejó de ser un enum
+ * cerrado para pasar a ser un slug validado (string) data-driven. La pertenencia
+ * a la taxonomía concreta (tabla `categories` / `CategoryRegistry`) se comprueba
+ * en el caso de uso, no aquí — este validador solo garantiza el formato.
+ *
+ * `CORE_CATEGORY_SLUGS` se documenta como conjunto de ejemplo en Swagger, pero
+ * el tipo del contrato es `string` (abierto), no un enum cerrado.
+ */
+@ValidatorConstraint({ name: 'isCategorySlug', async: false })
+export class IsCategorySlugConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string') return false;
+    try {
+      CategorySlug.of(value);
+      return true;
+    } catch (err) {
+      if (err instanceof CategoryValidationError) return false;
+      throw err;
+    }
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} debe ser un slug de categoría válido (lowercase snake_case, p.ej. ${CORE_CATEGORY_SLUGS.slice(0, 3).join(', ')})`;
+  }
+}
+
+/** Metadatos de Swagger compartidos para el campo `category`. */
+const CATEGORY_API_META = {
+  type: String,
+  example: 'water',
+  description:
+    'Slug de categoría de material (data-driven, lowercase snake_case). ' +
+    `Los slugs core son: ${CORE_CATEGORY_SLUGS.join(', ')}. ` +
+    'El conjunto es abierto: la taxonomía puede crecer vía datos (tabla `categories`).',
+} as const;
+
+/** Decorador para el campo `category` requerido de un {@link SupplyLineDto}. */
+export function CategorySlugProperty(): PropertyDecorator {
+  return applyDecorators(
+    ApiProperty(CATEGORY_API_META),
+    IsString(),
+    Validate(IsCategorySlugConstraint),
+  );
+}
+
+/** Variante opcional del campo `category` (filtros, respuestas). */
+export function OptionalCategorySlugProperty(): PropertyDecorator {
+  return applyDecorators(
+    ApiPropertyOptional(CATEGORY_API_META),
+    IsString(),
+    Validate(IsCategorySlugConstraint),
+  );
+}

--- a/apps/api/src/contexts/supplies/infrastructure/http/supply-line.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supply-line.dto.ts
@@ -1,5 +1,4 @@
 import {
-  IsEnum,
   IsInt,
   IsNotEmpty,
   IsOptional,
@@ -9,7 +8,7 @@ import {
   Matches,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Category } from '@globalemergency/warehouse-core/kernel';
+import { CategorySlugProperty } from './category-slug.validator';
 
 /**
  * SupplyLineDto — the single request shape for a line of aid material
@@ -47,9 +46,8 @@ export class SupplyLineDto {
   @IsString()
   unit?: string;
 
-  @ApiProperty({ enum: Category, example: Category.Water })
-  @IsEnum(Category)
-  category!: Category;
+  @CategorySlugProperty()
+  category!: string;
 
   @ApiPropertyOptional({
     example: 'ampolla',
@@ -92,8 +90,13 @@ export class SupplyLineResponseDto {
   @ApiPropertyOptional({ example: 'liters', nullable: true, type: String })
   unit!: string | null;
 
-  @ApiProperty({ enum: Category, example: Category.Water })
-  category!: Category;
+  @ApiProperty({
+    type: String,
+    example: 'water',
+    description:
+      'Slug de categoría de material (data-driven, lowercase snake_case).',
+  })
+  category!: string;
 
   @ApiPropertyOptional({
     example: 'ampolla',

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -3120,10 +3120,10 @@ export interface components {
              */
             unit?: string;
             /**
+             * @description Slug de categoría de material (data-driven, lowercase snake_case). Los slugs core son: food, water, hygiene, clothing, medical, shelter, tools, other, medicines, medical_equipment, medical_supplies, medical_personnel, food_fresh, food_non_perishable, hygiene_infantile, hygiene_personal, tools_extraction, other_pets. El conjunto es abierto: la taxonomía puede crecer vía datos (tabla `categories`).
              * @example water
-             * @enum {string}
              */
-            category: "food" | "water" | "hygiene" | "clothing" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel" | "food_fresh" | "food_non_perishable" | "hygiene_infantile" | "hygiene_personal" | "tools_extraction" | "other_pets";
+            category: string;
             /**
              * @description Presentation / route of administration: ampolla, EV (intravenoso), inhalador, pastilla, jarabe… Optional, free-form (#61).
              * @example ampolla
@@ -3250,10 +3250,10 @@ export interface components {
             /** @example liters */
             unit?: string | null;
             /**
+             * @description Slug de categoría de material (data-driven, lowercase snake_case).
              * @example water
-             * @enum {string}
              */
-            category: "food" | "water" | "hygiene" | "clothing" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel" | "food_fresh" | "food_non_perishable" | "hygiene_infantile" | "hygiene_personal" | "tools_extraction" | "other_pets";
+            category: string;
             /**
              * @description Presentation / route of administration (ampolla, EV, inhalador…) — #61.
              * @example ampolla
@@ -4835,10 +4835,10 @@ export interface components {
             /** @example liters */
             unit?: string | null;
             /**
+             * @description Slug de categoría de material (data-driven, lowercase snake_case).
              * @example water
-             * @enum {string}
              */
-            category: "food" | "water" | "hygiene" | "clothing" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel" | "food_fresh" | "food_non_perishable" | "hygiene_infantile" | "hygiene_personal" | "tools_extraction" | "other_pets";
+            category: string;
             /**
              * @description Presentation / route of administration (ampolla, EV, inhalador…) — #61.
              * @example ampolla
@@ -8514,8 +8514,8 @@ export interface operations {
     NeedsController_listPublic: {
         parameters: {
             query?: {
-                /** @description Filter by item category (needs with at least one item of this category) */
-                category?: "food" | "water" | "hygiene" | "clothing" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel" | "food_fresh" | "food_non_perishable" | "hygiene_infantile" | "hygiene_personal" | "tools_extraction" | "other_pets";
+                /** @description Filter by item category slug (needs with at least one item of this category). Core slugs: food, water, hygiene, clothing, medical, shelter, tools, other, medicines, medical_equipment, medical_supplies, medical_personnel, food_fresh, food_non_perishable, hygiene_infantile, hygiene_personal, tools_extraction, other_pets. */
+                category?: string;
                 /** @description Filter by need priority */
                 priority?: "low" | "medium" | "high" | "urgent";
                 /** @description Filter to needs linked to this resource / final recipient */
@@ -8614,8 +8614,8 @@ export interface operations {
     NeedsController_listQueue: {
         parameters: {
             query?: {
-                /** @description Filter by item category (needs with at least one item of this category) */
-                category?: "food" | "water" | "hygiene" | "clothing" | "medical" | "shelter" | "tools" | "other" | "medicines" | "medical_equipment" | "medical_supplies" | "medical_personnel" | "food_fresh" | "food_non_perishable" | "hygiene_infantile" | "hygiene_personal" | "tools_extraction" | "other_pets";
+                /** @description Filter by item category slug (needs with at least one item of this category). Core slugs: food, water, hygiene, clothing, medical, shelter, tools, other, medicines, medical_equipment, medical_supplies, medical_personnel, food_fresh, food_non_perishable, hygiene_infantile, hygiene_personal, tools_extraction, other_pets. */
+                category?: string;
                 /** @description Filter by need priority */
                 priority?: "low" | "medium" | "high" | "urgent";
             };

--- a/packages/warehouse-core/src/kernel/supply-line.test.ts
+++ b/packages/warehouse-core/src/kernel/supply-line.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SupplyLine, SupplyLineValidationError } from './supply-line.js';
+import { CategoryValidationError } from './category-errors.js';
+import { Category } from './category.js';
+
+const base = {
+  name: 'Agua embotellada',
+  quantity: 10,
+  unit: 'l',
+  category: Category.Water,
+} as const;
+
+test('create normaliza el slug de categoría (trim + lowercase)', () => {
+  const line = SupplyLine.create({ ...base, category: ' Food ' });
+  assert.equal(line.category, 'food');
+  assert.equal(line.toSnapshot().category, 'food');
+});
+
+test('create acepta los slugs core del enum', () => {
+  const line = SupplyLine.create({ ...base, category: Category.MedicalEquipment });
+  assert.equal(line.category, 'medical_equipment');
+});
+
+test('create rechaza un slug con formato inválido', () => {
+  assert.throws(
+    () => SupplyLine.create({ ...base, category: 'food-fresh' }),
+    CategoryValidationError,
+  );
+  assert.throws(
+    () => SupplyLine.create({ ...base, category: '   ' }),
+    CategoryValidationError,
+  );
+});
+
+test('create sigue validando nombre y cantidad', () => {
+  assert.throws(
+    () => SupplyLine.create({ ...base, name: '   ' }),
+    SupplyLineValidationError,
+  );
+  assert.throws(
+    () => SupplyLine.create({ ...base, quantity: 0 }),
+    SupplyLineValidationError,
+  );
+});

--- a/packages/warehouse-core/src/kernel/supply-line.test.ts
+++ b/packages/warehouse-core/src/kernel/supply-line.test.ts
@@ -18,7 +18,10 @@ test('create normaliza el slug de categoría (trim + lowercase)', () => {
 });
 
 test('create acepta los slugs core del enum', () => {
-  const line = SupplyLine.create({ ...base, category: Category.MedicalEquipment });
+  const line = SupplyLine.create({
+    ...base,
+    category: Category.MedicalEquipment,
+  });
   assert.equal(line.category, 'medical_equipment');
 });
 

--- a/packages/warehouse-core/src/kernel/supply-line.ts
+++ b/packages/warehouse-core/src/kernel/supply-line.ts
@@ -1,4 +1,4 @@
-import { Category } from './category.js';
+import { CategorySlug } from './category-slug.js';
 
 /**
  * SupplyLine — the core "line of aid material" of the platform: a quantity of a
@@ -25,7 +25,13 @@ export interface SupplyLineProps {
   name: string;
   quantity: number;
   unit: string | null;
-  category: Category;
+  /**
+   * Slug de categoría (data-driven). Se valida el *formato* con
+   * {@link CategorySlug} en {@link SupplyLine.create}; la pertenencia a la
+   * taxonomía concreta (tabla `categories` / `CategoryRegistry`) es
+   * responsabilidad del host, no del value object.
+   */
+  category: string;
   supplyId?: string | null;
   presentation?: string | null;
   expiresAt?: string | null;
@@ -35,7 +41,8 @@ export interface SupplyLineSnapshot {
   name: string;
   quantity: number;
   unit: string | null;
-  category: Category;
+  /** Slug de categoría (data-driven) ya normalizado. */
+  category: string;
   /** Soft link to the canonical supply master data, or null when absent. */
   supplyId: string | null;
   /** Optional (legacy-safe) presentation / route of administration (#61). */
@@ -79,7 +86,7 @@ export class SupplyLine {
   readonly name: string;
   readonly quantity: number;
   readonly unit: string | null;
-  readonly category: Category;
+  readonly category: string;
   readonly supplyId: string | null;
   readonly presentation: string | null;
   readonly expiresAt: string | null;
@@ -103,11 +110,14 @@ export class SupplyLine {
         'SupplyLine quantity must be a positive integer',
       );
     }
+    // Valida el *formato* del slug (trim + lowercase + snake_case) y lo
+    // normaliza. La pertenencia a la taxonomía es cosa del host.
+    const category = CategorySlug.of(props.category).value;
     return new SupplyLine({
       name: props.name.trim(),
       quantity: props.quantity,
       unit: props.unit ?? null,
-      category: props.category,
+      category,
       supplyId: props.supplyId ?? null,
       presentation: props.presentation ?? null,
       expiresAt: props.expiresAt ?? null,


### PR DESCRIPTION
Closes #382 · Fase 0 de la épica #355 (follow-up de #380).

Migración **breaking y compiler-driven**: abre el `Category` (enum cerrado) al modelo de slug data-driven que sembró #380 (`CategorySlug`/`CategoryRegistry`/`CORE_CATEGORY_SLUGS`). El tipo del contrato se **ensancha** (enum → `string` validado); los valores válidos actuales siguen funcionando.

## Cambios por capa
- **Kernel**: `SupplyLine.category` pasa de `Category` a `string`, validado en `create()` con `CategorySlug.of()` (formato: trim + lowercase + snake_case). La pertenencia a la taxonomía concreta es responsabilidad del host (tabla `categories`/`CategoryRegistry`), no del VO. `Category` y `CORE_CATEGORY_SLUGS` quedan como **semilla** de las categorías core. + test unitario.
- **API**: validador compartido `CategorySlugProperty()`/`OptionalCategorySlugProperty()` sustituye a `@IsEnum(Category)` (delega en `CategorySlug`, documenta los slugs core como ejemplo en Swagger, tipo `string`). Anotaciones `: Category` → `string` en DTOs/aplicación/dominio de needs/offers/resources/logistics. Filtros de categoría con `isCoreCategory` (equivalente 1:1 al viejo `Object.values(Category).includes`).
- **api-client**: `gen:api` regenerado — `category` abierto a `string` (sin unión cerrada); `inventoryCategories: string[]`.
- **Web**: sin cambios — ya era data-driven (lee `GET /categories`, nunca el enum cerrado del cliente).

## Comportamiento
1:1 con el anterior. El filtro de categoría de needs/offers acepta exactamente el mismo conjunto (los 18 slugs core), porque `CORE_CATEGORY_SLUGS === Object.values(Category)`. Abrir el filtro a categorías de BBDD es mejora futura, fuera de alcance.

## Verificación (local)
warehouse-core build + 95 tests · api build (nest/tsc, tsc-neutral 46 sin empeorar) · api eslint (0) · api prettier · api-client build · web build · web lint · frozen-lockfile — todo verde. Los int-tests Jest de api los valida CI (necesitan Postgres).