### PR TITLE
feat(catalog): interop external_codes en Supply y Category (Inc 4 catálogo escalable)

### DIFF
--- a/apps/api/drizzle/0058_external_codes.sql
+++ b/apps/api/drizzle/0058_external_codes.sql
@@ -1,0 +1,18 @@
+-- Códigos externos estándar para interop (#398, épica #228): mapa abierto
+-- namespace→código (jsonb) en insumos y categorías, mapeable/compatible con
+-- estándares (UNSPSC, WHO EML, HXL, …) SIN acoplarse a ninguno. Por defecto '{}'.
+-- Los ~574 insumos y las categorías previas quedan con el mapa vacío.
+
+ALTER TABLE "supplies"
+  ADD COLUMN IF NOT EXISTS "external_codes" jsonb NOT NULL DEFAULT '{}'::jsonb;
+--> statement-breakpoint
+
+ALTER TABLE "categories"
+  ADD COLUMN IF NOT EXISTS "external_codes" jsonb NOT NULL DEFAULT '{}'::jsonb;
+--> statement-breakpoint
+
+-- GIN sobre supplies.external_codes: habilita la búsqueda inversa por código
+-- externo (p.ej. `external_codes @> '{"unspsc":"51101500"}'` o `? 'unspsc'`)
+-- sin escanear la tabla. jsonb_ops (por defecto) soporta tanto `@>` como `?`.
+CREATE INDEX IF NOT EXISTS "supplies_external_codes_gin"
+  ON "supplies" USING gin ("external_codes");

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -14838,6 +14838,16 @@
             "items": {
               "$ref": "#/components/schemas/CategoryTranslationDto"
             }
+          },
+          "externalCodes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Códigos externos estándar para interop (#398): mapa namespace→código. `{}` si no tiene.",
+            "example": {
+              "unspsc": "51101500"
+            }
           }
         },
         "required": [
@@ -14849,7 +14859,8 @@
           "vertical",
           "sort",
           "archivedAt",
-          "translations"
+          "translations",
+          "externalCodes"
         ]
       },
       "CreateCategoryDto": {
@@ -14887,6 +14898,13 @@
             "items": {
               "$ref": "#/components/schemas/CategoryTranslationDto"
             }
+          },
+          "externalCodes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Códigos externos estándar para interop (#398): mapa namespace→código."
           }
         },
         "required": [
@@ -14928,6 +14946,13 @@
             "items": {
               "$ref": "#/components/schemas/CategoryTranslationDto"
             }
+          },
+          "externalCodes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Códigos externos de interop (#398). Si se indica, reemplaza el mapa; omitir lo conserva."
           },
           "archived": {
             "type": "boolean",
@@ -15189,6 +15214,13 @@
             ],
             "description": "Naturaleza logística (#269): fungible | reusable | human. Omitir = sin clasificar."
           },
+          "externalCodes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Códigos externos estándar para interop (#398): mapa namespace→código, p.ej. { \"unspsc\": \"51101500\", \"hxl\": \"#item+code\" }."
+          },
           "variantOfId": {
             "type": "object",
             "format": "uuid",
@@ -15282,6 +15314,17 @@
             "example": "fungible",
             "description": "Naturaleza logística (#269): fungible | reusable | human. Null = sin clasificar."
           },
+          "externalCodes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Códigos externos estándar para interop (#398): mapa namespace→código. `{}` si no tiene.",
+            "example": {
+              "unspsc": "51101500",
+              "hxl": "#item+code"
+            }
+          },
           "aliases": {
             "example": [
               "agua embotellada",
@@ -15313,6 +15356,7 @@
           "categorySlug",
           "attributes",
           "status",
+          "externalCodes",
           "aliases",
           "translations"
         ]
@@ -15447,6 +15491,13 @@
             ],
             "nullable": true,
             "description": "Naturaleza logística (#269). `null` la limpia (sin clasificar); omitir no la toca."
+          },
+          "externalCodes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Códigos externos de interop (#398). Si se indica, reemplaza el mapa completo; `{}` los limpia."
           },
           "variantOfId": {
             "type": "object",

--- a/apps/api/src/contexts/supplies/application/admin-supply-view.ts
+++ b/apps/api/src/contexts/supplies/application/admin-supply-view.ts
@@ -21,6 +21,7 @@ export interface AdminSupplyView {
   status: Supply['status'];
   registrationNotes: string | null;
   nature: Supply['nature'];
+  externalCodes: Supply['externalCodes'];
   aliases: string[];
   translations: SupplyTranslationInput[];
 }

--- a/apps/api/src/contexts/supplies/application/create-category.ts
+++ b/apps/api/src/contexts/supplies/application/create-category.ts
@@ -3,7 +3,10 @@ import {
   CategoryParentNotFoundError,
   CategoryValidationError,
 } from './category-admin.errors';
-import { CategoryDefinition } from '@globalemergency/warehouse-core/kernel';
+import {
+  CategoryDefinition,
+  normalizeExternalCodes,
+} from '@globalemergency/warehouse-core/kernel';
 import {
   CategoryRepository,
   CategoryWriteInput,
@@ -45,6 +48,7 @@ export class CreateCategory {
       parentSlug: cmd.parentSlug,
       archivedAt: cmd.archivedAt ?? null,
       translations: cmd.translations ?? [],
+      externalCodes: normalizeExternalCodes(cmd.externalCodes),
     });
   }
 }

--- a/apps/api/src/contexts/supplies/application/create-supply.ts
+++ b/apps/api/src/contexts/supplies/application/create-supply.ts
@@ -21,6 +21,11 @@ export interface CreateSupplyCommand {
   registrationNotes?: string | null;
   /** Naturaleza logística (#269): fungible | reusable | human. Null = sin clasificar. */
   nature?: SupplyNature | null;
+  /**
+   * Códigos externos estándar para interop (#398): mapa abierto namespace→código.
+   * Se valida/normaliza en el agregado. Omitir = sin códigos (`{}`).
+   */
+  externalCodes?: Record<string, string> | null;
   /** Si se indica, el insumo es una variante de otro existente (#222). */
   variantOfId?: string | null;
   /** Traducciones de nombre por idioma (#320). El nombre base (`name`) es `es`. */
@@ -89,6 +94,7 @@ export class CreateSupply {
       attributes,
       registrationNotes: cmd.registrationNotes ?? null,
       nature: cmd.nature ?? null,
+      externalCodes: cmd.externalCodes ?? {},
       variantOfId,
       scopeId,
     });

