### PR TITLE
feat(catalog): naturaleza logística del insumo (fungible/reusable/human) — Inc 3 catálogo escalable

### DIFF
--- a/apps/api/drizzle/0057_supply_nature.sql
+++ b/apps/api/drizzle/0057_supply_nature.sql
@@ -1,0 +1,18 @@
+-- Naturaleza logística del insumo (#269): clasificación fina extensible en el
+-- INSUMO (no en la categoría — una categoría puede mezclar naturalezas).
+-- Nullable: null = sin clasificar; los ~574 insumos previos NO se rellenan.
+-- Enum-via-CHECK, no un boolean, para poder crecer sin una migración destructiva.
+
+ALTER TABLE "supplies" ADD COLUMN IF NOT EXISTS "nature" text;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'supplies_nature_check'
+  ) THEN
+    ALTER TABLE "supplies"
+      ADD CONSTRAINT "supplies_nature_check"
+      CHECK ("nature" IS NULL OR "nature" IN ('fungible', 'reusable', 'human'));
+  END IF;
+END $$;

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -15180,6 +15180,15 @@
             "type": "object",
             "description": "Notas internas de gestión"
           },
+          "nature": {
+            "type": "string",
+            "enum": [
+              "fungible",
+              "reusable",
+              "human"
+            ],
+            "description": "Naturaleza logística (#269): fungible | reusable | human. Omitir = sin clasificar."
+          },
           "variantOfId": {
             "type": "object",
             "format": "uuid",
@@ -15261,6 +15270,17 @@
           "registrationNotes": {
             "type": "string",
             "nullable": true
+          },
+          "nature": {
+            "type": "string",
+            "enum": [
+              "fungible",
+              "reusable",
+              "human"
+            ],
+            "nullable": true,
+            "example": "fungible",
+            "description": "Naturaleza logística (#269): fungible | reusable | human. Null = sin clasificar."
           },
           "aliases": {
             "example": [
@@ -15417,6 +15437,16 @@
           },
           "registrationNotes": {
             "type": "object"
+          },
+          "nature": {
+            "type": "string",
+            "enum": [
+              "fungible",
+              "reusable",
+              "human"
+            ],
+            "nullable": true,
+            "description": "Naturaleza logística (#269). `null` la limpia (sin clasificar); omitir no la toca."
           },
           "variantOfId": {
             "type": "object",

--- a/apps/api/src/contexts/supplies/application/admin-supply-view.ts
+++ b/apps/api/src/contexts/supplies/application/admin-supply-view.ts
@@ -20,6 +20,7 @@ export interface AdminSupplyView {
   variantOfId: string | null;
   status: Supply['status'];
   registrationNotes: string | null;
+  nature: Supply['nature'];
   aliases: string[];
   translations: SupplyTranslationInput[];
 }

--- a/apps/api/src/contexts/supplies/application/create-supply.ts
+++ b/apps/api/src/contexts/supplies/application/create-supply.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import {
   Supply,
+  SupplyNature,
   formatSupplyCode,
   VariantTargetNotFoundError,
   CategoryNotFoundError,
@@ -18,6 +19,8 @@ export interface CreateSupplyCommand {
   defaultUnit?: string | null;
   attributes?: Record<string, unknown> | null;
   registrationNotes?: string | null;
+  /** Naturaleza logística (#269): fungible | reusable | human. Null = sin clasificar. */
+  nature?: SupplyNature | null;
   /** Si se indica, el insumo es una variante de otro existente (#222). */
   variantOfId?: string | null;
   /** Traducciones de nombre por idioma (#320). El nombre base (`name`) es `es`. */
@@ -85,6 +88,7 @@ export class CreateSupply {
       defaultUnit: cmd.defaultUnit ?? null,
       attributes,
       registrationNotes: cmd.registrationNotes ?? null,
+      nature: cmd.nature ?? null,
       variantOfId,
       scopeId,
     });

--- a/apps/api/src/contexts/supplies/application/edit-supply.spec.ts
+++ b/apps/api/src/contexts/supplies/application/edit-supply.spec.ts
@@ -266,4 +266,64 @@ describe('EditSupply', () => {
     ).rejects.toBeInstanceOf(AttributeValidationError);
     expect(save).not.toHaveBeenCalled();
   });
+
+  it('naturaleza (#269): omitir no la toca', async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    const repo = makeRepo(
+      Supply.create({
+        id: ID,
+        code: 'WAT-0001',
+        name: 'Agua',
+        categorySlug: 'water',
+        nature: 'fungible',
+      }),
+      save,
+    );
+    await new EditSupply(repo, makeCategoryRepo(), makeAttributeRepo()).execute(
+      {
+        id: ID,
+        name: 'Agua mineral',
+      },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const saved = save.mock.calls[0][0] as Supply;
+    expect(saved.nature).toBe('fungible'); // conservada
+  });
+
+  it('naturaleza (#269): null la limpia', async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    const repo = makeRepo(
+      Supply.create({
+        id: ID,
+        code: 'WAT-0001',
+        name: 'Agua',
+        categorySlug: 'water',
+        nature: 'fungible',
+      }),
+      save,
+    );
+    await new EditSupply(repo, makeCategoryRepo(), makeAttributeRepo()).execute(
+      {
+        id: ID,
+        nature: null,
+      },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const saved = save.mock.calls[0][0] as Supply;
+    expect(saved.nature).toBeNull();
+  });
+
+  it('naturaleza (#269): reclasifica con un valor válido', async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    const repo = makeRepo(existing(), save); // arranca sin naturaleza (null)
+    await new EditSupply(repo, makeCategoryRepo(), makeAttributeRepo()).execute(
+      {
+        id: ID,
+        nature: 'reusable',
+      },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const saved = save.mock.calls[0][0] as Supply;
+    expect(saved.nature).toBe('reusable');
+  });
 });

--- a/apps/api/src/contexts/supplies/application/edit-supply.ts
+++ b/apps/api/src/contexts/supplies/application/edit-supply.ts
@@ -1,5 +1,6 @@
 import {
   Supply,
+  SupplyNature,
   SupplyNotFoundError,
   VariantTargetNotFoundError,
   CategoryNotFoundError,
@@ -18,6 +19,8 @@ export interface EditSupplyCommand {
   defaultUnit?: string | null;
   attributes?: Record<string, unknown>;
   registrationNotes?: string | null;
+  /** Naturaleza logística (#269). Si se indica, reclasifica; `null` la limpia. */
+  nature?: SupplyNature | null;
   variantOfId?: string | null;
   /**
    * Traducciones de nombre por idioma (#320). Si se indica, REEMPLAZA el set
@@ -65,6 +68,7 @@ export class EditSupply {
     if (cmd.registrationNotes !== undefined) {
       next = next.setRegistrationNotes(cmd.registrationNotes);
     }
+    if (cmd.nature !== undefined) next = next.reclassify(cmd.nature);
     if (cmd.variantOfId !== undefined) {
       if (cmd.variantOfId) {
         const parent = await this.repo.findById(cmd.variantOfId);

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.int-spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.int-spec.ts
@@ -65,6 +65,23 @@ describe('DrizzleSupplyRepository (integration)', () => {
     expect(found!.categorySlug).toBe('food');
   });
 
+  it('persiste y actualiza la naturaleza logística (#269), por defecto null', async () => {
+    await repo.save(makeSupply({ id: A, code: 'INS-9001', name: 'Agua' }));
+    expect((await repo.findById(A))!.nature).toBeNull();
+
+    // Clasifica y relee.
+    await repo.save((await repo.findById(A))!.reclassify('fungible'));
+    expect((await repo.findById(A))!.nature).toBe('fungible');
+
+    // Reclasifica a otra naturaleza (upsert set).
+    await repo.save((await repo.findById(A))!.reclassify('reusable'));
+    expect((await repo.findById(A))!.nature).toBe('reusable');
+
+    // Limpia (vuelve a sin clasificar).
+    await repo.save((await repo.findById(A))!.reclassify(null));
+    expect((await repo.findById(A))!.nature).toBeNull();
+  });
+
   it('save persiste y reemplaza las traducciones, normalizando locale/nombre (#320)', async () => {
     await repo.save(makeSupply({ id: A, code: 'INS-9001', name: 'Agua' }), [
       { locale: 'en', name: 'Water' },

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
@@ -13,6 +13,7 @@ import { Db } from '../../../../shared/db';
 import {
   Supply,
   SupplyStatus,
+  SupplyNature,
   SupplyAlias,
   AliasConflictError,
   SupplyListFilter,
@@ -79,6 +80,7 @@ export class DrizzleSupplyRepository implements SupplyRepository {
       attributes: s.attributes,
       variantOfId: s.variantOfId,
       scopeId: s.scopeId,
+      nature: s.nature,
       createdAt: now,
       updatedAt: now,
     };
@@ -92,6 +94,7 @@ export class DrizzleSupplyRepository implements SupplyRepository {
         defaultUnit: s.defaultUnit,
         attributes: s.attributes,
         variantOfId: s.variantOfId,
+        nature: s.nature,
         updatedAt: now,
       },
     };
@@ -320,6 +323,7 @@ export class DrizzleSupplyRepository implements SupplyRepository {
       status: row.status as SupplyStatus,
       registrationNotes: row.registrationNotes ?? null,
       scopeId: row.scopeId ?? null,
+      nature: (row.nature ?? null) as SupplyNature | null,
     });
   }
 

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
@@ -75,6 +75,11 @@ export const suppliesTable = pgTable(
     ),
     /** Tenencia (#397): null = fila global · set = extensión de un tenant. */
     scopeId: uuid('scope_id'),
+    /**
+     * Naturaleza logística (#269): null = sin clasificar · fungible | reusable |
+     * human. CHECK en la migración 0057 (enum extensible, no boolean).
+     */
+    nature: text('nature'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },

--- a/apps/api/src/contexts/supplies/infrastructure/http/admin-supply-response.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/admin-supply-response.dto.ts
@@ -1,4 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  SUPPLY_NATURES,
+  type SupplyNature,
+} from '@globalemergency/warehouse-core/catalog';
 import { SupplyTranslationDto } from './supplies-admin.dto';
 
 /**
@@ -33,6 +37,15 @@ export class AdminSupplyDto {
 
   @ApiPropertyOptional({ nullable: true, type: String })
   registrationNotes!: string | null;
+
+  @ApiPropertyOptional({
+    enum: SUPPLY_NATURES,
+    nullable: true,
+    example: 'fungible',
+    description:
+      'Naturaleza logística (#269): fungible | reusable | human. Null = sin clasificar.',
+  })
+  nature!: SupplyNature | null;
 
   @ApiProperty({ type: [String], example: ['agua embotellada', 'botellon'] })
   aliases!: string[];

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.controller.ts
@@ -97,6 +97,7 @@ export class SuppliesAdminController {
       defaultUnit: dto.defaultUnit ?? null,
       attributes: dto.attributes ?? null,
       registrationNotes: dto.registrationNotes ?? null,
+      nature: dto.nature ?? null,
       variantOfId: dto.variantOfId ?? null,
       ...(dto.translations !== undefined
         ? { translations: dto.translations }

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.dto.ts
@@ -1,4 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  SUPPLY_NATURES,
+  type SupplyNature,
+} from '@globalemergency/warehouse-core/catalog';
 import { Type } from 'class-transformer';
 import {
   IsArray,
@@ -65,6 +69,15 @@ export class CreateSupplyDto {
   registrationNotes?: string | null;
 
   @ApiPropertyOptional({
+    enum: SUPPLY_NATURES,
+    description:
+      'Naturaleza logística (#269): fungible | reusable | human. Omitir = sin clasificar.',
+  })
+  @IsOptional()
+  @IsIn(SUPPLY_NATURES)
+  nature?: SupplyNature;
+
+  @ApiPropertyOptional({
     format: 'uuid',
     description: 'Si es variante, id del insumo padre (debe existir)',
   })
@@ -114,6 +127,16 @@ export class EditSupplyDto {
   @IsOptional()
   @IsString()
   registrationNotes?: string | null;
+
+  @ApiPropertyOptional({
+    enum: SUPPLY_NATURES,
+    nullable: true,
+    description:
+      'Naturaleza logística (#269). `null` la limpia (sin clasificar); omitir no la toca.',
+  })
+  @IsOptional()
+  @IsIn(SUPPLY_NATURES)
+  nature?: SupplyNature | null;
 
   @ApiPropertyOptional({ format: 'uuid' })
   @IsOptional()

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -5512,6 +5512,11 @@ export interface components {
             /** @description Notas internas de gestión */
             registrationNotes?: Record<string, never>;
             /**
+             * @description Naturaleza logística (#269): fungible | reusable | human. Omitir = sin clasificar.
+             * @enum {string}
+             */
+            nature?: "fungible" | "reusable" | "human";
+            /**
              * Format: uuid
              * @description Si es variante, id del insumo padre (debe existir)
              */
@@ -5550,6 +5555,12 @@ export interface components {
              */
             status: "active" | "archived";
             registrationNotes?: string | null;
+            /**
+             * @description Naturaleza logística (#269): fungible | reusable | human. Null = sin clasificar.
+             * @example fungible
+             * @enum {string|null}
+             */
+            nature?: "fungible" | "reusable" | "human" | null;
             /**
              * @example [
              *       "agua embotellada",
@@ -5621,6 +5632,11 @@ export interface components {
                 [key: string]: unknown;
             };
             registrationNotes?: Record<string, never>;
+            /**
+             * @description Naturaleza logística (#269). `null` la limpia (sin clasificar); omitir no la toca.
+             * @enum {string|null}
+             */
+            nature?: "fungible" | "reusable" | "human" | null;
             /** Format: uuid */
             variantOfId?: Record<string, never>;
             /** @description Reemplaza el conjunto de traducciones del insumo; omitir para no tocarlas. */

--- a/packages/warehouse-core/src/catalog/supply-nature.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-nature.test.ts
@@ -1,0 +1,107 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  Supply,
+  SUPPLY_NATURES,
+  isSupplyNature,
+  SupplyValidationError,
+} from './supply.js';
+
+// Naturaleza logística (#269): clasificación fina extensible en el INSUMO
+// (fungible|reusable|human). Nullable (null = sin clasificar, por defecto).
+
+function base(nature?: 'fungible' | 'reusable' | 'human' | null) {
+  return Supply.create({
+    id: 'a',
+    code: 'INS-0001',
+    name: 'Agua',
+    categorySlug: 'food',
+    defaultUnit: 'und',
+    ...(nature !== undefined ? { nature } : {}),
+  });
+}
+
+test('SUPPLY_NATURES contiene las tres naturalezas', () => {
+  assert.deepEqual([...SUPPLY_NATURES], ['fungible', 'reusable', 'human']);
+});
+
+test('isSupplyNature acepta valores válidos y rechaza el resto', () => {
+  for (const n of SUPPLY_NATURES) {
+    assert.equal(isSupplyNature(n), true);
+  }
+  assert.equal(isSupplyNature('bulk'), false);
+  assert.equal(isSupplyNature(''), false);
+  assert.equal(isSupplyNature(null), false);
+  assert.equal(isSupplyNature(undefined), false);
+  assert.equal(isSupplyNature(3), false);
+});
+
+test('Supply.create sin nature queda sin clasificar (null)', () => {
+  const s = base();
+  assert.equal(s.nature, null);
+  assert.equal(s.toSnapshot().nature, null);
+});
+
+test('Supply.create acepta cada naturaleza válida', () => {
+  for (const n of SUPPLY_NATURES) {
+    assert.equal(base(n).nature, n);
+  }
+});
+
+test('Supply.create con nature null es válido (sin clasificar explícito)', () => {
+  assert.equal(base(null).nature, null);
+});
+
+test('Supply.create rechaza una naturaleza inválida', () => {
+  assert.throws(
+    () =>
+      Supply.create({
+        id: 'a',
+        code: 'INS-0001',
+        name: 'Agua',
+        categorySlug: 'food',
+        defaultUnit: 'und',
+        // @ts-expect-error valor inválido a propósito
+        nature: 'bulk',
+      }),
+    SupplyValidationError,
+  );
+});
+
+test('reclassify asigna, cambia y limpia la naturaleza (inmutable, round-trip)', () => {
+  const s = base();
+  const fungible = s.reclassify('fungible');
+  assert.equal(fungible.nature, 'fungible');
+  // No muta el original.
+  assert.equal(s.nature, null);
+  // Cambia a otra naturaleza.
+  assert.equal(fungible.reclassify('reusable').nature, 'reusable');
+  // Limpia (vuelve a sin clasificar).
+  assert.equal(fungible.reclassify(null).nature, null);
+});
+
+test('reclassify preserva el resto de la identidad', () => {
+  const s = base();
+  const human = s.reclassify('human');
+  assert.equal(human.id, s.id);
+  assert.equal(human.code, s.code);
+  assert.equal(human.name, s.name);
+  assert.equal(human.categorySlug, s.categorySlug);
+});
+
+test('Supply round-trip por snapshot conserva nature', () => {
+  const snap = {
+    id: 'a',
+    code: 'INS-0001',
+    name: 'Agua',
+    categorySlug: 'food',
+    defaultUnit: 'und',
+    attributes: {},
+    variantOfId: null,
+    status: 'active' as const,
+    registrationNotes: null,
+    scopeId: null,
+    nature: 'reusable' as const,
+  };
+  assert.deepEqual(Supply.fromSnapshot(snap).toSnapshot(), snap);
+});

--- a/packages/warehouse-core/src/catalog/supply-resolver.ts
+++ b/packages/warehouse-core/src/catalog/supply-resolver.ts
@@ -78,6 +78,7 @@ export function supplyResolverFromCatalog(
       status: 'active',
       registrationNotes: null,
       scopeId: null,
+      nature: null,
     });
 
   const supplies = records.flatMap((record) =>

--- a/packages/warehouse-core/src/catalog/supply-scope.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-scope.test.ts
@@ -56,6 +56,7 @@ test('Supply round-trip por snapshot conserva scopeId', () => {
     status: 'active' as const,
     registrationNotes: null,
     scopeId: 'tenant-1',
+    nature: null,
   };
   assert.deepEqual(Supply.fromSnapshot(snap).toSnapshot(), snap);
 });

--- a/packages/warehouse-core/src/catalog/supply.ts
+++ b/packages/warehouse-core/src/catalog/supply.ts
@@ -1,5 +1,29 @@
 export type SupplyStatus = 'active' | 'archived';
 
+/**
+ * Clasificación fina de un insumo por su naturaleza logística (#269). Vive en el
+ * INSUMO, no en la categoría (una categoría puede mezclar naturalezas). Enum
+ * extensible (no boolean) para poder crecer sin una migración destructiva:
+ * - `fungible`: se consume (gasas, agua).
+ * - `reusable`: no se consume, se presta/devuelve (maquinaria, equipos).
+ * - `human`: se asigna, no es carga (personal).
+ *
+ * `null` = sin clasificar (los insumos previos no se rellenan).
+ */
+export type SupplyNature = 'fungible' | 'reusable' | 'human';
+
+export const SUPPLY_NATURES: readonly SupplyNature[] = [
+  'fungible',
+  'reusable',
+  'human',
+] as const;
+
+export function isSupplyNature(x: unknown): x is SupplyNature {
+  return (
+    typeof x === 'string' && (SUPPLY_NATURES as readonly string[]).includes(x)
+  );
+}
+
 export interface SupplyProps {
   id: string;
   code: string;
@@ -12,6 +36,8 @@ export interface SupplyProps {
   registrationNotes?: string | null;
   /** Tenencia (#397): null = insumo global · set = insumo de un tenant. */
   scopeId?: string | null;
+  /** Naturaleza logística (#269): null = sin clasificar (por defecto). */
+  nature?: SupplyNature | null;
 }
 
 export interface SupplySnapshot {
@@ -25,6 +51,7 @@ export interface SupplySnapshot {
   status: SupplyStatus;
   registrationNotes: string | null;
   scopeId: string | null;
+  nature: SupplyNature | null;
 }
 
 export class SupplyValidationError extends Error {
@@ -63,6 +90,7 @@ export class Supply {
   readonly status: SupplyStatus;
   readonly registrationNotes: string | null;
   readonly scopeId: string | null;
+  readonly nature: SupplyNature | null;
 
   private constructor(props: SupplyProps) {
     this.id = props.id;
@@ -75,6 +103,7 @@ export class Supply {
     this.status = props.status ?? 'active';
     this.registrationNotes = props.registrationNotes ?? null;
     this.scopeId = props.scopeId ?? null;
+    this.nature = props.nature ?? null;
   }
 
   static create(props: SupplyProps): Supply {
@@ -100,6 +129,12 @@ export class Supply {
         'Supply status must be active or archived',
       );
     }
+    const nature = props.nature ?? null;
+    if (nature !== null && !isSupplyNature(nature)) {
+      throw new SupplyValidationError(
+        'Supply nature must be fungible, reusable or human',
+      );
+    }
 
     return new Supply({
       id,
@@ -112,6 +147,7 @@ export class Supply {
       status,
       registrationNotes,
       scopeId,
+      nature,
     });
   }
 
@@ -127,6 +163,7 @@ export class Supply {
       status: s.status,
       registrationNotes: s.registrationNotes,
       scopeId: s.scopeId,
+      nature: s.nature,
     });
   }
 
@@ -142,6 +179,7 @@ export class Supply {
       status: this.status,
       registrationNotes: this.registrationNotes,
       scopeId: this.scopeId,
+      nature: this.nature,
     };
   }
 
@@ -180,6 +218,14 @@ export class Supply {
 
   setVariantOf(variantOfId: string | null): Supply {
     return this.withChanges({ variantOfId });
+  }
+
+  /**
+   * Reclasifica el insumo por su naturaleza logística (#269). `null` lo deja sin
+   * clasificar. Inmutable: produce una instancia nueva vía `withChanges`.
+   */
+  reclassify(nature: SupplyNature | null): Supply {
+    return this.withChanges({ nature });
   }
 
   archive(): Supply {

--- a/packages/warehouse-core/src/catalog/supply.ts
+++ b/packages/warehouse-core/src/catalog/supply.ts
@@ -132,7 +132,7 @@ export class Supply {
     const nature = props.nature ?? null;
     if (nature !== null && !isSupplyNature(nature)) {
       throw new SupplyValidationError(
-        'Supply nature must be fungible, reusable or human',
+        `Supply nature must be one of: ${SUPPLY_NATURES.join(', ')}`,
       );
     }
 


### PR DESCRIPTION
Closes #269 · **Incremento 3** de la épica #228. Añade la clasificación fina **`nature`** al `Supply`: `fungible | reusable | human` (enum extensible + CHECK, **nullable** = sin clasificar). Vive en el insumo, no en la categoría (una categoría puede mezclar naturalezas). El `kind` grueso de la categoría se mantiene.

- **fungible**: se consume (gasas, agua) · **reusable**: no se consume, se presta/devuelve (maquinaria, equipos) · **human**: se asigna, no es carga (personal).

## Qué incluye
- **Dominio** (`warehouse-core/catalog/supply.ts`): `SupplyNature`/`SUPPLY_NATURES`/`isSupplyNature`; `nature` en props/snapshot/agregado; validación en `create`; mutador inmutable `reclassify`. + tests puros.
- **Migración 0057**: `ALTER TABLE supplies ADD COLUMN nature text` + CHECK `nature IS NULL OR IN (fungible,reusable,human)` (idempotente, guardado por `pg_constraint`). Sin backfill de los ~574 insumos.
- **Persistencia**: schema + mapper round-trip + int-spec.
- **HTTP**: `nature` en DTOs de create/edit (validado) y en la respuesta admin. `gen:api` regenerado (aparece en `schema.ts`).

## Fuera de alcance (no bloqueante, por diseño de #269)
Las implicaciones downstream —**retornos en logística** (un reutilizable vuelve), **préstamo vs consumo en inventario**, **matching**— NO se tocan. `nature` es el campo base sobre el que se injertan después (OCP).

## Verificación (local)
warehouse-core build + **139 tests** · api build (nest/tsc, tsc-neutral 46) · eslint (0) · prettier api+packages · api-client + web build · frozen-lockfile — todo verde. Int-specs Jest los valida CI.