### PR TITLE
feat(wms): peso/volumen del material + computeLoad (Inc 1 vehículos como almacén móvil)

### DIFF
--- a/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
+++ b/apps/api/src/contexts/supplies/infrastructure/drizzle/drizzle-supply.repository.ts
@@ -327,6 +327,11 @@ export class DrizzleSupplyRepository implements SupplyRepository {
       scopeId: row.scopeId ?? null,
       nature: (row.nature ?? null) as SupplyNature | null,
       externalCodes: row.externalCodes ?? {},
+      // Inc 1 vehículos: el host aún no persiste las medidas unitarias (la
+      // adopción por ResponseGrid es una pista aparte del spec); se mapean a
+      // null hasta entonces — frontera 1:1, sin cambio de columna ni de API.
+      unitWeightKg: null,
+      unitVolumeM3: null,
     });
   }
 

--- a/packages/warehouse-core/src/catalog/supply-external-codes.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-external-codes.test.ts
@@ -99,6 +99,8 @@ test('Supply round-trip por snapshot conserva externalCodes', () => {
     scopeId: null,
     nature: null,
     externalCodes: { unspsc: '51101500', hxl: '#item+code' },
+    unitWeightKg: null,
+    unitVolumeM3: null,
   };
   assert.deepEqual(Supply.fromSnapshot(snap).toSnapshot(), snap);
 });

--- a/packages/warehouse-core/src/catalog/supply-nature.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-nature.test.ts
@@ -103,6 +103,8 @@ test('Supply round-trip por snapshot conserva nature', () => {
     scopeId: null,
     nature: 'reusable' as const,
     externalCodes: {},
+    unitWeightKg: null,
+    unitVolumeM3: null,
   };
   assert.deepEqual(Supply.fromSnapshot(snap).toSnapshot(), snap);
 });

--- a/packages/warehouse-core/src/catalog/supply-resolver.ts
+++ b/packages/warehouse-core/src/catalog/supply-resolver.ts
@@ -80,6 +80,8 @@ export function supplyResolverFromCatalog(
       scopeId: null,
       nature: null,
       externalCodes: {},
+      unitWeightKg: null,
+      unitVolumeM3: null,
     });
 
   const supplies = records.flatMap((record) =>

--- a/packages/warehouse-core/src/catalog/supply-scope.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-scope.test.ts
@@ -58,6 +58,8 @@ test('Supply round-trip por snapshot conserva scopeId', () => {
     scopeId: 'tenant-1',
     nature: null,
     externalCodes: {},
+    unitWeightKg: null,
+    unitVolumeM3: null,
   };
   assert.deepEqual(Supply.fromSnapshot(snap).toSnapshot(), snap);
 });

--- a/packages/warehouse-core/src/catalog/supply-unit-measures.test.ts
+++ b/packages/warehouse-core/src/catalog/supply-unit-measures.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Supply, SupplyValidationError } from './supply.js';
+
+const BASE = {
+  id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  code: 'WAT-0001',
+  name: 'Agua embotellada 1.5L',
+  categorySlug: 'water',
+  defaultUnit: 'und',
+};
+
+test('sin medidas: por defecto null (desconocidas)', () => {
+  const s = Supply.create(BASE);
+  assert.equal(s.unitWeightKg, null);
+  assert.equal(s.unitVolumeM3, null);
+});
+
+test('acepta medidas positivas y hacen round-trip por snapshot', () => {
+  const s = Supply.create({
+    ...BASE,
+    unitWeightKg: 1.55,
+    unitVolumeM3: 0.0016,
+  });
+  const back = Supply.fromSnapshot(s.toSnapshot());
+  assert.equal(back.unitWeightKg, 1.55);
+  assert.equal(back.unitVolumeM3, 0.0016);
+});
+
+test('rechaza peso no positivo o no finito', () => {
+  for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(
+      () => Supply.create({ ...BASE, unitWeightKg: bad }),
+      SupplyValidationError,
+    );
+  }
+});
+
+test('rechaza volumen no positivo o no finito', () => {
+  assert.throws(
+    () => Supply.create({ ...BASE, unitVolumeM3: 0 }),
+    SupplyValidationError,
+  );
+});
+
+test('setUnitMeasures reclasifica inmutablemente y null limpia', () => {
+  const s = Supply.create({ ...BASE, unitWeightKg: 2 });
+  const updated = s.setUnitMeasures(1.5, 0.002);
+  assert.equal(s.unitWeightKg, 2); // el original intacto
+  assert.equal(updated.unitWeightKg, 1.5);
+  assert.equal(updated.unitVolumeM3, 0.002);
+  const cleared = updated.setUnitMeasures(null, null);
+  assert.equal(cleared.unitWeightKg, null);
+  assert.equal(cleared.unitVolumeM3, null);
+});