--- a/apps/api/src/contexts/supplies/application/edit-supply.spec.ts
+++ b/apps/api/src/contexts/supplies/application/edit-supply.spec.ts
@@ -326,4 +326,50 @@ describe('EditSupply', () => {
     const saved = save.mock.calls[0][0] as Supply;
     expect(saved.nature).toBe('reusable');
   });
+
+  it('externalCodes (#398): omitir no los toca', async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    const repo = makeRepo(
+      Supply.create({
+        id: ID,
+        code: 'WAT-0001',
+        name: 'Agua',
+        categorySlug: 'water',
+        externalCodes: { unspsc: '51101500' },
+      }),
+      save,
+    );
+    await new EditSupply(repo, makeCategoryRepo(), makeAttributeRepo()).execute(
+      {
+        id: ID,
+        name: 'Agua mineral',
+      },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const saved = save.mock.calls[0][0] as Supply;
+    expect(saved.externalCodes).toEqual({ unspsc: '51101500' }); // conservados
+  });
+
+  it('externalCodes (#398): proveer reemplaza el mapa completo', async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    const repo = makeRepo(
+      Supply.create({
+        id: ID,
+        code: 'WAT-0001',
+        name: 'Agua',
+        categorySlug: 'water',
+        externalCodes: { unspsc: '51101500' },
+      }),
+      save,
+    );
+    await new EditSupply(repo, makeCategoryRepo(), makeAttributeRepo()).execute(
+      {
+        id: ID,
+        externalCodes: { who_eml: 'ABC' },
+      },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const saved = save.mock.calls[0][0] as Supply;
+    expect(saved.externalCodes).toEqual({ who_eml: 'ABC' }); // reemplazado, no fusionado
+  });
 });

--- a/apps/api/src/contexts/supplies/application/edit-supply.ts
+++ b/apps/api/src/contexts/supplies/application/edit-supply.ts
@@ -21,6 +21,11 @@ export interface EditSupplyCommand {
   registrationNotes?: string | null;
   /** Naturaleza logística (#269). Si se indica, reclasifica; `null` la limpia. */
   nature?: SupplyNature | null;
+  /**
+   * Códigos externos de interop (#398). Si se indica, REEMPLAZA el mapa
+   * completo (mapa vacío los limpia); si se omite, no se tocan.
+   */
+  externalCodes?: Record<string, string>;
   variantOfId?: string | null;
   /**
    * Traducciones de nombre por idioma (#320). Si se indica, REEMPLAZA el set
@@ -69,6 +74,9 @@ export class EditSupply {
       next = next.setRegistrationNotes(cmd.registrationNotes);
     }
     if (cmd.nature !== undefined) next = next.reclassify(cmd.nature);
+    if (cmd.externalCodes !== undefined) {
+      next = next.setExternalCodes(cmd.externalCodes);
+    }
     if (cmd.variantOfId !== undefined) {
       if (cmd.variantOfId) {
         const parent = await this.repo.findById(cmd.variantOfId);

--- a/apps/api/src/contexts/supplies/application/list-categories.spec.ts
+++ b/apps/api/src/contexts/supplies/application/list-categories.spec.ts
@@ -19,6 +19,7 @@ const FOOD: CategoryDefinition = {
     { locale: 'es', label: 'Alimentos' },
     { locale: 'en', label: 'Food' },
   ],
+  externalCodes: {},
 };
 
 function makeRepo(listCategoriesFn: jest.Mock): CategoryRepository {

--- a/apps/api/src/contexts/supplies/application/update-category.spec.ts
+++ b/apps/api/src/contexts/supplies/application/update-category.spec.ts
@@ -14,8 +14,10 @@ const BASE: CategoryDefinition = {
   vertical: 'general',
   sort: 140,
   kind: 'material',
+  codePrefix: null,
   archivedAt: null,
   translations: [],
+  externalCodes: {},
 };
 
 function makeRepo(

--- a/apps/api/src/contexts/supplies/application/update-category.ts
+++ b/apps/api/src/contexts/supplies/application/update-category.ts
@@ -7,6 +7,7 @@ import {
 import {
   isCoreCategory,
   CategoryDefinition,
+  normalizeExternalCodes,
 } from '@globalemergency/warehouse-core/kernel';
 import { CategoryRepository } from '@globalemergency/warehouse-core/catalog';
 
@@ -18,6 +19,11 @@ export interface UpdateCategoryCommand {
   sort?: number | undefined;
   archived?: boolean | undefined;
   translations?: CategoryDefinition['translations'] | undefined;
+  /**
+   * Códigos externos de interop (#398). Si se indica, REEMPLAZA el mapa; si se
+   * omite, se conserva el actual de la categoría.
+   */
+  externalCodes?: Record<string, string> | null | undefined;
 }
 
 export class UpdateCategory {
@@ -73,6 +79,10 @@ export class UpdateCategory {
             ? new Date()
             : null,
       translations: cmd.translations ?? current.translations,
+      externalCodes:
+        cmd.externalCodes !== undefined
+          ? normalizeExternalCodes(cmd.externalCodes)
+          : current.externalCodes,
     });
   }
 }

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.int-spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.int-spec.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import { createDb, Db } from '../../../../shared/db';
 import { DrizzleCategoryRepository } from './drizzle-category.repository';
 import type { Pool } from 'pg';
@@ -34,5 +35,48 @@ describe('DrizzleCategoryRepository — kind (integration)', () => {
       includeArchived: true,
     });
     expect(personnel?.kind).toBe('personnel');
+  });
+
+  it('round-trip de externalCodes (#398): crea con códigos, edita y por defecto {}', async () => {
+    const slug = 'interop_test_398';
+    try {
+      const created = await repo.createCategory({
+        slug,
+        labelEs: 'Interop',
+        labelEn: 'Interop',
+        parentSlug: null,
+        vertical: 'general',
+        sort: 999,
+        externalCodes: { unspsc: '51101500' },
+      });
+      expect(created.externalCodes).toEqual({ unspsc: '51101500' });
+      expect((await repo.findBySlug(slug))!.externalCodes).toEqual({
+        unspsc: '51101500',
+      });
+
+      const updated = await repo.updateCategory(slug, {
+        slug,
+        labelEs: 'Interop',
+        labelEn: 'Interop',
+        parentSlug: null,
+        vertical: 'general',
+        sort: 999,
+        externalCodes: { hxl: '#item+code' },
+      });
+      expect(updated.externalCodes).toEqual({ hxl: '#item+code' });
+
+      // Sin externalCodes en el input → el repo cae al mapa vacío por defecto.
+      const cleared = await repo.updateCategory(slug, {
+        slug,
+        labelEs: 'Interop',
+        labelEn: 'Interop',
+        parentSlug: null,
+        vertical: 'general',
+        sort: 999,
+      });
+      expect(cleared.externalCodes).toEqual({});
+    } finally {
+      await db.execute(sql`DELETE FROM categories WHERE slug = ${slug}`);
+    }
   });
 });

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.ts
@@ -77,6 +77,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
       translations: (translationsBySlug.get(row.slug) ?? []).sort((a, b) =>
         a.locale.localeCompare(b.locale),
       ),
