### PR TITLE
feat(wms): vehículo = Warehouse(kind=vehicle) + maxCapacity + Capacity→kernel (Inc 2 flota)

### DIFF
--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -36,9 +36,11 @@ export {
   WarehouseValidationError,
   DuplicateZoneCodeError,
   WarehouseArchivedError,
+  WarehouseNotEmptyError,
   BinValidationError,
   BinArchivedError,
 } from './inventory-errors.js';
+export { assertWarehouseCanBeArchived } from './warehouse-archival.js';
 export {
   StockValidationError,
   QuantityUnitMismatchError,

--- a/packages/warehouse-core/src/inventory/index.ts
+++ b/packages/warehouse-core/src/inventory/index.ts
@@ -23,6 +23,7 @@ export { BinId } from './bin-id.js';
 export { StockItemId } from './stock-item-id.js';
 export { StockMovementId } from './stock-movement-id.js';
 export {
+  WarehouseKind,
   WarehouseStatus,
   ZoneStatus,
   ZoneKind,

--- a/packages/warehouse-core/src/inventory/inventory-enums.ts
+++ b/packages/warehouse-core/src/inventory/inventory-enums.ts
@@ -10,6 +10,17 @@ export enum WarehouseStatus {
 }
 
 /**
+ * Naturaleza física de un {@link Warehouse}. `fixed` = almacén de obra (edificio,
+ * depósito); `vehicle` = almacén móvil (camión/furgón) que se carga, descarga e
+ * inspecciona a lo largo del tiempo y tiene una carga útil máxima (`maxCapacity`).
+ * Sólo los vehículos declaran capacidad. Por defecto `fixed`.
+ */
+export enum WarehouseKind {
+  Fixed = 'fixed',
+  Vehicle = 'vehicle',
+}
+
+/**
  * Lifecycle of a {@link Zone}. Mirrors the warehouse: `active` or `archived`.
  * Archiving a zone (e.g. a bay taken out of service) keeps its id valid for
  * historical references while removing it from the operational layout.

--- a/packages/warehouse-core/src/inventory/inventory-errors.ts
+++ b/packages/warehouse-core/src/inventory/inventory-errors.ts
@@ -35,6 +35,20 @@ export class WarehouseArchivedError extends Error {
 }
 
 /**
+ * Raised when archiving a warehouse that still holds stock (StockItems on
+ * board). Archiving it would orphan that inventory, so the host must relocate or
+ * unload it first. The HTTP layer maps this to 409 Conflict.
+ */
+export class WarehouseNotEmptyError extends Error {
+  constructor(stockItemCount: number) {
+    super(
+      `Warehouse still holds ${stockItemCount} stock item(s) and cannot be archived`,
+    );
+    this.name = 'WarehouseNotEmptyError';
+  }
+}
+
+/**
  * Raised on invalid bin input (empty/oversized code, empty warehouse id). The
  * HTTP layer of each host maps it to 422.
  */

--- a/packages/warehouse-core/src/inventory/warehouse-archival.test.ts
+++ b/packages/warehouse-core/src/inventory/warehouse-archival.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { assertWarehouseCanBeArchived } from './warehouse-archival.js';
+import { WarehouseNotEmptyError } from './inventory-errors.js';
+
+test('allows archiving an empty warehouse (zero stock items)', () => {
+  assert.doesNotThrow(() => assertWarehouseCanBeArchived(0));
+});
+
+test('throws WarehouseNotEmptyError when stock remains on board', () => {
+  assert.throws(() => assertWarehouseCanBeArchived(1), WarehouseNotEmptyError);
+  assert.throws(() => assertWarehouseCanBeArchived(42), WarehouseNotEmptyError);
+});

--- a/packages/warehouse-core/src/inventory/warehouse-archival.ts
+++ b/packages/warehouse-core/src/inventory/warehouse-archival.ts
@@ -1,0 +1,16 @@
+import { WarehouseNotEmptyError } from './inventory-errors.js';
+
+/**
+ * Guard puro de "no archivar con carga": archivar un {@link Warehouse} (fijo o
+ * vehículo) que todavía tiene stock a bordo dejaría inventario huérfano. El
+ * conteo de StockItems lo aporta el host (el paquete no conoce la persistencia);
+ * esta función sólo aplica la política.
+ *
+ * Es una precondición del port de archivado del host/app: DEBE llamarse antes de
+ * archivar. Lanza {@link WarehouseNotEmptyError} si queda carga.
+ */
+export function assertWarehouseCanBeArchived(stockItemCount: number): void {
+  if (stockItemCount > 0) {
+    throw new WarehouseNotEmptyError(stockItemCount);
+  }
+}

--- a/packages/warehouse-core/src/inventory/warehouse.test.ts
+++ b/packages/warehouse-core/src/inventory/warehouse.test.ts
@@ -3,7 +3,12 @@ import assert from 'node:assert/strict';
 import { Warehouse, Zone } from './warehouse.js';
 import { WarehouseId } from './warehouse-id.js';
 import { ZoneId } from './zone-id.js';
-import { WarehouseStatus, ZoneKind, ZoneStatus } from './inventory-enums.js';
+import {
+  WarehouseKind,
+  WarehouseStatus,
+  ZoneKind,
+  ZoneStatus,
+} from './inventory-enums.js';
 import {
   DuplicateZoneCodeError,
   WarehouseArchivedError,
@@ -203,4 +208,109 @@ test('round-trips through a snapshot', () => {
   assert.deepEqual(restored.toSnapshot(), snap);
   assert.ok(restored instanceof Warehouse);
   assert.ok(restored.zones[0] instanceof Zone);
+});
+
+// --- kind + maxCapacity (vehículo como almacén móvil) ----------------------
+
+test('defaults kind to fixed with null maxCapacity', () => {
+  const w = make();
+  assert.equal(w.kind, WarehouseKind.Fixed);
+  assert.equal(w.maxCapacity, null);
+});
+
+test('creates a vehicle warehouse with partial (weight-only) capacity', () => {
+  const w = Warehouse.create({
+    id: WarehouseId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    code: 'VEH-1',
+    name: 'Camión 1',
+    kind: WarehouseKind.Vehicle,
+    maxCapacity: { weightKg: 3500, volumeM3: null },
+  });
+  assert.equal(w.kind, WarehouseKind.Vehicle);
+  assert.deepEqual(w.maxCapacity, { weightKg: 3500, volumeM3: null });
+});
+
+test('allows a vehicle with an as-yet-undeclared (null) maxCapacity', () => {
+  const w = Warehouse.create({
+    id: WarehouseId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    code: 'VEH-2',
+    name: 'Camión 2',
+    kind: WarehouseKind.Vehicle,
+    maxCapacity: null,
+  });
+  assert.equal(w.kind, WarehouseKind.Vehicle);
+  assert.equal(w.maxCapacity, null);
+});
+
+test('rejects a fixed warehouse that declares a maxCapacity', () => {
+  assert.throws(
+    () =>
+      Warehouse.create({
+        id: WarehouseId.create(),
+        scopeId: ScopeId.fromString(SCOPE),
+        code: 'ALM-X',
+        name: 'Almacén X',
+        kind: WarehouseKind.Fixed,
+        maxCapacity: { weightKg: 1000, volumeM3: null },
+      }),
+    WarehouseValidationError,
+  );
+});
+
+test('rejects a maxCapacity with no dimension at all (VO invariant)', () => {
+  assert.throws(
+    () =>
+      Warehouse.create({
+        id: WarehouseId.create(),
+        scopeId: ScopeId.fromString(SCOPE),
+        code: 'VEH-3',
+        name: 'Camión 3',
+        kind: WarehouseKind.Vehicle,
+        maxCapacity: { weightKg: null, volumeM3: null },
+      }),
+    Error,
+  );
+});
+
+test('setMaxCapacity sets and clears the capacity of a vehicle', () => {
+  const w = Warehouse.create({
+    id: WarehouseId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    code: 'VEH-4',
+    name: 'Camión 4',
+    kind: WarehouseKind.Vehicle,
+    maxCapacity: null,
+  });
+  w.setMaxCapacity({ weightKg: 2000, volumeM3: 12 });
+  assert.deepEqual(w.maxCapacity, { weightKg: 2000, volumeM3: 12 });
+  w.setMaxCapacity(null);
+  assert.equal(w.maxCapacity, null);
+});
+
+test('setMaxCapacity rejects a non-null capacity on a fixed warehouse', () => {
+  const w = make(); // fixed
+  assert.throws(
+    () => w.setMaxCapacity({ weightKg: 1000, volumeM3: null }),
+    WarehouseValidationError,
+  );
+});
+
+test('round-trips a vehicle warehouse with capacity through a snapshot', () => {
+  const w = Warehouse.create({
+    id: WarehouseId.create(),
+    scopeId: ScopeId.fromString(SCOPE),
+    code: 'VEH-5',
+    name: 'Camión 5',
+    kind: WarehouseKind.Vehicle,
+    maxCapacity: { weightKg: 3500, volumeM3: null },
+  });
+  const snap = w.toSnapshot();
+  assert.equal(snap.kind, WarehouseKind.Vehicle);
+  assert.deepEqual(snap.maxCapacity, { weightKg: 3500, volumeM3: null });
+  const restored = Warehouse.fromSnapshot(snap);
+  assert.deepEqual(restored.toSnapshot(), snap);
+  assert.equal(restored.kind, WarehouseKind.Vehicle);
+  assert.deepEqual(restored.maxCapacity, { weightKg: 3500, volumeM3: null });
 });

--- a/packages/warehouse-core/src/inventory/warehouse.ts
+++ b/packages/warehouse-core/src/inventory/warehouse.ts
@@ -1,12 +1,18 @@
 import { WarehouseId } from './warehouse-id.js';
 import { ZoneId } from './zone-id.js';
-import { WarehouseStatus, ZoneKind, ZoneStatus } from './inventory-enums.js';
+import {
+  WarehouseKind,
+  WarehouseStatus,
+  ZoneKind,
+  ZoneStatus,
+} from './inventory-enums.js';
 import {
   DuplicateZoneCodeError,
   WarehouseArchivedError,
   WarehouseValidationError,
 } from './inventory-errors.js';
-import { ScopeId } from '../kernel/index.js';
+import { Capacity, ScopeId } from '../kernel/index.js';
+import type { CapacityProps } from '../kernel/index.js';
 
 /** Optional geographic point of the warehouse building (WGS84). */
 export interface WarehouseGeo {
@@ -29,6 +35,13 @@ export interface CreateWarehouseProps {
   address?: string | null;
   geo?: WarehouseGeo | null;
   zones?: AddZoneProps[];
+  /** Naturaleza física del almacén. Por defecto `fixed`. */
+  kind?: WarehouseKind;
+  /**
+   * Carga útil máxima (payload). Sólo válida en vehículos; un almacén fijo la
+   * deja `null`. Puede ser parcial (sólo peso o sólo volumen).
+   */
+  maxCapacity?: CapacityProps | null;
 }
 
 export interface ZoneSnapshot {
@@ -48,6 +61,8 @@ export interface WarehouseSnapshot {
   lat: number | null;
   lng: number | null;
   status: WarehouseStatus;
+  kind: WarehouseKind;
+  maxCapacity: CapacityProps | null;
   zones: ZoneSnapshot[];
   createdAt: Date;
   updatedAt: Date;
@@ -147,6 +162,8 @@ export class Warehouse {
     private _address: string | null,
     private _geo: WarehouseGeo,
     private _status: WarehouseStatus,
+    private readonly _kind: WarehouseKind,
+    private _maxCapacity: Capacity | null,
     private _zones: Zone[],
     public readonly createdAt: Date,
     private _updatedAt: Date,
@@ -157,6 +174,8 @@ export class Warehouse {
     const name = normalizeName(props.name, 'Warehouse name');
     const address = normalizeAddress(props.address ?? null);
     const geo = normalizeGeo(props.geo ?? null);
+    const kind = props.kind ?? WarehouseKind.Fixed;
+    const maxCapacity = buildMaxCapacity(kind, props.maxCapacity ?? null);
 
     const zones = (props.zones ?? []).map((z) => Zone.create(z));
     assertUniqueZoneCodes(zones);
@@ -170,6 +189,8 @@ export class Warehouse {
       address,
       geo,
       WarehouseStatus.Active,
+      kind,
+      maxCapacity,
       zones,
       now,
       now,
@@ -185,6 +206,8 @@ export class Warehouse {
       s.address,
       { lat: s.lat, lng: s.lng },
       s.status,
+      s.kind,
+      s.maxCapacity ? Capacity.create(s.maxCapacity) : null,
       s.zones.map((z) => Zone.fromSnapshot(z)),
       s.createdAt,
       s.updatedAt,
@@ -205,6 +228,13 @@ export class Warehouse {
   }
   get status(): WarehouseStatus {
     return this._status;
+  }
+  get kind(): WarehouseKind {
+    return this._kind;
+  }
+  /** Carga útil máxima como props planas, o `null` (sólo la declaran vehículos). */
+  get maxCapacity(): CapacityProps | null {
+    return this._maxCapacity?.toPlain() ?? null;
   }
   get isArchived(): boolean {
     return this._status === WarehouseStatus.Archived;
@@ -228,6 +258,17 @@ export class Warehouse {
     this.assertActive();
     this._address = normalizeAddress(address);
     this._geo = normalizeGeo(geo);
+    this.touch();
+  }
+
+  /**
+   * Declara o borra (`null`) la carga útil máxima del vehículo. Sólo válida en
+   * almacenes `vehicle`; un almacén fijo la rechaza. La capacidad puede ser
+   * parcial (sólo peso o sólo volumen), como exige el VO {@link Capacity}.
+   */
+  setMaxCapacity(props: CapacityProps | null): void {
+    this.assertActive();
+    this._maxCapacity = buildMaxCapacity(this._kind, props);
     this.touch();
   }
 
@@ -273,6 +314,8 @@ export class Warehouse {
       lat: this._geo.lat,
       lng: this._geo.lng,
       status: this._status,
+      kind: this._kind,
+      maxCapacity: this._maxCapacity?.toPlain() ?? null,
       zones: this._zones.map((z) => z.toSnapshot()),
       createdAt: this.createdAt,
       updatedAt: this._updatedAt,
@@ -352,6 +395,25 @@ function normalizeGeo(geo: WarehouseGeo | null): WarehouseGeo {
     );
   }
   return { lat, lng };
+}
+
+/**
+ * Construye (y valida) la carga útil máxima según la naturaleza del almacén:
+ * sólo un vehículo puede declararla; un almacén fijo con capacidad es un error.
+ * Un vehículo sin capacidad declarada (`null`) es válido. Delega la invariante de
+ * "al menos una dimensión positiva" al VO {@link Capacity}.
+ */
+function buildMaxCapacity(
+  kind: WarehouseKind,
+  props: CapacityProps | null,
+): Capacity | null {
+  if (props === null) return null;
+  if (kind !== WarehouseKind.Vehicle) {
+    throw new WarehouseValidationError(
+      'Only a vehicle warehouse can declare a maxCapacity',
+    );
+  }
+  return Capacity.create(props);
 }
 
 function assertUniqueZoneCodes(zones: Zone[]): void {

--- a/packages/warehouse-core/src/kernel/capacity.ts
+++ b/packages/warehouse-core/src/kernel/capacity.ts
@@ -1,0 +1,63 @@
+/**
+ * Capacidad expresada como peso y/o volumen. Invariante: al menos una de las dos
+ * dimensiones debe estar presente y ser positiva (un contenedor/vehículo que no
+ * puede llevar ninguna no es una capacidad). Cualquiera de las dos puede omitirse
+ * cuando sólo se conoce una de ellas.
+ *
+ * Vive en el `kernel` (no en `logistics`) porque tanto `inventory` (la carga útil
+ * máxima de un vehículo) como `logistics` (una oferta de transporte) la comparten,
+ * y el kernel no puede depender de ningún módulo. `logistics/capacity.ts` la
+ * re-exporta para no romper a sus consumidores.
+ */
+
+export interface CapacityProps {
+  weightKg: number | null;
+  volumeM3: number | null;
+}
+
+/** Se lanza cuando una capacidad no declara ni peso ni volumen. */
+export class CapacityMustHaveWeightOrVolumeError extends Error {
+  constructor() {
+    super('Transport capacity must declare at least weightKg or volumeM3');
+    this.name = 'CapacityMustHaveWeightOrVolumeError';
+  }
+}
+
+/** Se lanza cuando una dimensión de capacidad presente no es positiva. */
+export class InvalidCapacityAmountError extends Error {
+  constructor(field: string, value: number) {
+    super(`Capacity ${field} must be greater than 0, got ${value}`);
+    this.name = 'InvalidCapacityAmountError';
+  }
+}
+
+export class Capacity {
+  readonly weightKg: number | null;
+  readonly volumeM3: number | null;
+
+  private constructor(props: CapacityProps) {
+    this.weightKg = props.weightKg;
+    this.volumeM3 = props.volumeM3;
+  }
+
+  static create(props: CapacityProps): Capacity {
+    const weightKg = props.weightKg ?? null;
+    const volumeM3 = props.volumeM3 ?? null;
+
+    if (weightKg === null && volumeM3 === null) {
+      throw new CapacityMustHaveWeightOrVolumeError();
+    }
+    if (weightKg !== null && weightKg <= 0) {
+      throw new InvalidCapacityAmountError('weightKg', weightKg);
+    }
+    if (volumeM3 !== null && volumeM3 <= 0) {
+      throw new InvalidCapacityAmountError('volumeM3', volumeM3);
+    }
+
+    return new Capacity({ weightKg, volumeM3 });
+  }
+
+  toPlain(): CapacityProps {
+    return { weightKg: this.weightKg, volumeM3: this.volumeM3 };
+  }
+}

--- a/packages/warehouse-core/src/kernel/index.ts
+++ b/packages/warehouse-core/src/kernel/index.ts
@@ -34,3 +34,9 @@ export {
 export type { ExternalCodes } from './external-codes.js';
 export type { DomainEvent } from './domain-event.js';
 export { haversineMeters } from './geo-distance.js';
+export {
+  Capacity,
+  CapacityMustHaveWeightOrVolumeError,
+  InvalidCapacityAmountError,
+} from './capacity.js';
+export type { CapacityProps } from './capacity.js';

--- a/packages/warehouse-core/src/logistics/capacity.ts
+++ b/packages/warehouse-core/src/logistics/capacity.ts
@@ -1,46 +1,7 @@
-import {
-  CapacityMustHaveWeightOrVolumeError,
-  InvalidCapacityAmountError,
-} from './transport-capacity-errors.js';
-
-export interface CapacityProps {
-  weightKg: number | null;
-  volumeM3: number | null;
-}
-
 /**
- * Transport capacity expressed as weight and/or volume. Invariant: at least one
- * of the two must be present and positive (a vehicle that can carry neither is
- * not a capacity offer). Either dimension may be omitted when the provider only
- * knows one of them.
+ * El VO `Capacity` se promovió al `kernel` (lo comparten `inventory` y
+ * `logistics` sin dependencia cruzada). Se re-exporta aquí para que los
+ * consumidores de logistics sigan importándolo `from './capacity.js'` sin
+ * cambios.
  */
-export class Capacity {
-  readonly weightKg: number | null;
-  readonly volumeM3: number | null;
-
-  private constructor(props: CapacityProps) {
-    this.weightKg = props.weightKg;
-    this.volumeM3 = props.volumeM3;
-  }
-
-  static create(props: CapacityProps): Capacity {
-    const weightKg = props.weightKg ?? null;
-    const volumeM3 = props.volumeM3 ?? null;
-
-    if (weightKg === null && volumeM3 === null) {
-      throw new CapacityMustHaveWeightOrVolumeError();
-    }
-    if (weightKg !== null && weightKg <= 0) {
-      throw new InvalidCapacityAmountError('weightKg', weightKg);
-    }
-    if (volumeM3 !== null && volumeM3 <= 0) {
-      throw new InvalidCapacityAmountError('volumeM3', volumeM3);
-    }
-
-    return new Capacity({ weightKg, volumeM3 });
-  }
-
-  toPlain(): CapacityProps {
-    return { weightKg: this.weightKg, volumeM3: this.volumeM3 };
-  }
-}
+export { Capacity, type CapacityProps } from '../kernel/capacity.js';

--- a/packages/warehouse-core/src/logistics/transport-capacity-errors.ts
+++ b/packages/warehouse-core/src/logistics/transport-capacity-errors.ts
@@ -1,16 +1,10 @@
-export class CapacityMustHaveWeightOrVolumeError extends Error {
-  constructor() {
-    super('Transport capacity must declare at least weightKg or volumeM3');
-    this.name = 'CapacityMustHaveWeightOrVolumeError';
-  }
-}
-
-export class InvalidCapacityAmountError extends Error {
-  constructor(field: string, value: number) {
-    super(`Capacity ${field} must be greater than 0, got ${value}`);
-    this.name = 'InvalidCapacityAmountError';
-  }
-}
+// Estos dos errores se movieron al `kernel` junto con el VO `Capacity`. Se
+// re-exportan desde aquí para no romper a sus consumidores (misma clase, así que
+// `instanceof` sigue funcionando).
+export {
+  CapacityMustHaveWeightOrVolumeError,
+  InvalidCapacityAmountError,
+} from '../kernel/capacity.js';
 
 export class InvalidCoverageError extends Error {
   constructor(message: string) {

--- a/packages/warehouse-postgres/migrations/wms_0002_vehicles.sql
+++ b/packages/warehouse-postgres/migrations/wms_0002_vehicles.sql
@@ -1,0 +1,38 @@
+-- wms_0002_vehicles — el vehículo como almacén móvil (Inc 2 del EPIC de flota).
+-- Añade a `wms.warehouses` la naturaleza física (`kind`) y la carga útil máxima
+-- (payload) en peso y/o volumen. Aditiva e idempotente: los almacenes existentes
+-- quedan `kind = 'fixed'` con capacidad nula.
+--
+-- La invariante "un vehículo puede tener capacidad parcial pero al menos una
+-- dimensión, y sólo un vehículo la declara" se valida en el DOMINIO (VO Capacity
+-- + Warehouse). Aquí sólo se restringe el dominio de valores de `kind`.
+--
+-- Migración inmutable una vez fusionada: corregir hacia adelante con un nuevo
+-- `wms_*.sql`, nunca editar este fichero.
+
+ALTER TABLE wms.warehouses
+  ADD COLUMN IF NOT EXISTS kind text NOT NULL DEFAULT 'fixed';
+--> statement-breakpoint
+
+ALTER TABLE wms.warehouses
+  ADD COLUMN IF NOT EXISTS max_weight_kg numeric(18, 6);
+--> statement-breakpoint
+
+ALTER TABLE wms.warehouses
+  ADD COLUMN IF NOT EXISTS max_volume_m3 numeric(18, 6);
+--> statement-breakpoint
+
+-- CHECK del dominio de `kind`. Postgres no soporta `ADD CONSTRAINT IF NOT EXISTS`,
+-- así que se guarda con un bloque idempotente sobre `pg_constraint`.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'wms_warehouses_kind_chk'
+      AND conrelid = 'wms.warehouses'::regclass
+  ) THEN
+    ALTER TABLE wms.warehouses
+      ADD CONSTRAINT wms_warehouses_kind_chk CHECK (kind IN ('fixed', 'vehicle'));
+  END IF;
+END $$;

--- a/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.test.ts
@@ -5,6 +5,7 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import {
   Warehouse,
   WarehouseId,
+  WarehouseKind,
   ZoneId,
   ZoneKind,
   WarehouseStatus,
@@ -167,5 +168,73 @@ describe('DrizzleWarehouseRepository (integración)', () => {
   it('findById devuelve null cuando no existe', async () => {
     const missing = await repo.findById(WarehouseId.create());
     assert.equal(missing, null);
+  });
+
+  it('un almacén fijo por defecto conserva kind=fixed y maxCapacity null', async () => {
+    const scopeId = ScopeId.create();
+    const warehouse = newWarehouse(scopeId, 'FIX-1');
+    await repo.save(warehouse);
+
+    const loaded = await repo.findById(warehouse.id);
+    assert.ok(loaded);
+    assert.equal(loaded.kind, WarehouseKind.Fixed);
+    assert.equal(loaded.maxCapacity, null);
+    assert.deepEqual(loaded.toSnapshot(), warehouse.toSnapshot());
+  });
+
+  it('un vehículo conserva kind=vehicle y su maxCapacity parcial (solo peso)', async () => {
+    const scopeId = ScopeId.create();
+    const vehicle = Warehouse.create({
+      id: WarehouseId.create(),
+      scopeId,
+      code: 'VEH-1',
+      name: 'Camión 1',
+      kind: WarehouseKind.Vehicle,
+      maxCapacity: { weightKg: 3500, volumeM3: null },
+    });
+    await repo.save(vehicle);
+
+    const loaded = await repo.findById(vehicle.id);
+    assert.ok(loaded);
+    assert.equal(loaded.kind, WarehouseKind.Vehicle);
+    assert.deepEqual(loaded.maxCapacity, { weightKg: 3500, volumeM3: null });
+    assert.deepEqual(loaded.toSnapshot(), vehicle.toSnapshot());
+  });
+
+  it('un vehículo con capacidad completa (peso + volumen) round-trip', async () => {
+    const scopeId = ScopeId.create();
+    const vehicle = Warehouse.create({
+      id: WarehouseId.create(),
+      scopeId,
+      code: 'VEH-2',
+      name: 'Furgón 2',
+      kind: WarehouseKind.Vehicle,
+      maxCapacity: { weightKg: 1200.5, volumeM3: 8.75 },
+    });
+    await repo.save(vehicle);
+
+    const loaded = await repo.findById(vehicle.id);
+    assert.ok(loaded);
+    assert.deepEqual(loaded.maxCapacity, { weightKg: 1200.5, volumeM3: 8.75 });
+  });
+
+  it('actualiza la maxCapacity de un vehículo (upsert)', async () => {
+    const scopeId = ScopeId.create();
+    const vehicle = Warehouse.create({
+      id: WarehouseId.create(),
+      scopeId,
+      code: 'VEH-3',
+      name: 'Camión 3',
+      kind: WarehouseKind.Vehicle,
+      maxCapacity: null,
+    });
+    await repo.save(vehicle);
+
+    vehicle.setMaxCapacity({ weightKg: 5000, volumeM3: 20 });
+    await repo.save(vehicle);
+
+    const loaded = await repo.findById(vehicle.id);
+    assert.ok(loaded);
+    assert.deepEqual(loaded.maxCapacity, { weightKg: 5000, volumeM3: 20 });
   });
 });

--- a/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-warehouse.repository.ts
@@ -46,6 +46,15 @@ export class DrizzleWarehouseRepository implements WarehouseRepository {
             lat: s.lat,
             lng: s.lng,
             status: s.status,
+            kind: s.kind,
+            maxWeightKg:
+              s.maxCapacity?.weightKg != null
+                ? s.maxCapacity.weightKg.toString()
+                : null,
+            maxVolumeM3:
+              s.maxCapacity?.volumeM3 != null
+                ? s.maxCapacity.volumeM3.toString()
+                : null,
             updatedAt: s.updatedAt,
           },
         });

--- a/packages/warehouse-postgres/src/inventory/mappers.ts
+++ b/packages/warehouse-postgres/src/inventory/mappers.ts
@@ -6,6 +6,7 @@ import type {
   StockMovementSnapshot,
 } from '@globalemergency/warehouse-core/inventory';
 import {
+  WarehouseKind,
   WarehouseStatus,
   ZoneStatus,
   ZoneKind,
@@ -14,6 +15,7 @@ import {
   StockStatus,
   MovementKind,
 } from '@globalemergency/warehouse-core/inventory';
+import type { CapacityProps } from '@globalemergency/warehouse-core/kernel';
 import type {
   warehousesTable,
   zonesTable,
@@ -39,6 +41,27 @@ function numericToNumber(value: string): number {
     throw new Error(`Valor numeric no finito en la BBDD: "${value}"`);
   }
   return n;
+}
+
+/** `numeric` nullable → number | null (misma cautela que {@link numericToNumber}). */
+function nullableNumericToNumber(value: string | null): number | null {
+  return value === null ? null : numericToNumber(value);
+}
+
+/**
+ * Reconstruye la carga útil máxima del vehículo a partir de las dos columnas
+ * `max_weight_kg` / `max_volume_m3`: `null` si ambas son nulas (almacén fijo o
+ * vehículo sin capacidad declarada); en otro caso, las props del VO Capacity.
+ */
+function rowToMaxCapacity(
+  maxWeightKg: string | null,
+  maxVolumeM3: string | null,
+): CapacityProps | null {
+  if (maxWeightKg === null && maxVolumeM3 === null) return null;
+  return {
+    weightKg: nullableNumericToNumber(maxWeightKg),
+    volumeM3: nullableNumericToNumber(maxVolumeM3),
+  };
 }
 
 // --- Warehouse + Zone ------------------------------------------------------
@@ -72,6 +95,8 @@ export function rowsToWarehouseSnapshot(
     lat: row.lat ?? null,
     lng: row.lng ?? null,
     status: row.status as WarehouseStatus,
+    kind: row.kind as WarehouseKind,
+    maxCapacity: rowToMaxCapacity(row.maxWeightKg, row.maxVolumeM3),
     zones: zones.map(rowToZoneSnapshot),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -91,6 +116,16 @@ export function warehouseSnapshotToRow(
     lat: s.lat,
     lng: s.lng,
     status: s.status,
+    kind: s.kind,
+    // `numeric` acepta string; se serializa igual que quantityAmount. null → null.
+    maxWeightKg:
+      s.maxCapacity?.weightKg != null
+        ? s.maxCapacity.weightKg.toString()
+        : null,
+    maxVolumeM3:
+      s.maxCapacity?.volumeM3 != null
+        ? s.maxCapacity.volumeM3.toString()
+        : null,
     createdAt: s.createdAt,
     updatedAt: s.updatedAt,
   };

--- a/packages/warehouse-postgres/src/inventory/schema.ts
+++ b/packages/warehouse-postgres/src/inventory/schema.ts
@@ -27,6 +27,11 @@ export const warehousesTable = wms.table('warehouses', {
   lat: doublePrecision('lat'),
   lng: doublePrecision('lng'),
   status: text('status').notNull(),
+  // Naturaleza física (`fixed` | `vehicle`) y carga útil máxima del vehículo.
+  // `numeric` llega como string: el mapper lo convierte a number con cuidado.
+  kind: text('kind').notNull(),
+  maxWeightKg: numeric('max_weight_kg', { precision: 18, scale: 6 }),
+  maxVolumeM3: numeric('max_volume_m3', { precision: 18, scale: 6 }),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
 });


### PR DESCRIPTION
Closes #412 · **Incremento 2** del EPIC #409. El vehículo como almacén móvil con capacidad. Todo en el paquete (dominio + persistencia), sin HTTP/auth.

## Qué incluye
- **`Capacity` promovido de `logistics` al `kernel`** (lo comparten inventory y logistics sin dependencia cruzada). `logistics/capacity.ts` y `transport-capacity-errors.ts` quedan como **re-exports puros** → `TransportCapacity`/`window-overlap` intactos, `instanceof` preservado (misma clase).
- **`Warehouse` gana `kind` (`fixed|vehicle`, default fixed) + `maxCapacity: Capacity | null`** (carga útil/payload). Invariante `buildMaxCapacity`: solo un vehículo declara capacidad (fijo+capacidad → error); capacidad **parcial** (solo peso o solo volumen) permitida; vehículo sin declarar (null) ok. Mutador `setMaxCapacity`. Round-trip por snapshot.
- **Guard no-archivar-con-carga**: `WarehouseNotEmptyError` + `assertWarehouseCanBeArchived(stockItemCount)` puro (el conteo lo aporta el host; el paquete da el guard).
- **Persistencia**: `wms_0002_vehicles.sql` (runner del paquete; `kind` text CHECK + `max_weight_kg`/`max_volume_m3` numeric, idempotente con guard `pg_constraint`) + schema + mapper round-trip + int-tests.

## Verificación (local, por mí)
warehouse-core build + **186 tests** · api build + **clean typecheck 0 errores** (el re-export de Capacity no rompe el host) · warehouse-postgres build + **32 int-tests** (contra Postgres local) · prettier packages · api-client + web · frozen-lockfile — todo verde.

Spec §1 · runner de migraciones del paquete valida en el step CI `Test`.