--- a/packages/warehouse-core/src/catalog/supply.ts
+++ b/packages/warehouse-core/src/catalog/supply.ts
@@ -48,6 +48,13 @@ export interface SupplyProps {
    * namespace→código (`{ unspsc: '51101500', … }`). Por defecto `{}`.
    */
   externalCodes?: Record<string, string> | null;
+  /**
+   * Peso unitario en kg, respecto al `defaultUnit` del insumo (vehículos,
+   * Inc 1). Null = desconocido; la carga que lo use queda marcada incompleta.
+   */
+  unitWeightKg?: number | null;
+  /** Volumen unitario en m³, misma base `defaultUnit`. Null = desconocido. */
+  unitVolumeM3?: number | null;
 }
 
 export interface SupplySnapshot {
@@ -63,6 +70,8 @@ export interface SupplySnapshot {
   scopeId: string | null;
   nature: SupplyNature | null;
   externalCodes: ExternalCodes;
+  unitWeightKg: number | null;
+  unitVolumeM3: number | null;
 }
 
 export class SupplyValidationError extends Error {
@@ -90,6 +99,18 @@ function normalizeOptionalText(
   return normalized.length === 0 ? null : normalized;
 }
 
+/** Medida unitaria (kg o m³): null = desconocida; si viene, debe ser > 0 y finita. */
+function normalizeUnitMeasure(
+  value: number | null | undefined,
+  field: string,
+): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new SupplyValidationError(`${field} must be a positive number`);
+  }
+  return value;
+}
+
 export class Supply {
   readonly id: string;
   readonly code: string;
@@ -103,6 +124,8 @@ export class Supply {
   readonly scopeId: string | null;
   readonly nature: SupplyNature | null;
   readonly externalCodes: ExternalCodes;
+  readonly unitWeightKg: number | null;
+  readonly unitVolumeM3: number | null;
 
   private constructor(props: SupplyProps) {
     this.id = props.id;
@@ -117,6 +140,8 @@ export class Supply {
     this.scopeId = props.scopeId ?? null;
     this.nature = props.nature ?? null;
     this.externalCodes = { ...(props.externalCodes ?? {}) };
+    this.unitWeightKg = props.unitWeightKg ?? null;
+    this.unitVolumeM3 = props.unitVolumeM3 ?? null;
   }
 
   static create(props: SupplyProps): Supply {
@@ -149,6 +174,14 @@ export class Supply {
       );
     }
     const externalCodes = normalizeExternalCodes(props.externalCodes);
+    const unitWeightKg = normalizeUnitMeasure(
+      props.unitWeightKg,
+      'Supply unitWeightKg',
+    );
+    const unitVolumeM3 = normalizeUnitMeasure(
+      props.unitVolumeM3,
+      'Supply unitVolumeM3',
+    );
 
     return new Supply({
       id,
@@ -163,6 +196,8 @@ export class Supply {
       scopeId,
       nature,
       externalCodes,
+      unitWeightKg,
+      unitVolumeM3,
     });
   }
 
@@ -180,6 +215,8 @@ export class Supply {
       scopeId: s.scopeId,
       nature: s.nature,
       externalCodes: s.externalCodes,
+      unitWeightKg: s.unitWeightKg,
+      unitVolumeM3: s.unitVolumeM3,
     });
   }
 
@@ -197,6 +234,8 @@ export class Supply {
       scopeId: this.scopeId,
       nature: this.nature,
       externalCodes: { ...this.externalCodes },
+      unitWeightKg: this.unitWeightKg,
+      unitVolumeM3: this.unitVolumeM3,
     };
   }
 