+      externalCodes: (row.externalCodes ?? {}) as Record<string, string>,
     }));
   }
 
@@ -119,6 +120,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
       kind: row.kind as CategoryKind,
       archivedAt: row.archivedAt ?? null,
       translations,
+      externalCodes: (row.externalCodes ?? {}) as Record<string, string>,
     };
   }
 
@@ -134,6 +136,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
         vertical: input.vertical,
         sort: input.sort,
         archivedAt: input.archivedAt ?? null,
+        externalCodes: input.externalCodes ?? {},
       });
 
       const translations = this.buildTranslationRows(
@@ -171,6 +174,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
           vertical: input.vertical,
           sort: input.sort,
           archivedAt: input.archivedAt ?? null,
+          externalCodes: input.externalCodes ?? {},
         })
         .where(eq(categoriesTable.slug, slug));
 

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-category.repository.ts
@@ -77,7 +77,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
       translations: (translationsBySlug.get(row.slug) ?? []).sort((a, b) =>
         a.locale.localeCompare(b.locale),
       ),
-      externalCodes: (row.externalCodes ?? {}) as Record<string, string>,
+      externalCodes: row.externalCodes ?? {},
     }));
   }
 
@@ -120,7 +120,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
       kind: row.kind as CategoryKind,
       archivedAt: row.archivedAt ?? null,
       translations,
-      externalCodes: (row.externalCodes ?? {}) as Record<string, string>,
+      externalCodes: row.externalCodes ?? {},
     };
   }
 

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.int-spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.int-spec.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import { createDb, Db } from '../../../../shared/db';
 import { suppliesTable, supplyAliasesTable } from './schema';
 import { DrizzleSupplyRepository } from './drizzle-supply.repository';
@@ -80,6 +81,44 @@ describe('DrizzleSupplyRepository (integration)', () => {
     // Limpia (vuelve a sin clasificar).
     await repo.save((await repo.findById(A))!.reclassify(null));
     expect((await repo.findById(A))!.nature).toBeNull();
+  });
+
+  it('persiste, actualiza y limpia los códigos externos de interop (#398), por defecto {}', async () => {
+    await repo.save(makeSupply({ id: A, code: 'INS-9001', name: 'Agua' }));
+    expect((await repo.findById(A))!.externalCodes).toEqual({});
+
+    // Asigna códigos y relee (jsonb round-trip).
+    await repo.save(
+      (await repo.findById(A))!.setExternalCodes({
+        unspsc: '51101500',
+        hxl: '#item+code',
+      }),
+    );
+    expect((await repo.findById(A))!.externalCodes).toEqual({
+      unspsc: '51101500',
+      hxl: '#item+code',
+    });
+
+    // Reemplaza el mapa (upsert set).
+    await repo.save(
+      (await repo.findById(A))!.setExternalCodes({ who_eml: 'core-121' }),
+    );
+    expect((await repo.findById(A))!.externalCodes).toEqual({
+      who_eml: 'core-121',
+    });
+
+    // Búsqueda inversa por código externo (usa el índice GIN, operador @>).
+    const [hit] = await db
+      .select()
+      .from(suppliesTable)
+      .where(
+        sql`${suppliesTable.externalCodes} @> ${'{"who_eml":"core-121"}'}`,
+      );
+    expect(hit?.id).toBe(A);
+
+    // Limpia (vuelve al mapa vacío).
+    await repo.save((await repo.findById(A))!.setExternalCodes({}));
+    expect((await repo.findById(A))!.externalCodes).toEqual({});
   });
 
   it('save persiste y reemplaza las traducciones, normalizando locale/nombre (#320)', async () => {

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
@@ -81,6 +81,7 @@ export class DrizzleSupplyRepository implements SupplyRepository {
       variantOfId: s.variantOfId,
       scopeId: s.scopeId,
       nature: s.nature,
+      externalCodes: s.externalCodes,
       createdAt: now,
       updatedAt: now,
     };
@@ -95,6 +96,7 @@ export class DrizzleSupplyRepository implements SupplyRepository {
         attributes: s.attributes,
         variantOfId: s.variantOfId,
         nature: s.nature,
+        externalCodes: s.externalCodes,
         updatedAt: now,
       },
     };
@@ -324,6 +326,7 @@ export class DrizzleSupplyRepository implements SupplyRepository {
       registrationNotes: row.registrationNotes ?? null,
       scopeId: row.scopeId ?? null,
       nature: (row.nature ?? null) as SupplyNature | null,
+      externalCodes: (row.externalCodes ?? {}) as Record<string, string>,
     });
   }
 

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
@@ -326,7 +326,7 @@ export class DrizzleSupplyRepository implements SupplyRepository {
       registrationNotes: row.registrationNotes ?? null,
       scopeId: row.scopeId ?? null,
       nature: (row.nature ?? null) as SupplyNature | null,
-      externalCodes: (row.externalCodes ?? {}) as Record<string, string>,
+      externalCodes: row.externalCodes ?? {},
     });
   }
 

