### PR TITLE
feat(wms): persistencia de containers en warehouse-postgres + UoW (Inc 4 flota)

### DIFF
--- a/packages/warehouse-postgres/migrations/wms_0003_containers.sql
+++ b/packages/warehouse-postgres/migrations/wms_0003_containers.sql
@@ -1,0 +1,64 @@
+-- wms_0003_containers — persistencia del agregado Container (palet/caja/lote) del
+-- módulo `containers` de warehouse-core. Vive en el esquema dedicado `wms.` para
+-- que el paquete migre independiente del host que lo consuma.
+--
+-- Tenencia: la columna de partición es `scope_id` (uuid opaco), NUNCA
+-- `emergency_id`: el paquete es agnóstico del sector (Protección Civil,
+-- emergencia de ResponseGrid, etc.). El host mapea su propio id a `scope_id`.
+--
+-- Composición por referencia: `parent_container_id` es una self-FK con ON DELETE
+-- SET NULL (borrar un padre des-anida a sus hijos, no los borra). El holder es
+-- polimórfico (resource|shipment) SIN FK, igual que el carrier de un shipment.
+-- Las líneas de material van como jsonb (SupplyLineSnapshot[]), como en el host.
+-- Peso/volumen brutos son `double precision` (declarados, aún no derivados).
+--
+-- El código secuencial por (scope, type) se asigna con un allocator atómico y
+-- monotónico en `container_code_sequences` (INSERT … ON CONFLICT (scope_id, type)
+-- DO UPDATE SET last_value = last_value + 1 RETURNING): dos altas concurrentes
+-- nunca acuñan el mismo código y un container borrado nunca libera su código.
+--
+-- Migración inmutable una vez fusionada (convención del repo): corregir hacia
+-- adelante con un nuevo `wms_*.sql`, nunca editar este fichero.
+
+CREATE SCHEMA IF NOT EXISTS wms;
+--> statement-breakpoint
+
+-- Unidad de empaquetado rastreable (agregado raíz). `code` único por scope; el
+-- árbol se compone por referencia (`parent_container_id`).
+CREATE TABLE IF NOT EXISTS wms.containers (
+  id                  uuid PRIMARY KEY,
+  scope_id            uuid NOT NULL,
+  code                text NOT NULL,
+  type                text NOT NULL,
+  parent_container_id uuid REFERENCES wms.containers (id) ON DELETE SET NULL,
+  lines               jsonb NOT NULL DEFAULT '[]'::jsonb,
+  gross_weight_kg     double precision,
+  gross_volume_m3     double precision,
+  holder_type         text,
+  holder_id           uuid,
+  status              text NOT NULL,
+  created_at          timestamptz NOT NULL,
+  updated_at          timestamptz NOT NULL
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS wms_containers_scope_idx ON wms.containers (scope_id);
+--> statement-breakpoint
+
+-- Código único por scope (lo que garantiza el allocator monotónico de abajo).
+CREATE UNIQUE INDEX IF NOT EXISTS wms_containers_scope_code_uq
+  ON wms.containers (scope_id, code);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS wms_containers_parent_idx
+  ON wms.containers (parent_container_id);
+--> statement-breakpoint
+
+-- Allocator de código por (scope, type). `last_value` monotónico; la PK compuesta
+-- (scope_id, type) es la diana del upsert atómico `ON CONFLICT`.
+CREATE TABLE IF NOT EXISTS wms.container_code_sequences (
+  scope_id   uuid NOT NULL,
+  type       text NOT NULL,
+  last_value integer NOT NULL,
+  CONSTRAINT wms_container_code_sequences_pk PRIMARY KEY (scope_id, type)
+);

--- a/packages/warehouse-postgres/src/inventory/consumer-validation.test.ts
+++ b/packages/warehouse-postgres/src/inventory/consumer-validation.test.ts
@@ -24,12 +24,20 @@ import {
   StockStatus,
   MovementKind,
 } from '@globalemergency/warehouse-core/inventory';
-import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import {
+  Container,
+  ContainerId,
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '@globalemergency/warehouse-core/containers';
+import { ScopeId, SupplyLine } from '@globalemergency/warehouse-core/kernel';
 import {
   DrizzleWarehouseRepository,
   DrizzleBinRepository,
   DrizzleStockItemRepository,
   DrizzleStockMovementRepository,
+  DrizzleContainerRepository,
   StaleStockItemError,
   runInWmsTransaction,
 } from './index.js';
@@ -54,6 +62,7 @@ describe('Consumidor standalone: flujo WMS end-to-end (dominio + persistencia)',
   let bins: DrizzleBinRepository;
   let items: DrizzleStockItemRepository;
   let movements: DrizzleStockMovementRepository;
+  let containers: DrizzleContainerRepository;
 
   before(async () => {
     pool = newPool();
@@ -63,6 +72,7 @@ describe('Consumidor standalone: flujo WMS end-to-end (dominio + persistencia)',
     bins = new DrizzleBinRepository(db);
     items = new DrizzleStockItemRepository(db);
     movements = new DrizzleStockMovementRepository(db);
+    containers = new DrizzleContainerRepository(db);
   });
 
   after(async () => {
@@ -332,5 +342,88 @@ describe('Consumidor standalone: flujo WMS end-to-end (dominio + persistencia)',
     assert.equal(reloadedTo?.quantity.amount, 0);
     assert.equal(reloadedTo?.version, 1);
     assert.equal((await movements.findByScope(scopeId, {})).length, 0);
+  });
+
+  it('empaqueta un palet y su stock en la MISMA transacción (atomicidad palet+stock)', async () => {
+    const scopeId = ScopeId.create();
+    const supplyId = uuid();
+    const unit = 'unit';
+    const warehouseId = WarehouseId.create();
+    const binId = BinId.create();
+
+    // El código del palet lo asigna el allocator atómico del propio repo.
+    const seq = await containers.nextSequence(scopeId, ContainerType.Pallet);
+    assert.equal(seq, 1);
+    const pallet = Container.create({
+      id: ContainerId.create(),
+      code: `PAL-${String(seq).padStart(4, '0')}`,
+      type: ContainerType.Pallet,
+      scopeId,
+      lines: [
+        SupplyLine.create({
+          name: 'Agua 1.5L',
+          quantity: 24,
+          unit: 'botella',
+          category: 'water',
+        }),
+      ],
+      grossWeightKg: 36,
+    });
+
+    const stock = StockItem.create({
+      id: StockItemId.create(),
+      scopeId,
+      warehouseId,
+      binId,
+      supplyId,
+      lot: null,
+      quantity: Quantity.of(24, unit),
+      status: StockStatus.Available,
+    });
+
+    // Palet + stock que lo constituye se confirman juntos: un fallo revertiría
+    // ambos (misma transacción de la Unit of Work).
+    await runInWmsTransaction(db, async (uow) => {
+      await uow.containers.save(pallet);
+      await uow.items.save(stock);
+    });
+
+    const loadedPallet = await containers.findById(pallet.id);
+    assert.ok(loadedPallet);
+    assert.equal(loadedPallet.code, 'PAL-0001');
+    assert.equal(loadedPallet.status, ContainerStatus.Open);
+    assert.equal(loadedPallet.lines.length, 1);
+    assert.equal((await items.findById(stock.id))?.quantity.amount, 24);
+
+    // Un fallo a mitad revierte el palet Y el stock (nada queda persistido).
+    const boom = new Error('fallo deliberado empaquetando');
+    const orphanPallet = Container.create({
+      id: ContainerId.create(),
+      code: 'PAL-0002',
+      type: ContainerType.Pallet,
+      scopeId,
+      holder: { type: ContainerHolderType.Shipment, id: uuid() },
+    });
+    const orphanStock = StockItem.create({
+      id: StockItemId.create(),
+      scopeId,
+      warehouseId,
+      binId: BinId.create(),
+      supplyId,
+      lot: null,
+      quantity: Quantity.of(5, unit),
+      status: StockStatus.Available,
+    });
+    await assert.rejects(
+      () =>
+        runInWmsTransaction(db, async (uow) => {
+          await uow.containers.save(orphanPallet);
+          await uow.items.save(orphanStock);
+          throw boom;
+        }),
+      (err) => err === boom,
+    );
+    assert.equal(await containers.findById(orphanPallet.id), null);
+    assert.equal(await items.findById(orphanStock.id), null);
   });
 });

--- a/packages/warehouse-postgres/src/inventory/drizzle-container.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-container.repository.test.ts
@@ -1,0 +1,221 @@
+import { after, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Pool } from 'pg';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { sql } from 'drizzle-orm';
+
+// Sólo warehouse-core (dominio) + warehouse-postgres (persistencia). Nunca
+// `apps/*`: es la prueba de que el adaptador de containers es reutilizable sin
+// ResponseGrid (un WMS standalone lo consumiría exactamente así).
+import {
+  Container,
+  ContainerId,
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '@globalemergency/warehouse-core/containers';
+import { ScopeId, SupplyLine } from '@globalemergency/warehouse-core/kernel';
+import { DrizzleContainerRepository } from './index.js';
+import { newPool, resetSchema, makeDb } from './test-support.js';
+
+describe('DrizzleContainerRepository (persistencia del agregado Container)', () => {
+  let pool: Pool;
+  let db: NodePgDatabase;
+  let repo: DrizzleContainerRepository;
+
+  before(async () => {
+    pool = newPool();
+    await resetSchema(pool);
+    db = makeDb(pool);
+    repo = new DrizzleContainerRepository(db);
+  });
+
+  after(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await db.execute(
+      sql`TRUNCATE TABLE wms.containers, wms.container_code_sequences RESTART IDENTITY CASCADE`,
+    );
+  });
+
+  it('round-trip: save → findById reconstruye el snapshot completo', async () => {
+    const scopeId = ScopeId.create();
+    const container = Container.create({
+      id: ContainerId.create(),
+      code: 'PAL-0001',
+      type: ContainerType.Pallet,
+      scopeId,
+      lines: [
+        SupplyLine.create({
+          name: 'Agua 1.5L',
+          quantity: 24,
+          unit: 'botella',
+          category: 'water',
+        }),
+        SupplyLine.create({
+          name: 'Manta térmica',
+          quantity: 10,
+          unit: 'unidad',
+          category: 'shelter',
+        }),
+      ],
+      grossWeightKg: 42.5,
+      grossVolumeM3: 1.2,
+      holder: { type: ContainerHolderType.Resource, id: ScopeId.create().value },
+    });
+    await repo.save(container);
+
+    const loaded = await repo.findById(container.id);
+    assert.ok(loaded);
+    const s = loaded.toSnapshot();
+    assert.equal(s.id, container.id.value);
+    assert.equal(s.code, 'PAL-0001');
+    assert.equal(s.type, ContainerType.Pallet);
+    assert.equal(s.scopeId, scopeId.value);
+    assert.equal(s.parentContainerId, null);
+    assert.equal(s.lines.length, 2);
+    assert.equal(s.lines[0]?.name, 'Agua 1.5L');
+    assert.equal(s.lines[0]?.category, 'water');
+    assert.equal(s.grossWeightKg, 42.5);
+    assert.equal(s.grossVolumeM3, 1.2);
+    assert.equal(s.holderType, ContainerHolderType.Resource);
+    assert.equal(s.status, ContainerStatus.Open);
+  });
+
+  it('save es un upsert: re-guardar refresca contenido, holder y estado', async () => {
+    const scopeId = ScopeId.create();
+    const container = Container.create({
+      id: ContainerId.create(),
+      code: 'CAJ-0001',
+      type: ContainerType.Box,
+      scopeId,
+    });
+    await repo.save(container);
+
+    container.addLine(
+      SupplyLine.create({
+        name: 'Arroz 1kg',
+        quantity: 20,
+        unit: 'paquete',
+        category: 'food',
+      }),
+    );
+    container.moveToHolder({
+      type: ContainerHolderType.Shipment,
+      id: ScopeId.create().value,
+    });
+    container.seal();
+    await repo.save(container);
+
+    const loaded = await repo.findById(container.id);
+    assert.ok(loaded);
+    assert.equal(loaded.lines.length, 1);
+    assert.equal(loaded.status, ContainerStatus.Sealed);
+    assert.equal(loaded.holder?.type, ContainerHolderType.Shipment);
+    // Sigue habiendo una sola fila (upsert por id, no un segundo insert).
+    const all = await repo.findByScope(scopeId, {});
+    assert.equal(all.length, 1);
+  });
+
+  it('findChildren: el árbol se compone por referencia (parentContainerId)', async () => {
+    const scopeId = ScopeId.create();
+    const pallet = Container.create({
+      id: ContainerId.create(),
+      code: 'PAL-0002',
+      type: ContainerType.Pallet,
+      scopeId,
+    });
+    await repo.save(pallet);
+
+    const boxA = Container.create({
+      id: ContainerId.create(),
+      code: 'CAJ-0002',
+      type: ContainerType.Box,
+      scopeId,
+    });
+    const boxB = Container.create({
+      id: ContainerId.create(),
+      code: 'CAJ-0003',
+      type: ContainerType.Box,
+      scopeId,
+    });
+    boxA.setParent(pallet.id);
+    boxB.setParent(pallet.id);
+    await repo.save(boxA);
+    await repo.save(boxB);
+
+    const children = await repo.findChildren(pallet.id);
+    assert.equal(children.length, 2);
+    const codes = children.map((c) => c.code).sort();
+    assert.deepEqual(codes, ['CAJ-0002', 'CAJ-0003']);
+    for (const child of children) {
+      assert.equal(child.parentContainerId?.value, pallet.id.value);
+    }
+
+    // topLevelOnly deja fuera a las cajas anidadas: sólo el palet raíz.
+    const roots = await repo.findByScope(scopeId, { topLevelOnly: true });
+    assert.equal(roots.length, 1);
+    assert.equal(roots[0]?.id.value, pallet.id.value);
+  });
+
+  it('findByScope filtra por type, status y holder', async () => {
+    const scopeId = ScopeId.create();
+    const holderId = ScopeId.create().value;
+
+    const sealedPallet = Container.create({
+      id: ContainerId.create(),
+      code: 'PAL-0003',
+      type: ContainerType.Pallet,
+      scopeId,
+      holder: { type: ContainerHolderType.Shipment, id: holderId },
+    });
+    sealedPallet.seal();
+    await repo.save(sealedPallet);
+
+    const openBox = Container.create({
+      id: ContainerId.create(),
+      code: 'CAJ-0004',
+      type: ContainerType.Box,
+      scopeId,
+    });
+    await repo.save(openBox);
+
+    assert.equal(
+      (await repo.findByScope(scopeId, { type: ContainerType.Pallet })).length,
+      1,
+    );
+    assert.equal(
+      (await repo.findByScope(scopeId, { status: ContainerStatus.Sealed }))
+        .length,
+      1,
+    );
+    assert.equal(
+      (
+        await repo.findByScope(scopeId, {
+          holderType: ContainerHolderType.Shipment,
+          holderId,
+        })
+      ).length,
+      1,
+    );
+    assert.equal((await repo.findByScope(scopeId, {})).length, 2);
+  });
+
+  it('nextSequence es monotónico y aislado por (scope, type)', async () => {
+    const scopeA = ScopeId.create();
+    const scopeB = ScopeId.create();
+
+    assert.equal(await repo.nextSequence(scopeA, ContainerType.Pallet), 1);
+    assert.equal(await repo.nextSequence(scopeA, ContainerType.Pallet), 2);
+    assert.equal(await repo.nextSequence(scopeA, ContainerType.Pallet), 3);
+
+    // Otro type del mismo scope arranca en 1 (secuencia independiente).
+    assert.equal(await repo.nextSequence(scopeA, ContainerType.Box), 1);
+    // Otro scope arranca en 1 (aislamiento por tenencia).
+    assert.equal(await repo.nextSequence(scopeB, ContainerType.Pallet), 1);
+    // La secuencia de scopeA/Pallet sigue avanzando, no se ve afectada.
+    assert.equal(await repo.nextSequence(scopeA, ContainerType.Pallet), 4);
+  });
+});

--- a/packages/warehouse-postgres/src/inventory/drizzle-container.repository.test.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-container.repository.test.ts
@@ -63,7 +63,10 @@ describe('DrizzleContainerRepository (persistencia del agregado Container)', () 
       ],
       grossWeightKg: 42.5,
       grossVolumeM3: 1.2,
-      holder: { type: ContainerHolderType.Resource, id: ScopeId.create().value },
+      holder: {
+        type: ContainerHolderType.Resource,
+        id: ScopeId.create().value,
+      },
     });
     await repo.save(container);
 

--- a/packages/warehouse-postgres/src/inventory/drizzle-container.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-container.repository.ts
@@ -1,0 +1,180 @@
+import { and, asc, desc, eq, isNull, sql, type SQL } from 'drizzle-orm';
+import {
+  Container,
+  ContainerId,
+  ContainerHolderType,
+  ContainerStatus,
+  ContainerType,
+} from '@globalemergency/warehouse-core/containers';
+import type {
+  ContainerRepository,
+  ContainerSnapshot,
+  ListContainersFilter,
+} from '@globalemergency/warehouse-core/containers';
+import { ScopeId } from '@globalemergency/warehouse-core/kernel';
+import type { WmsDatabase } from './db.js';
+import { containerCodeSequencesTable, containersTable } from './schema.js';
+
+type ContainerRow = typeof containersTable.$inferSelect;
+
+/**
+ * Fila → {@link ContainerSnapshot}. `gross_weight_kg`/`gross_volume_m3` son
+ * `double precision`, así que Drizzle los devuelve como number directo (no como
+ * string, a diferencia del `numeric` del stock): no hace falta coerción. Las
+ * líneas viajan como jsonb ya tipado (`SupplyLineSnapshot[]`).
+ */
+function rowToContainerSnapshot(row: ContainerRow): ContainerSnapshot {
+  return {
+    id: row.id,
+    code: row.code,
+    type: row.type as ContainerType,
+    scopeId: row.scopeId,
+    parentContainerId: row.parentContainerId ?? null,
+    lines: row.lines ?? [],
+    grossWeightKg: row.grossWeightKg ?? null,
+    grossVolumeM3: row.grossVolumeM3 ?? null,
+    holderType: (row.holderType as ContainerHolderType | null) ?? null,
+    holderId: row.holderId ?? null,
+    status: row.status as ContainerStatus,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** {@link ContainerSnapshot} → columnas de la fila del container (para el alta). */
+function containerSnapshotToRow(
+  s: ContainerSnapshot,
+): typeof containersTable.$inferInsert {
+  return {
+    id: s.id,
+    scopeId: s.scopeId,
+    code: s.code,
+    type: s.type,
+    parentContainerId: s.parentContainerId,
+    lines: s.lines,
+    grossWeightKg: s.grossWeightKg,
+    grossVolumeM3: s.grossVolumeM3,
+    holderType: s.holderType,
+    holderId: s.holderId,
+    status: s.status,
+    createdAt: s.createdAt,
+    updatedAt: s.updatedAt,
+  };
+}
+
+/**
+ * Adaptador Drizzle/Postgres del puerto {@link ContainerRepository} de
+ * warehouse-core. Opera sobre `scope_id` opaco (la tenencia); no sabe si es una
+ * emergencia (ResponseGrid) o una organización (WMS standalone).
+ *
+ * `save` es un upsert por id (idempotente): el alta fija código/tipo/scope/alta
+ * y las mutaciones posteriores (nido, líneas, holder, estado, updatedAt) se
+ * refrescan en el `ON CONFLICT DO UPDATE`. Se tipa sobre {@link WmsDatabase}
+ * para poder construirse tanto sobre el `db` del pool como sobre un `tx` de la
+ * Unit of Work (persistir un palet y su stock en la misma transacción).
+ */
+export class DrizzleContainerRepository implements ContainerRepository {
+  constructor(private readonly db: WmsDatabase) {}
+
+  async save(container: Container): Promise<void> {
+    const s = container.toSnapshot();
+    await this.db
+      .insert(containersTable)
+      .values(containerSnapshotToRow(s))
+      .onConflictDoUpdate({
+        target: containersTable.id,
+        set: {
+          // El código/tipo/scope/createdAt son inmutables tras el alta; sólo
+          // cambian la posición, el contenido, el holder y el estado.
+          parentContainerId: s.parentContainerId,
+          lines: s.lines,
+          grossWeightKg: s.grossWeightKg,
+          grossVolumeM3: s.grossVolumeM3,
+          holderType: s.holderType,
+          holderId: s.holderId,
+          status: s.status,
+          updatedAt: s.updatedAt,
+        },
+      });
+  }
+
+  async findById(id: ContainerId): Promise<Container | null> {
+    const [row] = await this.db
+      .select()
+      .from(containersTable)
+      .where(eq(containersTable.id, id.value))
+      .limit(1);
+    return row ? Container.fromSnapshot(rowToContainerSnapshot(row)) : null;
+  }
+
+  async findByScope(
+    scopeId: ScopeId,
+    filter: ListContainersFilter,
+  ): Promise<Container[]> {
+    const rows = await this.db
+      .select()
+      .from(containersTable)
+      .where(and(eq(containersTable.scopeId, scopeId.value), ...containerFilters(filter)))
+      .orderBy(desc(containersTable.createdAt));
+    return rows.map((row) =>
+      Container.fromSnapshot(rowToContainerSnapshot(row)),
+    );
+  }
+
+  /** Hijos directos de un container (la composición es por referencia). */
+  async findChildren(parentId: ContainerId): Promise<Container[]> {
+    const rows = await this.db
+      .select()
+      .from(containersTable)
+      .where(eq(containersTable.parentContainerId, parentId.value))
+      .orderBy(asc(containersTable.createdAt));
+    return rows.map((row) =>
+      Container.fromSnapshot(rowToContainerSnapshot(row)),
+    );
+  }
+
+  /**
+   * Asigna atómicamente el siguiente valor de código para el par (scope, type).
+   * El upsert incrementa y devuelve en una sola sentencia, así que dos altas
+   * concurrentes nunca colisionan y un container borrado nunca libera su código
+   * (la secuencia es monotónica, desacoplada del recuento de filas vivas).
+   */
+  async nextSequence(scopeId: ScopeId, type: ContainerType): Promise<number> {
+    const [row] = await this.db
+      .insert(containerCodeSequencesTable)
+      .values({ scopeId: scopeId.value, type, lastValue: 1 })
+      .onConflictDoUpdate({
+        target: [
+          containerCodeSequencesTable.scopeId,
+          containerCodeSequencesTable.type,
+        ],
+        set: { lastValue: sql`${containerCodeSequencesTable.lastValue} + 1` },
+      })
+      .returning({ value: containerCodeSequencesTable.lastValue });
+    if (!row) {
+      throw new Error('Container code sequence allocation returned no row');
+    }
+    return row.value;
+  }
+}
+
+/** Condiciones AND del filtro de listado de containers dentro de un scope. */
+function containerFilters(filter: ListContainersFilter): SQL[] {
+  const conditions: SQL[] = [];
+  if (filter.type !== undefined) {
+    conditions.push(eq(containersTable.type, filter.type));
+  }
+  if (filter.status !== undefined) {
+    conditions.push(eq(containersTable.status, filter.status));
+  }
+  if (filter.holderType !== undefined) {
+    conditions.push(eq(containersTable.holderType, filter.holderType));
+  }
+  if (filter.holderId !== undefined) {
+    conditions.push(eq(containersTable.holderId, filter.holderId));
+  }
+  if (filter.topLevelOnly) {
+    conditions.push(isNull(containersTable.parentContainerId));
+  }
+  return conditions;
+}

--- a/packages/warehouse-postgres/src/inventory/drizzle-container.repository.ts
+++ b/packages/warehouse-postgres/src/inventory/drizzle-container.repository.ts
@@ -114,7 +114,12 @@ export class DrizzleContainerRepository implements ContainerRepository {
     const rows = await this.db
       .select()
       .from(containersTable)
-      .where(and(eq(containersTable.scopeId, scopeId.value), ...containerFilters(filter)))
+      .where(
+        and(
+          eq(containersTable.scopeId, scopeId.value),
+          ...containerFilters(filter),
+        ),
+      )
       .orderBy(desc(containersTable.createdAt));
     return rows.map((row) =>
       Container.fromSnapshot(rowToContainerSnapshot(row)),

--- a/packages/warehouse-postgres/src/inventory/index.ts
+++ b/packages/warehouse-postgres/src/inventory/index.ts
@@ -13,6 +13,8 @@ export {
   binsTable,
   stockItemsTable,
   stockMovementsTable,
+  containersTable,
+  containerCodeSequencesTable,
 } from './schema.js';
 export {
   rowToZoneSnapshot,
@@ -30,6 +32,7 @@ export { DrizzleWarehouseRepository } from './drizzle-warehouse.repository.js';
 export { DrizzleBinRepository } from './drizzle-bin.repository.js';
 export { DrizzleStockItemRepository } from './drizzle-stock-item.repository.js';
 export { DrizzleStockMovementRepository } from './drizzle-stock-movement.repository.js';
+export { DrizzleContainerRepository } from './drizzle-container.repository.js';
 export {
   StaleStockItemError,
   DuplicateStockItemError,

--- a/packages/warehouse-postgres/src/inventory/schema.ts
+++ b/packages/warehouse-postgres/src/inventory/schema.ts
@@ -6,7 +6,10 @@ import {
   doublePrecision,
   integer,
   numeric,
+  jsonb,
+  primaryKey,
 } from 'drizzle-orm/pg-core';
+import type { SupplyLineSnapshot } from '@globalemergency/warehouse-core/kernel';
 
 /**
  * Esquema Postgres dedicado del WMS. Aísla las tablas del módulo `inventory` en
@@ -109,3 +112,46 @@ export const stockMovementsTable = wms.table('stock_movements', {
   idempotencyKey: text('idempotency_key'),
   occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull(),
 });
+
+/**
+ * Unidad de empaquetado rastreable (palet/caja/lote) — agregado `Container`.
+ * La composición es por referencia mediante la self-FK `parent_container_id`
+ * (ON DELETE SET NULL en el DDL: borrar un padre des-anida a sus hijos). Las
+ * líneas de material se guardan como jsonb (`SupplyLineSnapshot[]`), igual que en
+ * el host; el holder es polimórfico (resource|shipment) sin FK. Peso/volumen
+ * brutos son `double precision` → el mapper los usa como number directo.
+ * Refleja `migrations/wms_0003_containers.sql` (fuente de verdad del DDL).
+ */
+export const containersTable = wms.table('containers', {
+  id: uuid('id').primaryKey(),
+  scopeId: uuid('scope_id').notNull(),
+  code: text('code').notNull(),
+  type: text('type').notNull(),
+  parentContainerId: uuid('parent_container_id'),
+  lines: jsonb('lines').$type<SupplyLineSnapshot[]>().notNull(),
+  grossWeightKg: doublePrecision('gross_weight_kg'),
+  grossVolumeM3: doublePrecision('gross_volume_m3'),
+  holderType: text('holder_type'),
+  holderId: uuid('holder_id'),
+  status: text('status').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});
+
+/**
+ * Allocator monotónico del código de container por (scope, type). Un upsert
+ * atómico (`INSERT … ON CONFLICT (scope_id, type) DO UPDATE SET
+ * last_value = last_value + 1 RETURNING last_value`) reparte el siguiente valor,
+ * de modo que dos altas concurrentes nunca acuñan el mismo código y un container
+ * borrado nunca libera el suyo. La PK compuesta (scope_id, type) es la diana del
+ * `ON CONFLICT` (definida en `wms_0003_containers.sql`).
+ */
+export const containerCodeSequencesTable = wms.table(
+  'container_code_sequences',
+  {
+    scopeId: uuid('scope_id').notNull(),
+    type: text('type').notNull(),
+    lastValue: integer('last_value').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.scopeId, t.type] })],
+);

--- a/packages/warehouse-postgres/src/inventory/test-support.ts
+++ b/packages/warehouse-postgres/src/inventory/test-support.ts
@@ -41,8 +41,9 @@ export async function resetSchema(pool: Pool): Promise<void> {
 /** Vacía las tablas de datos entre tests (mantiene el esquema/migraciones). */
 export async function truncateAll(db: NodePgDatabase): Promise<void> {
   // CASCADE + RESTART IDENTITY: borra almacenes y, por la FK con cascada, zonas.
+  // Incluye los containers y su allocator de código (self-FK → CASCADE).
   await db.execute(
-    sql`TRUNCATE TABLE wms.stock_movements, wms.stock_items, wms.bins, wms.zones, wms.warehouses RESTART IDENTITY CASCADE`,
+    sql`TRUNCATE TABLE wms.stock_movements, wms.stock_items, wms.bins, wms.zones, wms.warehouses, wms.containers, wms.container_code_sequences RESTART IDENTITY CASCADE`,
   );
 }
 

--- a/packages/warehouse-postgres/src/inventory/unit-of-work.ts
+++ b/packages/warehouse-postgres/src/inventory/unit-of-work.ts
@@ -3,18 +3,20 @@ import { DrizzleWarehouseRepository } from './drizzle-warehouse.repository.js';
 import { DrizzleBinRepository } from './drizzle-bin.repository.js';
 import { DrizzleStockItemRepository } from './drizzle-stock-item.repository.js';
 import { DrizzleStockMovementRepository } from './drizzle-stock-movement.repository.js';
+import { DrizzleContainerRepository } from './drizzle-container.repository.js';
 
 /**
- * Los 4 repositorios del módulo inventory, ligados a una misma transacción.
+ * Los repositorios del módulo inventory, ligados a una misma transacción.
  * Es lo que recibe el callback de {@link runInWmsTransaction}: úsalos para
  * componer varias escrituras (p. ej. las dos patas de un traslado + el asiento
- * del libro mayor) de forma atómica.
+ * del libro mayor, o un palet y el stock que lo empaqueta) de forma atómica.
  */
 export interface WmsUnitOfWork {
   warehouses: DrizzleWarehouseRepository;
   bins: DrizzleBinRepository;
   items: DrizzleStockItemRepository;
   movements: DrizzleStockMovementRepository;
+  containers: DrizzleContainerRepository;
 }
 
 /**
@@ -50,6 +52,7 @@ export async function runInWmsTransaction<T>(
       bins: new DrizzleBinRepository(tx),
       items: new DrizzleStockItemRepository(tx),
       movements: new DrizzleStockMovementRepository(tx),
+      containers: new DrizzleContainerRepository(tx),
     };
     return work(uow);
   });


### PR DESCRIPTION
Closes #414 · **Incremento 4** del EPIC #409 (pre-paso para cargar palets). Baja la persistencia del agregado `Container` (palet/caja/lote) al paquete `warehouse-postgres`, sobre `scope_id` opaco — hasta ahora su adaptador solo existía en ResponseGrid, así que el WMS standalone no podía persistir palets.

## Qué incluye
- **`wms_0003_containers.sql`** (runner del paquete): `wms.containers` (self-FK `parent_container_id` ON DELETE SET NULL, `lines` jsonb, `gross_weight/volume` double precision, holder polimórfico sin FK, único `(scope_id, code)`) + `wms.container_code_sequences` (PK `(scope_id, type)`). Idempotente.
- **Repo Drizzle** `DrizzleContainerRepository` implementando el port: `save` (upsert por id, respeta inmutables), `findById`, `findByScope` (filtros type/status/holder/topLevelOnly), `findChildren` (árbol), `nextSequence` (**upsert atómico** `ON CONFLICT DO UPDATE SET last_value = last_value + 1 RETURNING` — códigos monotónicos, sin colisión concurrente). Tipado sobre `WmsDatabase` para entrar en el UoW.
- **UoW**: `containers` añadido a `WmsUnitOfWork`/`runInWmsTransaction` → un palet y su stock se persisten en la **misma transacción** (caso de atomicidad + rollback en el consumidor de validación).

## Verificación (local, SIN Postgres — Docker no arranca en esta sesión)
core build + **186 tests** · warehouse-postgres build (typecheck 0) · api build + **clean typecheck 0 errores** · prettier packages · api-client + web · lockfile — todo verde. **Los int-tests del paquete (round-trip, árbol, nextSequence, atomicidad) NO se corrieron en local por falta de BD — los valida el job Test de CI** (Postgres propio), igual que la suite Jest del api. Repo + migración revisados a fondo por inspección.