@@ -252,6 +291,17 @@ export class Supply {
    */
   setExternalCodes(externalCodes: Record<string, string>): Supply {
     return this.withChanges({ externalCodes });
+  }
+
+  /**
+   * Fija/limpia las medidas unitarias del insumo (base `defaultUnit`), para el
+   * cálculo de carga (vehículos, Inc 1). Inmutable: instancia nueva.
+   */
+  setUnitMeasures(
+    unitWeightKg: number | null,
+    unitVolumeM3: number | null,
+  ): Supply {
+    return this.withChanges({ unitWeightKg, unitVolumeM3 });
   }
 
   archive(): Supply {

--- a/packages/warehouse-core/src/inventory/compute-load.test.ts
+++ b/packages/warehouse-core/src/inventory/compute-load.test.ts
@@ -115,3 +115,119 @@ test('nature=human se excluye del peso/volumen y se reporta como personal', () =
   assert.equal(r.personnel.length, 1);
   assert.equal(r.personnel[0]!.quantity, 4);
 });
+
+test('container con bruto declarado: cuenta el declarado y sus líneas NO suman', () => {
+  const r = computeLoad(
+    [],
+    [
+      {
+        id: 'PAL-1',
+        parentId: null,
+        grossWeightKg: 120,
+        grossVolumeM3: 0.5,
+        lines: [{ supplyId: 'water', quantity: 999, unit: 'und', ref: 'L' }],
+      },
+    ],
+    lookup,
+  );
+  assert.equal(r.weightKg, 120);
+  assert.equal(r.volumeM3, 0.5);
+  assert.equal(r.complete, true);
+});
+
+test('container sin declarar deriva de sus líneas (vía catálogo)', () => {
+  const r = computeLoad(
+    [],
+    [
+      {
+        id: 'BOX-1',
+        parentId: null,
+        grossWeightKg: null,
+        grossVolumeM3: null,
+        lines: [{ supplyId: 'water', quantity: 12, unit: null, ref: 'L' }],
+      },
+    ],
+    lookup,
+  );
+  assert.equal(r.weightKg, 18); // 12 × 1.5
+  assert.equal(r.complete, true);
+});
+
+test('declarado parcial: el peso declarado corta SU dimensión; el volumen se deriva', () => {
+  const r = computeLoad(
+    [],
+    [
+      {
+        id: 'PAL-1',
+        parentId: null,
+        grossWeightKg: 200, // pesado en báscula (incluye tara)
+        grossVolumeM3: null,
+        lines: [{ supplyId: 'water', quantity: 100, unit: null, ref: 'L' }],
+      },
+    ],
+    lookup,
+  );
+  assert.equal(r.weightKg, 200); // NO 150: el declarado gana en peso
+  assert.equal(r.volumeM3, 0.16); // 100 × 0.0016 derivado
+  assert.equal(r.complete, true);
+});
+
+test('árbol anidado: el declarado del ancestro gana y corta a los descendientes', () => {
+  const r = computeLoad(
+    [],
+    [
+      {
+        id: 'PAL-1',
+        parentId: null,
+        grossWeightKg: 300,
+        grossVolumeM3: 1.2,
+        lines: [],
+      },
+      {
+        id: 'BOX-1',
+        parentId: 'PAL-1',
+        grossWeightKg: 50, // se ignora: el palet ya declaró
+        grossVolumeM3: null,
+        lines: [{ supplyId: 'water', quantity: 10, unit: null, ref: 'L' }],
+      },
+    ],
+    lookup,
+  );
+  assert.equal(r.weightKg, 300);
+  assert.equal(r.volumeM3, 1.2);
+});
+
+test('padre desconocido en el conjunto ⇒ el hijo cuenta como raíz (no se pierde)', () => {
+  const r = computeLoad(
+    [],
+    [
+      {
+        id: 'BOX-9',
+        parentId: 'PAL-QUE-NO-VINO',
+        grossWeightKg: 10,
+        grossVolumeM3: null,
+        lines: [],
+      },
+    ],
+    lookup,
+  );
+  assert.equal(r.weightKg, 10);
+});
+
+test('línea no calculable dentro de un container sin declarar → unknown', () => {
+  const r = computeLoad(
+    [],
+    [
+      {
+        id: 'BOX-1',
+        parentId: null,
+        grossWeightKg: null,
+        grossVolumeM3: null,
+        lines: [{ supplyId: null, quantity: 5, unit: null, ref: 'BOX-1/L1' }],
+      },
+    ],
+    lookup,
+  );
+  assert.equal(r.complete, false);
+  assert.equal(r.unknowns[0]!.reason, 'unknown_supply');
+});

--- a/packages/warehouse-core/src/inventory/compute-load.test.ts
+++ b/packages/warehouse-core/src/inventory/compute-load.test.ts
@@ -1,0 +1,117 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeLoad,
+  SupplyLoadInfo,
+  SupplyLoadLookup,
+} from './compute-load.js';
+
+const CATALOG = new Map<string, SupplyLoadInfo>([
+  // agua: 1.5 kg y 0.0016 m³ por unidad
+  [
+    'water',
+    {
+      unitWeightKg: 1.5,
+      unitVolumeM3: 0.0016,
+      defaultUnit: 'und',
+      nature: 'fungible',
+    },
+  ],
+  // camilla: solo peso conocido
+  [
+    'stretcher',
+    {
+      unitWeightKg: 8,
+      unitVolumeM3: null,
+      defaultUnit: 'und',
+      nature: 'reusable',
+    },
+  ],
+  // sanitario: personal, no es carga
+  [
+    'medic',
+    {
+      unitWeightKg: null,
+      unitVolumeM3: null,
+      defaultUnit: 'und',
+      nature: 'human',
+    },
+  ],
+]);
+const lookup: SupplyLoadLookup = (id) => CATALOG.get(id) ?? null;
+
+test('suma peso y volumen de líneas sueltas conocidas (completo)', () => {
+  const r = computeLoad(
+    [{ supplyId: 'water', quantity: 10, unit: 'und', ref: 'L1' }],
+    [],
+    lookup,
+  );
+  assert.equal(r.weightKg, 15);
+  assert.equal(r.volumeM3, 0.016);
+  assert.equal(r.complete, true);
+  assert.deepEqual(r.unknowns, []);
+});
+
+test('unit null se asume en la unidad base (defaultUnit)', () => {
+  const r = computeLoad(
+    [{ supplyId: 'water', quantity: 2, unit: null, ref: 'L1' }],
+    [],
+    lookup,
+  );
+  assert.equal(r.weightKg, 3);
+  assert.equal(r.complete, true);
+});
+
+test('mismatch de unidad → desconocida en ambas dimensiones (no multiplica)', () => {
+  const r = computeLoad(
+    [{ supplyId: 'water', quantity: 3, unit: 'cajas', ref: 'L1' }],
+    [],
+    lookup,
+  );
+  assert.equal(r.weightKg, 0);
+  assert.equal(r.complete, false);
+  assert.deepEqual(r.unknowns, [
+    { ref: 'L1', dimensions: ['weight', 'volume'], reason: 'unit_mismatch' },
+  ]);
+});
+
+test('insumo sin volumen: pesa pero el volumen queda incompleto (límite inferior)', () => {
+  const r = computeLoad(
+    [{ supplyId: 'stretcher', quantity: 2, unit: 'und', ref: 'L1' }],
+    [],
+    lookup,
+  );
+  assert.equal(r.weightKg, 16);
+  assert.equal(r.volumeM3, 0);
+  assert.equal(r.weightComplete, true);
+  assert.equal(r.volumeComplete, false);
+  assert.equal(r.complete, false);
+  assert.deepEqual(r.unknowns, [
+    { ref: 'L1', dimensions: ['volume'], reason: 'missing_unit_measure' },
+  ]);
+});
+
+test('supplyId null o no resuelto → desconocido', () => {
+  const r = computeLoad(
+    [
+      { supplyId: null, quantity: 1, unit: null, ref: 'suelto' },
+      { supplyId: 'nope', quantity: 1, unit: null, ref: 'L2' },
+    ],
+    [],
+    lookup,
+  );
+  assert.equal(r.unknowns.length, 2);
+  assert.equal(r.unknowns[0]!.reason, 'unknown_supply');
+});
+
+test('nature=human se excluye del peso/volumen y se reporta como personal', () => {
+  const r = computeLoad(
+    [{ supplyId: 'medic', quantity: 4, unit: 'und', ref: 'P1' }],
+    [],
+    lookup,
+  );
+  assert.equal(r.weightKg, 0);
+  assert.equal(r.complete, true); // el personal no cuenta como dato faltante
+  assert.equal(r.personnel.length, 1);
+  assert.equal(r.personnel[0]!.quantity, 4);
+});