--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/schema.ts
@@ -29,6 +29,14 @@ export const categoriesTable = pgTable('categories', {
   codePrefix: text('code_prefix'),
   kind: text('kind').notNull().default('material'),
   archivedAt: timestamp('archived_at', { withTimezone: true }),
+  /**
+   * Códigos externos estándar para interop (#398): mapa abierto namespace→código
+   * (migración 0058). Por defecto '{}'.
+   */
+  externalCodes: jsonb('external_codes')
+    .$type<Record<string, string>>()
+    .notNull()
+    .default({}),
 });
 
 export const categoryAliasesTable = pgTable('category_aliases', {
@@ -80,6 +88,15 @@ export const suppliesTable = pgTable(
      * human. CHECK en la migración 0057 (enum extensible, no boolean).
      */
     nature: text('nature'),
+    /**
+     * Códigos externos estándar para interop (#398): mapa abierto
+     * namespace→código (migración 0058). GIN `supplies_external_codes_gin` para
+     * la búsqueda inversa. Por defecto '{}'.
+     */
+    externalCodes: jsonb('external_codes')
+      .$type<Record<string, string>>()
+      .notNull()
+      .default({}),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
@@ -95,6 +112,8 @@ export const suppliesTable = pgTable(
     index('supplies_category_slug_idx').on(t.categorySlug),
     index('supplies_variant_of_id_idx').on(t.variantOfId),
     index('supplies_scope_id_idx').on(t.scopeId),
+    // Búsqueda inversa por código externo (#398, migración 0058): `@>` / `?`.
+    index('supplies_external_codes_gin').using('gin', t.externalCodes),
   ],
 );
 

--- a/apps/api/src/contexts/supplies/infrastructure/http/admin-category.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/admin-category.dto.ts
@@ -3,6 +3,7 @@ import {
   IsArray,
   IsBoolean,
   IsInt,
+  IsObject,
   IsOptional,
   IsString,
   Matches,
@@ -64,6 +65,16 @@ export class CreateCategoryDto {
   @ValidateNested({ each: true })
   @Type(() => CategoryTranslationDto)
   translations?: CategoryTranslationDto[];
+
+  @ApiPropertyOptional({
+    type: 'object',
+    additionalProperties: { type: 'string' },
+    description:
+      'Códigos externos estándar para interop (#398): mapa namespace→código.',
+  })
+  @IsOptional()
+  @IsObject()
+  externalCodes?: Record<string, string>;
 }
 
 export class UpdateCategoryDto {
@@ -105,6 +116,16 @@ export class UpdateCategoryDto {
   @ValidateNested({ each: true })
   @Type(() => CategoryTranslationDto)
   translations?: CategoryTranslationDto[];
+
+  @ApiPropertyOptional({
+    type: 'object',
+    additionalProperties: { type: 'string' },
+    description:
+      'Códigos externos de interop (#398). Si se indica, reemplaza el mapa; omitir lo conserva.',
+  })
+  @IsOptional()
+  @IsObject()
+  externalCodes?: Record<string, string>;
 
   @ApiPropertyOptional({
     example: false,
@@ -154,4 +175,13 @@ export class CategoryAdminDto {
 
   @ApiProperty({ type: [CategoryTranslationDto] })
   translations!: CategoryTranslationDto[];
+
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: { type: 'string' },
+    description:
+      'Códigos externos estándar para interop (#398): mapa namespace→código. `{}` si no tiene.',
+    example: { unspsc: '51101500' },
+  })
+  externalCodes!: Record<string, string>;
 }

--- a/apps/api/src/contexts/supplies/infrastructure/http/admin-supply-response.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/admin-supply-response.dto.ts
@@ -47,6 +47,15 @@ export class AdminSupplyDto {
   })
   nature!: SupplyNature | null;
 
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: { type: 'string' },
+    description:
+      'Códigos externos estándar para interop (#398): mapa namespace→código. `{}` si no tiene.',
+    example: { unspsc: '51101500', hxl: '#item+code' },
+  })
+  externalCodes!: Record<string, string>;
+
   @ApiProperty({ type: [String], example: ['agua embotellada', 'botellon'] })
   aliases!: string[];
 

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
@@ -10,12 +10,14 @@ describe('CategoriesAdminController', () => {
     vertical: 'general',
     sort: 140,
     kind: 'material',
+    codePrefix: null,
     archivedAt: null,
     translations: [
       { locale: 'es', label: 'Alimentos para bebé' },
       { locale: 'en', label: 'Baby food' },
       { locale: 'fr', label: 'Nourriture pour bébé' },
     ],
+    externalCodes: {},
   };
 
   it('lists and localizes categories for admin', async () => {

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.spec.ts
@@ -67,6 +67,7 @@ describe('CategoriesAdminController', () => {
       sort: 140,
       archivedAt: null,
       translations: [{ locale: 'fr', label: 'Nourriture pour bébé' }],
+      externalCodes: {},
     });
     expect(result.label).toBe('Nourriture pour bébé');
   });
@@ -108,6 +109,7 @@ describe('CategoriesAdminController', () => {
       sort: undefined,
       archived: false,
       translations: undefined,
+      externalCodes: undefined,
     });
     expect(result.archivedAt).toBeNull();
   });

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories-admin.controller.ts
@@ -167,6 +167,7 @@ export class CategoriesAdminController {
         locale: translation.locale,
         label: translation.label,
       })),
+      externalCodes: category.externalCodes,
     };
   }
 
@@ -180,6 +181,7 @@ export class CategoriesAdminController {
       sort: dto.sort,
       archivedAt: null,
       translations: dto.translations ?? [],
+      externalCodes: dto.externalCodes ?? {},
     };
   }
 
@@ -192,6 +194,7 @@ export class CategoriesAdminController {
       sort: dto.sort,
       archived: dto.archived,
       translations: dto.translations,
+      externalCodes: dto.externalCodes,
     };
   }
 }

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.spec.ts
@@ -58,6 +58,9 @@ describe('CategoriesController', () => {
       vertical: 'general',
       sort: 1,
       kind: 'material',
+      codePrefix: null,
     });
+    // externalCodes NO se expone en la proyección pública (solo admin).
+    expect(result[0]).not.toHaveProperty('externalCodes');
   });
 });

