### PR TITLE
feat(catalog): tenencia base global + extensión por tenant (Inc 2 catálogo escalable)

### DIFF
--- a/apps/api/drizzle/0056_catalog_tenancy.sql
+++ b/apps/api/drizzle/0056_catalog_tenancy.sql
@@ -1,0 +1,65 @@
+-- Tenencia del catálogo maestro escalable (#397, épica #228, Inc 2). Añade
+-- `scope_id` (uuid, nullable) a `supplies` y `supply_aliases` — la columna ya
+-- existe en `attribute_definitions` desde 0055. `scope_id IS NULL` = fila global
+-- (base curada por admins globales); `scope_id = T` = extensión de un tenant.
+-- Visible para T = global ∪ lo suyo; la fusión aditiva la resuelve el dominio
+-- (`resolveEffectiveSchema`). La tenencia es un `scope_id` OPACO: el host lo mapea
+-- a emergencia/organización; el modelo no fija qué es.
+--
+-- Unicidad por scope: cada unicidad global existente se convierte en un PAR de
+-- índices únicos parciales — uno para globales (WHERE scope_id IS NULL, que
+-- preserva el candado global anterior) y otro por tenant (WHERE scope_id IS NOT
+-- NULL, que incluye scope_id en la clave). Así un tenant puede reutilizar un
+-- code/alias/key que ya existe en global sin chocar, pero nunca duplicar dentro
+-- de su propio scope. Fix-forward: se dropean los constraints/índices globales
+-- previos y se recrean como el par (las migraciones aplicadas son inmutables).
+-- Todo idempotente (IF EXISTS / IF NOT EXISTS) para BD ya migradas.
+
+-- === attribute_definitions ===
+-- 0055 dejó el índice global parcial `(category_slug,key) WHERE scope_id IS NULL`.
+-- Aquí se añade sólo el contraparte de tenant (la columna ya existe).
+CREATE UNIQUE INDEX IF NOT EXISTS "attribute_definitions_scope_category_key_uniq"
+  ON "attribute_definitions" ("category_slug", "key", "scope_id")
+  WHERE "scope_id" IS NOT NULL;
+--> statement-breakpoint
+
+-- === supplies ===
+ALTER TABLE "supplies" ADD COLUMN IF NOT EXISTS "scope_id" uuid;
+--> statement-breakpoint
+
+-- La unicidad de `code` era global (índice `supplies_code_uniq` sobre (code),
+-- creado en 0037). Se dropea y se recrea como par por scope.
+DROP INDEX IF EXISTS "supplies_code_uniq";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "supplies_code_global_uniq"
+  ON "supplies" ("code")
+  WHERE "scope_id" IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "supplies_code_scope_uniq"
+  ON "supplies" ("code", "scope_id")
+  WHERE "scope_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "supplies_scope_id_idx" ON "supplies" ("scope_id");
+--> statement-breakpoint
+
+-- === supply_aliases ===
+ALTER TABLE "supply_aliases" ADD COLUMN IF NOT EXISTS "scope_id" uuid;
+--> statement-breakpoint
+
+-- La unicidad del alias normalizado era la PRIMARY KEY sobre `alias_norm`
+-- (creada en 0037). Un alias global y uno de tenant pueden compartir el mismo
+-- texto (apuntando a supplies distintos), así que la PK global estorba: se
+-- dropea y la unicidad pasa a ser el par de índices parciales por scope. La
+-- tabla queda sin PK (nadie la referencia por FK), con `alias_norm` aún NOT NULL.
+ALTER TABLE "supply_aliases" DROP CONSTRAINT IF EXISTS "supply_aliases_pkey";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "supply_aliases_alias_global_uniq"
+  ON "supply_aliases" ("alias_norm")
+  WHERE "scope_id" IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "supply_aliases_alias_scope_uniq"
+  ON "supply_aliases" ("alias_norm", "scope_id")
+  WHERE "scope_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "supply_aliases_scope_id_idx"
+  ON "supply_aliases" ("scope_id");

--- a/apps/api/src/contexts/supplies/application/add-supply-alias.ts
+++ b/apps/api/src/contexts/supplies/application/add-supply-alias.ts
@@ -7,11 +7,19 @@ import {
 export interface AddSupplyAliasCommand {
   supplyId: string;
   term: string;
+  /**
+   * Tenencia (#397): `undefined`/`null` = alias global (por defecto; HTTP hoy
+   * opera en global). Un `scopeId` de tenant crea el alias en su scope. El alias
+   * hereda el scope del insumo destino.
+   */
+  scopeId?: string | null;
 }
 
 /**
- * Asocia un sinónimo a un insumo (#222). El término se normaliza en el dominio;
- * el repositorio rechaza el alias si ya apunta a otro insumo.
+ * Asocia un sinónimo a un insumo (#222, tenencia #397). El término se normaliza
+ * en el dominio; el repositorio rechaza el alias si ya apunta a otro insumo
+ * dentro del mismo scope. El alias se crea en el scope del propio insumo (un
+ * alias de tenant apunta a un insumo de ese tenant o a uno global visible).
  */
 export class AddSupplyAlias {
   constructor(private readonly repo: SupplyRepository) {}
@@ -21,8 +29,12 @@ export class AddSupplyAlias {
     if (!supply) {
       throw new SupplyNotFoundError(cmd.supplyId);
     }
+    // El alias hereda el scope del insumo (un insumo de tenant lleva aliases de
+    // tenant; uno global, aliases globales). Si el comando fuerza un scopeId, se
+    // respeta (p.ej. un tenant aliasando un insumo global desde su scope).
+    const scopeId = cmd.scopeId ?? supply.scopeId;
     await this.repo.addAlias(
-      SupplyAlias.create({ alias: cmd.term, supplyId: cmd.supplyId }),
+      SupplyAlias.create({ alias: cmd.term, supplyId: cmd.supplyId, scopeId }),
     );
   }
 }

--- a/apps/api/src/contexts/supplies/application/admin-supply-use-cases.spec.ts
+++ b/apps/api/src/contexts/supplies/application/admin-supply-use-cases.spec.ts
@@ -108,11 +108,13 @@ describe('ListSuppliesAdmin / GetSupplyAdmin', () => {
   it('list adjunta los alias y expone campos internos', async () => {
     const repo = makeRepo({
       list: jest.fn().mockResolvedValue([supply('archived')]),
-      listAliases: jest
-        .fn()
-        .mockResolvedValue([
-          SupplyAlias.fromSnapshot({ alias: 'aguita', supplyId: ID }),
-        ]),
+      listAliases: jest.fn().mockResolvedValue([
+        SupplyAlias.fromSnapshot({
+          alias: 'aguita',
+          supplyId: ID,
+          scopeId: null,
+        }),
+      ]),
     });
     const views = await new ListSuppliesAdmin(repo).execute({});
     expect(views).toHaveLength(1);

--- a/apps/api/src/contexts/supplies/application/create-attribute-definition.ts
+++ b/apps/api/src/contexts/supplies/application/create-attribute-definition.ts
@@ -15,13 +15,25 @@ export interface CreateAttributeDefinitionCommand {
   options?: readonly AttributeOption[] | null | undefined;
   unit?: string | null | undefined;
   sort?: number | undefined;
+  /**
+   * Tenencia (#397): destino de la definición. `undefined`/`null` = global
+   * (comportamiento por defecto; los hosts HTTP hoy operan en global). Un
+   * `scopeId` de tenant crea una definición que extiende la familia sólo para
+   * ese tenant.
+   */
+  scopeId?: string | null | undefined;
 }
 
 /**
- * Alta de una definición de atributo del metamodelo (#396). La categoría debe
- * existir en la taxonomía. Las invariantes del metamodelo (key, dataType,
- * options/unit) las aplica el agregado `AttributeDefinition.create`. Inc 1: sólo
- * definiciones globales (`scopeId === null`).
+ * Alta de una definición de atributo del metamodelo (#396, tenencia #397). La
+ * categoría debe existir en la taxonomía. Las invariantes del metamodelo (key,
+ * dataType, options/unit) las aplica el agregado `AttributeDefinition.create`.
+ *
+ * Tenencia (#397): `scopeId` null = definición global; un tenant añade la suya.
+ * La regla aditiva (una key de tenant no puede chocar con la misma key global de
+ * la ascendencia) la garantiza `resolveEffectiveSchema` al escribir un Supply;
+ * aquí sólo se persiste en el scope indicado (candado de unicidad por scope en
+ * BD). HTTP se mantiene global en este incremento.
  */
 export class CreateAttributeDefinition {
   constructor(
@@ -47,7 +59,7 @@ export class CreateAttributeDefinition {
       options: cmd.options ?? null,
       unit: cmd.unit ?? null,
       sort: cmd.sort ?? 0,
-      scopeId: null,
+      scopeId: cmd.scopeId ?? null,
     });
 
     await this.repo.save(definition);

--- a/apps/api/src/contexts/supplies/application/create-supply.spec.ts
+++ b/apps/api/src/contexts/supplies/application/create-supply.spec.ts
@@ -4,6 +4,7 @@ import {
   VariantTargetNotFoundError,
   CategoryNotFoundError,
   AttributeValidationError,
+  AttributeKeyCollisionError,
   AttributeDefinition,
   SupplyRepository,
   CategoryRepository,
@@ -288,5 +289,100 @@ describe('CreateSupply', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const saved = save.mock.calls[0][0] as Supply;
     expect(saved.attributes).toEqual({ cualquier_cosa: 'libre' });
+  });
+
+  // === Tenencia (#397) ===
+
+  const TENANT = '11111111-1111-4111-8111-111111111111';
+
+  it('sin scopeId el insumo es global (null) y consulta sólo definiciones globales', async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    const findByCategoryAncestry = jest.fn().mockResolvedValue([]);
+    const repo = makeRepo({ save });
+    const attributeRepo = makeAttributeRepo({ findByCategoryAncestry });
+
+    await new CreateSupply(repo, makeCategoryRepo(), attributeRepo).execute({
+      name: 'Agua',
+      categorySlug: 'water',
+    });
+
+    // El repo se consulta con scope null (sólo globales).
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const scopeArg = findByCategoryAncestry.mock.calls[0][1] as string | null;
+    expect(scopeArg).toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const saved = save.mock.calls[0][0] as Supply;
+    expect(saved.scopeId).toBeNull();
+  });
+
+  it('con scopeId el insumo es de tenant y valida contra global ∪ tenant', async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    // El repo (con scope de tenant) devuelve global ∪ tenant; el use-case pasa
+    // ese conjunto y el mismo scope a resolveEffectiveSchema.
+    const findByCategoryAncestry = jest.fn().mockResolvedValue([
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'principio_activo',
+        dataType: 'text',
+        required: true,
+      }),
+      AttributeDefinition.create({
+        categorySlug: 'medicines',
+        key: 'nota_local',
+        dataType: 'text',
+        scopeId: TENANT,
+      }),
+    ]);
+    const repo = makeRepo({ save });
+    const attributeRepo = makeAttributeRepo({ findByCategoryAncestry });
+
+    await new CreateSupply(repo, makeCategoryRepo(), attributeRepo).execute({
+      name: 'Amoxicilina local',
+      categorySlug: 'medicines',
+      attributes: { principio_activo: 'Amoxicilina', nota_local: 'lote X' },
+      scopeId: TENANT,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const scopeArg = findByCategoryAncestry.mock.calls[0][1] as string | null;
+    expect(scopeArg).toBe(TENANT);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const saved = save.mock.calls[0][0] as Supply;
+    expect(saved.scopeId).toBe(TENANT);
+    // Valida contra el atributo de tenant además del global.
+    expect(saved.attributes).toEqual({
+      principio_activo: 'Amoxicilina',
+      nota_local: 'lote X',
+    });
+  });
+
+  it('rechaza una colisión de key global↔tenant en el esquema efectivo del tenant', async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    const findByCategoryAncestry = jest.fn().mockResolvedValue([
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'dosis',
+        dataType: 'text',
+      }),
+      // Un tenant que intenta redefinir una key global de su ascendencia.
+      AttributeDefinition.create({
+        categorySlug: 'medicines',
+        key: 'dosis',
+        dataType: 'text',
+        scopeId: TENANT,
+      }),
+    ]);
+    const repo = makeRepo({ save });
+    const attributeRepo = makeAttributeRepo({ findByCategoryAncestry });
+
+    await expect(
+      new CreateSupply(repo, makeCategoryRepo(), attributeRepo).execute({
+        name: 'Colisión',
+        categorySlug: 'medicines',
+        attributes: { dosis: 'x' },
+        scopeId: TENANT,
+      }),
+    ).rejects.toThrow(AttributeKeyCollisionError);
+    expect(save).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/contexts/supplies/application/create-supply.ts
+++ b/apps/api/src/contexts/supplies/application/create-supply.ts
@@ -8,13 +8,9 @@ import {
   SupplyTranslationInput,
   CategoryRepository,
   AttributeDefinitionRepository,
-  resolveEffectiveSchema,
-  validateAttributes,
 } from '@globalemergency/warehouse-core/catalog';
-import {
-  getCategoryPrefix,
-  CategoryRegistry,
-} from '@globalemergency/warehouse-core/kernel';
+import { getCategoryPrefix } from '@globalemergency/warehouse-core/kernel';
+import { validateSupplyAttributes } from './validate-supply-attributes';
 
 export interface CreateSupplyCommand {
   name: string;
@@ -69,7 +65,8 @@ export class CreateSupply {
     // unión de definiciones de la ascendencia de su categoría). Con scope de
     // tenant, el esquema efectivo es global ∪ tenant. Si la familia no tiene
     // definiciones, el esquema es vacío y los atributos pasan tal cual.
-    const attributes = await this.validateAttributes(
+    const attributes = await validateSupplyAttributes(
+      this.attributeRepo,
       cmd.categorySlug,
       cmd.attributes ?? {},
       categories,
@@ -94,37 +91,5 @@ export class CreateSupply {
 
     await this.repo.save(supply, cmd.translations);
     return { id: supply.id, code: supply.code };
-  }
-
-  private async validateAttributes(
-    categorySlug: string,
-    attributes: Record<string, unknown>,
-    categories: readonly { slug: string; parentSlug: string | null }[],
-    scopeId: string | null,
-  ): Promise<Record<string, unknown>> {
-    const registry = CategoryRegistry.fromNodes(
-      categories.map((c) => ({
-        slug: c.slug,
-        parentSlug: c.parentSlug,
-        codePrefix: null,
-      })),
-    );
-    const ancestrySlugs = [
-      categorySlug,
-      ...registry.ancestorsOf(categorySlug).map((n) => n.slug),
-    ];
-    // Con scope de tenant el repo devuelve global ∪ tenant; sin scope, sólo
-    // global. `resolveEffectiveSchema` fusiona ese conjunto por scope.
-    const defs = await this.attributeRepo.findByCategoryAncestry(
-      ancestrySlugs,
-      scopeId,
-    );
-    const schema = resolveEffectiveSchema(
-      categorySlug,
-      defs,
-      registry,
-      scopeId,
-    );
-    return validateAttributes(attributes, schema);
   }
 }

--- a/apps/api/src/contexts/supplies/application/create-supply.ts
+++ b/apps/api/src/contexts/supplies/application/create-supply.ts
@@ -26,6 +26,12 @@ export interface CreateSupplyCommand {
   variantOfId?: string | null;
   /** Traducciones de nombre por idioma (#320). El nombre base (`name`) es `es`. */
   translations?: readonly SupplyTranslationInput[];
+  /**
+   * Tenencia (#397): `undefined`/`null` = insumo global (por defecto; HTTP hoy
+   * opera en global). Un `scopeId` de tenant crea el insumo en su scope y valida
+   * sus atributos contra el esquema efectivo global ∪ tenant.
+   */
+  scopeId?: string | null;
 }
 
 /**
@@ -57,13 +63,17 @@ export class CreateSupply {
       throw new CategoryNotFoundError(cmd.categorySlug);
     }
 
+    const scopeId = cmd.scopeId ?? null;
+
     // Valida el `attributes` jsonb contra el esquema efectivo de la familia (la
-    // unión de definiciones de la ascendencia de su categoría). Si la familia no
-    // tiene definiciones, el esquema es vacío y los atributos pasan tal cual.
+    // unión de definiciones de la ascendencia de su categoría). Con scope de
+    // tenant, el esquema efectivo es global ∪ tenant. Si la familia no tiene
+    // definiciones, el esquema es vacío y los atributos pasan tal cual.
     const attributes = await this.validateAttributes(
       cmd.categorySlug,
       cmd.attributes ?? {},
       categories,
+      scopeId,
     );
 
     const prefix = getCategoryPrefix(cmd.categorySlug, categories);
@@ -79,6 +89,7 @@ export class CreateSupply {
       attributes,
       registrationNotes: cmd.registrationNotes ?? null,
       variantOfId,
+      scopeId,
     });
 
     await this.repo.save(supply, cmd.translations);
@@ -89,6 +100,7 @@ export class CreateSupply {
     categorySlug: string,
     attributes: Record<string, unknown>,
     categories: readonly { slug: string; parentSlug: string | null }[],
+    scopeId: string | null,
   ): Promise<Record<string, unknown>> {
     const registry = CategoryRegistry.fromNodes(
       categories.map((c) => ({
@@ -101,11 +113,18 @@ export class CreateSupply {
       categorySlug,
       ...registry.ancestorsOf(categorySlug).map((n) => n.slug),
     ];
+    // Con scope de tenant el repo devuelve global ∪ tenant; sin scope, sólo
+    // global. `resolveEffectiveSchema` fusiona ese conjunto por scope.
     const defs = await this.attributeRepo.findByCategoryAncestry(
       ancestrySlugs,
-      null,
+      scopeId,
     );
-    const schema = resolveEffectiveSchema(categorySlug, defs, registry);
+    const schema = resolveEffectiveSchema(
+      categorySlug,
+      defs,
+      registry,
+      scopeId,
+    );
     return validateAttributes(attributes, schema);
   }
 }

--- a/apps/api/src/contexts/supplies/application/edit-supply.ts
+++ b/apps/api/src/contexts/supplies/application/edit-supply.ts
@@ -7,13 +7,9 @@ import {
   SupplyTranslationInput,
   CategoryRepository,
   AttributeDefinitionRepository,
-  resolveEffectiveSchema,
-  validateAttributes,
 } from '@globalemergency/warehouse-core/catalog';
-import {
-  getCategoryPrefix,
-  CategoryRegistry,
-} from '@globalemergency/warehouse-core/kernel';
+import { getCategoryPrefix } from '@globalemergency/warehouse-core/kernel';
+import { validateSupplyAttributes } from './validate-supply-attributes';
 
 export interface EditSupplyCommand {
   id: string;
@@ -84,7 +80,8 @@ export class EditSupply {
       // Tenencia (#397): valida contra el esquema efectivo del scope del propio
       // insumo (global ∪ tenant si es de tenant). El scope es identidad: no se
       // edita, se conserva del agregado cargado.
-      const attributes = await this.validateAttributes(
+      const attributes = await validateSupplyAttributes(
+        this.attributeRepo,
         next.categorySlug,
         next.attributes,
         categories,
@@ -97,35 +94,5 @@ export class EditSupply {
     next = next.updateCodePrefix(prefix);
 
     await this.repo.save(next, cmd.translations);
-  }
-
-  private async validateAttributes(
-    categorySlug: string,
-    attributes: Record<string, unknown>,
-    categories: readonly { slug: string; parentSlug: string | null }[],
-    scopeId: string | null,
-  ): Promise<Record<string, unknown>> {
-    const registry = CategoryRegistry.fromNodes(
-      categories.map((c) => ({
-        slug: c.slug,
-        parentSlug: c.parentSlug,
-        codePrefix: null,
-      })),
-    );
-    const ancestrySlugs = [
-      categorySlug,
-      ...registry.ancestorsOf(categorySlug).map((n) => n.slug),
-    ];
-    const defs = await this.attributeRepo.findByCategoryAncestry(
-      ancestrySlugs,
-      scopeId,
-    );
-    const schema = resolveEffectiveSchema(
-      categorySlug,
-      defs,
-      registry,
-      scopeId,
-    );
-    return validateAttributes(attributes, schema);
   }
 }

--- a/apps/api/src/contexts/supplies/application/edit-supply.ts
+++ b/apps/api/src/contexts/supplies/application/edit-supply.ts
@@ -81,10 +81,14 @@ export class EditSupply {
     // cambian los atributos o la categoría (una recategorización puede invalidar
     // atributos válidos en la familia anterior). Persiste la versión validada.
     if (cmd.attributes !== undefined || cmd.categorySlug !== undefined) {
+      // Tenencia (#397): valida contra el esquema efectivo del scope del propio
+      // insumo (global ∪ tenant si es de tenant). El scope es identidad: no se
+      // edita, se conserva del agregado cargado.
       const attributes = await this.validateAttributes(
         next.categorySlug,
         next.attributes,
         categories,
+        next.scopeId,
       );
       next = next.setAttributes(attributes);
     }
@@ -99,6 +103,7 @@ export class EditSupply {
     categorySlug: string,
     attributes: Record<string, unknown>,
     categories: readonly { slug: string; parentSlug: string | null }[],
+    scopeId: string | null,
   ): Promise<Record<string, unknown>> {
     const registry = CategoryRegistry.fromNodes(
       categories.map((c) => ({
@@ -113,9 +118,14 @@ export class EditSupply {
     ];
     const defs = await this.attributeRepo.findByCategoryAncestry(
       ancestrySlugs,
-      null,
+      scopeId,
     );
-    const schema = resolveEffectiveSchema(categorySlug, defs, registry);
+    const schema = resolveEffectiveSchema(
+      categorySlug,
+      defs,
+      registry,
+      scopeId,
+    );
     return validateAttributes(attributes, schema);
   }
 }

--- a/apps/api/src/contexts/supplies/application/validate-supply-attributes.ts
+++ b/apps/api/src/contexts/supplies/application/validate-supply-attributes.ts
@@ -1,0 +1,43 @@
+import {
+  AttributeDefinitionRepository,
+  resolveEffectiveSchema,
+  validateAttributes,
+} from '@globalemergency/warehouse-core/catalog';
+import { CategoryRegistry } from '@globalemergency/warehouse-core/kernel';
+
+/**
+ * Valida (y normaliza) los `attributes` de un insumo contra el **esquema
+ * efectivo** de su familia — la unión de definiciones de la ascendencia de su
+ * categoría (`resolveEffectiveSchema`). Fuente única del flujo de validación
+ * compartida por el alta (`CreateSupply`) y la edición (`EditSupply`).
+ *
+ * Tenencia (#397): con `scopeId` de tenant el repo devuelve global ∪ tenant y
+ * `resolveEffectiveSchema` fusiona ese conjunto por scope; sin scope (`null`),
+ * sólo globales. Si la familia no tiene definiciones, el esquema es vacío y los
+ * atributos pasan tal cual (catálogo libre).
+ */
+export async function validateSupplyAttributes(
+  attributeRepo: AttributeDefinitionRepository,
+  categorySlug: string,
+  attributes: Record<string, unknown>,
+  categories: readonly { slug: string; parentSlug: string | null }[],
+  scopeId: string | null,
+): Promise<Record<string, unknown>> {
+  const registry = CategoryRegistry.fromNodes(
+    categories.map((c) => ({
+      slug: c.slug,
+      parentSlug: c.parentSlug,
+      codePrefix: null,
+    })),
+  );
+  const ancestrySlugs = [
+    categorySlug,
+    ...registry.ancestorsOf(categorySlug).map((n) => n.slug),
+  ];
+  const defs = await attributeRepo.findByCategoryAncestry(
+    ancestrySlugs,
+    scopeId,
+  );
+  const schema = resolveEffectiveSchema(categorySlug, defs, registry, scopeId);
+  return validateAttributes(attributes, schema);
+}

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-attribute-definition.repository.int-spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-attribute-definition.repository.int-spec.ts
@@ -125,4 +125,117 @@ describe('DrizzleAttributeDefinitionRepository (integration)', () => {
     expect(found).not.toBeNull();
     expect(found!.isArchived).toBe(true);
   });
+
+  // === Tenencia (#397) ===
+
+  const TENANT_A = '11111111-1111-4111-8111-111111111111';
+  const TENANT_B = '22222222-2222-4222-8222-222222222222';
+
+  it('findOne apunta a la fila exacta del scope (global XOR tenant)', async () => {
+    await repo.save(
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'dosis',
+        dataType: 'text',
+      }),
+    );
+    await repo.save(
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'dosis_local',
+        dataType: 'text',
+        scopeId: TENANT_A,
+      }),
+    );
+
+    expect(await repo.findOne('medical', 'dosis', null)).not.toBeNull();
+    expect(await repo.findOne('medical', 'dosis', TENANT_A)).toBeNull();
+    expect(
+      await repo.findOne('medical', 'dosis_local', TENANT_A),
+    ).not.toBeNull();
+    expect(await repo.findOne('medical', 'dosis_local', null)).toBeNull();
+  });
+
+  it('findByScope(tenant) devuelve global ∪ tenant, excluye otros tenants', async () => {
+    await repo.save(
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'global_key',
+        dataType: 'text',
+      }),
+    );
+    await repo.save(
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'para_a',
+        dataType: 'text',
+        scopeId: TENANT_A,
+      }),
+    );
+    await repo.save(
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'para_b',
+        dataType: 'text',
+        scopeId: TENANT_B,
+      }),
+    );
+
+    expect((await repo.findByScope(null)).map((d) => d.key)).toEqual([
+      'global_key',
+    ]);
+    expect((await repo.findByScope(TENANT_A)).map((d) => d.key).sort()).toEqual(
+      ['global_key', 'para_a'],
+    );
+  });
+
+  it('findByCategoryAncestry(tenant) fusiona global ∪ tenant de la ascendencia', async () => {
+    await repo.save(
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'global_key',
+        dataType: 'text',
+      }),
+    );
+    await repo.save(
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'tenant_key',
+        dataType: 'text',
+        scopeId: TENANT_A,
+      }),
+    );
+
+    const global = await repo.findByCategoryAncestry(['medical'], null);
+    expect(global.map((d) => d.key)).toEqual(['global_key']);
+
+    const merged = await repo.findByCategoryAncestry(['medical'], TENANT_A);
+    expect(merged.map((d) => d.key).sort()).toEqual([
+      'global_key',
+      'tenant_key',
+    ]);
+  });
+
+  it('un tenant puede reutilizar una key que ya existe en global (sin chocar)', async () => {
+    await repo.save(
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'dosis',
+        dataType: 'text',
+      }),
+    );
+    // Misma (categoría, key) pero scope de tenant → fila aparte, no upsert.
+    await repo.save(
+      AttributeDefinition.create({
+        categorySlug: 'medical',
+        key: 'dosis',
+        dataType: 'text',
+        scopeId: TENANT_A,
+      }),
+    );
+
+    expect(await repo.findOne('medical', 'dosis', null)).not.toBeNull();
+    expect(await repo.findOne('medical', 'dosis', TENANT_A)).not.toBeNull();
+    expect(await repo.findByScope(TENANT_A)).toHaveLength(2);
+  });
 });

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-attribute-definition.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-attribute-definition.repository.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { and, asc, eq, inArray, isNull } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import {
   AttributeDefinition,
   AttributeDataType,
@@ -11,10 +11,18 @@ import { attributeDefinitionsTable } from './schema';
 type AttributeDefinitionRow = typeof attributeDefinitionsTable.$inferSelect;
 
 /**
- * Persistencia Drizzle del metamodelo `AttributeDefinition` (#396). Usa el query
- * builder tipado (no SQL crudo) para que timestamptz/jsonb lleguen ya tipados.
- * `scope_id` null = global (Inc 1); las firmas aceptan un `scopeId` para que la
- * tenencia (Inc 2) reutilice el repo sin cambiarlas.
+ * Persistencia Drizzle del metamodelo `AttributeDefinition` (#396, tenencia #397).
+ * Usa el query builder tipado (no SQL crudo) para que timestamptz/jsonb lleguen
+ * ya tipados.
+ *
+ * Tenencia (#397): dos semánticas de scope conviven —
+ * - **Visibilidad** (`findByScope`, `findByCategoryAncestry`): sin scope (null)
+ *   devuelve sólo las globales; con un `scopeId` de tenant devuelve **global ∪
+ *   tenant** (nunca las de otros tenants). El dominio `resolveEffectiveSchema`
+ *   fusiona ese superconjunto.
+ * - **Identidad exacta** (`findOne`, `save`, `archive`): apuntan a la fila del
+ *   scope dado exactamente (global XOR tenant), para que el upsert/archive
+ *   globales nunca toquen una fila de tenant y viceversa.
  */
 export class DrizzleAttributeDefinitionRepository implements AttributeDefinitionRepository {
   constructor(private readonly db: Db) {}
@@ -23,7 +31,7 @@ export class DrizzleAttributeDefinitionRepository implements AttributeDefinition
     const rows = await this.db
       .select()
       .from(attributeDefinitionsTable)
-      .where(this.scopeFilter(scopeId))
+      .where(this.visibilityFilter(scopeId))
       .orderBy(
         asc(attributeDefinitionsTable.categorySlug),
         asc(attributeDefinitionsTable.sort),
@@ -45,7 +53,7 @@ export class DrizzleAttributeDefinitionRepository implements AttributeDefinition
       .where(
         and(
           inArray(attributeDefinitionsTable.categorySlug, [...ancestorSlugs]),
-          this.scopeFilter(scopeId),
+          this.visibilityFilter(scopeId),
         ),
       )
       .orderBy(
@@ -135,10 +143,24 @@ export class DrizzleAttributeDefinitionRepository implements AttributeDefinition
       );
   }
 
-  private scopeFilter(scopeId: string | null) {
+  /** Identidad exacta: la fila del scope dado (global XOR ese tenant). */
+  private scopeFilter(scopeId: string | null): SQL | undefined {
     return scopeId === null
       ? isNull(attributeDefinitionsTable.scopeId)
       : eq(attributeDefinitionsTable.scopeId, scopeId);
+  }
+
+  /**
+   * Visibilidad: sin scope, sólo globales; con tenant, global ∪ tenant (el
+   * superconjunto que fusiona `resolveEffectiveSchema`).
+   */
+  private visibilityFilter(scopeId: string | null): SQL | undefined {
+    return scopeId === null
+      ? isNull(attributeDefinitionsTable.scopeId)
+      : or(
+          isNull(attributeDefinitionsTable.scopeId),
+          eq(attributeDefinitionsTable.scopeId, scopeId),
+        );
   }
 
   private toDefinition(row: AttributeDefinitionRow): AttributeDefinition {

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
@@ -1,4 +1,14 @@
-import { and, asc, eq, ilike, ne, or, sql, type SQL } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  eq,
+  ilike,
+  isNull,
+  ne,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
 import { Db } from '../../../../shared/db';
 import {
   Supply,
@@ -34,14 +44,20 @@ export class DrizzleSupplyRepository implements SupplyRepository {
     return row ? this.toSupply(row) : null;
   }
 
-  async findByCode(code: string): Promise<Supply | null> {
+  async findByCode(
+    code: string,
+    scopeId: string | null = null,
+  ): Promise<Supply | null> {
     // Búsqueda por código normalizada a mayúsculas (los códigos canónicos son
-    // 'INS-NNNN', lo que permite usar el índice único).
+    // 'INS-NNNN', lo que permite usar el índice único). Tenencia (#397): global
+    // por defecto; con tenant busca en global ∪ tenant.
     const normalized = code.trim().toUpperCase();
     const [row] = await this.db
       .select()
       .from(suppliesTable)
-      .where(eq(suppliesTable.code, normalized))
+      .where(
+        and(eq(suppliesTable.code, normalized), this.supplyVisibility(scopeId)),
+      )
       .limit(1);
     return row ? this.toSupply(row) : null;
   }
@@ -62,6 +78,7 @@ export class DrizzleSupplyRepository implements SupplyRepository {
       defaultUnit: s.defaultUnit,
       attributes: s.attributes,
       variantOfId: s.variantOfId,
+      scopeId: s.scopeId,
       createdAt: now,
       updatedAt: now,
     };
@@ -154,6 +171,11 @@ export class DrizzleSupplyRepository implements SupplyRepository {
 
   async list(filter: SupplyListFilter): Promise<Supply[]> {
     const conditions: SQL[] = [];
+    // Tenencia (#397): visibilidad por scope. Sin scope, sólo globales.
+    const visibility = this.supplyVisibility(filter.scopeId);
+    if (visibility) {
+      conditions.push(visibility);
+    }
     if (filter.status) {
       conditions.push(eq(suppliesTable.status, filter.status));
     }
@@ -185,16 +207,30 @@ export class DrizzleSupplyRepository implements SupplyRepository {
       .where(eq(supplyAliasesTable.supplyId, supplyId))
       .orderBy(asc(supplyAliasesTable.aliasNorm));
     return rows.map((r) =>
-      SupplyAlias.fromSnapshot({ alias: r.aliasNorm, supplyId: r.supplyId }),
+      SupplyAlias.fromSnapshot({
+        alias: r.aliasNorm,
+        supplyId: r.supplyId,
+        scopeId: r.scopeId ?? null,
+      }),
     );
   }
 
   async addAlias(alias: SupplyAlias): Promise<void> {
     const aliasNorm = SupplyAlias.normalize(alias.alias);
+    const scopeId = alias.scopeId;
+    // La unicidad del alias es por scope (#397): el candado global no ve los de
+    // tenant y viceversa. Se comprueba el conflicto dentro del mismo scope.
     const [existing] = await this.db
       .select()
       .from(supplyAliasesTable)
-      .where(eq(supplyAliasesTable.aliasNorm, aliasNorm))
+      .where(
+        and(
+          eq(supplyAliasesTable.aliasNorm, aliasNorm),
+          scopeId === null
+            ? isNull(supplyAliasesTable.scopeId)
+            : eq(supplyAliasesTable.scopeId, scopeId),
+        ),
+      )
       .limit(1);
     if (existing) {
       // Idempotente si ya apunta al mismo insumo; conflicto si apunta a otro.
@@ -203,14 +239,22 @@ export class DrizzleSupplyRepository implements SupplyRepository {
     }
     await this.db
       .insert(supplyAliasesTable)
-      .values({ aliasNorm, supplyId: alias.supplyId });
+      .values({ aliasNorm, supplyId: alias.supplyId, scopeId });
   }
 
-  async removeAlias(aliasNorm: string): Promise<void> {
+  async removeAlias(
+    aliasNorm: string,
+    scopeId: string | null = null,
+  ): Promise<void> {
     await this.db
       .delete(supplyAliasesTable)
       .where(
-        eq(supplyAliasesTable.aliasNorm, SupplyAlias.normalize(aliasNorm)),
+        and(
+          eq(supplyAliasesTable.aliasNorm, SupplyAlias.normalize(aliasNorm)),
+          scopeId === null
+            ? isNull(supplyAliasesTable.scopeId)
+            : eq(supplyAliasesTable.scopeId, scopeId),
+        ),
       );
   }
 
@@ -275,6 +319,29 @@ export class DrizzleSupplyRepository implements SupplyRepository {
       variantOfId: row.variantOfId ?? null,
       status: row.status as SupplyStatus,
       registrationNotes: row.registrationNotes ?? null,
+      scopeId: row.scopeId ?? null,
     });
+  }
+
+  /**
+   * Visibilidad por scope (#397): sin scope, sólo globales (`scope_id IS NULL`);
+   * con un tenant, global ∪ tenant (nunca otros tenants). El default global
+   * preserva el comportamiento actual (los hosts HTTP operan en global).
+   */
+  private supplyVisibility(
+    scopeId: string | null | undefined,
+  ): SQL | undefined {
+    return scopeId === null || scopeId === undefined
+      ? isNull(suppliesTable.scopeId)
+      : or(isNull(suppliesTable.scopeId), eq(suppliesTable.scopeId, scopeId));
+  }
+
+  private aliasVisibility(scopeId: string | null | undefined): SQL | undefined {
+    return scopeId === null || scopeId === undefined
+      ? isNull(supplyAliasesTable.scopeId)
+      : or(
+          isNull(supplyAliasesTable.scopeId),
+          eq(supplyAliasesTable.scopeId, scopeId),
+        );
   }
 }

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
@@ -73,13 +73,23 @@ export const suppliesTable = pgTable(
       (): AnyPgColumn => suppliesTable.id,
       { onDelete: 'set null' },
     ),
+    /** Tenencia (#397): null = fila global · set = extensión de un tenant. */
+    scopeId: uuid('scope_id'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (t) => [
-    uniqueIndex('supplies_code_uniq').on(t.code),
+    // Unicidad de `code` por scope (#397, migración 0056): par de índices
+    // parciales — global (scope_id IS NULL) + por tenant (code, scope_id).
+    uniqueIndex('supplies_code_global_uniq')
+      .on(t.code)
+      .where(sql`${t.scopeId} IS NULL`),
+    uniqueIndex('supplies_code_scope_uniq')
+      .on(t.code, t.scopeId)
+      .where(sql`${t.scopeId} IS NOT NULL`),
     index('supplies_category_slug_idx').on(t.categorySlug),
     index('supplies_variant_of_id_idx').on(t.variantOfId),
+    index('supplies_scope_id_idx').on(t.scopeId),
   ],
 );
 
@@ -113,18 +123,42 @@ export const attributeDefinitionsTable = pgTable(
       .notNull()
       .default(sql`now()`),
   },
-  (t) => [index('attribute_definitions_category_slug_idx').on(t.categorySlug)],
+  (t) => [
+    index('attribute_definitions_category_slug_idx').on(t.categorySlug),
+    // Unicidad por scope: global (categoría,key) WHERE scope_id IS NULL en 0055;
+    // por tenant (categoría,key,scope_id) WHERE scope_id IS NOT NULL en 0056 (#397).
+    uniqueIndex('attribute_definitions_global_category_key_uniq')
+      .on(t.categorySlug, t.key)
+      .where(sql`${t.scopeId} IS NULL`),
+    uniqueIndex('attribute_definitions_scope_category_key_uniq')
+      .on(t.categorySlug, t.key, t.scopeId)
+      .where(sql`${t.scopeId} IS NOT NULL`),
+  ],
 );
 
 export const supplyAliasesTable = pgTable(
   'supply_aliases',
   {
-    aliasNorm: text('alias_norm').primaryKey(),
+    aliasNorm: text('alias_norm').notNull(),
     supplyId: uuid('supply_id')
       .notNull()
       .references(() => suppliesTable.id, { onDelete: 'cascade' }),
+    /** Tenencia (#397): null = alias global · set = alias de un tenant. */
+    scopeId: uuid('scope_id'),
   },
-  (t) => [index('supply_aliases_supply_id_idx').on(t.supplyId)],
+  (t) => [
+    index('supply_aliases_supply_id_idx').on(t.supplyId),
+    // Unicidad del alias normalizado por scope (#397, migración 0056): par de
+    // índices parciales — global (alias_norm) + por tenant (alias_norm, scope_id).
+    // Reemplaza la PRIMARY KEY global sobre alias_norm de 0037.
+    uniqueIndex('supply_aliases_alias_global_uniq')
+      .on(t.aliasNorm)
+      .where(sql`${t.scopeId} IS NULL`),
+    uniqueIndex('supply_aliases_alias_scope_uniq')
+      .on(t.aliasNorm, t.scopeId)
+      .where(sql`${t.scopeId} IS NOT NULL`),
+    index('supply_aliases_scope_id_idx').on(t.scopeId),
+  ],
 );
 
 export const supplyTranslationsTable = pgTable(

--- a/packages/warehouse-core/src/catalog/ports/supply.repository.ts
+++ b/packages/warehouse-core/src/catalog/ports/supply.repository.ts
@@ -9,6 +9,12 @@ export interface SupplyListFilter {
   status?: SupplyStatus;
   /** Búsqueda libre por código o nombre (normalizada en infraestructura). */
   q?: string;
+  /**
+   * Tenencia (#397): visibilidad por scope. `undefined`/`null` = sólo globales
+   * (comportamiento por defecto de los hosts HTTP, que hoy operan en global). Un
+   * `scopeId` de tenant devuelve **global ∪ tenant** (nunca otros tenants).
+   */
+  scopeId?: string | null;
 }
 
 /**
@@ -36,7 +42,11 @@ export interface SupplyTranslationInput {
  */
 export interface SupplyRepository {
   findById(id: string): Promise<Supply | null>;
-  findByCode(code: string): Promise<Supply | null>;
+  /**
+   * Busca por código. Tenencia (#397): `scopeId` `undefined`/`null` = sólo
+   * globales; un tenant busca en global ∪ tenant. Por defecto global.
+   */
+  findByCode(code: string, scopeId?: string | null): Promise<Supply | null>;
   /**
    * Persiste el agregado. Si `translations` se indica, REEMPLAZA por completo el
    * conjunto de traducciones del insumo en `supply_translations` (quitar una
@@ -54,8 +64,17 @@ export interface SupplyRepository {
   /** Traducciones de nombre del insumo (i18n admin, #320), ordenadas por locale. */
   listTranslations(supplyId: string): Promise<SupplyTranslationInput[]>;
   listAliases(supplyId: string): Promise<SupplyAlias[]>;
+  /**
+   * Añade un alias. Tenencia (#397): el `scopeId` del propio `SupplyAlias`
+   * decide el candado de unicidad (global vs tenant). Idempotente si ya apunta
+   * al mismo insumo dentro de ese scope; conflicto si apunta a otro.
+   */
   addAlias(alias: SupplyAlias): Promise<void>;
-  removeAlias(aliasNorm: string): Promise<void>;
+  /**
+   * Elimina un alias por su forma normalizada dentro del scope dado
+   * (`undefined`/`null` = global). No cruza scopes.
+   */
+  removeAlias(aliasNorm: string, scopeId?: string | null): Promise<void>;
   /**
    * Fusiona `sourceId` en `targetId`: mueve los alias de A a B, repunta las
    * variantes hijas de A a B y archiva A. No borra A (preserva referencias

--- a/packages/warehouse-core/src/catalog/resolve-effective-schema.test.ts
+++ b/packages/warehouse-core/src/catalog/resolve-effective-schema.test.ts
@@ -63,7 +63,7 @@ test('ordena de la raíz hacia la hoja, luego por sort y key', () => {
   );
 });
 
-test('ignora definiciones archivadas y de otro scope (Inc 1: sólo globales)', () => {
+test('ignora definiciones archivadas y de otro scope (sin scope: sólo globales)', () => {
   const defs = [
     def('medicines', 'archivada', {
       archivedAt: new Date('2026-01-01T00:00:00Z'),
@@ -76,6 +76,68 @@ test('ignora definiciones archivadas y de otro scope (Inc 1: sólo globales)', (
     schema.map((d) => d.key),
     ['viva'],
   );
+});
+
+test('con scope de tenant: fusiona global ∪ tenant (extensión aditiva)', () => {
+  const defs = [
+    def('medicines', 'global_key'),
+    def('medicines', 'tenant_key', { scopeId: 'tenant-1' }),
+  ];
+  const schema = resolveEffectiveSchema(
+    'medicines',
+    defs,
+    registry,
+    'tenant-1',
+  );
+  assert.deepEqual(schema.map((d) => d.key).sort(), [
+    'global_key',
+    'tenant_key',
+  ]);
+});
+
+test('con scope de tenant: el tenant añade una key nueva a una familia con globales', () => {
+  const defs = [
+    def('medical', 'expiry_tracked', { dataType: 'boolean' }),
+    def('medicines', 'principio_activo'),
+    def('medicines', 'nota_local', { scopeId: 'tenant-1' }),
+  ];
+  const schema = resolveEffectiveSchema(
+    'antibioticos',
+    defs,
+    registry,
+    'tenant-1',
+  );
+  assert.deepEqual(schema.map((d) => d.key).sort(), [
+    'expiry_tracked',
+    'nota_local',
+    'principio_activo',
+  ]);
+});
+
+test('con scope de tenant: colisión de key global↔tenant se rechaza', () => {
+  const defs = [
+    def('medicines', 'dosis'),
+    def('medicines', 'dosis', { scopeId: 'tenant-1' }),
+  ];
+  assert.throws(
+    () => resolveEffectiveSchema('medicines', defs, registry, 'tenant-1'),
+    AttributeKeyCollisionError,
+  );
+});
+
+test('con scope de tenant: excluye las definiciones de otros tenants', () => {
+  const defs = [
+    def('medicines', 'global_key'),
+    def('medicines', 'para_t1', { scopeId: 'tenant-1' }),
+    def('medicines', 'para_t2', { scopeId: 'tenant-2' }),
+  ];
+  const schema = resolveEffectiveSchema(
+    'medicines',
+    defs,
+    registry,
+    'tenant-1',
+  );
+  assert.deepEqual(schema.map((d) => d.key).sort(), ['global_key', 'para_t1']);
 });
 
 test('rechaza una colisión de key entre la categoría y un ancestro', () => {

--- a/packages/warehouse-core/src/catalog/resolve-effective-schema.ts
+++ b/packages/warehouse-core/src/catalog/resolve-effective-schema.ts
@@ -17,8 +17,13 @@ import { AttributeKeyCollisionError } from './supply-errors.js';
  * - Sólo entran definiciones activas (no archivadas).
  * - La extensión es **aditiva, sin precedencia**: dos definiciones con la misma
  *   `key` en la cadena de ascendencia son una colisión → {@link AttributeKeyCollisionError}.
- * - Inc 1: sólo definiciones globales (`scopeId === null`). La fusión con las de
- *   tenant es Inc 2; este parámetro queda abierto para entonces.
+ * - **Tenencia (Inc 2):** sin `scopeId` (o `null`) sólo entran las definiciones
+ *   globales (`def.scopeId === null`) — el comportamiento global es idéntico al
+ *   de Inc 1. Con un `scopeId` de tenant se fusiona **global ∪ tenant**: entran
+ *   las globales (`scopeId === null`) y las del tenant dado (`scopeId ===
+ *   scopeId`), nunca las de otros tenants. La colisión de `key` se comprueba
+ *   sobre el conjunto fusionado, así que una key global que un tenant repite es
+ *   colisión (la extensión es aditiva, no sobrescribe la base global).
  *
  * Orden de salida: de la raíz hacia la hoja (ancestros primero), y dentro de
  * cada nivel por `sort` y luego `key` — estable y predecible para formularios.
@@ -27,6 +32,7 @@ export function resolveEffectiveSchema(
   categorySlug: string,
   allDefs: readonly AttributeDefinition[],
   registry: CategoryRegistry,
+  scopeId: string | null = null,
 ): AttributeDefinition[] {
   // Cadena de ascendencia: la propia categoría (hoja) + ancestros hacia la raíz.
   const chain = [
@@ -42,7 +48,7 @@ export function resolveEffectiveSchema(
 
   const applicable = allDefs.filter(
     (def) =>
-      def.scopeId === null &&
+      (def.scopeId === null || def.scopeId === scopeId) &&
       !def.isArchived &&
       chainDepth.has(def.categorySlug),
   );

--- a/packages/warehouse-core/src/catalog/supply-alias.ts
+++ b/packages/warehouse-core/src/catalog/supply-alias.ts
@@ -3,11 +3,14 @@ import { normalizeSupplyText } from './supply-normalize.js';
 export interface SupplyAliasProps {
   alias: string;
   supplyId: string;
+  /** Tenencia (#397): null = alias global · set = alias de un tenant. */
+  scopeId?: string | null;
 }
 
 export interface SupplyAliasSnapshot {
   alias: string;
   supplyId: string;
+  scopeId: string | null;
 }
 
 export class SupplyAliasValidationError extends Error {
@@ -25,19 +28,30 @@ function normalizeRequiredText(value: string, field: string): string {
   return normalized;
 }
 
+function normalizeScopeId(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const normalized = value.trim();
+  return normalized.length === 0 ? null : normalized;
+}
+
 export class SupplyAlias {
   readonly alias: string;
   readonly supplyId: string;
+  readonly scopeId: string | null;
 
   private constructor(props: SupplyAliasProps) {
     this.alias = props.alias;
     this.supplyId = props.supplyId;
+    this.scopeId = props.scopeId ?? null;
   }
 
   static create(props: SupplyAliasProps): SupplyAlias {
     return new SupplyAlias({
       alias: normalizeRequiredText(props.alias, 'Supply alias'),
       supplyId: normalizeRequiredText(props.supplyId, 'Supply alias supplyId'),
+      scopeId: normalizeScopeId(props.scopeId),
     });
   }
 
@@ -49,6 +63,7 @@ export class SupplyAlias {
     return {
       alias: this.alias,
       supplyId: this.supplyId,
+      scopeId: this.scopeId,
     };
   }
 

--- a/packages/warehouse-core/src/catalog/supply-resolver.ts
+++ b/packages/warehouse-core/src/catalog/supply-resolver.ts
@@ -77,6 +77,7 @@ export function supplyResolverFromCatalog(
       variantOfId: record.variantOfId,
       status: 'active',
       registrationNotes: null,
+      scopeId: null,
     });
 
   const supplies = records.flatMap((record) =>

--- a/packages/warehouse-core/src/catalog/supply-scope.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-scope.test.ts
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Supply } from './supply.js';
+import { SupplyAlias } from './supply-alias.js';
+
+// Tenencia (#397): `scopeId` opaco en Supply y SupplyAlias. Global = null;
+// tenant = un id. Aditivo: por defecto null (comportamiento previo).
+
+test('Supply.create sin scopeId es global (null)', () => {
+  const s = Supply.create({
+    id: 'a',
+    code: 'INS-0001',
+    name: 'Agua',
+    categorySlug: 'food',
+    defaultUnit: 'und',
+  });
+  assert.equal(s.scopeId, null);
+  assert.equal(s.toSnapshot().scopeId, null);
+});
+
+test('Supply.create con scopeId lo conserva (normalizado)', () => {
+  const s = Supply.create({
+    id: 'a',
+    code: 'INS-0001',
+    name: 'Agua',
+    categorySlug: 'food',
+    defaultUnit: 'und',
+    scopeId: '  tenant-1  ',
+  });
+  assert.equal(s.scopeId, 'tenant-1');
+});
+
+test('Supply mutadores preservan el scopeId (la identidad de tenant no cambia)', () => {
+  const s = Supply.create({
+    id: 'a',
+    code: 'INS-0001',
+    name: 'Agua',
+    categorySlug: 'food',
+    defaultUnit: 'und',
+    scopeId: 'tenant-1',
+  });
+  assert.equal(s.rename('Agua potable').scopeId, 'tenant-1');
+  assert.equal(s.recategorize('water').scopeId, 'tenant-1');
+  assert.equal(s.archive().scopeId, 'tenant-1');
+});
+
+test('Supply round-trip por snapshot conserva scopeId', () => {
+  const snap = {
+    id: 'a',
+    code: 'INS-0001',
+    name: 'Agua',
+    categorySlug: 'food',
+    defaultUnit: 'und',
+    attributes: {},
+    variantOfId: null,
+    status: 'active' as const,
+    registrationNotes: null,
+    scopeId: 'tenant-1',
+  };
+  assert.deepEqual(Supply.fromSnapshot(snap).toSnapshot(), snap);
+});
+
+test('SupplyAlias sin scopeId es global (null); con scope lo conserva', () => {
+  assert.equal(
+    SupplyAlias.create({ alias: 'agua', supplyId: 's1' }).scopeId,
+    null,
+  );
+  assert.equal(
+    SupplyAlias.create({ alias: 'agua', supplyId: 's1', scopeId: 'tenant-1' })
+      .scopeId,
+    'tenant-1',
+  );
+});

--- a/packages/warehouse-core/src/catalog/supply.ts
+++ b/packages/warehouse-core/src/catalog/supply.ts
@@ -10,6 +10,8 @@ export interface SupplyProps {
   variantOfId?: string | null;
   status?: SupplyStatus;
   registrationNotes?: string | null;
+  /** Tenencia (#397): null = insumo global · set = insumo de un tenant. */
+  scopeId?: string | null;
 }
 
 export interface SupplySnapshot {
@@ -22,6 +24,7 @@ export interface SupplySnapshot {
   variantOfId: string | null;
   status: SupplyStatus;
   registrationNotes: string | null;
+  scopeId: string | null;
 }
 
 export class SupplyValidationError extends Error {
@@ -59,6 +62,7 @@ export class Supply {
   readonly variantOfId: string | null;
   readonly status: SupplyStatus;
   readonly registrationNotes: string | null;
+  readonly scopeId: string | null;
 
   private constructor(props: SupplyProps) {
     this.id = props.id;
@@ -70,6 +74,7 @@ export class Supply {
     this.variantOfId = props.variantOfId ?? null;
     this.status = props.status ?? 'active';
     this.registrationNotes = props.registrationNotes ?? null;
+    this.scopeId = props.scopeId ?? null;
   }
 
   static create(props: SupplyProps): Supply {
@@ -88,6 +93,7 @@ export class Supply {
     const defaultUnit = normalizeOptionalText(props.defaultUnit);
     const variantOfId = normalizeOptionalText(props.variantOfId);
     const registrationNotes = normalizeOptionalText(props.registrationNotes);
+    const scopeId = normalizeOptionalText(props.scopeId);
     const status = props.status ?? 'active';
     if (status !== 'active' && status !== 'archived') {
       throw new SupplyValidationError(
@@ -105,6 +111,7 @@ export class Supply {
       variantOfId,
       status,
       registrationNotes,
+      scopeId,
     });
   }
 
@@ -119,6 +126,7 @@ export class Supply {
       variantOfId: s.variantOfId,
       status: s.status,
       registrationNotes: s.registrationNotes,
+      scopeId: s.scopeId,
     });
   }
 
@@ -133,6 +141,7 @@ export class Supply {
       variantOfId: this.variantOfId,
       status: this.status,
       registrationNotes: this.registrationNotes,
+      scopeId: this.scopeId,
     };
   }
 


### PR DESCRIPTION
Closes #397 · **Incremento 2** de la épica #228. Plumbing de tenencia del catálogo sobre un **`scope_id` opaco** (el host lo mapea a emergencia/organización; el modelo no fija qué es). `scope_id IS NULL` = base global curada; `scope_id = T` = extensión de tenant. Visible para T = global ∪ lo suyo. Extensión **aditiva** (el tenant añade, nunca sobrescribe). **Comportamiento global idéntico.**

## Qué incluye
- **Dominio**: `resolveEffectiveSchema(categorySlug, defs, registry, scopeId?)` fusiona definiciones global (`scope_id NULL`) ∪ tenant, manteniendo el rechazo de colisión de `key` en la cadena de ascendencia; el camino global (sin scope) queda idéntico. `Supply` gana `scopeId`.
- **Migración 0056**: `scope_id` en `supplies` y `supply_aliases` (ya estaba en `attribute_definitions`). Cada unicidad global se convierte en un **par de índices parciales por scope**: `supplies.code` (índice `supplies_code_uniq` → global `WHERE scope_id IS NULL` + tenant `(code,scope_id) WHERE scope_id IS NOT NULL`), `attribute_definitions (category_slug,key)`, y el alias normalizado (PK `supply_aliases_pkey` → par por scope). Fix-forward, idempotente.
- **Persistencia** scope-aware: los finders devuelven global ∪ tenant cuando se da scope, sólo global si no.
- **Casos de uso** (create/edit Supply, alta de alias, alta de definición) aceptan un `scopeId` opaco (null por defecto). La validación de atributos de un Supply de tenant usa el esquema efectivo global ∪ tenant.

## Alcance deliberado
Los **endpoints HTTP siguen operando en global** en este incremento (scope null); la exposición por-tenant + authz va con la UI admin (Inc 5). No cambian DTOs ni el contrato público (`gen:api` no-op).

## Verificación (local)
warehouse-core build + **130 tests** · api build (nest/tsc, tsc-neutral 46) · eslint (0) · prettier api **y packages** · api-client + web build · web lint · frozen-lockfile — todo verde. Los int-specs Jest/Postgres (incl. migración por scope) los valida CI. Verificada a mano la conversión de índices (nombres/tipos reales: `supplies_code_uniq` índice, `supply_aliases_pkey` PK).