--- a/packages/warehouse-core/src/inventory/compute-load.test.ts
+++ b/packages/warehouse-core/src/inventory/compute-load.test.ts
@@ -231,3 +231,23 @@ test('línea no calculable dentro de un container sin declarar → unknown', () 
   assert.equal(r.complete, false);
   assert.equal(r.unknowns[0]!.reason, 'unknown_supply');
 });
+
+test('personal dentro de un container con bruto declarado: se reporta igual (no es carga)', () => {
+  const r = computeLoad(
+    [],
+    [
+      {
+        id: 'PAL-1',
+        parentId: null,
+        grossWeightKg: 120, // ambas dimensiones cubiertas por el bruto
+        grossVolumeM3: 0.5,
+        lines: [{ supplyId: 'medic', quantity: 2, unit: 'und', ref: 'P1' }],
+      },
+    ],
+    lookup,
+  );
+  assert.equal(r.weightKg, 120); // el personal no altera el peso
+  assert.equal(r.complete, true);
+  assert.equal(r.personnel.length, 1); // pero sí aparece en el manifiesto
+  assert.equal(r.personnel[0]!.quantity, 2);
+});

--- a/packages/warehouse-core/src/inventory/compute-load.ts
+++ b/packages/warehouse-core/src/inventory/compute-load.ts
@@ -1,0 +1,250 @@
+/**
+ * computeLoad — suma la carga (peso kg / volumen m³) de un contenido de almacén
+ * o vehículo: líneas sueltas de stock + árboles de containers (palets/cajas).
+ * Servicio PURO del diseño de vehículos (Inc 1): no importa catalog ni
+ * containers — el llamador mapea a formas estructurales y aporta el catálogo
+ * vía el port `SupplyLoadLookup`.
+ *
+ * Reglas (spec 2026-07-13-vehiculos-almacen-movil-design.md §2):
+ * - **Base de unidades:** el unitario del catálogo se define respecto al
+ *   `defaultUnit` del insumo. Una línea con unidad distinta NO se multiplica:
+ *   queda como desconocida (`unit_mismatch`). Unidad null = se asume la base.
+ * - **Nodo más alto (anti doble-conteo), POR DIMENSIÓN:** un container con
+ *   bruto declarado aporta ese número y corta la recursión de esa dimensión en
+ *   todo su subárbol (hijos y líneas no suman en ella); la dimensión no
+ *   declarada se deriva del contenido.
+ * - **`nature === 'human'` no es carga:** se excluye del total y se reporta
+ *   aparte en `personnel` (el manifiesto lo muestra como personal a bordo).
+ * - **Honestidad:** todo lo no calculable va a `unknowns` con su dimensión y
+ *   motivo; `weightComplete`/`volumeComplete` marcan si el total de cada
+ *   dimensión es exacto o un límite inferior ("al menos X").
+ */
+
+/** Lo que el catálogo sabe de un insumo a efectos de carga (port de lookup). */
+export interface SupplyLoadInfo {
+  unitWeightKg: number | null;
+  unitVolumeM3: number | null;
+  /** Unidad base respecto a la que se definen los unitarios. */
+  defaultUnit: string | null;
+  /** Naturaleza logística; 'human' se excluye de la carga. */
+  nature: string | null;
+}
+
+/** Port síncrono: el llamador precarga su catálogo (p.ej. en un Map). */
+export type SupplyLoadLookup = (supplyId: string) => SupplyLoadInfo | null;
+
+/** Una línea de material (stock suelto o línea de un container). */
+export interface LoadLine {
+  /** Id del insumo del catálogo; null = no vinculado (no calculable). */
+  supplyId: string | null;
+  quantity: number;
+  /** Unidad de la línea; null = se asume la unidad base del insumo. */
+  unit: string | null;
+  /** Referencia legible para reportar (id de stock item, nombre de línea…). */
+  ref: string;
+}
+
+/** Un container (palet/caja) del árbol de carga, aplanado por el llamador. */
+export interface ContainerLoadNode {
+  id: string;
+  /** Container padre, o null si es raíz (un padre desconocido cuenta como raíz). */
+  parentId: string | null;
+  grossWeightKg: number | null;
+  grossVolumeM3: number | null;
+  lines: LoadLine[];
+}
+
+export type LoadDimension = 'weight' | 'volume';
+
+export interface LoadUnknown {
+  ref: string;
+  dimensions: LoadDimension[];
+  reason: 'unknown_supply' | 'unit_mismatch' | 'missing_unit_measure';
+}
+
+export interface LoadTotals {
+  weightKg: number;
+  volumeM3: number;
+  weightComplete: boolean;
+  volumeComplete: boolean;
+  /** true solo si ambas dimensiones son exactas. */
+  complete: boolean;
+  unknowns: LoadUnknown[];
+  /** Líneas de personal (nature=human), excluidas del peso/volumen. */
+  personnel: LoadLine[];
+}
+
+interface Accumulator {
+  weight: number;
+  volume: number;
+}
+
+/** Dimensiones ya cubiertas por un bruto declarado más arriba en el árbol. */
+interface Covered {
+  weight: boolean;
+  volume: boolean;
+}
+
+export function computeLoad(
+  looseLines: readonly LoadLine[],
+  containers: readonly ContainerLoadNode[],
+  lookup: SupplyLoadLookup,
+): LoadTotals {
+  const acc: Accumulator = { weight: 0, volume: 0 };
+  const unknowns: LoadUnknown[] = [];
+  const personnel: LoadLine[] = [];
+
+  for (const line of looseLines) {
+    addLine(
+      line,
+      { weight: false, volume: false },
+      acc,
+      unknowns,
+      personnel,
+      lookup,
+    );
+  }
+
+  // Árbol de containers: raíces = sin padre o con padre fuera del conjunto.
+  const ids = new Set(containers.map((c) => c.id));
+  const byParent = new Map<string, ContainerLoadNode[]>();
+  const roots: ContainerLoadNode[] = [];
+  for (const c of containers) {
+    if (c.parentId !== null && ids.has(c.parentId)) {
+      const siblings = byParent.get(c.parentId) ?? [];
+      siblings.push(c);
+      byParent.set(c.parentId, siblings);
+    } else {
+      roots.push(c);
+    }
+  }
+  for (const root of roots) {
+    addContainer(
+      root,
+      byParent,
+      { weight: false, volume: false },
+      acc,
+      unknowns,
+      personnel,
+      lookup,
+    );
+  }
+
+  const weightComplete = !unknowns.some((u) => u.dimensions.includes('weight'));
+  const volumeComplete = !unknowns.some((u) => u.dimensions.includes('volume'));
+  return {
+    weightKg: round6(acc.weight),
+    volumeM3: round6(acc.volume),
+    weightComplete,
+    volumeComplete,
+    complete: weightComplete && volumeComplete,
+    unknowns,
+    personnel,
+  };
+}
+
+function addContainer(
+  node: ContainerLoadNode,
+  byParent: Map<string, ContainerLoadNode[]>,
+  covered: Covered,
+  acc: Accumulator,
+  unknowns: LoadUnknown[],
+  personnel: LoadLine[],
+  lookup: SupplyLoadLookup,
+): void {
+  // El bruto declarado aporta y corta la recursión de SU dimensión (si un
+  // ancestro ya la cubrió, este declarado se ignora: el nodo más alto gana).
+  if (!covered.weight && node.grossWeightKg !== null) {
+    acc.weight += node.grossWeightKg;
+  }
+  if (!covered.volume && node.grossVolumeM3 !== null) {
+    acc.volume += node.grossVolumeM3;
+  }
+
+  const next: Covered = {
+    weight: covered.weight || node.grossWeightKg !== null,
+    volume: covered.volume || node.grossVolumeM3 !== null,
+  };
+
+  if (!next.weight || !next.volume) {
+    for (const line of node.lines) {
+      addLine(line, next, acc, unknowns, personnel, lookup);
+    }
+  }
+  for (const child of byParent.get(node.id) ?? []) {
+    addContainer(child, byParent, next, acc, unknowns, personnel, lookup);
+  }
+}
+
+function addLine(
+  line: LoadLine,
+  covered: Covered,
+  acc: Accumulator,
+  unknowns: LoadUnknown[],
+  personnel: LoadLine[],
+  lookup: SupplyLoadLookup,
+): void {
+  const open: LoadDimension[] = [];
+  if (!covered.weight) open.push('weight');
+  if (!covered.volume) open.push('volume');
+  if (open.length === 0) return;
+
+  if (line.supplyId === null) {
+    unknowns.push({
+      ref: line.ref,
+      dimensions: open,
+      reason: 'unknown_supply',
+    });
+    return;
+  }
+  const info = lookup(line.supplyId);
+  if (info === null) {
+    unknowns.push({
+      ref: line.ref,
+      dimensions: open,
+      reason: 'unknown_supply',
+    });
+    return;
+  }
+  if (info.nature === 'human') {
+    personnel.push(line);
+    return;
+  }
+  const lineUnit = normalizeUnit(line.unit);
+  if (lineUnit !== null && lineUnit !== normalizeUnit(info.defaultUnit)) {
+    unknowns.push({
+      ref: line.ref,
+      dimensions: open,
+      reason: 'unit_mismatch',
+    });
+    return;
+  }
+
+  const missing: LoadDimension[] = [];
+  if (!covered.weight) {
+    if (info.unitWeightKg === null) missing.push('weight');
+    else acc.weight += line.quantity * info.unitWeightKg;
+  }
+  if (!covered.volume) {
+    if (info.unitVolumeM3 === null) missing.push('volume');
+    else acc.volume += line.quantity * info.unitVolumeM3;
+  }
+  if (missing.length > 0) {
+    unknowns.push({
+      ref: line.ref,
+      dimensions: missing,
+      reason: 'missing_unit_measure',
+    });
+  }
+}
+
+function normalizeUnit(unit: string | null): string | null {
+  if (unit === null) return null;
+  const trimmed = unit.trim().toLowerCase();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+/** Redondeo a 6 decimales (la escala del VO Quantity) contra ruido flotante. */
+function round6(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}

--- a/packages/warehouse-core/src/inventory/compute-load.ts
+++ b/packages/warehouse-core/src/inventory/compute-load.ts
@@ -18,6 +18,14 @@
  * - **Honestidad:** todo lo no calculable va a `unknowns` con su dimensión y
  *   motivo; `weightComplete`/`volumeComplete` marcan si el total de cada
  *   dimensión es exacto o un límite inferior ("al menos X").
+ *
+ * Precondiciones (garantizadas por el llamador, que mapea desde agregados WMS
+ * ya validados; esta función NO las re-valida):
+ * - `quantity` finita y ≥ 0 (viene del VO `Quantity` de un `StockItem`). Un
+ *   valor no finito/negativo envenenaría el total sin marcarse como desconocido.
+ * - Los containers forman un **bosque acíclico** (lo garantiza el agregado
+ *   `Container` vía `ContainerCycleError`). Un ciclo dejaría esos containers
+ *   fuera del cómputo (nunca serían raíz), no un bucle infinito.
  */
 
 /** Lo que el catálogo sabe de un insumo a efectos de carga (port de lookup). */
@@ -51,7 +59,7 @@ export interface ContainerLoadNode {
   parentId: string | null;
   grossWeightKg: number | null;
   grossVolumeM3: number | null;
-  lines: LoadLine[];
+  lines: readonly LoadLine[];
 }
 
 export type LoadDimension = 'weight' | 'volume';
@@ -166,10 +174,12 @@ function addContainer(
     volume: covered.volume || node.grossVolumeM3 !== null,
   };
 
-  if (!next.weight || !next.volume) {
-    for (const line of node.lines) {
-      addLine(line, next, acc, unknowns, personnel, lookup);
-    }
+  // Siempre se recorren líneas e hijos, aunque ambas dimensiones estén
+  // cubiertas por el bruto declarado: el peso/volumen no suma (lo corta
+  // `addLine`/la propagación de `next`), pero el PERSONAL de un subárbol
+  // declarado debe reportarse igual (no es carga).
+  for (const line of node.lines) {
+    addLine(line, next, acc, unknowns, personnel, lookup);
   }
   for (const child of byParent.get(node.id) ?? []) {
     addContainer(child, byParent, next, acc, unknowns, personnel, lookup);
@@ -184,30 +194,29 @@ function addLine(
   personnel: LoadLine[],
   lookup: SupplyLoadLookup,
 ): void {
+  const info = line.supplyId !== null ? lookup(line.supplyId) : null;
+
+  // El personal (nature=human) NUNCA es carga: se reporta siempre, aun cuando
+  // un container ancestro ya tenga el bruto declarado (no depende de las
+  // dimensiones abiertas, a diferencia del peso/volumen de abajo).
+  if (info !== null && info.nature === 'human') {
+    personnel.push(line);
+    return;
+  }
+
   const open: LoadDimension[] = [];
   if (!covered.weight) open.push('weight');
   if (!covered.volume) open.push('volume');
+  // Dimensiones cubiertas por un bruto declarado más arriba: la línea no aporta
+  // (ni cuenta como desconocida — el declarado ya la incluye).
   if (open.length === 0) return;
 
-  if (line.supplyId === null) {
+  if (line.supplyId === null || info === null) {
     unknowns.push({
       ref: line.ref,
       dimensions: open,
       reason: 'unknown_supply',
     });
-    return;
-  }
-  const info = lookup(line.supplyId);
-  if (info === null) {
-    unknowns.push({
-      ref: line.ref,
-      dimensions: open,
-      reason: 'unknown_supply',
-    });
-    return;
-  }
-  if (info.nature === 'human') {
-    personnel.push(line);
     return;
   }
   const lineUnit = normalizeUnit(line.unit);

--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -94,6 +94,16 @@ export type {
   ExpiryStatusOptions,
   ExpiringWithinOptions,
 } from './expiry.js';
+export { computeLoad } from './compute-load.js';
+export type {
+  SupplyLoadInfo,
+  SupplyLoadLookup,
+  LoadLine,
+  ContainerLoadNode,
+  LoadDimension,
+  LoadUnknown,
+  LoadTotals,
+} from './compute-load.js';
 export {
   WAREHOUSE_REPOSITORY,
   type WarehouseRepository,


### PR DESCRIPTION
Closes #410 · **Incremento 1** del EPIC #409 (vehículos como almacén móvil, WMS-first para Protección Civil). Foundation: toda carga pasa a ser **calculable en peso y volumen**.

## Qué incluye
- **Catálogo**: `Supply.unitWeightKg`/`unitVolumeM3` (nullable, **base `defaultUnit`**, >0 validado) + mutador inmutable `setUnitMeasures`. Patrón exacto de `nature`/`externalCodes`.
- **`computeLoad`** (servicio puro en `inventory`, formas estructurales — no acopla módulos — + **port de lookup síncrono** `(supplyId) → info | null`):
  - **Regla del nodo más alto POR DIMENSIÓN** (anti doble-conteo): el bruto declarado de un container aporta y corta la recursión de SU dimensión en todo el subárbol (el ancestro gana); la dimensión sin declarar se deriva de las líneas vía catálogo.
  - Mismatch de unidad línea↔`defaultUnit` → **desconocido** (no multiplica).
  - `nature=human` **excluido** del peso/volumen (reportado en `personnel`).
  - **Honestidad**: `weightComplete`/`volumeComplete`/`complete` + `unknowns[]` con dimensión y motivo — un total incompleto es un **límite inferior**, nunca un dato falso.
- **Host (ResponseGrid)**: solo compile-fix — el mapper mapea los campos a `null` (su persistencia llega cuando el host adopte la feature; frontera 1:1, sin migración ni cambio de API). Detectado con typecheck limpio (la caché incremental de `nest build` lo enmascaraba en local).

## Verificación (local)
warehouse-core build + **175 tests** (158→175: 5 de medidas + 12 de computeLoad) · api build + **tsc limpio sin caché** (0 errores) · eslint (0) · prettier api **y packages** · api-client + web build · frozen-lockfile — todo verde. TDD estricto (test-fail-first en cada tarea).

Spec: `docs/superpowers/specs/2026-07-13-vehiculos-almacen-movil-design.md` §2 · Plan: `docs/superpowers/plans/2026-07-13-vehiculos-inc1-peso-volumen.md`.