--- a/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.spec.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/categories.controller.spec.ts
@@ -11,12 +11,14 @@ describe('CategoriesController', () => {
       vertical: 'general',
       sort: 1,
       kind: 'material',
+      codePrefix: null,
       archivedAt: null,
       translations: [
         { locale: 'es', label: 'Alimentos' },
         { locale: 'en', label: 'Food' },
         { locale: 'fr', label: 'Nourriture' },
       ],
+      externalCodes: {},
     },
   ];
 

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.controller.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.controller.ts
@@ -98,6 +98,7 @@ export class SuppliesAdminController {
       attributes: dto.attributes ?? null,
       registrationNotes: dto.registrationNotes ?? null,
       nature: dto.nature ?? null,
+      externalCodes: dto.externalCodes ?? {},
       variantOfId: dto.variantOfId ?? null,
       ...(dto.translations !== undefined
         ? { translations: dto.translations }

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.dto.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-admin.dto.ts
@@ -78,6 +78,16 @@ export class CreateSupplyDto {
   nature?: SupplyNature;
 
   @ApiPropertyOptional({
+    type: 'object',
+    additionalProperties: { type: 'string' },
+    description:
+      'Códigos externos estándar para interop (#398): mapa namespace→código, p.ej. { "unspsc": "51101500", "hxl": "#item+code" }.',
+  })
+  @IsOptional()
+  @IsObject()
+  externalCodes?: Record<string, string>;
+
+  @ApiPropertyOptional({
     format: 'uuid',
     description: 'Si es variante, id del insumo padre (debe existir)',
   })
@@ -137,6 +147,16 @@ export class EditSupplyDto {
   @IsOptional()
   @IsIn(SUPPLY_NATURES)
   nature?: SupplyNature | null;
+
+  @ApiPropertyOptional({
+    type: 'object',
+    additionalProperties: { type: 'string' },
+    description:
+      'Códigos externos de interop (#398). Si se indica, reemplaza el mapa completo; `{}` los limpia.',
+  })
+  @IsOptional()
+  @IsObject()
+  externalCodes?: Record<string, string>;
 
   @ApiPropertyOptional({ format: 'uuid' })
   @IsOptional()

--- a/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/http/supplies-domain-exception.filter.ts
@@ -12,7 +12,10 @@ import {
   ContainerSealedError,
   ContainerValidationError,
 } from '@globalemergency/warehouse-core/containers';
-import { SupplyLineValidationError } from '@globalemergency/warehouse-core/kernel';
+import {
+  SupplyLineValidationError,
+  ExternalCodesValidationError,
+} from '@globalemergency/warehouse-core/kernel';
 import {
   SupplyValidationError,
   SupplyAliasValidationError,
@@ -42,6 +45,7 @@ type DomainError =
   | ContainerScopeMismatchError
   | ContainerValidationError
   | SupplyLineValidationError
+  | ExternalCodesValidationError
   | SupplyValidationError
   | SupplyAliasValidationError
   | SupplyNotFoundError
@@ -77,6 +81,7 @@ type DomainError =
   ContainerScopeMismatchError,
   ContainerValidationError,
   SupplyLineValidationError,
+  ExternalCodesValidationError,
   SupplyValidationError,
   SupplyAliasValidationError,
   SupplyNotFoundError,
@@ -127,6 +132,7 @@ export class SuppliesDomainExceptionFilter implements ExceptionFilter {
     }
     if (
       exception instanceof SupplyLineValidationError ||
+      exception instanceof ExternalCodesValidationError ||
       exception instanceof SupplyValidationError ||
       exception instanceof SupplyAliasValidationError ||
       exception instanceof MergeIntoSelfError ||

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -5339,6 +5339,15 @@ export interface components {
              */
             archivedAt: Record<string, never> | null;
             translations: components["schemas"]["CategoryTranslationDto"][];
+            /**
+             * @description Códigos externos estándar para interop (#398): mapa namespace→código. `{}` si no tiene.
+             * @example {
+             *       "unspsc": "51101500"
+             *     }
+             */
+            externalCodes: {
+                [key: string]: string;
+            };
         };
         CreateCategoryDto: {
             /** @example baby_food */
@@ -5358,6 +5367,10 @@ export interface components {
             sort: number;
             /** @description Additional locale labels to persist in category_translations */
             translations?: components["schemas"]["CategoryTranslationDto"][];
+            /** @description Códigos externos estándar para interop (#398): mapa namespace→código. */
+            externalCodes?: {
+                [key: string]: string;
+            };
         };
         UpdateCategoryDto: {
             /** @example Alimentos para bebé */
@@ -5375,6 +5388,10 @@ export interface components {
             sort?: number;
             /** @description Replace the category_translation rows with this set */
             translations?: components["schemas"]["CategoryTranslationDto"][];
+            /** @description Códigos externos de interop (#398). Si se indica, reemplaza el mapa; omitir lo conserva. */
+            externalCodes?: {
+                [key: string]: string;
+            };
             /**
              * @description True to hide/archive the category, false to restore it
              * @example false
@@ -5516,6 +5533,10 @@ export interface components {
              * @enum {string}
              */
             nature?: "fungible" | "reusable" | "human";
+            /** @description Códigos externos estándar para interop (#398): mapa namespace→código, p.ej. { "unspsc": "51101500", "hxl": "#item+code" }. */
+            externalCodes?: {
+                [key: string]: string;
+            };
             /**
              * Format: uuid
              * @description Si es variante, id del insumo padre (debe existir)
@@ -5561,6 +5582,16 @@ export interface components {
              * @enum {string|null}
              */
             nature?: "fungible" | "reusable" | "human" | null;
+            /**
+             * @description Códigos externos estándar para interop (#398): mapa namespace→código. `{}` si no tiene.
+             * @example {
+             *       "unspsc": "51101500",
+             *       "hxl": "#item+code"
+             *     }
+             */
+            externalCodes: {
+                [key: string]: string;
+            };
             /**
              * @example [
              *       "agua embotellada",
@@ -5637,6 +5668,10 @@ export interface components {
              * @enum {string|null}
              */
             nature?: "fungible" | "reusable" | "human" | null;
+            /** @description Códigos externos de interop (#398). Si se indica, reemplaza el mapa completo; `{}` los limpia. */
+            externalCodes?: {
+                [key: string]: string;
+            };
             /** Format: uuid */
             variantOfId?: Record<string, never>;
             /** @description Reemplaza el conjunto de traducciones del insumo; omitir para no tocarlas. */

--- a/packages/warehouse-core/src/catalog/ports/category.repository.ts
+++ b/packages/warehouse-core/src/catalog/ports/category.repository.ts
@@ -20,6 +20,8 @@ export interface CategoryWriteInput {
   sort: number;
   archivedAt?: Date | null;
   translations?: readonly CategoryTranslationInput[];
+  /** Códigos externos estándar para interop (#398). Por defecto `{}`. */
+  externalCodes?: Record<string, string> | null;
 }
 
 export interface CategoryRepository {

--- a/packages/warehouse-core/src/catalog/supply-external-codes.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-external-codes.test.ts
@@ -1,0 +1,104 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Supply, SupplyValidationError } from './supply.js';
+import { ExternalCodesValidationError } from '../kernel/external-codes.js';
+
+// Códigos externos estándar para interop en el INSUMO (#398): mapa abierto
+// namespace→código. Por defecto `{}` (los insumos previos no se rellenan).
+
+function base(externalCodes?: Record<string, string>) {
+  return Supply.create({
+    id: 'a',
+    code: 'INS-0001',
+    name: 'Agua',
+    categorySlug: 'water',
+    defaultUnit: 'und',
+    ...(externalCodes !== undefined ? { externalCodes } : {}),
+  });
+}
+
+test('Supply.create sin externalCodes queda con el mapa vacío', () => {
+  const s = base();
+  assert.deepEqual(s.externalCodes, {});
+  assert.deepEqual(s.toSnapshot().externalCodes, {});
+});
+
+test('Supply.create acepta y normaliza un mapa válido', () => {
+  const s = base({ unspsc: '51101500', hxl: '#item+code' });
+  assert.deepEqual(s.externalCodes, {
+    unspsc: '51101500',
+    hxl: '#item+code',
+  });
+});
+
+test('Supply.create rechaza una clave de namespace inválida', () => {
+  assert.throws(
+    () => base({ 'UN-SPSC': '51101500' }),
+    ExternalCodesValidationError,
+  );
+});
+
+test('Supply.create rechaza un valor vacío', () => {
+  assert.throws(() => base({ unspsc: '   ' }), ExternalCodesValidationError);
+});
+
+test('ExternalCodesValidationError NO es un SupplyValidationError (error tipado propio)', () => {
+  assert.throws(
+    () => base({ unspsc: '' }),
+    (err: unknown) => {
+      assert.ok(err instanceof ExternalCodesValidationError);
+      assert.ok(!(err instanceof SupplyValidationError));
+      return true;
+    },
+  );
+});
+
+test('setExternalCodes reemplaza el mapa (inmutable, no muta el original)', () => {
+  const s = base({ unspsc: '51101500' });
+  const next = s.setExternalCodes({ who_eml: 'core-121' });
+  assert.deepEqual(next.externalCodes, { who_eml: 'core-121' });
+  // El original no se toca.
+  assert.deepEqual(s.externalCodes, { unspsc: '51101500' });
+});
+
+test('setExternalCodes con {} limpia los códigos', () => {
+  const s = base({ unspsc: '51101500' });
+  assert.deepEqual(s.setExternalCodes({}).externalCodes, {});
+});
+
+test('setExternalCodes preserva el resto de la identidad', () => {
+  const s = base();
+  const next = s.setExternalCodes({ unspsc: '51101500' });
+  assert.equal(next.id, s.id);
+  assert.equal(next.code, s.code);
+  assert.equal(next.name, s.name);
+  assert.equal(next.categorySlug, s.categorySlug);
+});
+
+test('mutar el mapa devuelto no afecta al agregado (copia defensiva)', () => {
+  const s = base({ unspsc: '51101500' });
+  s.externalCodes.unspsc = 'mutated';
+  assert.equal(base({ unspsc: '51101500' }).externalCodes.unspsc, '51101500');
+  // El snapshot también es una copia.
+  const snap = s.toSnapshot();
+  snap.externalCodes.unspsc = 'mutated-too';
+  assert.equal(s.externalCodes.unspsc, 'mutated');
+});
+
+test('Supply round-trip por snapshot conserva externalCodes', () => {
+  const snap = {
+    id: 'a',
+    code: 'INS-0001',
+    name: 'Agua',
+    categorySlug: 'water',
+    defaultUnit: 'und',
+    attributes: {},
+    variantOfId: null,
+    status: 'active' as const,
+    registrationNotes: null,
+    scopeId: null,
+    nature: null,
+    externalCodes: { unspsc: '51101500', hxl: '#item+code' },
+  };
+  assert.deepEqual(Supply.fromSnapshot(snap).toSnapshot(), snap);
+});

--- a/packages/warehouse-core/src/catalog/supply-nature.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-nature.test.ts
@@ -102,6 +102,7 @@ test('Supply round-trip por snapshot conserva nature', () => {
     registrationNotes: null,
     scopeId: null,
     nature: 'reusable' as const,
+    externalCodes: {},
   };
   assert.deepEqual(Supply.fromSnapshot(snap).toSnapshot(), snap);
 });

--- a/packages/warehouse-core/src/catalog/supply-resolver.ts
+++ b/packages/warehouse-core/src/catalog/supply-resolver.ts
@@ -79,6 +79,7 @@ export function supplyResolverFromCatalog(
       registrationNotes: null,
       scopeId: null,
       nature: null,
+      externalCodes: {},
     });
 
   const supplies = records.flatMap((record) =>

--- a/packages/warehouse-core/src/catalog/supply-scope.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-scope.test.ts
@@ -57,6 +57,7 @@ test('Supply round-trip por snapshot conserva scopeId', () => {
     registrationNotes: null,
     scopeId: 'tenant-1',
     nature: null,
+    externalCodes: {},
   };
   assert.deepEqual(Supply.fromSnapshot(snap).toSnapshot(), snap);
 });

--- a/packages/warehouse-core/src/catalog/supply.ts
+++ b/packages/warehouse-core/src/catalog/supply.ts
@@ -1,3 +1,8 @@
+import {
+  ExternalCodes,
+  normalizeExternalCodes,
+} from '../kernel/external-codes.js';
+
 export type SupplyStatus = 'active' | 'archived';
 
 /**
@@ -38,6 +43,11 @@ export interface SupplyProps {
   scopeId?: string | null;
   /** Naturaleza logística (#269): null = sin clasificar (por defecto). */
   nature?: SupplyNature | null;
+  /**
+   * Códigos externos estándar para interop (#398): mapa abierto
+   * namespace→código (`{ unspsc: '51101500', … }`). Por defecto `{}`.
+   */
+  externalCodes?: Record<string, string> | null;
 }
 
 export interface SupplySnapshot {
@@ -52,6 +62,7 @@ export interface SupplySnapshot {
   registrationNotes: string | null;
   scopeId: string | null;
   nature: SupplyNature | null;
+  externalCodes: ExternalCodes;
 }
 
 export class SupplyValidationError extends Error {
@@ -91,6 +102,7 @@ export class Supply {
   readonly registrationNotes: string | null;
   readonly scopeId: string | null;
   readonly nature: SupplyNature | null;
+  readonly externalCodes: ExternalCodes;
 
   private constructor(props: SupplyProps) {
     this.id = props.id;
@@ -104,6 +116,7 @@ export class Supply {
     this.registrationNotes = props.registrationNotes ?? null;
     this.scopeId = props.scopeId ?? null;
     this.nature = props.nature ?? null;
+    this.externalCodes = { ...(props.externalCodes ?? {}) };
   }
 
   static create(props: SupplyProps): Supply {
@@ -135,6 +148,7 @@ export class Supply {
         `Supply nature must be one of: ${SUPPLY_NATURES.join(', ')}`,
       );
     }
+    const externalCodes = normalizeExternalCodes(props.externalCodes);
 
     return new Supply({
       id,
@@ -148,6 +162,7 @@ export class Supply {
       registrationNotes,
       scopeId,
       nature,
+      externalCodes,
     });
   }
 
@@ -164,6 +179,7 @@ export class Supply {
       registrationNotes: s.registrationNotes,
       scopeId: s.scopeId,
       nature: s.nature,
+      externalCodes: s.externalCodes,
     });
   }
 
@@ -180,6 +196,7 @@ export class Supply {
       registrationNotes: this.registrationNotes,
       scopeId: this.scopeId,
       nature: this.nature,
+      externalCodes: { ...this.externalCodes },
     };
   }
 
@@ -226,6 +243,15 @@ export class Supply {
    */
   reclassify(nature: SupplyNature | null): Supply {
     return this.withChanges({ nature });
+  }
+
+  /**
+   * Reemplaza el mapa de códigos externos de interop (#398). El mapa se
+   * normaliza y valida en `create` (vía `withChanges`); un mapa vacío los
+   * limpia. Inmutable: produce una instancia nueva.
+   */
+  setExternalCodes(externalCodes: Record<string, string>): Supply {
+    return this.withChanges({ externalCodes });
   }
 
   archive(): Supply {

--- a/packages/warehouse-core/src/kernel/category-definition.ts
+++ b/packages/warehouse-core/src/kernel/category-definition.ts
@@ -8,6 +8,8 @@
  * solo campos publicables. NO debe crecer con datos de gestión interna (notas,
  * flag de desactivación, etc.); esos quedan para la API interna.
  */
+import { ExternalCodes } from './external-codes.js';
+
 export interface CategoryTranslation {
   locale: string;
   label: string;
@@ -26,4 +28,9 @@ export interface CategoryDefinition {
   kind: CategoryKind;
   archivedAt: Date | null;
   translations: readonly CategoryTranslation[];
+  /**
+   * Códigos externos estándar para interop (#398): mapa abierto
+   * namespace→código (`{ unspsc: '…', hxl: '#item+code' }`). Por defecto `{}`.
+   */
+  externalCodes: ExternalCodes;
 }

--- a/packages/warehouse-core/src/kernel/external-codes.test.ts
+++ b/packages/warehouse-core/src/kernel/external-codes.test.ts
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isExternalCodeNamespace,
+  normalizeExternalCodes,
+  ExternalCodesValidationError,
+} from './external-codes.js';
+
+// Códigos externos estándar para interop (#398): mapa abierto namespace→código,
+// compartido por `Supply` (catalog) y `CategoryDefinition` (kernel). Este es el
+// validador puro que ambos usan.
+
+test('isExternalCodeNamespace acepta slugs de namespace válidos', () => {
+  for (const ns of ['unspsc', 'who_eml', 'hxl', 'a', 'x9', 'a_b_c']) {
+    assert.equal(isExternalCodeNamespace(ns), true);
+  }
+});
+
+test('isExternalCodeNamespace rechaza formatos inválidos', () => {
+  for (const ns of ['UNSPSC', '9abc', '_ns', 'with-dash', 'with space', '']) {
+    assert.equal(isExternalCodeNamespace(ns), false);
+  }
+  assert.equal(isExternalCodeNamespace(null), false);
+  assert.equal(isExternalCodeNamespace(undefined), false);
+  assert.equal(isExternalCodeNamespace(3), false);
+  assert.equal(isExternalCodeNamespace('a'.repeat(65)), false);
+});
+
+test('normalizeExternalCodes null/undefined → {} (por defecto)', () => {
+  assert.deepEqual(normalizeExternalCodes(null), {});
+  assert.deepEqual(normalizeExternalCodes(undefined), {});
+  assert.deepEqual(normalizeExternalCodes({}), {});
+});
+
+test('normalizeExternalCodes acepta un mapa válido y lo devuelve normalizado', () => {
+  const out = normalizeExternalCodes({
+    unspsc: '51101500',
+    who_eml: 'core-121',
+    hxl: '#item+code',
+  });
+  assert.deepEqual(out, {
+    unspsc: '51101500',
+    who_eml: 'core-121',
+    hxl: '#item+code',
+  });
+});
+
+test('normalizeExternalCodes recorta claves y valores', () => {
+  const out = normalizeExternalCodes({ ' unspsc ': '  51101500  ' });
+  assert.deepEqual(out, { unspsc: '51101500' });
+});
+
+test('normalizeExternalCodes devuelve un objeto nuevo (no aliasa la entrada)', () => {
+  const input = { unspsc: '51101500' };
+  const out = normalizeExternalCodes(input);
+  assert.notEqual(out, input);
+  out.unspsc = 'mutated';
+  assert.equal(input.unspsc, '51101500');
+});
+
+test('normalizeExternalCodes rechaza una clave con formato inválido', () => {
+  assert.throws(
+    () => normalizeExternalCodes({ UNSPSC: '51101500' }),
+    ExternalCodesValidationError,
+  );
+  assert.throws(
+    () => normalizeExternalCodes({ 'with-dash': 'x' }),
+    ExternalCodesValidationError,
+  );
+});
+
+test('normalizeExternalCodes rechaza un valor vacío o no-string', () => {
+  assert.throws(
+    () => normalizeExternalCodes({ unspsc: '   ' }),
+    ExternalCodesValidationError,
+  );
+  assert.throws(
+    () => normalizeExternalCodes({ unspsc: 123 as unknown as string }),
+    ExternalCodesValidationError,
+  );
+});
+
+test('normalizeExternalCodes rechaza un no-objeto (array o primitivo)', () => {
+  assert.throws(
+    () => normalizeExternalCodes([] as unknown as Record<string, unknown>),
+    ExternalCodesValidationError,
+  );
+  assert.throws(
+    () => normalizeExternalCodes('nope' as unknown as Record<string, unknown>),
+    ExternalCodesValidationError,
+  );
+});

--- a/packages/warehouse-core/src/kernel/external-codes.ts
+++ b/packages/warehouse-core/src/kernel/external-codes.ts
@@ -1,0 +1,78 @@
+/**
+ * ExternalCodes — un mapa ABIERTO de códigos externos estándar para interop
+ * (mapeable/compatible, SIN acoplarse a ningún estándar concreto): #398.
+ *
+ * Las claves son slugs de namespace (`unspsc`, `who_eml`, `hxl`, …) con el
+ * mismo formato snake_case que un slug de categoría (`^[a-z][a-z0-9_]*$`); los
+ * valores son cadenas no vacías (el código en ese estándar). Ej.:
+ * `{ unspsc: '51101500', who_eml: '…', hxl: '#item+code' }`.
+ *
+ * Vive en el `kernel` porque lo comparten `Supply` (catalog) y
+ * `CategoryDefinition` (kernel), y el kernel no puede importar catalog (evitaría
+ * un ciclo). Mapa vacío `{}` = sin códigos (por defecto). No fija el conjunto de
+ * llaves permitidas: los estándares crecen por datos, sin migración de código.
+ */
+export type ExternalCodes = Record<string, string>;
+
+const NAMESPACE_RE = /^[a-z][a-z0-9_]*$/;
+const MAX_NAMESPACE_LENGTH = 64;
+
+export class ExternalCodesValidationError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'ExternalCodesValidationError';
+  }
+}
+
+/**
+ * ¿Es `x` un slug de namespace válido (`^[a-z][a-z0-9_]*$`, ≤64 chars)? Guard
+ * puro, sin efectos: la membresía en un estándar concreto no es su incumbencia.
+ */
+export function isExternalCodeNamespace(x: unknown): x is string {
+  return (
+    typeof x === 'string' &&
+    x.length <= MAX_NAMESPACE_LENGTH &&
+    NAMESPACE_RE.test(x)
+  );
+}
+
+/**
+ * Normaliza y valida un mapa de códigos externos: claves = slug de namespace
+ * (se recortan; deben cumplir el formato), valores = cadena no vacía (se
+ * recortan). `null`/`undefined` → `{}`. Rechaza claves o valores inválidos con
+ * `ExternalCodesValidationError`. Devuelve un `Record<string,string>` nuevo.
+ */
+export function normalizeExternalCodes(
+  map: Record<string, unknown> | null | undefined,
+): ExternalCodes {
+  if (map === null || map === undefined) {
+    return {};
+  }
+  if (typeof map !== 'object' || Array.isArray(map)) {
+    throw new ExternalCodesValidationError(
+      'External codes must be an object mapping namespace to code',
+    );
+  }
+  const normalized: ExternalCodes = {};
+  for (const [rawKey, rawValue] of Object.entries(map)) {
+    const key = rawKey.trim();
+    if (!isExternalCodeNamespace(key)) {
+      throw new ExternalCodesValidationError(
+        `External code namespace "${rawKey}" must be a lowercase snake_case token (^[a-z][a-z0-9_]*$)`,
+      );
+    }
+    if (typeof rawValue !== 'string') {
+      throw new ExternalCodesValidationError(
+        `External code for "${key}" must be a string`,
+      );
+    }
+    const value = rawValue.trim();
+    if (value.length === 0) {
+      throw new ExternalCodesValidationError(
+        `External code for "${key}" must not be empty`,
+      );
+    }
+    normalized[key] = value;
+  }
+  return normalized;
+}

--- a/packages/warehouse-core/src/kernel/index.ts
+++ b/packages/warehouse-core/src/kernel/index.ts
@@ -26,5 +26,11 @@ export type { CategoryNode } from './category-registry.js';
 export { SupplyLine, SupplyLineValidationError } from './supply-line.js';
 export type { SupplyLineProps, SupplyLineSnapshot } from './supply-line.js';
 export { ScopeId, ScopeIdValidationError } from './scope-id.js';
+export {
+  ExternalCodesValidationError,
+  isExternalCodeNamespace,
+  normalizeExternalCodes,
+} from './external-codes.js';
+export type { ExternalCodes } from './external-codes.js';
 export type { DomainEvent } from './domain-event.js';
 export { haversineMeters } from './geo-distance.js';


### PR DESCRIPTION
Closes #398 · **Incremento 4** de la épica #228. Añade **`externalCodes`** — un mapa abierto `namespace→código` (`{ unspsc, who_eml, hxl, … }`) para interop **mapeable/compatible sin acoplarse** a ningún estándar — a `Supply` y `CategoryDefinition`.

## Qué incluye
- **Dominio** (`warehouse-core/kernel/external-codes.ts`): `ExternalCodes` (type), `isExternalCodeNamespace` (guard `^[a-z][a-z0-9_]*$`, ≤64), `normalizeExternalCodes` (trim, rechaza clave/valor inválidos → `ExternalCodesValidationError`, null→{}). Vive en kernel porque lo comparten `Supply` (catalog) y `CategoryDefinition` (kernel) — evita ciclo. `setExternalCodes` en Supply; `CategoryWriteInput.externalCodes`. + tests.
- **Migración 0058**: `external_codes jsonb NOT NULL DEFAULT '{}'` en `supplies` y `categories` + **GIN** en `supplies.external_codes` (búsqueda inversa `@>`/`?`). Idempotente. Sin backfill.
- **Persistencia**: schemas + mappers round-trip (supplies y categories) + int-specs.
- **HTTP**: `externalCodes` en DTOs admin de Supply y Category (create/edit/response). Omitir no toca; proveer reemplaza (normalizado). `GET /categories` público NO lo expone. `gen:api` regenerado (aparece en 6 DTOs de `schema.ts`).

## Fuera de alcance (follow-up)
El **pipeline de import/seed** (casar códigos externos → supplies) NO se construye aquí — solo el campo, persistencia, índice GIN y exposición admin.

## Verificación (local, por mí)
warehouse-core build + **158 tests** · api build (nest/tsc, **tsc-neutral 45**, no empeora) · eslint (0) · prettier api+packages · api-client + web build · frozen-lockfile — todo verde. Revisado: validación, migración, round-trip de ambos mappers, semántica omitir-vs-reemplazar en edición — sin bugs. Int-specs Jest los valida CI.